### PR TITLE
r.sample.category: python3 compatible

### DIFF
--- a/grass7/raster/r.sample.category/r.sample.category.py
+++ b/grass7/raster/r.sample.category/r.sample.category.py
@@ -133,9 +133,9 @@ def main():
     categories = map(int, [z.split('|')[0] for z in catlab])
     catlab = dict([z.split('|') for z in catlab])
     if len(npoints) == 1:
-        npoints = npoints * len(categories)
+        npoints = npoints * len(list(categories))
     else:
-        if len(catlab) != len(npoints):
+        if len(list(categories)) != len(npoints):
             gscript.fatal(_("Number of categories in raster does not match the number of provided sampling points numbers."))
 
     # Create sample points per category

--- a/grass7/raster/r.sample.category/r.sample.category.py
+++ b/grass7/raster/r.sample.category/r.sample.category.py
@@ -135,7 +135,7 @@ def main():
     if len(npoints) == 1:
         npoints = npoints * len(categories)
     else:
-        if len(categories) != len(npoints):
+        if len(catlab) != len(npoints):
             gscript.fatal(_("Number of categories in raster does not match the number of provided sampling points numbers."))
 
     # Create sample points per category


### PR DESCRIPTION
In python 3 maps do not have a length so the len of catlab has to be used from which the map is created.