### PR TITLE
Simplify Makefile to build all i.sentinel subdirs

### DIFF
--- a/grass7/imagery/i.sentinel/Makefile
+++ b/grass7/imagery/i.sentinel/Makefile
@@ -2,13 +2,16 @@ MODULE_TOPDIR = ../..
 
 PGM = i.sentinel
 
+# note: to deactivate a module, just place a file "DEPRECATED" into the subdir
 ALL_SUBDIRS := ${sort ${dir ${wildcard */.}}}
 DEPRECATED_SUBDIRS := ${sort ${dir ${wildcard */DEPRECATED}}}
-SUBDIRS := $(filter-out $(DEPRECATED_SUBDIRS), $(ALL_SUBDIRS))
+RM_SUBDIRS := bin/ docs/ etc/ scripts/
+SUBDIRS_1 := $(filter-out $(DEPRECATED_SUBDIRS), $(ALL_SUBDIRS))
+SUBDIRS := $(filter-out $(RM_SUBDIRS), $(SUBDIRS_1))
 
 include $(MODULE_TOPDIR)/include/Make/Dir.make
 
-default: subdirs htmldir
+default: parsubdirs htmldir
 
-install:
+install: installsubdirs
 	$(INSTALL_DATA) $(PGM).html $(INST_DIR)/docs/html/

--- a/grass7/imagery/i.sentinel/Makefile
+++ b/grass7/imagery/i.sentinel/Makefile
@@ -2,15 +2,13 @@ MODULE_TOPDIR = ../..
 
 PGM = i.sentinel
 
-SUBDIRS = \
-	i.sentinel.download \
-        i.sentinel.import \
-	i.sentinel.preproc \
-	i.sentinel.mask
+ALL_SUBDIRS := ${sort ${dir ${wildcard */.}}}
+DEPRECATED_SUBDIRS := ${sort ${dir ${wildcard */DEPRECATED}}}
+SUBDIRS := $(filter-out $(DEPRECATED_SUBDIRS), $(ALL_SUBDIRS))
 
 include $(MODULE_TOPDIR)/include/Make/Dir.make
 
-default: parsubdirs htmldir
+default: subdirs htmldir
 
-install: installsubdirs
+install:
 	$(INSTALL_DATA) $(PGM).html $(INST_DIR)/docs/html/

--- a/grass7/raster/r.futures/Makefile
+++ b/grass7/raster/r.futures/Makefile
@@ -2,14 +2,12 @@ MODULE_TOPDIR =../..
 
 PGM = r.futures
 
-SUBDIRS = \
-		r.futures.calib \
-		r.futures.devpressure \
-		r.futures.demand \
-		r.futures.potential \
-		r.futures.potsurface \
-		r.futures.parallelpga \
-		r.futures.pga
+# note: to deactivate a module, just place a file "DEPRECATED" into the subdir
+ALL_SUBDIRS := ${sort ${dir ${wildcard */.}}}
+DEPRECATED_SUBDIRS := ${sort ${dir ${wildcard */DEPRECATED}}}
+RM_SUBDIRS := bin/ docs/ etc/ scripts/
+SUBDIRS_1 := $(filter-out $(DEPRECATED_SUBDIRS), $(ALL_SUBDIRS))
+SUBDIRS := $(filter-out $(RM_SUBDIRS), $(SUBDIRS_1))
 
 include $(MODULE_TOPDIR)/include/Make/Dir.make
 


### PR DESCRIPTION
Approach following #30

If ok, also the Makefiles of 
- imagery/i.modis
- raster/r.futures
- raster/r.green
- raster/r.pi
to be updated accordingly.

