### PR TITLE
i.sentinel.import: implement register_output option 

### DIFF
--- a/grass7/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.html
+++ b/grass7/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.html
@@ -38,7 +38,7 @@ spatial resolutions:
 </tr>
 <tr>
 <td>20</td>
-<td>B5, B6, B7, B8a, B11, B12</td>
+<td>B5, B6, B7, B8A, B11, B12</td>
 </tr>
 <tr>
 <td>60</td>
@@ -46,13 +46,21 @@ spatial resolutions:
 </tr>
 </tbody>
 </table>
-  
+
 <h2>NOTES</h2>
 
 <p>
 If <b>-c</b> flag is given, than also cloud mask file is imported as
 vector map if available. The name of created vector map is determined from
 input Sentinel product.
+
+<p>
+By <b>register_file</b> option <em>i.sentinel.import</em> allows
+creating a file which can be used to register imported imagery data
+into space-time raster dateset (STRDS)
+by <em><a href="t.register.html">t.register</a></em>. Note that
+currently a register file can be created only for Sentinel-2 data. See
+example below.
 
 <h2>EXAMPLES</h2>
 
@@ -70,7 +78,7 @@ data/S2B_MSIL1C_20180216T102059_N0206_R065_T32UPB_20180216T140508.SAFE/GRANULE/.
 data/S2B_MSIL1C_20180216T102059_N0206_R065_T32UPB_20180216T140508.SAFE/GRANULE/.../T32UPB_20180216T102059_B11.jp2 1 (EPSG: 32632)
 </pre></div>
 
-<h3>Import Sentinel bands</h3>
+<h3>Import Sentinel data</h3>
 
 Import all Sentinel bands found in <i>data</i> directory:
 
@@ -103,6 +111,34 @@ i.sentinel.import -l -c input=data
 <img src="i_sentinel_import_band_4_clouds.png" width="600" height="356"><br>
 <i>Fig: Band 4 with imported cloud mask</i>
 </center>
+
+<h3>Register imported Sentinel data into STRDS</h3>
+
+<div class="code"><pre>
+i.sentinel.import input=data register_output=t_register.txt
+
+# register imported data into existing STRDS
+t.register input=sentinel_ds input=t_register.txt
+</pre></div>
+
+A register file typically contains two columns: imported raster map
+name and timestamp separated by <tt>|</tt>. In the case of current
+development version of GRASS which supports band references concept
+(see <em><a href="g.bands.html">g.bands</a></em> module for details) a
+register file is extended by a third column containg band reference
+information, see the examples below.
+
+<div class="code"><pre>
+# register file produced by stable GRASS GIS 7.8 version
+T33UVR_20181205T101401_B05|2018-12-05 10:16:43.275000
+T33UVR_20181205T101401_B03|2018-12-05 10:16:43.275000
+T33UVR_20181205T101401_B06|2018-12-05 10:16:43.275000
+...
+# register file produced by development GRASS GIS 7.9 version
+T33UVR_20181205T101401_B05|2018-12-05 10:16:43.275000|S2_5
+T33UVR_20181205T101401_B03|2018-12-05 10:16:43.275000|S2_3
+T33UVR_20181205T101401_B06|2018-12-05 10:16:43.275000|S2_6
+</pre></div>
 
 <h2>SEE ALSO</h2>
 

--- a/grass7/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.html
+++ b/grass7/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.html
@@ -118,7 +118,7 @@ i.sentinel.import -l -c input=data
 i.sentinel.import input=data register_output=t_register.txt
 
 # register imported data into existing STRDS
-t.register input=sentinel_ds input=t_register.txt
+t.register input=sentinel_ds file=t_register.txt
 </pre></div>
 
 A register file typically contains two columns: imported raster map

--- a/grass7/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
@@ -6,7 +6,7 @@
 # AUTHOR(S):   Martin Landa
 # PURPOSE:     Imports Sentinel data downloaded from Copernicus Open Access Hub
 #              using i.sentinel.download.
-# COPYRIGHT:   (C) 2018 by Martin Landa, and the GRASS development team
+# COPYRIGHT:   (C) 2018-2019 by Martin Landa, and the GRASS development team
 #
 #              This program is free software under the GNU General Public
 #              License (>=v2). Read the file COPYING that comes with GRASS
@@ -23,7 +23,7 @@
 #%end
 #%option G_OPT_M_DIR
 #% key: input
-#% description: Name for input directory where downloaded Sentinel data lives
+#% description: Name of input directory with downloaded Sentinel data
 #% required: yes
 #%end
 #%option
@@ -39,6 +39,11 @@
 #% label: Maximum memory to be used (in MB)
 #% description: Cache size for raster rows
 #% answer: 300
+#%end
+#%option G_OPT_F_OUTPUT
+#% key: register_output
+#% description: Name for output file to use with t.register
+#% required: no
 #%end
 #%flag
 #% key: r
@@ -200,9 +205,13 @@ class SentinelImporter(object):
         dsn = None
 
         return ret
-        
+
+    @staticmethod
+    def _map_name(filename):
+        return os.path.splitext(os.path.basename(filename))[0]
+
     def _import_file(self, filename, module, args):
-        mapname = os.path.splitext(os.path.basename(filename))[0]
+        mapname = self._map_name(filename)
         gs.message(_('Processing <{}>...').format(mapname))
         if module == 'r.import':
             args['resolution_value'] = self._raster_resolution(filename)
@@ -246,19 +255,100 @@ class SentinelImporter(object):
                 os.linesep
             ))
 
+    @staticmethod
+    def _read_timestamp_from_mtd_file(mtd_file):
+        try:
+            from xml.etree import ElementTree
+            from datetime import datetime
+        except ImportError as e:
+            gs.fatal(_("Unable to parse metadata file. {}").format(e))
+
+        timestamp = None
+        with open(mtd_file, encoding='utf-8') as fd:
+            root = ElementTree.fromstring(fd.read())
+            nsPrefix = root.tag[:root.tag.index('}')+1]
+            nsDict = {'n1':nsPrefix[1:-1]}
+            node = root.find('n1:General_Info', nsDict)
+            if node is not None:
+                try:
+                    # check S2
+                    is_s2 = node.find('TILE_ID', nsDict).text.startswith('S2')
+                    if not is_s2:
+                        gs.fatal(_("Register file can be created only for Sentinel-2 data."))
+
+                    # get timestamp
+                    ts_str = node.find('SENSING_TIME', nsDict).text
+                    timestamp = datetime.strptime(
+                        ts_str, "%Y-%m-%dT%H:%M:%S.%fZ"
+                    )
+                except AttributeError:
+                    # error is reported below
+                    pass
+
+        if not timestamp:
+            gs.error(_("Unable to determine timestamp from <{}>").format(mtd_file))
+
+        return timestamp
+
+    @staticmethod
+    def _ip_from_path(path):
+        return os.path.basename(path[:path.find('.SAFE')])
+
+    def create_register_file(self, filename):
+        ip_timestamp = {}
+        for mtd_file in self._filter("MTD_TL.xml"):
+            ip = self._ip_from_path(mtd_file)
+            ip_timestamp[ip] = self._read_timestamp_from_mtd_file(mtd_file)
+
+        if not ip_timestamp:
+            gs.warning(_("Unable to determine timestamps. No metadata file found"))
+        has_band_ref = gs.version()['version'] == '7.9.dev'
+        sep = '|'
+        with open(filename, 'w') as fd:
+            for img_file in self.files:
+                map_name = self._map_name(img_file)
+                ip = self._ip_from_path(img_file)
+                timestamp = ip_timestamp[ip]
+                if timestamp:
+                    timestamp_str = timestamp.strftime("%Y-%m-%d %H:%M:%S.%f")
+                else:
+                    timestamp_str = ''
+                fd.write('{img}{sep}{ts}'.format(
+                    img=map_name,
+                    sep=sep,
+                    ts=timestamp_str
+                ))
+                if has_band_ref:
+                    fd.write('{sep}{br}'.format(
+                        sep=sep,
+                        br='S2_{}'.format(
+                            map_name[-2:].lstrip('0')
+                        )
+                    ))
+                fd.write(os.linesep)
 def main():
     importer = SentinelImporter(options['input'])
 
     importer.filter(options['pattern'])
 
     if flags['p']:
+        if options['register_output']:
+            gs.warning(_("Register output file name is not created "
+                         "when -{} flag given").format('p'))
         importer.print_products()
         return 0
     
     importer.import_products(flags['r'], flags['l'])
 
     if flags['c']:
+        # import cloud mask if requested
         importer.import_cloud_masks()
+
+    if options['register_output']:
+        # create t.register file if requested
+        importer.create_register_file(
+            options['register_output']
+        )
 
     return 0
 

--- a/grass7/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
@@ -73,6 +73,7 @@ import sys
 import re
 import glob
 import shutil
+import io
 from zipfile import ZipFile
 
 import grass.script as gs
@@ -264,7 +265,7 @@ class SentinelImporter(object):
             gs.fatal(_("Unable to parse metadata file. {}").format(e))
 
         timestamp = None
-        with open(mtd_file, encoding='utf-8') as fd:
+        with io.open(mtd_file, encoding='utf-8') as fd:
             root = ElementTree.fromstring(fd.read())
             nsPrefix = root.tag[:root.tag.index('}')+1]
             nsDict = {'n1':nsPrefix[1:-1]}


### PR DESCRIPTION
This PR implements `raster_output` option into `i.sentinel.import`. In GRASS 7.9 also band references are stored into output register file.

```
i.sentinel.import input=data register_output=t_register.txt

# register imported data into existing STRDS
t.register input=sentinel_ds input=t_register.txt
```

A register file typically contains two columns: imported raster map name and timestamp separated by |. In the case of current development version of GRASS which supports band references concept (see g.bands module for details) a register file is extended by a third column containg band reference information, see the examples below.

```
# register file produced by stable GRASS GIS 7.8 version
T33UVR_20181205T101401_B05|2018-12-05 10:16:43.275000
T33UVR_20181205T101401_B03|2018-12-05 10:16:43.275000
T33UVR_20181205T101401_B06|2018-12-05 10:16:43.275000
...
# register file produced by development GRASS GIS 7.9 version
T33UVR_20181205T101401_B05|2018-12-05 10:16:43.275000|S2_5
T33UVR_20181205T101401_B03|2018-12-05 10:16:43.275000|S2_3
T33UVR_20181205T101401_B06|2018-12-05 10:16:43.275000|S2_6
