### PR TITLE
New addon "r.zonal.classes" for class proportion in raster areas

### DIFF
--- a/grass7/raster/Makefile
+++ b/grass7/raster/Makefile
@@ -135,7 +135,8 @@ SUBDIRS = \
 	r.vif \
 	r.vol.dem \
 	r.wateroutlet.lessmem \
-	r.width.funct
+	r.width.funct \
+	r.zonal.classes 
 
 include $(MODULE_TOPDIR)/include/Make/Dir.make
 

--- a/grass7/raster/r.zonal.classes/Makefile
+++ b/grass7/raster/r.zonal.classes/Makefile
@@ -1,0 +1,7 @@
+MODULE_TOPDIR = ../..
+
+PGM = r.zonal.classes
+
+include $(MODULE_TOPDIR)/include/Make/Script.make
+
+default: script

--- a/grass7/raster/r.zonal.classes/r.zonal.classes
+++ b/grass7/raster/r.zonal.classes/r.zonal.classes
@@ -143,7 +143,7 @@ def main():
     
     # Check if input layer is CELL
     if gscript.parse_command('r.info', flags='g', map=raster)['datatype'] != 'CELL':
-        gscript.fatal("The type of the input map 'raster' is not CELL. Please use raster with integer values.")
+        gscript.fatal(_("The type of the input map 'raster' is not CELL. Please use raster with integer values"))
     if gscript.parse_command('r.info', flags='g', map=zone_map)['datatype'] != 'CELL':
         gscript.fatal("The type of the input map 'zone_map' is not CELL. Please use raster with integer values.")
      

--- a/grass7/raster/r.zonal.classes/r.zonal.classes
+++ b/grass7/raster/r.zonal.classes/r.zonal.classes
@@ -149,7 +149,7 @@ def main():
      
     # Check if 'decimals' is + and with credible value
     if decimals <= 0:
-        gscript.fatal("The number of decimals should be positive.")
+        gscript.fatal(_("The number of decimals should be positive"))
     if decimals > 100:
         gscript.fatal("The number of decimals should not be more than 100.")
         

--- a/grass7/raster/r.zonal.classes/r.zonal.classes
+++ b/grass7/raster/r.zonal.classes/r.zonal.classes
@@ -169,7 +169,7 @@ def main():
                                 input='%s,%s'%(zone_map,raster), output=tmpfile, separator=separator) # Do not consider null values in R.STATS
         gscript.message(_("r.stats command finished..."))
     except:
-        gscript.fatal("The execution of r.stats failed.")
+        gscript.fatal(_("The execution of r.stats failed"))
 
     # COMPUTE STATISTICS
     # Open csv file and create a csv reader

--- a/grass7/raster/r.zonal.classes/r.zonal.classes
+++ b/grass7/raster/r.zonal.classes/r.zonal.classes
@@ -281,7 +281,7 @@ def main():
             if gscript.overwrite():
                 fsql.write('DROP TABLE %s;' % temporary_vect)
             else:
-                gscript.fatal(_("Table %s already exists. Use --o to overwrite" % temporary_vect))
+                gscript.fatal(_("Table %s already exists. Use --o to overwrite") % temporary_vect)
         create_statement = 'CREATE TABLE ' + temporary_vect + ' (cat int PRIMARY KEY);\n'
         fsql.write(create_statement)
         for col in header[1:]:

--- a/grass7/raster/r.zonal.classes/r.zonal.classes
+++ b/grass7/raster/r.zonal.classes/r.zonal.classes
@@ -229,7 +229,7 @@ def main():
         else:
             class_list = [int(k) for k in class_dict.keys()]    
             class_list.sort()
-    gscript.verbose("Statistics computed...")
+    gscript.verbose(_("Statistics computed..."))
     
     # OUTPUT CONTENT
     # Header

--- a/grass7/raster/r.zonal.classes/r.zonal.classes
+++ b/grass7/raster/r.zonal.classes/r.zonal.classes
@@ -167,7 +167,7 @@ def main():
         else:
             gscript.run_command('r.stats', overwrite=True, flags='cn', 
                                 input='%s,%s'%(zone_map,raster), output=tmpfile, separator=separator) # Do not consider null values in R.STATS
-        gscript.message("r.stats command finished...")
+        gscript.message(_("r.stats command finished..."))
     except:
         gscript.fatal("The execution of r.stats failed.")
 

--- a/grass7/raster/r.zonal.classes/r.zonal.classes
+++ b/grass7/raster/r.zonal.classes/r.zonal.classes
@@ -151,7 +151,7 @@ def main():
     if decimals <= 0:
         gscript.fatal(_("The number of decimals should be positive"))
     if decimals > 100:
-        gscript.fatal("The number of decimals should not be more than 100.")
+        gscript.fatal(_("The number of decimals should not be more than 100"))
         
     # Adjust region to input map is flag active
     if flags['r']:

--- a/grass7/raster/r.zonal.classes/r.zonal.classes
+++ b/grass7/raster/r.zonal.classes/r.zonal.classes
@@ -142,9 +142,9 @@ def main():
     mode = False if 'mode' not in options['statistics'].split(',') else True
     
     # Check if input layer is CELL
-    if gscript.parse_command('r.info', flags='g', map=raster)['datatype'] <> 'CELL':
+    if gscript.parse_command('r.info', flags='g', map=raster)['datatype'] != 'CELL':
         gscript.fatal("The type of the input map 'raster' is not CELL. Please use raster with integer values.")
-    if gscript.parse_command('r.info', flags='g', map=zone_map)['datatype'] <> 'CELL':
+    if gscript.parse_command('r.info', flags='g', map=zone_map)['datatype'] != 'CELL':
         gscript.fatal("The type of the input map 'zone_map' is not CELL. Please use raster with integer values.")
      
     # Check if 'decimals' is + and with credible value
@@ -152,7 +152,7 @@ def main():
         gscript.fatal("The number of decimals should be positive.")
     if decimals > 100:
         gscript.fatal("The number of decimals should not be more than 100.")
-		
+        
     # Adjust region to input map is flag active
     if flags['r']:
         gscript.use_temp_region()
@@ -162,9 +162,11 @@ def main():
     tmpfile = gscript.tempfile()
     try:
         if flags['n']:
-            gscript.run_command('r.stats', overwrite=True, flags='c', input='%s,%s'%(zone_map,raster), output=tmpfile, separator=separator) # Consider null values in R.STATS
+            gscript.run_command('r.stats', overwrite=True, flags='c', 
+                                input='%s,%s'%(zone_map,raster), output=tmpfile, separator=separator) # Consider null values in R.STATS
         else:
-            gscript.run_command('r.stats', overwrite=True, flags='cn', input='%s,%s'%(zone_map,raster), output=tmpfile, separator=separator) # Do not consider null values in R.STATS
+            gscript.run_command('r.stats', overwrite=True, flags='cn', 
+                                input='%s,%s'%(zone_map,raster), output=tmpfile, separator=separator) # Do not consider null values in R.STATS
         gscript.message("r.stats command finished...")
     except:
         gscript.fatal("The execution of r.stats failed.")
@@ -180,24 +182,25 @@ def main():
             totals_dict[row[0]] = {} # Declare a new embedded dictionnary for the current zone ID
         totals_dict[row[0]][row[1]] = int(row[2])
     # Delete key '*' in 'totals_dict' that could append if there are null values on the zone raster
-    if "*" in totals_dict:
-        del totals_dict["*"]
+    if '*' in totals_dict:
+        del totals_dict['*']
     # Close file
     rstatsfile.close()
     # Mode
     if mode:
         modalclass_dict = {}
         for ID in totals_dict:
-            mode = max(totals_dict[ID].iteritems(), key=operator.itemgetter(1))[0] # The trick was found here : https://stackoverflow.com/a/268285/8013239
-            if mode =="*":   # If the mode is NULL values
-                modalclass_dict[ID] = "NULL"
+            # The trick was found here : https://stackoverflow.com/a/268285/8013239
+            mode = max(totals_dict[ID].iteritems(), key=operator.itemgetter(1))[0] 
+            if mode == '*':   # If the mode is NULL values
+                modalclass_dict[ID] = 'NULL'
             else:
                 modalclass_dict[ID] = mode
     # Classes proportions
     if prop:
         # Get list of categories to output
         if classes_list:   #If list of classes provided by user
-            class_dict = {str(a):"" for a in classes_list}  #To be sure it's string format
+            class_dict = {str(a):'' for a in classes_list}  #To be sure it's string format
         else:
             class_dict = {}
         # Proportion of each category per zone
@@ -209,18 +212,18 @@ def main():
                     proportion_dict[ID][cl] = round(float(totals_dict[ID][cl]) / sum(totals_dict[ID].values())*100,decimals)
                 else:
                     proportion_dict[ID][cl] = round(float(totals_dict[ID][cl]) / sum(totals_dict[ID].values()),decimals)
-                if cl=="*":
-                    class_dict["NULL"] = ""
+                if cl== '*':
+                    class_dict['NULL'] = ''
                 else:
-                    class_dict[cl] = ""
+                    class_dict[cl] = ''
         # Fill class not met in the raster with zero
         for ID in proportion_dict:
             for cl in class_dict:
                 if cl not in proportion_dict[ID].keys():
-                    proportion_dict[ID][cl] = "{:.{}f}".format(0,decimals)
+                    proportion_dict[ID][cl] = '{:.{}f}'.format(0,decimals)
         # Get list of class sorted by value (arithmetic)
         if 'NULL' in class_dict.keys():
-            class_list = [int(k) for k in class_dict.keys() if k <> 'NULL']
+            class_list = [int(k) for k in class_dict.keys() if k != 'NULL']
             class_list.sort()
             class_list.append('NULL')
         else:
@@ -288,13 +291,13 @@ def main():
                 addcol_statement = 'ALTER TABLE %s ADD COLUMN %s double precision;\n' % (temporary_vect, col)
             fsql.write(addcol_statement)
         for key in value_dict:
-                insert_statement = "INSERT INTO %s VALUES (%s, %s);\n" % (temporary_vect, key, ",".join([str(x) for x in value_dict[key]]))
+                insert_statement = 'INSERT INTO %s VALUES (%s, %s);\n' % (temporary_vect, key, ','.join([str(x) for x in value_dict[key]]))
                 fsql.write(insert_statement)
         fsql.write('END TRANSACTION;')
         fsql.close()
         gscript.run_command('db.execute', input=insert_sql, quiet=True)
         gscript.run_command('v.db.connect', map_=temporary_vect, table=temporary_vect, quiet=True)
-        gscript.run_command('g.copy', vector="%s,%s" % (temporary_vect, vectormap), quiet=True)
+        gscript.run_command('g.copy', vector='%s,%s' % (temporary_vect, vectormap), quiet=True)
 
 
 if __name__ == "__main__":

--- a/grass7/raster/r.zonal.classes/r.zonal.classes
+++ b/grass7/raster/r.zonal.classes/r.zonal.classes
@@ -1,0 +1,303 @@
+#!/usr/bin/env python
+############################################################################
+#
+# MODULE:       r.zonal.classes
+# AUTHOR:       Tais Grippa
+# PURPOSE:      Calculates statistics describing raster areas's (zones) composition in terms of classes (e.g.,land cover map)
+#
+# COPYRIGHT:    (c) 2019 Tais Grippa, and the GRASS Development Team
+#               This program is free software under the GNU General Public
+#               License (>=v2). Read the file COPYING that comes with GRASS
+#               for details.
+#
+#############################################################################
+
+#%module
+#% description: Calculates zonal classes proportion describing raster areas's composition, e.g., in terms of land-cover classes.
+#% keyword: raster
+#% keyword: statistics
+#% keyword: zonal statistics
+#%end
+#%option G_OPT_R_INPUT
+#% key: zone_map
+#% label: Name for input raster map with areas 
+#% description: Raster map with areas (all pixels of an area have same id), such as the output of r.clump
+#% required: yes
+#%end
+#%option G_OPT_R_INPUT
+#% key: raster
+#% description: Name of input categorical raster maps for statistics
+#% required: yes
+#%end
+#%option
+#% key: statistics
+#% type: string
+#% label: Statistics to calculate for each input raster map
+#% required: yes
+#% multiple: yes
+#% options: proportion,mode
+#% answer: proportion,mode
+#% guisection: Statistics
+#%end
+#%rules
+#% required: raster,statistics
+#%end
+#%option
+#% key: prefix
+#% type: string
+#% label: Prefix for statistics name
+#% required: no
+#% guisection: Statistics
+#%end
+#%option
+#% key: decimals
+#% type: integer
+#% label: Number of decimals for proportion numbers
+#% answer: 5
+#% required: no
+#% guisection: Statistics
+#%end
+#%option
+#% key: classes_list
+#% type: string
+#% label: List of classes to be considered in the calculation
+#% required: no
+#% guisection: Statistics
+#%end
+#%option G_OPT_F_OUTPUT
+#% key: csvfile
+#% description: Name for output CSV file containing statistics
+#% required: no
+#% guisection: Output
+#%end
+#%option G_OPT_F_SEP
+#% guisection: Output
+#%end
+#%option G_OPT_V_OUTPUT
+#% key: vectormap
+#% description: Name for optional vector output map with statistics as attributes
+#% required: no
+#% guisection: Output
+#%end
+#%rules
+#% required: csvfile,vectormap
+#%end
+#%flag
+#% key: r
+#% description: Adjust region to input map
+#%end
+#%flag
+#% key: n
+#% description: Consider null values in the calculations
+#% guisection: Statistics
+#%end
+#%flag
+#% key: p
+#% description: Proportions as percentages instead of zone's area ratio
+#% guisection: Statistics
+#%END
+
+import os
+import csv
+import operator
+import copy
+import atexit
+from functools import partial    
+from multiprocessing import Pool
+import grass.script as gscript
+
+def cleanup():
+    if temporary_vect:
+        if gscript.find_file(temporary_vect, element='vector')['name']:
+            gscript.run_command('g.remove', flags='f', type_='vector',
+                    name=temporary_vect, quiet=True)
+        if gscript.db_table_exist(temporary_vect):
+            gscript.run_command('db.execute', 
+                                sql='DROP TABLE %s' % temporary_vect,
+                                quiet=True)
+
+def main():
+    global insert_sql
+    insert_sql = None
+    global temporary_vect
+    temporary_vect = None
+    global stats_temp_file
+    stats_temp_file = None
+    global content
+    content = None
+    global raster
+    raster = options['raster']
+    global decimals
+    decimals = int(options['decimals'])
+    global zone_map
+    zone_map = options['zone_map']  
+    
+    csvfile = options['csvfile'] if options['csvfile'] else []
+    separator = gscript.separator(options['separator'])
+    prefix = options['prefix'] if options['prefix'] else []
+    classes_list = options['classes_list'].split(',') if options['classes_list'] else []
+    vectormap = options['vectormap'] if options['vectormap'] else []
+
+    prop = False if 'proportion' not in options['statistics'].split(',') else True
+    mode = False if 'mode' not in options['statistics'].split(',') else True
+    
+    # Check if input layer is CELL
+    if gscript.parse_command('r.info', flags='g', map=raster)['datatype'] <> 'CELL':
+        gscript.fatal("The type of the input map 'raster' is not CELL. Please use raster with integer values.")
+    if gscript.parse_command('r.info', flags='g', map=zone_map)['datatype'] <> 'CELL':
+        gscript.fatal("The type of the input map 'zone_map' is not CELL. Please use raster with integer values.")
+     
+    # Check if 'decimals' is + and with credible value
+    if decimals <= 0:
+        gscript.fatal("The number of decimals should be positive.")
+    if decimals > 100:
+        gscript.fatal("The number of decimals should not be more than 100.")
+		
+    # Adjust region to input map is flag active
+    if flags['r']:
+        gscript.use_temp_region()
+        gscript.run_command('g.region', raster=zone_map)
+        
+    # R.STATS
+    tmpfile = gscript.tempfile()
+    try:
+        if flags['n']:
+            gscript.run_command('r.stats', overwrite=True, flags='c', input='%s,%s'%(zone_map,raster), output=tmpfile, separator=separator) # Consider null values in R.STATS
+        else:
+            gscript.run_command('r.stats', overwrite=True, flags='cn', input='%s,%s'%(zone_map,raster), output=tmpfile, separator=separator) # Do not consider null values in R.STATS
+        gscript.message("r.stats command finished...")
+    except:
+        gscript.fatal("The execution of r.stats failed.")
+
+    # COMPUTE STATISTICS
+    # Open csv file and create a csv reader
+    rstatsfile = open(tmpfile, 'r')
+    reader = csv.reader(rstatsfile, delimiter=separator)
+    # Total pixels per category per zone
+    totals_dict = {}
+    for row in reader:
+        if row[0] not in totals_dict: # Will pass the condition only if the current zone ID does not exists in the dictionary
+            totals_dict[row[0]] = {} # Declare a new embedded dictionnary for the current zone ID
+        totals_dict[row[0]][row[1]] = int(row[2])
+    # Delete key '*' in 'totals_dict' that could append if there are null values on the zone raster
+    if "*" in totals_dict:
+        del totals_dict["*"]
+    # Close file
+    rstatsfile.close()
+    # Mode
+    if mode:
+        modalclass_dict = {}
+        for ID in totals_dict:
+            mode = max(totals_dict[ID].iteritems(), key=operator.itemgetter(1))[0] # The trick was found here : https://stackoverflow.com/a/268285/8013239
+            if mode =="*":   # If the mode is NULL values
+                modalclass_dict[ID] = "NULL"
+            else:
+                modalclass_dict[ID] = mode
+    # Classes proportions
+    if prop:
+        # Get list of categories to output
+        if classes_list:   #If list of classes provided by user
+            class_dict = {str(a):"" for a in classes_list}  #To be sure it's string format
+        else:
+            class_dict = {}
+        # Proportion of each category per zone
+        proportion_dict = {}
+        for ID in totals_dict:
+            proportion_dict[ID] = {}
+            for cl in totals_dict[ID]:
+                if flags['p']:
+                    proportion_dict[ID][cl] = round(float(totals_dict[ID][cl]) / sum(totals_dict[ID].values())*100,decimals)
+                else:
+                    proportion_dict[ID][cl] = round(float(totals_dict[ID][cl]) / sum(totals_dict[ID].values()),decimals)
+                if cl=="*":
+                    class_dict["NULL"] = ""
+                else:
+                    class_dict[cl] = ""
+        # Fill class not met in the raster with zero
+        for ID in proportion_dict:
+            for cl in class_dict:
+                if cl not in proportion_dict[ID].keys():
+                    proportion_dict[ID][cl] = "{:.{}f}".format(0,decimals)
+        # Get list of class sorted by value (arithmetic)
+        if 'NULL' in class_dict.keys():
+            class_list = [int(k) for k in class_dict.keys() if k <> 'NULL']
+            class_list.sort()
+            class_list.append('NULL')
+        else:
+            class_list = [int(k) for k in class_dict.keys()]    
+            class_list.sort()
+    gscript.verbose("Statistics computed...")
+    
+    # OUTPUT CONTENT
+    # Header
+    header = ['cat',]
+    if mode:
+        if prefix:
+            header.append('%s_mode'%prefix)
+        else:
+            header.append('mode')
+    if prop:
+        if prefix:
+            [header.append('%s_prop_%s'%(prefix,cl)) for cl in class_list]
+        else:
+            [header.append('prop_%s'%cl) for cl in class_list]
+    # Values
+    value_dict = {}
+    for ID in totals_dict:
+        value_dict[ID] = []
+        if mode:
+                value_dict[ID].append(modalclass_dict[ID])
+        if prop:
+            for cl in class_list:
+                value_dict[ID].append(proportion_dict[ID]['%s'%cl])
+    
+    # WRITE OUTPUT
+    if csvfile:
+        outfile = open(csvfile, 'w')
+        writer = csv.writer(outfile, delimiter=separator)
+        writer.writerow(header)
+        csvcontent_dict = copy.deepcopy(value_dict)
+        [csvcontent_dict[ID].insert(0,ID) for ID in csvcontent_dict]
+        [csvcontent_dict[ID] for ID in csvcontent_dict]
+        writer.writerows(csvcontent_dict.values())
+        outfile.close()
+    if vectormap:
+        gscript.message(_("Creating output vector map..."))
+        temporary_vect = 'rzonalclasses_tmp_vect_%d' % os.getpid()
+        gscript.run_command('r.to.vect',
+                            input_=zone_map,
+                            output=temporary_vect,
+                            type_='area',
+                            flags='vt',
+                            overwrite=True,
+                            quiet=True)
+        insert_sql = gscript.tempfile()
+        fsql = open(insert_sql, 'w')
+        fsql.write('BEGIN TRANSACTION;\n')
+        if gscript.db_table_exist(temporary_vect):
+            if gscript.overwrite():
+                fsql.write('DROP TABLE %s;' % temporary_vect)
+            else:
+                gscript.fatal(_("Table %s already exists. Use --o to overwrite" % temporary_vect))
+        create_statement = 'CREATE TABLE ' + temporary_vect + ' (cat int PRIMARY KEY);\n'
+        fsql.write(create_statement)
+        for col in header[1:]:
+            if col.split('_')[-1] == 'mode':  # Mode column should be integer
+                addcol_statement = 'ALTER TABLE %s ADD COLUMN %s integer;\n' % (temporary_vect, col)
+            else: # Proportions column should be double precision
+                addcol_statement = 'ALTER TABLE %s ADD COLUMN %s double precision;\n' % (temporary_vect, col)
+            fsql.write(addcol_statement)
+        for key in value_dict:
+                insert_statement = "INSERT INTO %s VALUES (%s, %s);\n" % (temporary_vect, key, ",".join([str(x) for x in value_dict[key]]))
+                fsql.write(insert_statement)
+        fsql.write('END TRANSACTION;')
+        fsql.close()
+        gscript.run_command('db.execute', input=insert_sql, quiet=True)
+        gscript.run_command('v.db.connect', map_=temporary_vect, table=temporary_vect, quiet=True)
+        gscript.run_command('g.copy', vector="%s,%s" % (temporary_vect, vectormap), quiet=True)
+
+
+if __name__ == "__main__":
+    options, flags = gscript.parser()
+    atexit.register(cleanup)
+    main()

--- a/grass7/raster/r.zonal.classes/r.zonal.classes
+++ b/grass7/raster/r.zonal.classes/r.zonal.classes
@@ -145,7 +145,7 @@ def main():
     if gscript.parse_command('r.info', flags='g', map=raster)['datatype'] != 'CELL':
         gscript.fatal(_("The type of the input map 'raster' is not CELL. Please use raster with integer values"))
     if gscript.parse_command('r.info', flags='g', map=zone_map)['datatype'] != 'CELL':
-        gscript.fatal("The type of the input map 'zone_map' is not CELL. Please use raster with integer values.")
+        gscript.fatal(_("The type of the input map 'zone_map' is not CELL. Please use raster with integer values"))
      
     # Check if 'decimals' is + and with credible value
     if decimals <= 0:

--- a/grass7/raster/r.zonal.classes/r.zonal.classes.html
+++ b/grass7/raster/r.zonal.classes/r.zonal.classes.html
@@ -1,0 +1,84 @@
+<h2>DESCRIPTION</h2>
+
+<em>r.zonal.classes</em> computes class proportions and majority class (mode) of a "cover layer" (<b>raster</b>) - e.g., a land cover map -
+according to how it intersects with areas/objects in a "base layer" (<b>zone_map</b>). Areas are defined by adjacent pixels with the same value. Such
+areas can be the output of <em><a href="r.clump.html">r.clump</a></em> or
+<em><a href="i.segment.html">i.segment</a></em>.
+
+<p>
+This function is similar to what <em><a href="r.stats.zonal.html">r.stats.zonal</a></em> performs, but 
+is intended to be used on integer values raster (CELL type) instead of floating-point as in <em>r.stats.zonal</em>. 
+
+<h2>NOTES</h2>	
+
+The user can choose between output in the form of a vector map of the areas contained in the "base layer" 
+with the statistics of the "cover layer" stored in the attribute table (<b>vectormap</b>) and/or in the form of a CSV text file (<b>csvfile</b>).
+<p>
+By default, the function compute the majority class as well as class proportions for each zone in the "base layer". 
+If only the majority class or class proportion is needed, it can be specified by using the <b>statistics</b> parameter. 
+<p>
+By default the function provides the ratio of classes (total = 1) but the <b>-p</b> flag allow to provide percentages (total = 100). 
+The number of decimals is set to 5 by default and can be changed using the <b>decimals</b> parameter.
+<p> 
+By default, the name of columns for proportions follows this logic : 'prop_XX' where XX is the class of the "base layer". 
+The user can add a prefix to proportion columns using the <b>prefix</b> parameter. 
+<p>	
+The function works under the current computation region. The <b>-r</b> flag can be used to define computational region based on the "base layer" for the processing.
+<p>
+By default, the function ignore NULL values. This behaviour can be reverted using the <b>-n</b> flag.
+<p>	
+By default, the output contains only columns for classes that actually exist in the "base layer" under the current computational region.
+This can create problems when the user run the function on different computational region with the aim to merge statistic tables at the end, because some classes could be present under 
+some computational regions and absent on others. For this reason, the <em>classes_list</em> parameter allows to force the output to provide statistics also for classes no present under 
+the current computation region. In this case, the proportion values added for this class are set to zero. This is particularly useful when the function is used in 
+multiple processing - sequentially or in parallel - to ensure all the output will have the same number (and order) of columns. 	
+
+<h2>EXAMPLE</h2>
+<p> On North Carolina Dataset:
+
+<div class="code"><pre>
+# Define region
+g.region raster=zipcodes
+# Get majority class and classes proportion of 'landuse96_28m' for each zone/object in 'zipcode' layer
+r.zonal.classes zone_map=zipcodes raster=landuse96_28m csvfile=/home/tais/output.csv vectormap=vect_output prefix=landuse96
+# Display attributes table
+v.db.select map=vect_output
+</pre></div>
+
+<table style="width:50% ;border: 1px solid black;">
+<caption>Attribute table of the vector layer</caption>
+<tr><th>cat</th><th>landuse96_mode</th><th>landuse96_prop_0</th><th>landuse96_prop_2</th><th>landuse96_prop_3</th><th>landuse96_prop_4</th><th>landuse96_prop_6</th><th>landuse96_prop_7</th><th>landuse96_prop_8</th><th>landuse96_prop_9</th><th>landuse96_prop_10</th><th>landuse96_prop_11</th><th>landuse96_prop_15</th><th>landuse96_prop_18</th><th>landuse96_prop_20</th><th>landuse96_prop_21</th></tr>
+<tr><td>27518</td><td>15</td><td>0</td><td>0.0156</td><td>0.00596</td><td>0.06725</td><td>0</td><td>0.14275</td><td>0</td><td>0</td><td>0.0496</td><td>0.15476</td><td>0.29469</td><td>0.23154</td><td>0.03785</td><td>0</td></tr>
+<tr><td>27607</td><td>15</td><td>0</td><td>0.23124</td><td>0</td><td>0.18572</td><td>0</td><td>0.07119</td><td>0.00039</td><td>0</td><td>0.05828</td><td>0.05583</td><td>0.29022</td><td>0.10002</td><td>0.00403</td><td>0.00307</td></tr>
+<tr><td>27529</td><td>15</td><td>0</td><td>0.26308</td><td>0.00685</td><td>0.034</td><td>0</td><td>0.01209</td><td>9e-05</td><td>0</td><td>0.01571</td><td>0.08357</td><td>0.49074</td><td>0.08991</td><td>0.00394</td><td>0</td></tr>
+<tr><td>27511</td><td>18</td><td>0.0001</td><td>0.08367</td><td>0</td><td>0.02604</td><td>0</td><td>0.06188</td><td>0</td><td>0</td><td>0.06618</td><td>0.02635</td><td>0.33796</td><td>0.39618</td><td>0.00164</td><td>0</td></tr>
+<tr><td>27539</td><td>11</td><td>0</td><td>0.00996</td><td>0.11627</td><td>0.01635</td><td>0</td><td>0.07514</td><td>0</td><td>0</td><td>0</td><td>0.43393</td><td>0.18606</td><td>0.15877</td><td>0.00352</td><td>0</td></tr>
+<tr><td>27608</td><td>2</td><td>0</td><td>0.65863</td><td>0</td><td>0.00444</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.33693</td><td>0</td><td>0</td><td>0</td></tr>
+<tr><td>27513</td><td>15</td><td>0</td><td>0.10406</td><td>0</td><td>0.03076</td><td>0</td><td>0.26989</td><td>0</td><td>0</td><td>0.02303</td><td>0</td><td>0.30589</td><td>0.26637</td><td>0</td><td>0</td></tr>
+<tr><td>27601</td><td>2</td><td>0</td><td>0.90186</td><td>0</td><td>0.06319</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.03462</td><td>0</td><td>0.00033</td><td>0</td><td>0</td></tr>
+<tr><td>27603</td><td>15</td><td>0</td><td>0.10748</td><td>0.00425</td><td>0.23257</td><td>0</td><td>0.05883</td><td>0.00248</td><td>0.00102</td><td>0.03418</td><td>0.07386</td><td>0.31686</td><td>0.16077</td><td>0.00463</td><td>0.00307</td></tr>
+<tr><td>27604</td><td>2</td><td>0</td><td>0.56527</td><td>0</td><td>0.1619</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.02527</td><td>0.01912</td><td>0.21111</td><td>0.01733</td><td>0</td><td>0</td></tr>
+<tr><td>27605</td><td>2</td><td>0</td><td>0.66853</td><td>0</td><td>0.03838</td><td>0</td><td>0.04436</td><td>0</td><td>0</td><td>0</td><td>0.19047</td><td>0.03293</td><td>0.02534</td><td>0</td><td>0</td></tr>
+<tr><td>27606</td><td>15</td><td>0</td><td>0.11138</td><td>0.01833</td><td>0.10006</td><td>0.00039</td><td>0.10619</td><td>0.00241</td><td>0</td><td>0.03543</td><td>0.1131</td><td>0.28194</td><td>0.17523</td><td>0.05554</td><td>0</td></tr>
+<tr><td>27610</td><td>2</td><td>0</td><td>0.47169</td><td>0</td><td>0.06257</td><td>0</td><td>0.00406</td><td>0.00132</td><td>0</td><td>0.03884</td><td>0.06651</td><td>0.31163</td><td>0.04162</td><td>0.00176</td><td>0</td></tr>
+</table>
+
+
+<h3>Acknowledgement</h3>
+This work was funded by the Belgian Federal Science Policy Office (BELSPO) (Research Program for 
+Earth Observation <a href="https://http://eo.belspo.be/About/Stereo3.aspx">STEREO III</a>, contract SR/00/304) as part of the <a href="https://http://maupp.ulb.ac.be/">MAUPP project</a> 
+and by  <a href="http://geoportail.wallonie.be">the department of Geomatics of the Walloon region</a> as part of the WALOUS project.
+
+<h2>SEE ALSO</h2>
+    
+<em>
+<a href="r.stats.zonal.html">r.stats.zonal</a>,
+<a href="r.univar.html">r.univar</a>
+<a href="v.rast.stats.html">v.rast.stats</a>
+<a href="i.segment.stats.html">i.segment.stats (Addon)</a>,
+</em>
+    
+<h2>AUTHOR</h2>
+    Tais GRIPPA - Universite Libre de Bruxelles. ANAGEO Lab.
+</body>
+</html>

--- a/grass7/raster/r.zonal.classes/r.zonal.classes.html
+++ b/grass7/raster/r.zonal.classes/r.zonal.classes.html
@@ -1,84 +1,107 @@
-<h2>DESCRIPTION</h2>
+<h2>DESCRIPTION</h2>  
+<em>r.zonal.classes</em> computes class 
+proportions and majority class (mode) of a "cover layer" 
+(<b>raster</b>) - e.g., a land cover map - according to how it 
+intersects with areas/objects in a "base layer" (<b>zone_map</b>). 
+Areas are defined by adjacent pixels with the same value. Such areas 
+can be the output of <em><a href="r.clump.html">r.clump</a></em> or 
+<em><a href="i.segment.html">i.segment</a></em>.  <p> This function is 
+similar to what <em><a href="r.stats.zonal.html">r.stats.zonal</a></em> 
+performs, but is intended to be used on integer values raster (CELL 
+type) instead of floating-point as in <em>r.stats.zonal</em>. 
 
-<em>r.zonal.classes</em> computes class proportions and majority class (mode) of a "cover layer" (<b>raster</b>) - e.g., a land cover map -
-according to how it intersects with areas/objects in a "base layer" (<b>zone_map</b>). Areas are defined by adjacent pixels with the same value. Such
-areas can be the output of <em><a href="r.clump.html">r.clump</a></em> or
-<em><a href="i.segment.html">i.segment</a></em>.
+<h2>NOTES</h2>  The user can choose between output in the form of a 
+vector map of the areas contained in the "base layer" with the 
+statistics of the "cover layer" stored in the attribute table 
+(<b>vectormap</b>) and/or in the form of a CSV text file 
+(<b>csvfile</b>). <p> By default, the function compute the majority 
+class as well as class proportions for each zone in the "base layer". 
+If only the majority class or class proportion is needed, it can be 
+specified by using the <b>statistics</b> parameter. <p> By default the 
+function provides the ratio of classes (total = 1) but the <b>-p</b> 
+flag allow to provide percentages (total = 100). The number of decimals 
+is set to 5 by default and can be changed using the <b>decimals</b> 
+parameter. <p> By default, the name of columns for proportions follows 
+this logic : 'prop_XX' where XX is the class of the "base layer". The 
+user can add a prefix to proportion columns using the <b>prefix</b> 
+parameter. <p> The function works under the current computation region. 
+The <b>-r</b> flag can be used to define computational region based on 
+the "base layer" for the processing. <p> By default, the function 
+ignore NULL values. This behaviour can be reverted using the <b>-n</b> 
+flag. <p> By default, the output contains only columns for classes that 
+actually exist in the "base layer" under the current computational 
+region. This can create problems when the user run the function on 
+different computational region with the aim to merge statistic tables 
+at the end, because some classes could be present under some 
+computational regions and absent on others. For this reason, the 
+<em>classes_list</em> parameter allows to force the output to provide 
+statistics also for classes no present under the current computation 
+region. In this case, the proportion values added for this class are 
+set to zero. This is particularly useful when the function is used in 
+multiple processing - sequentially or in parallel - to ensure all the 
+output will have the same number (and order) of columns. 
 
-<p>
-This function is similar to what <em><a href="r.stats.zonal.html">r.stats.zonal</a></em> performs, but 
-is intended to be used on integer values raster (CELL type) instead of floating-point as in <em>r.stats.zonal</em>. 
-
-<h2>NOTES</h2>	
-
-The user can choose between output in the form of a vector map of the areas contained in the "base layer" 
-with the statistics of the "cover layer" stored in the attribute table (<b>vectormap</b>) and/or in the form of a CSV text file (<b>csvfile</b>).
-<p>
-By default, the function compute the majority class as well as class proportions for each zone in the "base layer". 
-If only the majority class or class proportion is needed, it can be specified by using the <b>statistics</b> parameter. 
-<p>
-By default the function provides the ratio of classes (total = 1) but the <b>-p</b> flag allow to provide percentages (total = 100). 
-The number of decimals is set to 5 by default and can be changed using the <b>decimals</b> parameter.
-<p> 
-By default, the name of columns for proportions follows this logic : 'prop_XX' where XX is the class of the "base layer". 
-The user can add a prefix to proportion columns using the <b>prefix</b> parameter. 
-<p>	
-The function works under the current computation region. The <b>-r</b> flag can be used to define computational region based on the "base layer" for the processing.
-<p>
-By default, the function ignore NULL values. This behaviour can be reverted using the <b>-n</b> flag.
-<p>	
-By default, the output contains only columns for classes that actually exist in the "base layer" under the current computational region.
-This can create problems when the user run the function on different computational region with the aim to merge statistic tables at the end, because some classes could be present under 
-some computational regions and absent on others. For this reason, the <em>classes_list</em> parameter allows to force the output to provide statistics also for classes no present under 
-the current computation region. In this case, the proportion values added for this class are set to zero. This is particularly useful when the function is used in 
-multiple processing - sequentially or in parallel - to ensure all the output will have the same number (and order) of columns. 	
-
-<h2>EXAMPLE</h2>
-On North Carolina Dataset:
-
-<div class="code"><pre>
-# Define region
-g.region raster=zipcodes
-# Get majority class and classes proportion of 'landuse96_28m' for each zone/object in 'zipcode' layer
-r.zonal.classes zone_map=zipcodes raster=landuse96_28m csvfile=$HOME/output.csv vectormap=vect_output prefix=landuse96
-# Display attributes table
-v.db.select map=vect_output
-</pre></div>
-
-<table style="width:50% ;border: 1px solid black;">
-<caption>Attribute table of the vector layer</caption>
-<tr><th>cat</th><th>landuse96_mode</th><th>landuse96_prop_0</th><th>landuse96_prop_2</th><th>landuse96_prop_3</th><th>landuse96_prop_4</th><th>landuse96_prop_6</th><th>landuse96_prop_7</th><th>landuse96_prop_8</th><th>landuse96_prop_9</th><th>landuse96_prop_10</th><th>landuse96_prop_11</th><th>landuse96_prop_15</th><th>landuse96_prop_18</th><th>landuse96_prop_20</th><th>landuse96_prop_21</th></tr>
-<tr><td>27518</td><td>15</td><td>0</td><td>0.0156</td><td>0.00596</td><td>0.06725</td><td>0</td><td>0.14275</td><td>0</td><td>0</td><td>0.0496</td><td>0.15476</td><td>0.29469</td><td>0.23154</td><td>0.03785</td><td>0</td></tr>
-<tr><td>27607</td><td>15</td><td>0</td><td>0.23124</td><td>0</td><td>0.18572</td><td>0</td><td>0.07119</td><td>0.00039</td><td>0</td><td>0.05828</td><td>0.05583</td><td>0.29022</td><td>0.10002</td><td>0.00403</td><td>0.00307</td></tr>
-<tr><td>27529</td><td>15</td><td>0</td><td>0.26308</td><td>0.00685</td><td>0.034</td><td>0</td><td>0.01209</td><td>9e-05</td><td>0</td><td>0.01571</td><td>0.08357</td><td>0.49074</td><td>0.08991</td><td>0.00394</td><td>0</td></tr>
-<tr><td>27511</td><td>18</td><td>0.0001</td><td>0.08367</td><td>0</td><td>0.02604</td><td>0</td><td>0.06188</td><td>0</td><td>0</td><td>0.06618</td><td>0.02635</td><td>0.33796</td><td>0.39618</td><td>0.00164</td><td>0</td></tr>
-<tr><td>27539</td><td>11</td><td>0</td><td>0.00996</td><td>0.11627</td><td>0.01635</td><td>0</td><td>0.07514</td><td>0</td><td>0</td><td>0</td><td>0.43393</td><td>0.18606</td><td>0.15877</td><td>0.00352</td><td>0</td></tr>
-<tr><td>27608</td><td>2</td><td>0</td><td>0.65863</td><td>0</td><td>0.00444</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.33693</td><td>0</td><td>0</td><td>0</td></tr>
-<tr><td>27513</td><td>15</td><td>0</td><td>0.10406</td><td>0</td><td>0.03076</td><td>0</td><td>0.26989</td><td>0</td><td>0</td><td>0.02303</td><td>0</td><td>0.30589</td><td>0.26637</td><td>0</td><td>0</td></tr>
-<tr><td>27601</td><td>2</td><td>0</td><td>0.90186</td><td>0</td><td>0.06319</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.03462</td><td>0</td><td>0.00033</td><td>0</td><td>0</td></tr>
-<tr><td>27603</td><td>15</td><td>0</td><td>0.10748</td><td>0.00425</td><td>0.23257</td><td>0</td><td>0.05883</td><td>0.00248</td><td>0.00102</td><td>0.03418</td><td>0.07386</td><td>0.31686</td><td>0.16077</td><td>0.00463</td><td>0.00307</td></tr>
-<tr><td>27604</td><td>2</td><td>0</td><td>0.56527</td><td>0</td><td>0.1619</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.02527</td><td>0.01912</td><td>0.21111</td><td>0.01733</td><td>0</td><td>0</td></tr>
-<tr><td>27605</td><td>2</td><td>0</td><td>0.66853</td><td>0</td><td>0.03838</td><td>0</td><td>0.04436</td><td>0</td><td>0</td><td>0</td><td>0.19047</td><td>0.03293</td><td>0.02534</td><td>0</td><td>0</td></tr>
-<tr><td>27606</td><td>15</td><td>0</td><td>0.11138</td><td>0.01833</td><td>0.10006</td><td>0.00039</td><td>0.10619</td><td>0.00241</td><td>0</td><td>0.03543</td><td>0.1131</td><td>0.28194</td><td>0.17523</td><td>0.05554</td><td>0</td></tr>
-<tr><td>27610</td><td>2</td><td>0</td><td>0.47169</td><td>0</td><td>0.06257</td><td>0</td><td>0.00406</td><td>0.00132</td><td>0</td><td>0.03884</td><td>0.06651</td><td>0.31163</td><td>0.04162</td><td>0.00176</td><td>0</td></tr>
-</table>
-
-
-<h3>Acknowledgement</h3>
-This work was funded by the Belgian Federal Science Policy Office (BELSPO) (Research Program for 
-Earth Observation <a href="https://http://eo.belspo.be/About/Stereo3.aspx">STEREO III</a>, contract SR/00/304) as part of the <a href="https://http://maupp.ulb.ac.be/">MAUPP project</a> 
-and by  <a href="http://geoportail.wallonie.be">the department of Geomatics of the Walloon region</a> as part of the WALOUS project.
-
-<h2>SEE ALSO</h2>
-    
-<em>
-<a href="r.stats.zonal.html">r.stats.zonal</a>,
-<a href="r.univar.html">r.univar</a>
-<a href="v.rast.stats.html">v.rast.stats</a>
-<a href="i.segment.stats.html">i.segment.stats (Addon)</a>,
-</em>
-    
-<h2>AUTHOR</h2>
-    Tais GRIPPA - Universite Libre de Bruxelles. ANAGEO Lab.
-</body>
-</html>
+<h2>EXAMPLE</h2> <p> On North Carolina Dataset:  
+<p># Define region 
+<div class="code">g.region raster=zipcodes</div>
+<p># Get majority class and classes proportion of 'landuse96_28m' 
+for each zone/object in 'zipcode' layer 
+<div class="code">r.zonal.classes zone_map=zipcodes 
+raster=landuse96_28m csvfile=/home/tais/output.csv 
+vectormap=vect_output prefix=landuse96 </div>
+<p># Display attributes table 
+<div class="code">v.db.select map=vect_output </div>
+<table style="width:50% 
+;border: 1px solid black;"> <caption>Attribute table of the vector 
+layer</caption> <tr> <th>cat</th> <th>landuse96_mode</th> 
+<th>landuse96_prop_0</th> <th>landuse96_prop_2</th> 
+<th>landuse96_prop_3</th> <th>landuse96_prop_4</th> 
+<th>landuse96_prop_6</th> <th>landuse96_prop_7</th> 
+<th>landuse96_prop_8</th> <th>landuse96_prop_9</th> 
+<th>landuse96_prop_10</th> <th>landuse96_prop_11</th> 
+<th>landuse96_prop_15</th> <th>landuse96_prop_18</th> 
+<th>landuse96_prop_20</th> <th>landuse96_prop_21</th> </tr> <tr> 
+<td>27518</td><td>15</td><td>0</td><td>0.0156</td> 
+<td>0.00596</td><td>0.06725</td><td>0</td> 
+<td>0.14275</td><td>0</td><td>0</td><td>0.0496</td> 
+<td>0.15476</td><td>0.29469</td><td>0.23154</td> 
+<td>0.03785</td><td>0</td></tr> <tr> 
+<td>27607</td><td>15</td><td>0</td><td>0.23124</td> 
+<td>0</td><td>0.18572</td><td>0</td><td>0.07119</td> 
+<td>0.00039</td><td>0</td><td>0.05828</td> 
+<td>0.05583</td><td>0.29022</td><td>0.10002</td> 
+<td>0.00403</td><td>0.00307</td></tr> <tr> 
+<td>27529</td><td>15</td><td>0</td><td>0.26308</td> 
+<td>0.00685</td><td>0.034</td><td>0</td><td>0.01209</td> 
+<td>9e-05</td><td>0</td><td>0.01571</td><td>0.08357</td> 
+<td>0.49074</td><td>0.08991</td><td>0.00394</td> <td>0</td></tr> <tr> 
+<td>27511</td><td>18</td><td>0.0001</td><td>0.08367</td> 
+<td>0</td><td>0.02604</td><td>0</td><td>0.06188</td> 
+<td>0</td><td>0</td><td>0.06618</td><td>0.02635</td> 
+<td>0.33796</td><td>0.39618</td><td>0.00164</td> <td>0</td></tr> <tr> 
+<td>27539</td><td>11</td><td>0</td><td>0.00996</td> 
+<td>0.11627</td><td>0.01635</td><td>0</td> 
+<td>0.07514</td><td>0</td><td>0</td><td>0</td> 
+<td>0.43393</td><td>0.18606</td><td>0.15877</td> 
+<td>0.00352</td><td>0</td></tr> <tr> 
+<td>27608</td><td>2</td><td>0</td><td>0.65863</td> 
+<td>0</td><td>0.00444</td><td>0</td><td>0</td> 
+<td>0</td><td>0</td><td>0</td><td>0</td> 
+<td>0.33693</td><td>0</td><td>0</td><td>0</td></tr> <tr> 
+<td>27513</td><td>15</td><td>0</td><td>0.10406</td> 
+<td>0</td><td>0.03076</td><td>0</td><td>0.26989</td> 
+<td>0</td><td>0</td><td>0.02303</td><td>0</td> 
+<td>0.30589</td><td>0.26637</td><td>0</td><td>0</td></tr> </table> 
+<h3>Acknowledgement</h3> This work was funded by the Belgian Federal 
+Science Policy Office (BELSPO) (Research Program for Earth Observation 
+<a href="https://http://eo.belspo.be/About/Stereo3.aspx">STEREO 
+III</a>, contract SR/00/304) as part of the <a 
+href="https://http://maupp.ulb.ac.be/">MAUPP project</a> and by  <a 
+href="http://geoportail.wallonie.be">the department of Geomatics of the 
+Walloon region</a> as part of the WALOUS project.  <h2>SEE ALSO</h2> 
+<em> <a href="r.stats.zonal.html">r.stats.zonal</a>, <a 
+href="r.univar.html">r.univar</a> <a 
+href="v.rast.stats.html">v.rast.stats</a> <a 
+href="i.segment.stats.html">i.segment.stats (Addon)</a>, </em> 
+<h2>AUTHOR</h2> Tais GRIPPA - Universite Libre de Bruxelles. ANAGEO 
+Lab. </body> </html>

--- a/grass7/raster/r.zonal.classes/r.zonal.classes.html
+++ b/grass7/raster/r.zonal.classes/r.zonal.classes.html
@@ -34,7 +34,7 @@ the current computation region. In this case, the proportion values added for th
 multiple processing - sequentially or in parallel - to ensure all the output will have the same number (and order) of columns. 	
 
 <h2>EXAMPLE</h2>
-<p> On North Carolina Dataset:
+On North Carolina Dataset:
 
 <div class="code"><pre>
 # Define region

--- a/grass7/raster/r.zonal.classes/r.zonal.classes.html
+++ b/grass7/raster/r.zonal.classes/r.zonal.classes.html
@@ -40,7 +40,7 @@ On North Carolina Dataset:
 # Define region
 g.region raster=zipcodes
 # Get majority class and classes proportion of 'landuse96_28m' for each zone/object in 'zipcode' layer
-r.zonal.classes zone_map=zipcodes raster=landuse96_28m csvfile=/home/tais/output.csv vectormap=vect_output prefix=landuse96
+r.zonal.classes zone_map=zipcodes raster=landuse96_28m csvfile=$HOME/output.csv vectormap=vect_output prefix=landuse96
 # Display attributes table
 v.db.select map=vect_output
 </pre></div>


### PR DESCRIPTION
I abide to RFC2.

Pull request for merge of a new addon called "r.zonal.classes" to the grass-addons repository. 
This addon computes class proportions and majority class of a "cover layer"  (e.g., a land cover map) according to how it intersects with areas/objects in a "base layer". This function is similar to what r.stats.zonal performs, but is intended to be used on integer values raster (CELL type) instead.