### PR TITLE
Make MATRIX_PROPERTIES a list

### DIFF
--- a/grass7/imagery/i.fusion.hpf/constants.py
+++ b/grass7/imagery/i.fusion.hpf/constants.py
@@ -29,7 +29,7 @@ RATIO_RANGES = (
 
 KERNEL_SIZES = (5, 7, 9, 11, 13, 15)
 
-MATRIX_PROPERTIES = zip(RATIO_RANGES, KERNEL_SIZES)
+MATRIX_PROPERTIES = list(zip(RATIO_RANGES, KERNEL_SIZES))
 
 
 # Replicating ERDAS' Imagine parameters -------------------------------------


### PR DESCRIPTION
fixes "ValueError: 9 is not in list", issue https://github.com/NikosAlexandris/i.fusion.hpf/issues/14