### PR TITLE
addons manuals: comment out SVN Date tag

### DIFF
--- a/grass7/db/db.join/db.join.html
+++ b/grass7/db/db.join/db.join.html
@@ -44,4 +44,7 @@ cat|label|id|shortname|longname
 
 Markus Neteler
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/display/d.explanation.plot/d.explanation.plot.html
+++ b/grass7/display/d.explanation.plot/d.explanation.plot.html
@@ -96,4 +96,7 @@ d.explanation.plot a=input_1 b=input_2 c=result
 
 Vaclav Petras, <a href="http://gis.ncsu.edu/osgeorel/">NCSU GeoForAll Lab</a>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/display/d.frame/d.frame.html
+++ b/grass7/display/d.frame/d.frame.html
@@ -96,5 +96,7 @@ Laboratory<br>
 Michael Shapiro, U.S. Army Construction Engineering 
 Research Laboratory
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/display/d.mon2/d.mon2.html
+++ b/grass7/display/d.mon2/d.mon2.html
@@ -26,6 +26,7 @@ then just hit reload in your web browser whenever a refresh is needed.
 Hamish Bowman<br>
 Dunedin, New Zealand
 
-<br>
+<!--
 <p>
-<i>Last changed: $Date$</i></p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/display/d.vect.colbp/d.vect.colbp.html
+++ b/grass7/display/d.vect.colbp/d.vect.colbp.html
@@ -67,4 +67,7 @@ d.vect.colbp -h --overwrite map=schools_wake column=CORECAPACI where="CORECAPACI
 Paulo van Breugel<br>
 Based on the d.vect.colhist addon by Moritz Lennert  
 
-<p><em>Last changed: $Date$</em>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/display/d.vect.colhist/d.vect.colhist.html
+++ b/grass7/display/d.vect.colhist/d.vect.colhist.html
@@ -29,4 +29,7 @@ d.vect.colhist map=censusblk_swwake column=MEDIAN_AGE where="TOTAL_POP>0"
 <h2>AUTHOR</h2>
  Moritz Lennert
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/display/d.vect.thematic2/d.vect.thematic2.html
+++ b/grass7/display/d.vect.thematic2/d.vect.thematic2.html
@@ -118,7 +118,9 @@ Michael Barton, Arizona State University
 Various updates by:<br>
 Daniel Cavelo Aros,<br>
 Martin Landa,<br>
-Jachym Cepicky.
+Jachym Cepicky
 
+<!--
 <p>
-  <i>Last changed: $Date: 2008-08-15 08:16:42 +0200 (Fri, 15 Aug 2008)$</i>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/general/g.citation/g.citation.html
+++ b/grass7/general/g.citation/g.citation.html
@@ -75,4 +75,7 @@ Vaclav Petras, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU GeoForAll Lab
 Peter Loewe, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU GeoForAll Lab</a> (ORCID: 0000-0003-2257-0517)<br>
 Markus Neteler, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU GeoForAll Lab</a> (ORCID: 0000-0003-1916-1966)
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/general/g.cloud/g.cloud.html
+++ b/grass7/general/g.cloud/g.cloud.html
@@ -78,5 +78,7 @@ Luca Delucchi, Markus Neteler, Fondazione Edmund Mach, Research and
 Innovation Centre, Department of Biodiversity and Molecular Ecology,
 <a href="http://gis.cri.fmach.it">GIS and Remote Sensing Unit</a>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/general/g.copyall/g.copyall.html
+++ b/grass7/general/g.copyall/g.copyall.html
@@ -32,4 +32,8 @@ g.copyall mapset=test datatype=vect filter="s*"
 <h2>AUTHOR</h2>
 
 Michael Barton (Arizona State University, USA)
-<p><i>Last changed: $Date$</i>
+
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/general/g.download.location/g.download.location.html
+++ b/grass7/general/g.download.location/g.download.location.html
@@ -18,5 +18,7 @@ URL can be also a local file on the disk.
 
 Vaclav Petras, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU GeoForAll Lab</a>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/general/g.isis3mt/g.isis3mt.html
+++ b/grass7/general/g.isis3mt/g.isis3mt.html
@@ -12,4 +12,7 @@ The ISIS3 user should use  matchmap=yes in cam2map
 Alessandro Frigeri, INA, Ispra, Italy
 Added to GRASS 7 by Yann Chemin
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/general/g.proj.all/g.proj.all.html
+++ b/grass7/general/g.proj.all/g.proj.all.html
@@ -27,4 +27,7 @@ g.proj.all resolution=50 location=nc_spm_08 mapset=landsat
 Anna Petrasova, <a href="http://gis.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>,<br>
 Vaclav Petras, <a href="http://gis.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/general/g.rename.many/g.rename.many.html
+++ b/grass7/general/g.rename.many/g.rename.many.html
@@ -95,4 +95,7 @@ on input and puts it twice on one line on the output separated by comma.
 
 Vaclav Petras, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/gui/wxpython/wx.metadata/db.csw.run/db.csw.run.html
+++ b/grass7/gui/wxpython/wx.metadata/db.csw.run/db.csw.run.html
@@ -28,5 +28,7 @@ at the Czech Technical University in Prague, developed
 during <a href="http://trac.osgeo.org/grass/wiki/GSoC/2014/MetadataForGRASS">Google
     Summer of Code 2014</a> (mentors: Margherita Di Leo, Martin Landa)
 
+<!--
 <p>
-    <i>Last changed: $Date$</i>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/gui/wxpython/wx.metadata/g.gui.cswbrowser/g.gui.cswbrowser.html
+++ b/grass7/gui/wxpython/wx.metadata/g.gui.cswbrowser/g.gui.cswbrowser.html
@@ -88,5 +88,8 @@ at the Czech Technical University in Prague, developed
 during <a href="http://trac.osgeo.org/grass/wiki/GSoC/2014/MetadataForGRASS">Google
     Summer of Code 2015</a> (mentors: Martin Landa)
 
+<!--
 <p>
-    <i>Last changed: $Date$</i>
+<i>Last changed: $Date$</i>
+-->
+

--- a/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.html
+++ b/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.html
@@ -127,5 +127,7 @@ at the Czech Technical University in Prague, developed
 during <a href="http://trac.osgeo.org/grass/wiki/GSoC/2014/MetadataForGRASS">Google
     Summer of Code 2014</a> (mentors: Margherita Di Leo, Martin Landa)
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/gui/wxpython/wx.metadata/r.info.iso/r.info.iso.html
+++ b/grass7/gui/wxpython/wx.metadata/r.info.iso/r.info.iso.html
@@ -74,5 +74,8 @@ at the Czech Technical University in Prague, developed
 during <a href="http://trac.osgeo.org/grass/wiki/GSoC/2014/MetadataForGRASS">Google
     Summer of Code 2014</a> (mentors: Margherita Di Leo, Martin Landa)
 
+<!--
 <p>
-    <i>Last changed: $Date$</i>
+<i>Last changed: $Date$</i>
+-->
+

--- a/grass7/gui/wxpython/wx.metadata/v.info.iso/v.info.iso.html
+++ b/grass7/gui/wxpython/wx.metadata/v.info.iso/v.info.iso.html
@@ -75,5 +75,8 @@ at the Czech Technical University in Prague, developed
 during <a href="http://trac.osgeo.org/grass/wiki/GSoC/2014/MetadataForGRASS">Google
     Summer of Code 2014</a> (mentors: Margherita Di Leo, Martin Landa)
 
+<!--
 <p>
-    <i>Last changed: $Date$</i>
+<i>Last changed: $Date$</i>
+-->
+

--- a/grass7/imagery/i.ann.maskrcnn/i.ann.maskrcnn.detect/i.ann.maskrcnn.detect.html
+++ b/grass7/imagery/i.ann.maskrcnn/i.ann.maskrcnn.detect/i.ann.maskrcnn.detect.html
@@ -82,5 +82,7 @@ i.ann.maskrcnn.detect band1=map1.red band2=map1.green band3=map1.blue classes=bu
 
 Ondrej Pesek
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.ann.maskrcnn/i.ann.maskrcnn.html
+++ b/grass7/imagery/i.ann.maskrcnn/i.ann.maskrcnn.html
@@ -78,5 +78,7 @@ his GRASS GIS with the following patch:
 
 Ondrej Pesek
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.ann.maskrcnn/i.ann.maskrcnn.train/i.ann.maskrcnn.train.html
+++ b/grass7/imagery/i.ann.maskrcnn/i.ann.maskrcnn.train/i.ann.maskrcnn.train.html
@@ -152,5 +152,7 @@ i.ann.maskrcnn.train training_dataset=/home/user/Documents/crops classes=corn,ri
 
 Ondrej Pesek
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.cutlines/i.cutlines.html
+++ b/grass7/imagery/i.cutlines/i.cutlines.html
@@ -92,4 +92,7 @@ Soares, Anderson Reis, Thales Sehn K&ouml;rting, and Leila Maria Garcia Fonseca.
 
 Moritz Lennert
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.cva/i.cva.html
+++ b/grass7/imagery/i.cva/i.cva.html
@@ -134,6 +134,8 @@ LARS Symp. 1980;326-335.
 <h2>AUTHOR</h2>
 
 Anna Zanchetta
-<p><i>Last changed: $Date: 2016-12-11 23:00:00 +0200 (Sun, 11 Dec
-2016) $</i>
 
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.destripe/i.destripe.html
+++ b/grass7/imagery/i.destripe/i.destripe.html
@@ -24,4 +24,7 @@ Input:
 
 Yann Chemin, International Water Management Institute, Sri Lanka.
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.eb.deltat/i.eb.deltat.html
+++ b/grass7/imagery/i.eb.deltat/i.eb.deltat.html
@@ -18,6 +18,7 @@ Additionally, it is worth menitoning that Pawan only created this map once, and 
 
 Yann Chemin, Asian Institute of Technology, Thailand<br>
 
-
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.eb.hsebal95/i.eb.hsebal95.html
+++ b/grass7/imagery/i.eb.hsebal95/i.eb.hsebal95.html
@@ -99,4 +99,7 @@ Yann Chemin
 
 <p>Contact: <a href="mailto:y.chemin@cgiar.org"> Yann Chemin</a>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.eb.z0m/i.eb.z0m.html
+++ b/grass7/imagery/i.eb.z0m/i.eb.z0m.html
@@ -47,5 +47,7 @@ in: Irmak, A. (Ed.), Evapotranspiration - Remote Sensing and Modeling. InTech.
 
 Yann Chemin
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.eb.z0m0/i.eb.z0m0.html
+++ b/grass7/imagery/i.eb.z0m0/i.eb.z0m0.html
@@ -27,6 +27,7 @@ If you happen to have a vegetation height (hv) map, then z0m=hv/7 and z0h=0.1*z0
 
 Yann Chemin, International Rice Research Institute, The Philippines<br>
 
-
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.edge/i.edge.html
+++ b/grass7/imagery/i.edge/i.edge.html
@@ -139,5 +139,7 @@ Sensing 33.B3/2; PART 3 (2000), pp. 1063–1070.</li>
 Anna Kratochvilova,
 Vaclav Petras
 
-<p><i>Last changed: $Date$</i>
-
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.evapo.potrad/i.evapo.potrad.html
+++ b/grass7/imagery/i.evapo.potrad/i.evapo.potrad.html
@@ -49,5 +49,7 @@ in: Irmak, A. (Ed.), Evapotranspiration - Remote Sensing and Modeling. InTech.
 
 Yann Chemin, International Rice Research Institute, The Philippines<br>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.evapo.senay/i.evapo.senay.html
+++ b/grass7/imagery/i.evapo.senay/i.evapo.senay.html
@@ -57,6 +57,7 @@ in: Irmak, A. (Ed.), Evapotranspiration - Remote Sensing and Modeling. InTech.
 
 Yann Chemin, International Rice Research Institute, The Philippines.<br>
 
-
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.evapo.zk/i.evapo.zk.html
+++ b/grass7/imagery/i.evapo.zk/i.evapo.zk.html
@@ -105,5 +105,7 @@ in: Irmak, A. (Ed.), Evapotranspiration - Remote Sensing and Modeling. InTech.
 
 Yann Chemin, GRASS Development team, 2011
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.feotio2/i.feotio2.html
+++ b/grass7/imagery/i.feotio2/i.feotio2.html
@@ -64,4 +64,7 @@ Initially created for Clementine data.
 
 Yann Chemin (B.Sc. student), Birkbeck, University of London.
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.fusion.brovey/i.fusion.brovey.html
+++ b/grass7/imagery/i.fusion.brovey/i.fusion.brovey.html
@@ -110,4 +110,9 @@ Colors may be optionally optimized.
 <h2>AUTHOR</h2>
 
 Markus Neteler, ITC-irst, Italy
-<p><i>Last changed: $Date$</i>
+
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->
+

--- a/grass7/imagery/i.fusion.hpf/i.fusion.hpf.html
+++ b/grass7/imagery/i.fusion.hpf/i.fusion.hpf.html
@@ -111,6 +111,7 @@ PHOTOGRAMMETRIC ENGINEERING &amp; REMOTE SENSING, 74(9):1107--1118.</li>
 Nikos Alexandris<br>
 Panagiotis Mavrogiorgos
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
-
+-->

--- a/grass7/imagery/i.gcp/i.gcp.html
+++ b/grass7/imagery/i.gcp/i.gcp.html
@@ -91,5 +91,7 @@ Processing manual</a></em>
 
 <a href="mailto:grass4u@gmail com">Huidae Cho</a>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.gravity/i.gravity.html
+++ b/grass7/imagery/i.gravity/i.gravity.html
@@ -38,4 +38,7 @@
 
 Yann Chemin, University of London at Birkbeck, United Kingdom.
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.histo.match/i.histo.match.html
+++ b/grass7/imagery/i.histo.match/i.histo.match.html
@@ -48,4 +48,7 @@ developed by: Laura Zampa (2004), student of Dipartimento di Informatica e
 Telecomunicazioni, Facolta' di Ingegneria, University of Trento and ITC-irst, 
 Trento (Italy)
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.image.bathymetry/i.image.bathymetry.html
+++ b/grass7/imagery/i.image.bathymetry/i.image.bathymetry.html
@@ -78,8 +78,10 @@ depth_estimate='output'
 <h2>AUTHORS</h2>
 Vinayaraj Poliyapram (email:<em>vinay223333@gmail.com</em>), Luca 
 Delucchi and Venkatesh Raghavan
+
 <h2>SEE ALSO</h2>
 <em>r.gwr</em> and <em>r.regression.multi</em>
+
 <h2>REFERENCES</h2>
 <ul>
 <li>Vinayaraj, P., Raghavan, V. and Masumoto, S. (2016) Satellite 
@@ -92,4 +94,8 @@ Retrieval from Multispectral satellite Imagery. IEEE Transaction on
 Geosciences and Remote Sensing, 52(1) : 465-476, Accessed January 2013, 
 doi:10.1109/TGRS.2013.2241772.
 </ul>
-<p><i>Last changed by Vinayaraj: $Date$</i>
+
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.in.probav/i.in.probav.html
+++ b/grass7/imagery/i.in.probav/i.in.probav.html
@@ -50,4 +50,7 @@ i.in.probav input=c_gls_NDVI300_201611010000_GLOBE_PROBAV_V1.0.1.nc \
 
 Jonas Strobel<br>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.landsat8.qc/i.landsat8.qc.html
+++ b/grass7/imagery/i.landsat8.qc/i.landsat8.qc.html
@@ -179,6 +179,7 @@ r.reclass input=LC81980182015183LGN00_BQA \
 
 <p>Stefan Blumentrath, Norwegian Institute for Nature Research, Oslo (Norway)</p>
 
-<p><i>Last changed: $Date$</i></p>
-
-
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.lmf/i.lmf.html
+++ b/grass7/imagery/i.lmf/i.lmf.html
@@ -39,6 +39,7 @@ strength, for my actual experience with VIs curves.
 
 Yann Chemin, International Rice Research Institute, The Philippines<br>
 
-
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.lswt/i.lswt.html
+++ b/grass7/imagery/i.lswt/i.lswt.html
@@ -43,4 +43,7 @@ doi:10.3390/rs8030169
 <h2>AUTHORS</h2>
 Sajid Pareeth; Fondazione Edmund Mach
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.modis/i.modis.download/i.modis.download.html
+++ b/grass7/imagery/i.modis/i.modis.download/i.modis.download.html
@@ -137,4 +137,7 @@ i.modis.download -g settings=$HOME/.grass7/i.modis/SETTING startday=2011-05-01 e
 
 Luca Delucchi, Google Summer of Code 2011; subsequently updated.
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.modis/i.modis.html
+++ b/grass7/imagery/i.modis/i.modis.html
@@ -211,4 +211,7 @@ library. Please install it beforehand.
 
 Luca Delucchi, Initial version: Google Summer of Code 2011; subsequently updated
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.modis/i.modis.import/i.modis.import.html
+++ b/grass7/imagery/i.modis/i.modis.import/i.modis.import.html
@@ -195,4 +195,7 @@ t.register input=LST_Day_daily file=$HOME/list_for_tregister.csv
 
 Luca Delucchi, Google Summer of Code 2011; subsequently updated.
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.nightlights.intercalibration/i.nightlights.intercalibration.html
+++ b/grass7/imagery/i.nightlights.intercalibration/i.nightlights.intercalibration.html
@@ -176,5 +176,7 @@ Satellite + Year!
 
 Nikos Alexandris
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.ortho.corr/i.ortho.corr.html
+++ b/grass7/imagery/i.ortho.corr/i.ortho.corr.html
@@ -62,4 +62,7 @@ i.ortho.corr input=image.photo tiles=tile_images osuffix=.photo csuffix=.camera
 
 Luca Delucchi, Fondazione E. Mach (Italy)
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.points.auto/i.points.auto.html
+++ b/grass7/imagery/i.points.auto/i.points.auto.html
@@ -50,5 +50,7 @@ Ivan Michelazzi<br>
 Luca Miori<br>
 Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.pr/i.pr_features/description.html
+++ b/grass7/imagery/i.pr/i.pr_features/description.html
@@ -16,5 +16,9 @@ This module allows for the calculation of a range of statistics pertaining to th
 
 Stefano Merler, FBK, Trento, Italy<br>
 Documentation: Daniel McInerney (daniel.mcinerney ucd.ie)
+
+<!--
 <p>
-<p><i>Last changed: $Date$</i>
+<i>Last changed: $Date$</i>
+-->
+

--- a/grass7/imagery/i.pr/i.pr_training/description.html
+++ b/grass7/imagery/i.pr/i.pr_training/description.html
@@ -85,4 +85,7 @@ The output of this module will be an ascii file of type xy.z. The number of colu
 Stefano Merler, FBK, Trento, Italy<br>
 Documentation: Daniel McInerney (daniel.mcinerney ucd.ie)
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.rh/i.rh.html
+++ b/grass7/imagery/i.rh/i.rh.html
@@ -25,6 +25,7 @@ https://www.researchgate.net/publication/227247013_High-resolution_Surface_Relat
 
 Yann Chemin, Plumergat, France<br>
 
-
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.rotate/i.rotate.html
+++ b/grass7/imagery/i.rotate/i.rotate.html
@@ -19,6 +19,7 @@ Checking if all pixels in output raster are populated, if not apply a NN algorit
 
 Yann Chemin, CGIAR, Sri Lanka<BR>
 
-
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.sar.speckle/i.sar.speckle.html
+++ b/grass7/imagery/i.sar.speckle/i.sar.speckle.html
@@ -22,4 +22,7 @@ radar images. Optical engineering, 25(5), 255636.
 
 Margherita Di Leo
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.segment.gsoc/i.segment.gsoc.html
+++ b/grass7/imagery/i.segment.gsoc/i.segment.gsoc.html
@@ -222,5 +222,7 @@ Eric Momsen - North Dakota State University
 <p>
 GSoC mentor: Markus Metz
 
+<!--
 <p>
-<i>Last changed: $Date$
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.segment.hierarchical/i.segment.hierarchical.html
+++ b/grass7/imagery/i.segment.hierarchical/i.segment.hierarchical.html
@@ -17,6 +17,7 @@ TODO
 
 Pietro Zambelli (University of Trento)
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
-</p>
+-->

--- a/grass7/imagery/i.segment.stats/i.segment.stats.html
+++ b/grass7/imagery/i.segment.stats/i.segment.stats.html
@@ -99,5 +99,7 @@ i.segment.stats map=ls_pan_seg01 csvfile=segstats.csv vectormap=ls_pan_seg01 \
 
 Moritz Lennert
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.segment.uspo/i.segment.uspo.html
+++ b/grass7/imagery/i.segment.uspo/i.segment.uspo.html
@@ -122,4 +122,7 @@ Geo-Information, 4(4), pp. 2292-2305, <a href="http://dx.doi.org/10.3390/ijgi404
 
 Moritz Lennert
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.html
+++ b/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.html
@@ -269,5 +269,7 @@ Martin Landa, <a href="http://geomatics.fsv.cvut.cz/research/geoforall/">GeoForA
 Lab</a>, CTU in Prague, Czech Republic with support
 of <a href="http://opengeolabs.cz/en/home/">OpenGeoLabs</a> company
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.sentinel/i.sentinel.html
+++ b/grass7/imagery/i.sentinel/i.sentinel.html
@@ -49,5 +49,9 @@ CTU in Prague, Czech Republic with support
 of <a href="http://opengeolabs.cz/en/home/">OpenGeoLabs</a> company
 <p>
 Roberta Fagandini, GSoC 2018 student, Italy
- 
-<p><i>Last changed: $Date$</i>
+
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->
+

--- a/grass7/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.html
+++ b/grass7/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.html
@@ -252,5 +252,7 @@ Martin Landa, <a href="http://geomatics.fsv.cvut.cz/research/geoforall/">GeoForA
 Lab</a>, CTU in Prague, Czech Republic with support
 of <a href="http://opengeolabs.cz/en/home/">OpenGeoLabs</a> company
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.sentinel/i.sentinel.mask/i.sentinel.mask.html
+++ b/grass7/imagery/i.sentinel/i.sentinel.mask/i.sentinel.mask.html
@@ -175,5 +175,7 @@ Roberta Fagandini, GSoC 2018 student<br>
 <a href="https://wiki.osgeo.org/wiki/User:Mlennert">Moritz Lennert</a><br> 
 <a href="https://wiki.osgeo.org/wiki/User:Robertomarzocchi">Roberto Marzocchi</a>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.sentinel/i.sentinel.preproc/i.sentinel.preproc.html
+++ b/grass7/imagery/i.sentinel/i.sentinel.preproc/i.sentinel.preproc.html
@@ -378,5 +378,7 @@ Roberta Fagandini, GSoC 2018 student<br>
 <a href="https://wiki.osgeo.org/wiki/User:Mlennert">Moritz Lennert</a><br> 
 <a href="https://wiki.osgeo.org/wiki/User:Robertomarzocchi">Roberto Marzocchi</a>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.spec.sam/i.spec.sam.html
+++ b/grass7/imagery/i.spec.sam/i.spec.sam.html
@@ -33,6 +33,8 @@ fusion and classification. International Journal of Geoinformatics, 1(1), pp. 51
 Markus Neteler, University of Hannover, 1999
 <br>
 Updated to GRASS GIS 7: Yann Chemin, 2015
+
+<!--
 <p>
 <i>Last changed: $Date$</i>
-
+-->

--- a/grass7/imagery/i.spec.unmix/i.spec.unmix.html
+++ b/grass7/imagery/i.spec.unmix/i.spec.unmix.html
@@ -135,5 +135,7 @@ Markus Neteler, University of Hannover, 1999
 <p>
 Mohammed Rashad  (rashadkm gmail.com) (2012, update to GRASS 7)
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.superpixels.slic/i.superpixels.slic.html
+++ b/grass7/imagery/i.superpixels.slic/i.superpixels.slic.html
@@ -218,6 +218,7 @@ and Machine Intelligence, 34(11), 2274 - 2282. <br>
 Rashad Kanavath, India <br>
 Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
-
+-->

--- a/grass7/imagery/i.theilsen/i.theilsen.html
+++ b/grass7/imagery/i.theilsen/i.theilsen.html
@@ -17,4 +17,7 @@ https://en.wikipedia.org/wiki/Theil-Sen_estimator
 
 Yann Chemin, IWMI, Sri Lanka.
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.variance/i.variance.html
+++ b/grass7/imagery/i.variance/i.variance.html
@@ -155,4 +155,7 @@ Woodcock, C.E., Strahler, A.H., 1987. The factor of scale in remote sensing.
 
 Moritz Lennert
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.vi.mpi/i.vi.mpi.html
+++ b/grass7/imagery/i.vi.mpi/i.vi.mpi.html
@@ -58,5 +58,7 @@ Snail Mail:  Terrill Ray<br>
 <h2>AUTHORS</h2>
 GRASS Development Team.
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.water/i.water.html
+++ b/grass7/imagery/i.water/i.water.html
@@ -31,6 +31,7 @@ Roy D.P., Jin Y., Lewis P.E., Justice C.O. (2005). Prototyping a global algorith
 
 Yann Chemin, International Rice Research Insitute, The Philippines<br>
 
-
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.wavelet/i.wavelet.html
+++ b/grass7/imagery/i.wavelet/i.wavelet.html
@@ -21,5 +21,7 @@ More wavelet families to be included.
 
 Yann Chemin, International Water Management Institute
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/imagery/i.wi/i.wi.html
+++ b/grass7/imagery/i.wi/i.wi.html
@@ -71,5 +71,7 @@ Find other water indices and add them.
 
 Yann Chemin
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/misc/m.eigensystem/m.eigensystem.html
+++ b/grass7/misc/m.eigensystem/m.eigensystem.html
@@ -156,5 +156,7 @@ This code uses routines from the EISPACK system.<br>
 The interface was coded by Michael Shapiro, U.S.Army Construction Engineering
  Research Laboratory
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/misc/m.gcp.filter/m.gcp.filter.html
+++ b/grass7/misc/m.gcp.filter/m.gcp.filter.html
@@ -77,4 +77,7 @@ the higher coefficients equal to zero.
 
 Markus Metz
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.accumulate/r.accumulate.html
+++ b/grass7/raster/r.accumulate/r.accumulate.html
@@ -247,4 +247,7 @@ r.accumulate direction=drain_directions lfp=lfp id_column=id outlet=stream_outle
 
 <a href="mailto:grass4u@gmail com">Huidae Cho</a>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.agent/r.agent.aco/r.agent.aco.html
+++ b/grass7/raster/r.agent/r.agent.aco/r.agent.aco.html
@@ -77,6 +77,7 @@ Implement other ABM scenarios.
 
 Michael Lustenberger inofix.ch
 
-<p><i>Last changed: $Date$</i>
-
-
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.agent/r.agent.html
+++ b/grass7/raster/r.agent/r.agent.html
@@ -29,5 +29,7 @@ Agents wander around on the terrain, marking paths to new locations.</li>
 
 Michael Lustenberger inofix.ch
 
-<p><i>Last changed: $Date$</i>
-
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.basin/r.basin.html
+++ b/grass7/raster/r.basin/r.basin.html
@@ -211,5 +211,7 @@ Geomatics Workbooks</a>, n. 9</em></li>
 
 Margherita Di Leo (grass-dev AT lists DOT osgeo DOT org ), Massimo Di Stefano
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.bioclim/r.bioclim.html
+++ b/grass7/raster/r.bioclim/r.bioclim.html
@@ -90,5 +90,7 @@ r.bioclim tmin=`g.list type=rast pat=tmin_* map=. sep=,` \
 
 Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.bitpattern/r.bitpattern.html
+++ b/grass7/raster/r.bitpattern/r.bitpattern.html
@@ -49,4 +49,7 @@ image using <em>r.mapcalc</em> (OR and NOT operators).
 
 Radim Blazek, Markus Neteler
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.catchment/r.catchment.html
+++ b/grass7/raster/r.catchment/r.catchment.html
@@ -96,5 +96,7 @@ Isaac Ullah
 <p>
 Updated for GRASS 7, 23, Feb. 2015.
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.category.trim/r.category.trim.html
+++ b/grass7/raster/r.category.trim/r.category.trim.html
@@ -84,4 +84,7 @@ r.colors.out_sld</a>
 
 Paulo van Breugel, paulo at ecodiv.earth
 
-<p><em>Last changed: $Date$</em>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.cell.area/r.cell.area.html
+++ b/grass7/raster/r.cell.area/r.cell.area.html
@@ -18,4 +18,7 @@ This module is useful for determining the flow accumulation area to weight flow 
 
 Andrew D. Wickert<br>
 
-<p><i>Last changed: $Date 2017-10-12$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.change.info/r.change.info.html
+++ b/grass7/raster/r.change.info/r.change.info.html
@@ -225,4 +225,8 @@ Shannon, C.E. 1948. A Mathematical Theory of Communication. Bell System Technica
 
 Markus Metz 
 
-<p><i>Last changed: $Date$</i>  
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->
+  

--- a/grass7/raster/r.clip/r.clip.html
+++ b/grass7/raster/r.clip/r.clip.html
@@ -195,4 +195,7 @@ cells=2025000
 
 Vaclav Petras, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU GeoForAll Lab</a>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.colors.contrastbrightness/r.colors.contrastbrightness.html
+++ b/grass7/raster/r.colors.contrastbrightness/r.colors.contrastbrightness.html
@@ -45,5 +45,7 @@ r.colors.contrastbrightness min=0.0 max=255.0 contrast=1.0 brightness=100.0 inpu
 <h2>AUTHOR</h2>
 Yann Chemin, <a href="http://jrc.it/">JRC, Ispra, Italy</a><br>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.colors.cubehelix/r.colors.cubehelix.html
+++ b/grass7/raster/r.colors.cubehelix/r.colors.cubehelix.html
@@ -124,5 +124,7 @@ function documentation and an
 <h2>AUTHOR</h2>
 Vaclav Petras, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU OSGeoREL</a><br>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.colors.matplotlib/r.colors.matplotlib.html
+++ b/grass7/raster/r.colors.matplotlib/r.colors.matplotlib.html
@@ -202,5 +202,7 @@ example in Matplotlib documentation
 <h2>AUTHORS</h2>
 Vaclav Petras, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU OSGeoREL</a><br>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.connectivity/r.connectivity.corridors/r.connectivity.corridors.html
+++ b/grass7/raster/r.connectivity/r.connectivity.corridors/r.connectivity.corridors.html
@@ -122,5 +122,8 @@ g.remove type=raster pattern=hws_connectivity_patch_*
 
 <h2>AUTHOR</h2>
 Stefan Blumentrath, Norwegian Institute for Nature Research (NINA)
-<br><br>
-<p><i>Last changed: $Date$</i></p>
+
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.connectivity/r.connectivity.distance/r.connectivity.distance.html
+++ b/grass7/raster/r.connectivity/r.connectivity.distance/r.connectivity.distance.html
@@ -264,5 +264,8 @@ naturforskning (NINA), Trondheim.
 <h2>AUTHOR</h2>
 Stefan Blumentrath, Norwegian Institute for Nature Research, Oslo, Norway
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->
 

--- a/grass7/raster/r.connectivity/r.connectivity.html
+++ b/grass7/raster/r.connectivity/r.connectivity.html
@@ -79,4 +79,7 @@ naturforskning (NINA), Trondheim.
 
 For authors, please refer to each module of r.connectivity.
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.connectivity/r.connectivity.network/r.connectivity.network.html
+++ b/grass7/raster/r.connectivity/r.connectivity.network/r.connectivity.network.html
@@ -450,5 +450,8 @@ http://cran.r-project.org/web/packages/igraph/index.html</a></dt>
 
 <h2>AUTHOR</h2>
 Stefan Blumentrath, Norwegian Institute for Nature Research (NINA)
-<br>
-<p></p><i>Last changed: $Date$</i>
+
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.convergence/r.convergence.html
+++ b/grass7/raster/r.convergence/r.convergence.html
@@ -70,5 +70,7 @@ Böhner J., Blaschke T., Montanarella, L. (eds.) (2008). SAGA Seconds Out. Hambu
 <h2>AUTHOR</h2>
 Jarek Jasiewicz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.cpt2grass/r.cpt2grass.html
+++ b/grass7/raster/r.cpt2grass/r.cpt2grass.html
@@ -89,5 +89,7 @@ d.legend raster=elevation labelnum=10 at=5,50,7,10
 Anna Petrasova, <a href="http://gis.ncsu.edu/osgeorel/">NCSU OSGeoREL</a><br>
 Hamish Bowman (original Bash script)
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.crater/r.crater.html
+++ b/grass7/raster/r.crater/r.crater.html
@@ -60,5 +60,7 @@ argv[9]: [optional] enter the final crater diameter in m
 <h2>AUTHOR</h2>
 Yann Chemin
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.denoise/r.denoise.html
+++ b/grass7/raster/r.denoise/r.denoise.html
@@ -81,5 +81,7 @@ Module ported to Python by <a href="http://carlosgrohmann.com/">Carlos
 H. Grohmann</a><br>
 Institute of Energy and Environment, University of Sao Paulo, Brazil<br>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.divergence/r.divergence.html
+++ b/grass7/raster/r.divergence/r.divergence.html
@@ -52,4 +52,7 @@ EOF
 Anna Petrasova, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU OSGeoREL</a><br>
 Helena Mitasova, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.diversity/r.diversity.html
+++ b/grass7/raster/r.diversity/r.diversity.html
@@ -67,5 +67,7 @@ r.diversity input=ndvi_map prefix=diversity size=3,9 exclude=pielou alpha=3
 
 Luca Delucchi and Duccio Rocchini, Fondazione E. Mach (Italy)
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.edm.eval/r.edm.eval.html
+++ b/grass7/raster/r.edm.eval/r.edm.eval.html
@@ -34,4 +34,8 @@
 <h2>AUTHOR</h2>
 Paulo van Breugel <a href="https://ecodiv.earth/contact.html">ecodiv.earth/contact.html</a>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->
+

--- a/grass7/raster/r.estimap.recreation/r.estimap.recreation.html
+++ b/grass7/raster/r.estimap.recreation/r.estimap.recreation.html
@@ -1235,4 +1235,7 @@ language governing permissions and limitations under the Licence.
 
 Consult the LICENCE file for details.
 
-<p><i>Last changed: $Date: 2017-11-03 18:21:39 +0100 (Fri, 03 Nov 2017) $</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.estimap.recreation/r.estimap.recreation/r.estimap.recreation.html
+++ b/grass7/raster/r.estimap.recreation/r.estimap.recreation/r.estimap.recreation.html
@@ -1235,4 +1235,8 @@ language governing permissions and limitations under the Licence.
 
 Consult the LICENCE file for details.
 
-<p><i>Last changed: $Date: 2017-11-03 18:21:39 +0100 (Fri, 03 Nov 2017) $</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->
+

--- a/grass7/raster/r.euro.ecosystem/r.euro.ecosystem.html
+++ b/grass7/raster/r.euro.ecosystem/r.euro.ecosystem.html
@@ -51,6 +51,7 @@ Raster data definition rules are donated by EEA.
 
 Helmut Kudrnovsky
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
-</p>
+-->

--- a/grass7/raster/r.exdet/r.exdet.html
+++ b/grass7/raster/r.exdet/r.exdet.html
@@ -118,5 +118,7 @@ https://grass.osgeo.org/grass70/manuals/addons/r.exdet.html</li></ul>
 
 Paulo van Breugel, paulo at ecodiv.earth
 
-
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.fill.category/r.fill.category.html
+++ b/grass7/raster/r.fill.category/r.fill.category.html
@@ -72,4 +72,7 @@ r.fill.gaps add-on
 Paolo Zatelli and Stefano Gobbi,
 DICAM, University of Trento, Italy.
 
-<p><i>Last changed: $Date: 2019-06-12 18:10:36 +0100 (Wed, 12 Jun 2019) $</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.fill.gaps/r.fill.gaps.html
+++ b/grass7/raster/r.fill.gaps/r.fill.gaps.html
@@ -481,5 +481,7 @@ d.mon stop=cairo
 
 Benjamin Ducke
 
-<p><i>Last changed: $Date$</i>
-
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.findtheriver/r.findtheriver.html
+++ b/grass7/raster/r.findtheriver/r.findtheriver.html
@@ -43,4 +43,7 @@ pixels were found nothing is printed.</p>
 <a href="mailto:brian_miles@unc edu">Brian Miles</a><br>
 Update to GRASS 7 by <a href="mailto:grass4u@gmail com">Huidae Cho</a>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.flexure/r.flexure.html
+++ b/grass7/raster/r.flexure/r.flexure.html
@@ -59,4 +59,7 @@ van Wees, J. D., and S. Cloetingh (1994), A Finite-Difference Technique to Incor
 
 Andrew D. Wickert<br>
 
-<p><i>Last changed: $Date 2015-11-15 (Sun, 15 Nov 2015)$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.flip/r.flip.html
+++ b/grass7/raster/r.flip/r.flip.html
@@ -17,4 +17,7 @@ Added flags for East-West flip (w) and both N-S and E-W (b).
 <h2>AUTHORS</h2>
 Yann Chemin, International Water Management Institute, Sri Lanka
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.flowfill/r.flowfill.html
+++ b/grass7/raster/r.flowfill/r.flowfill.html
@@ -14,4 +14,7 @@ Callaghan, K.~L., and A.~D. Wickert (in revision), Computing water flow through 
 
 Kerry L. Callaghan, Andrew D. Wickert<br>
 
-<p><i>Last changed: $Date 2019-06-17$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.forestfrag/r.forestfrag.html
+++ b/grass7/raster/r.forestfrag/r.forestfrag.html
@@ -116,4 +116,7 @@ and E. Smith. 2000. Global-scale patterns of forest fragmentation.
 Conservation Ecology 4(2): 3. [online] URL:
 <a href="http://www.consecol.org/vol4/iss2/art3/">http://www.consecol.org/vol4/iss2/art3/</a>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.futures/r.futures.calib/r.futures.calib.html
+++ b/grass7/raster/r.futures/r.futures.calib/r.futures.calib.html
@@ -119,4 +119,7 @@ For all other parameters not mentioned above, please refer to
 
 Anna Petrasova, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll</a><br>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.futures/r.futures.demand/r.futures.demand.html
+++ b/grass7/raster/r.futures/r.futures.demand/r.futures.demand.html
@@ -136,4 +136,7 @@ simulation_times=`seq -s, 2011 2035` plot=plot_demand.pdf demand=demand.csv
 
 Anna Petrasova, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll</a><br>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.futures/r.futures.devpressure/r.futures.devpressure.html
+++ b/grass7/raster/r.futures/r.futures.devpressure/r.futures.devpressure.html
@@ -85,4 +85,7 @@ r.futures.devpressure input=developed output=pressure gamma=1.5 size=10 method=g
 
 Anna Petrasova, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll</a><br>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.futures/r.futures.html
+++ b/grass7/raster/r.futures/r.futures.html
@@ -169,5 +169,7 @@ Vaclav Petras, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll</
 
 Anna Petrasova, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll</a><br>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.futures/r.futures.parallelpga/r.futures.parallelpga.html
+++ b/grass7/raster/r.futures/r.futures.parallelpga/r.futures.parallelpga.html
@@ -53,4 +53,7 @@ happening on the subregion boundary.
 
 Anna Petrasova, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll</a><br>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.futures/r.futures.pga/r.futures.pga.html
+++ b/grass7/raster/r.futures/r.futures.pga/r.futures.pga.html
@@ -169,6 +169,7 @@ Jennifer A. Koch **<br>
 
 Vaclav Petras, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU OSGeoREL</a><br>
 
-
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.futures/r.futures.potential/r.futures.potential.html
+++ b/grass7/raster/r.futures/r.futures.potential/r.futures.potential.html
@@ -80,4 +80,7 @@ In case there is only one subregion, R function glm is used instead of glmer.
 
 Anna Petrasova, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll</a><br>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.futures/r.futures.potsurface/r.futures.potsurface.html
+++ b/grass7/raster/r.futures/r.futures.potsurface/r.futures.potsurface.html
@@ -57,4 +57,7 @@ representing developed (red) and undeveloped (green) cells over it.
 
 Anna Petrasova, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll</a><br>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.fuzzy.logic/r.fuzzy.logic.html
+++ b/grass7/raster/r.fuzzy.logic/r.fuzzy.logic.html
@@ -82,5 +82,8 @@ R~package version~1.0, URL http://CRAN.R-project.org/package=sets.<p>
 <h2>AUTHOR</h2>
 Jarek  Jasiewicz
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->
 

--- a/grass7/raster/r.fuzzy.set/r.fuzzy.set.html
+++ b/grass7/raster/r.fuzzy.set/r.fuzzy.set.html
@@ -146,4 +146,7 @@ R~package version~1.0, URL http://CRAN.R-project.org/package=sets.<p>
 <h2>AUTHOR</h2>
 Jarek Jasiewicz
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.fuzzy.system/r.fuzzy.system.html
+++ b/grass7/raster/r.fuzzy.system/r.fuzzy.system.html
@@ -321,4 +321,7 @@ R~package version~1.0, URL http://CRAN.R-project.org/package=sets.<p>
 <h2>AUTHOR</h2>
 Jarek Jasiewicz
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.gdd/r.gdd.html
+++ b/grass7/raster/r.gdd/r.gdd.html
@@ -122,4 +122,7 @@ r.gdd in=MOD11A1.Day,MOD11A1.Night,MYD11A1.Day,MYD11A1.Night out=MCD11A1.GDD \
 
 Markus Metz (based on r.series)
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.geomorphon/r.geomorphon.html
+++ b/grass7/raster/r.geomorphon/r.geomorphon.html
@@ -178,5 +178,7 @@ Geomorphology, vol. 182, 147-156 (DOI: <a href="http://dx.doi.org/10.1016/j.geom
 <h2>AUTHORS</h2>
 Jarek Jasiewicz, Tomek Stepinski (merit contribution)
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.gradient/r.gradient.html
+++ b/grass7/raster/r.gradient/r.gradient.html
@@ -35,6 +35,7 @@ Luca Delucchi, Fondazione E. Mach (Italy)
 <p>
 Thanks to Johannes Radinger for the code of horizontal and vertical gradient
 
-
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.green/r.green.biomassfor/r.green.biomassfor.co2/r.green.biomassfor.co2.html
+++ b/grass7/raster/r.green/r.green.biomassfor/r.green.biomassfor.co2/r.green.biomassfor.co2.html
@@ -1,6 +1,6 @@
 <h2>DESCRIPTION</h2>
 
-Compute the co2 emissions of using biomass forestry residuals for energy production.
+Compute the CO2 emissions of using biomass forestry residuals for energy production.
 
 <h2>NOTES</h2>
 
@@ -20,4 +20,7 @@ Pietro Zambelli,
 Sandro Sacchelli,
 Marco Ciolli
 
-<p><i>Last changed: $Date$</i></p>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.green/r.green.biomassfor/r.green.biomassfor.financial/r.green.biomassfor.financial.html
+++ b/grass7/raster/r.green/r.green.biomassfor/r.green.biomassfor.financial/r.green.biomassfor.financial.html
@@ -22,4 +22,7 @@ Marco Ciolli
 
 Code rewritten by Giulia Garegnani
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.green/r.green.biomassfor/r.green.biomassfor.html
+++ b/grass7/raster/r.green/r.green.biomassfor/r.green.biomassfor.html
@@ -36,4 +36,7 @@ Pietro Zambelli,
 Sandro Sacchelli,
 Marco Ciolli
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.green/r.green.biomassfor/r.green.biomassfor.impact/r.green.biomassfor.impact.html
+++ b/grass7/raster/r.green/r.green.biomassfor/r.green.biomassfor.impact/r.green.biomassfor.impact.html
@@ -20,4 +20,7 @@ Pietro Zambelli,
 Sandro Sacchelli,
 Marco Ciolli
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.green/r.green.biomassfor/r.green.biomassfor.legal/r.green.biomassfor.legal.html
+++ b/grass7/raster/r.green/r.green.biomassfor/r.green.biomassfor.legal/r.green.biomassfor.legal.html
@@ -43,4 +43,7 @@ Pietro Zambelli,
 Sandro Sacchelli,
 Marco Ciolli
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.green/r.green.biomassfor/r.green.biomassfor.recommended/r.green.biomassfor.recommended.html
+++ b/grass7/raster/r.green/r.green.biomassfor/r.green.biomassfor.recommended/r.green.biomassfor.recommended.html
@@ -20,4 +20,7 @@ Pietro Zambelli,
 Sandro Sacchelli,
 Marco Ciolli
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.green/r.green.biomassfor/r.green.biomassfor.technical/r.green.biomassfor.technical.html
+++ b/grass7/raster/r.green/r.green.biomassfor/r.green.biomassfor.technical/r.green.biomassfor.technical.html
@@ -21,4 +21,7 @@ Pietro Zambelli,
 Sandro Sacchelli,
 Marco Ciolli
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.green/r.green.biomassfor/r.green.biomassfor.theoretical/r.green.biomassfor.theoretical.html
+++ b/grass7/raster/r.green/r.green.biomassfor/r.green.biomassfor.theoretical/r.green.biomassfor.theoretical.html
@@ -44,4 +44,7 @@ Pietro Zambelli,
 Sandro Sacchelli,
 Marco Ciolli
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.green/r.green.gshp/r.green.gshp.html
+++ b/grass7/raster/r.green/r.green.gshp/r.green.gshp.html
@@ -54,4 +54,7 @@ pp. 765-773
 
 For authors and references, please refer to the respective module of <em>r.green</em>.
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.green/r.green.gshp/r.green.gshp.technical/r.green.gshp.technical.html
+++ b/grass7/raster/r.green/r.green.gshp/r.green.gshp.technical/r.green.gshp.technical.html
@@ -22,4 +22,7 @@ Pietro Zambelli (Eurac Research, Bolzano, Italy)<br>
 
 <h2>REFERENCES</h2>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.green/r.green.gshp/r.green.gshp.theoretical/r.green.gshp.theoretical.html
+++ b/grass7/raster/r.green/r.green.gshp/r.green.gshp.theoretical/r.green.gshp.theoretical.html
@@ -59,6 +59,9 @@ Alessandro Casasso, Rajandrea Sethi, 2016,<br>
 "G.POT: A quantitative method for the assessment and mapping of the
 shallow geothermal potential"<br>
 Energy 106, p 765 -- <br>
-<a href=http://dx.doi.org/10.1016/j.energy.2016.03.091>http://dx.doi.org/10.1016/j.energy.2016.03.091</a><br>
+<a href="http://dx.doi.org/10.1016/j.energy.2016.03.091">http://dx.doi.org/10.1016/j.energy.2016.03.091</a><br>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.green/r.green.html
+++ b/grass7/raster/r.green/r.green.html
@@ -71,4 +71,7 @@ The basis for creating the modules to calculate the energy potential is shown in
 
 For authors and references, please refer to the respective module of <em>r.green</em>.
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.green/r.green.hydro/r.green.hydro.closest/r.green.hydro.closest.html
+++ b/grass7/raster/r.green/r.green.hydro/r.green.hydro.closest/r.green.hydro.closest.html
@@ -5,4 +5,7 @@
 <h2>AUTHORS</h2>
 Pietro Zambelli
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.green/r.green.hydro/r.green.hydro.delplants/r.green.hydro.delplants.html
+++ b/grass7/raster/r.green/r.green.hydro/r.green.hydro.delplants/r.green.hydro.delplants.html
@@ -36,5 +36,9 @@ Output vector map in black : streams of Mis Valley without the existing plants (
 
 <h2>AUTHORS</h2>
 Giulia Garegnani and Pietro Zambelli (Eurac Research, Bolzano, Italy), Manual written by Julie Gros.<br>
-Last changed: $Date : 2015-07-07 15:17 GMT+1$
+
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->
 

--- a/grass7/raster/r.green/r.green.hydro/r.green.hydro.discharge/r.green.hydro.discharge.html
+++ b/grass7/raster/r.green/r.green.hydro/r.green.hydro.discharge/r.green.hydro.discharge.html
@@ -77,6 +77,10 @@ from Autorit&agrave; di bacino dei fiumi Isonzo, Tagliamento, Livenza, Piave, Br
 
 <h2>AUTHORS</h2>
 Giulia Garegnani (Eurac Research, Bolzano, Italy), Sara Biscaini (University of Trento, Italy), Manual written by Julie Gros.<br>
-Last changed: $Date : 2015-07-07 15:17 GMT+1$
+
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->
 
 

--- a/grass7/raster/r.green/r.green.hydro/r.green.hydro.financial/r.green.hydro.financial.html
+++ b/grass7/raster/r.green/r.green.hydro/r.green.hydro.financial/r.green.hydro.financial.html
@@ -230,4 +230,8 @@ The calculation of the yearly maintenance cost is based on the report AEEG for t
 
 <h2>AUTHORS</h2>
 Pietro Zambelli (Eurac Research, Bolzano, Italy), Sandro Sacchelli (University of Florence, Italy), Manual written by Julie Gros.<br>
-Last changed: $Date : 2015-07-07 16:13 GMT+1$
+
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.green/r.green.hydro/r.green.hydro.html
+++ b/grass7/raster/r.green/r.green.hydro/r.green.hydro.html
@@ -50,4 +50,7 @@ The <em>r.green.hydro</em> suite consists of the following six different parts:<
 
 For authors and references, please refer to the respective module of <em>r.green</em>.
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.green/r.green.hydro/r.green.hydro.optimal/r.green.hydro.optimal.html
+++ b/grass7/raster/r.green/r.green.hydro/r.green.hydro.optimal/r.green.hydro.optimal.html
@@ -63,5 +63,9 @@ Output vector maps potentialplants (in blue) and potentialpoints (in red)
 
 <h2>AUTHORS</h2>
 Giulia Garegnani (Eurac Research, Bolzano, Italy), Manual written by Julie Gros.<br>
-Last changed: $Date : 2015-07-08 10:57 GMT+1$
+
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->
 

--- a/grass7/raster/r.green/r.green.hydro/r.green.hydro.planning/r.green.hydro.planning.html
+++ b/grass7/raster/r.green/r.green.hydro/r.green.hydro.planning/r.green.hydro.planning.html
@@ -221,5 +221,9 @@ output vector map: superimposition of the potential segments vector file (potent
 
 <h2>AUTHORS</h2>
 Giulia Garegnani (Eurac Research, Bolzano, Italy), Manual written by Julie Gros.<br>
-Last changed: $Date: 2015-07-08 14:46 GMT+1$
+
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->
 

--- a/grass7/raster/r.green/r.green.hydro/r.green.hydro.recommended/r.green.hydro.recommended.html
+++ b/grass7/raster/r.green/r.green.hydro/r.green.hydro.recommended/r.green.hydro.recommended.html
@@ -221,5 +221,9 @@ output vector map: superimposition of the potential segments vector file (potent
 
 <h2>AUTHORS</h2>
 Giulia Garegnani (Eurac Research, Bolzano, Italy), Manual written by Julie Gros.<br>
-Last changed: $Date: 2015-07-08 14:46 GMT+1$
+
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->
 

--- a/grass7/raster/r.green/r.green.hydro/r.green.hydro.structure/r.green.hydro.structure.html
+++ b/grass7/raster/r.green/r.green.hydro/r.green.hydro.structure/r.green.hydro.structure.html
@@ -54,4 +54,8 @@ Picture of the plant structure taken from Micro-hydropower Systems - A Buyer's G
 
 <h2>AUTHORS</h2>
 Pietro Zambelli (Eurac Research, Bolzano, Italy), Manual written by Julie Gros.<br>
-Last changed: $Date : 2015-07-08 14:59 GMT+1$
+
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.green/r.green.hydro/r.green.hydro.technical/r.green.hydro.technical.html
+++ b/grass7/raster/r.green/r.green.hydro/r.green.hydro.technical/r.green.hydro.technical.html
@@ -128,4 +128,8 @@ Sources for the theory : Courses of French engineering schools ENSE3 Grenoble-IN
 
 <h2>AUTHORS</h2>
 Giulia Garegnani (Eurac Research, Bolzano, Italy), Julie Gros (Eurac Research, Bolzano, Italy), Manual written by Julie Gros.<br>
-Last changed: $Date : 2015-06-12 15:46 GMT+1$
+
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.green/r.green.hydro/r.green.hydro.theoretical/r.green.hydro.theoretical.html
+++ b/grass7/raster/r.green/r.green.hydro/r.green.hydro.theoretical/r.green.hydro.theoretical.html
@@ -103,4 +103,8 @@ output vector map with basin potential
 
 <h2>AUTHORS</h2>
 Giulia Garegnani (Eurac Research, Bolzano, Italy), Manual written by Sabrina Scheunert.<br>
-Last changed: $Date : 2015-10-16 14:46 GMT+1$
+
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.green/r.green.install/r.green.install.html
+++ b/grass7/raster/r.green/r.green.install/r.green.install.html
@@ -69,4 +69,7 @@ Close GRASS and restart the programm to have in the the menu the session energy 
 
 Pietro Zambelli (Eurac Research, Bolzano, Italy)
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.grow.shrink/r.grow.shrink.html
+++ b/grass7/raster/r.grow.shrink/r.grow.shrink.html
@@ -94,5 +94,7 @@ U.S. Army Construction Engineering Research Laboratory
 <p>
 Glynn Clements
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.gsflow.hydrodem/r.gsflow.hydrodem.html
+++ b/grass7/raster/r.gsflow.hydrodem/r.gsflow.hydrodem.html
@@ -11,18 +11,21 @@ Francisco, CA.
 
 <h2>SEE ALSO</h2>
 
-<a href="v.gsflow.export">v.gsflow.export</a><br>
-<a href="v.gsflow.gravres">v.gsflow.gravres</a><br>
-<a href="v.gsflow.grid">v.gsflow.grid</a><br>
-<a href="v.gsflow.hruparams">v.gsflow.hruparams</a><br>
-<a href="v.gsflow.reaches">v.gsflow.reaches</a><br>
-<a href="v.gsflow.segments">v.gsflow.segments</a><br>
-<a href="v.gsflow.mapdata">v.gsflow.mapdata</a><br>
-<a href="v.stream.inbasin">v.stream.inbasin</a><br>
+<a href="v.gsflow.export">v.gsflow.export</a>,
+<a href="v.gsflow.gravres">v.gsflow.gravres</a>,
+<a href="v.gsflow.grid">v.gsflow.grid</a>,
+<a href="v.gsflow.hruparams">v.gsflow.hruparams</a>,
+<a href="v.gsflow.reaches">v.gsflow.reaches</a>,
+<a href="v.gsflow.segments">v.gsflow.segments</a>,
+<a href="v.gsflow.mapdata">v.gsflow.mapdata</a>,
+<a href="v.stream.inbasin">v.stream.inbasin</a>,
 <a href="v.stream.network">v.stream.network</a>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Andrew D. Wickert<br>
 
-<p><i>Last changed: $Date 2018-04-22$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.gwr/r.gwr.html
+++ b/grass7/raster/r.gwr/r.gwr.html
@@ -132,4 +132,7 @@ R package
 
 Markus Metz
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.hants/r.hants.html
+++ b/grass7/raster/r.hants/r.hants.html
@@ -239,4 +239,7 @@ DOI: <a href=http://dx.doi.org/10.1080/014311600209814>10.1080/014311600209814</
 
 Markus Metz
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.hazard.flood/r.hazard.flood.html
+++ b/grass7/raster/r.hazard.flood/r.hazard.flood.html
@@ -76,5 +76,7 @@ Digital Elevation Models, Journal of Hydrologic Engineering,
 <h2>AUTHOR</h2>
 Margherita Di Leo (dileomargherita AT gmail DOT com)
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.houghtransform/r.houghtransform.html
+++ b/grass7/raster/r.houghtransform/r.houghtransform.html
@@ -192,5 +192,8 @@ IEEE. 2000, pp. 560-563.
 Anna Kratochvilova,
 Vaclav Petras
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->
 

--- a/grass7/raster/r.hydrodem/r.hydrodem.html
+++ b/grass7/raster/r.hydrodem/r.hydrodem.html
@@ -81,4 +81,7 @@ DOI: <a href=http://dx.doi.org/10.1002/hyp.5835>10.1002/hyp.5835</a>
 <h2>AUTHOR</h2>
 Markus Metz
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.hypso/r.hypso.html
+++ b/grass7/raster/r.hypso/r.hypso.html
@@ -51,5 +51,7 @@ n. 9 (2010)</em>
 <h2>AUTHORS</h2>
 <p>Margherita Di Leo (grass-dev AT lists DOT osgeo DOT org), Massimo Di Stefano, Francesco Di Stefano
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.in.arc/r.in.arc.html
+++ b/grass7/raster/r.in.arc/r.in.arc.html
@@ -53,4 +53,7 @@ r.in.arc input=elev_meters.asc output=elev_decimeters title="Elevation data conv
 <h2>AUTHOR</h2>
 Unknown German author, updated by Bill Brown to floating point support.
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.in.pdal/r.in.pdal.html
+++ b/grass7/raster/r.in.pdal/r.in.pdal.html
@@ -136,5 +136,8 @@ Vaclav Petras,
 (projection, computational region)
 <p>
 Documentation: Markus Neteler, mundialis GmbH &amp; Co. KG
+
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.in.srtm.region/r.in.srtm.region.html
+++ b/grass7/raster/r.in.srtm.region/r.in.srtm.region.html
@@ -81,4 +81,7 @@ M. Neteler, 2005. <a href="https://grass.osgeo.org/newsletter/GRASSNews_vol3.pdf
 
 Markus Metz<br>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.in.wcs/r.in.wcs.html
+++ b/grass7/raster/r.in.wcs/r.in.wcs.html
@@ -12,4 +12,7 @@
 
 Martin Zbinden
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.jpdf/r.jpdf.html
+++ b/grass7/raster/r.jpdf/r.jpdf.html
@@ -48,4 +48,7 @@ selecting map names.
 
 Thomas Huld
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.lake.series/r.lake.series.html
+++ b/grass7/raster/r.lake.series/r.lake.series.html
@@ -88,4 +88,7 @@ different areas).
 Vaclav Petras, <a href="http://gis.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>,<br>
 Maris Nartiss (author of <em><a href="r.lake.html">r.lake</a></em>)
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.landscape.evol/r.landscape.evol.html
+++ b/grass7/raster/r.landscape.evol/r.landscape.evol.html
@@ -372,4 +372,7 @@ Losses - A Guide to Conservation Planning. USDA Agriculture Handbook
 <h2>AUTHORS</h2>
 Isaac I. Ullah, C. Michael Barton, and Helena Mitasova
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.le.patch/r.le.patch.html
+++ b/grass7/raster/r.le.patch/r.le.patch.html
@@ -36,5 +36,7 @@ manual: Quantitative analysis of landscape structures</a> (GRASS 5; 2001)
 William L. Baker Department of Geography and Recreation University of
 Wyoming Laramie, Wyoming 82071 U.S.A.
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.le.pixel/r.le.pixel.html
+++ b/grass7/raster/r.le.pixel/r.le.pixel.html
@@ -35,5 +35,7 @@ manual: Quantitative analysis of landscape structures</a> (GRASS 5; 2001)
 William L. Baker Department of Geography and Recreation University of
 Wyoming Laramie, Wyoming 82071 U.S.A.
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.le.setup/r.le.setup.html
+++ b/grass7/raster/r.le.setup/r.le.setup.html
@@ -467,5 +467,7 @@ manual: Quantitative analysis of landscape structures</a> (GRASS 5; 2001)
 William L. Baker Department of Geography and Recreation University of
 Wyoming Laramie, Wyoming 82071 U.S.A.
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.le.trace/r.le.trace.html
+++ b/grass7/raster/r.le.trace/r.le.trace.html
@@ -39,5 +39,7 @@ manual: Quantitative analysis of landscape structures</a> (GRASS 5; 2001)
 William L. Baker Department of Geography and Recreation University of
 Wyoming Laramie, Wyoming 82071 U.S.A.
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.learn.ml/r.learn.ml.html
+++ b/grass7/raster/r.learn.ml/r.learn.ml.html
@@ -56,11 +56,18 @@ r.category rf_classification
 <center>
 <img src="rfclassification.png" alt="Random forest classification result">
 </center>
+
 <h2>ACKNOWLEDGEMENTS</h2>
 <p>Thanks for Paulo van Breugel and Vaclav Petras for testing.</p>
+
 <h2>REFERENCES</h2>
 <p>Brenning, A. 2012. Spatial cross-validation and bootstrap for the assessment of prediction rules in remote sensing: the R package 'sperrorest'. 2012 IEEE International Geoscience and Remote Sensing Symposium (IGARSS), 23-27 July 2012, p. 5372-5375.</p>
 <p>Scikit-learn: Machine Learning in Python, Pedregosa et al., JMLR 12, pp. 2825-2830, 2011.</p>
+
 <h2>AUTHOR</h2>
 Steven Pawley
-<p><em>Last changed: $Date$</em></p>
+
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.lfp/r.lfp.html
+++ b/grass7/raster/r.lfp/r.lfp.html
@@ -110,4 +110,7 @@ r.lfp input=drain_directions output=lfp id_column=id outlet=stream_outlets layer
 
 <a href="mailto:grass4u@gmail com">Huidae Cho</a>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.local.relief/r.local.relief.html
+++ b/grass7/raster/r.local.relief/r.local.relief.html
@@ -135,10 +135,13 @@ and custom red (negative values) and blue (positive values) color table
     (provided bash script with <em><a href="v.surf.bspline.html">v.surf.bspline</a></em>-based implementation)</li>
 </ul>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
+
 <p>
 Vaclav Petras, <a href="http://gis.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>,<br>
 Eric Goddard
-</p>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.los/r.los.html
+++ b/grass7/raster/r.los/r.los.html
@@ -86,4 +86,7 @@ b) or fix r.viewshed in Addons
 
 Kewan Q. Khawaja, Intelligent Engineering Systems Laboratory, M.I.T.
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.mapcalc.tiled/r.mapcalc.tiled.html
+++ b/grass7/raster/r.mapcalc.tiled/r.mapcalc.tiled.html
@@ -42,4 +42,7 @@ r.mapcalc.tiled expression="bright_pixels = if(ortho_2001_t792_1m > 200, 1, 0)" 
 
 Moritz Lennert
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.massmov/r.massmov.html
+++ b/grass7/raster/r.massmov/r.massmov.html
@@ -82,4 +82,7 @@ incline. Journal of Fluid Mechanics 199:177-215</p>
 <p><i>The current version of the program (ported to GRASS7.0)</i>:
 <br>Monia Molinari, Massimiliano Cannata, Santiago Begueria.<br>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.mblend/r.mblend.html
+++ b/grass7/raster/r.mblend/r.mblend.html
@@ -53,5 +53,7 @@ ISRIC - World Soil Information
 Jo&atilde;o Paulo Leit&atilde;o<br>
 EAWAG: Swiss Federal Institute of Aquatic Science and Technology.
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.mcda.ahp/r.mcda.ahp.html
+++ b/grass7/raster/r.mcda.ahp/r.mcda.ahp.html
@@ -29,5 +29,8 @@ The first row and first column are related to the first criteria (reclass_slope 
 <h2>AUTHORS</h2>
 Antonio Boggia - Gianluca Massei<br>
 Department of Economics and Appraisal - University of Perugia - Italy
-<p><i>Last changed: $Date$</i>
 
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.mcda.electre/r.mcda.electre.html
+++ b/grass7/raster/r.mcda.electre/r.mcda.electre.html
@@ -42,6 +42,7 @@ Volume 146, 15 December 2014, Pages 491-504, ISSN 0301-4797</p>
 Antonio Boggia - Gianluca Massei<br>
 Department of Economics and Appraisal - University of Perugia - Italy 
 
-
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.mcda.input/r.mcda.input.html
+++ b/grass7/raster/r.mcda.input/r.mcda.input.html
@@ -30,4 +30,7 @@ Antonio Boggia - Gianluca Massei<br>
 Department of Economics and Appraisal - University of Perugia - Italy 
 <p>
 
+<!--
+<p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.mcda.output/r.mcda.output.html
+++ b/grass7/raster/r.mcda.output/r.mcda.output.html
@@ -32,5 +32,8 @@ current region settings. See the <em>g.region</em> module for details.
 <h2>AUTHORS</h2>
 Antonio Boggia - Gianluca Massei<br>
 Department of Economics and Appraisal - University of Perugia - Italy 
+
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.mcda.promethee/r.mcda.promethee.html
+++ b/grass7/raster/r.mcda.promethee/r.mcda.promethee.html
@@ -34,6 +34,7 @@ Volume 146, 15 December 2014, Pages 491-504, ISSN 0301-4797</p>
 Antonio Boggia - Gianluca Massei<br>
 Department of Economics and Appraisal - University of Perugia - Italy 
 
-
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.mcda.roughset/r.mcda.roughset.html
+++ b/grass7/raster/r.mcda.roughset/r.mcda.roughset.html
@@ -27,5 +27,7 @@
 Antonio Boggia - Gianluca Massei<br>
 Department of Economics and Appraisal - University of Perugia - Italy 
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.mcda.topsis/r.mcda.topsis.html
+++ b/grass7/raster/r.mcda.topsis/r.mcda.topsis.html
@@ -17,5 +17,7 @@
 Antonio Boggia - Gianluca Massei<br>
 Department of Economics and Appraisal - University of Perugia - Italy 
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.meb/r.meb.html
+++ b/grass7/raster/r.meb/r.meb.html
@@ -101,4 +101,7 @@ ONE 10(4): e0121444. doi: 10.1371/journal.pone.0121444
 
 Paulo van Breugel, paulo at ecodiv.org
 
-<p><em>Last changed: $Date$</em>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.mess/r.mess.html
+++ b/grass7/raster/r.mess/r.mess.html
@@ -154,5 +154,7 @@ Efforts in Eastern Africa. PLoS ONE 10: e0121444.
 
 Paulo van Breugel, paulo at ecodiv.earth
 
-
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.mregression.series/r.mregression.series.html
+++ b/grass7/raster/r.mregression.series/r.mregression.series.html
@@ -164,4 +164,7 @@ This rasters contains the fitted coefitients.
 
 Dmitry Kolesov
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.neighborhoodmatrix/r.neighborhoodmatrix.html
+++ b/grass7/raster/r.neighborhoodmatrix/r.neighborhoodmatrix.html
@@ -81,4 +81,7 @@ r.neighborhoodmatrix -l n=bc_int sep=comma output=county_neighbors.csv
  C-Version: Markus Metz
  Original Python-Version: Moritz Lennert
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.niche.similarity/r.niche.similarity.html
+++ b/grass7/raster/r.niche.similarity/r.niche.similarity.html
@@ -51,4 +51,7 @@ http://CRAN.R-project.org/package=phyloclim</li>
 
 Paulo van Breugel, paulo at ecodiv.org
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.northerness.easterness/r.northerness.easterness.html
+++ b/grass7/raster/r.northerness.easterness/r.northerness.easterness.html
@@ -62,6 +62,7 @@ Developments in Soil Science, Volume 33. Elsevier.
 
 Helmut Kudrnovsky
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
-</p>
+-->

--- a/grass7/raster/r.object.activelearning/r.object.activelearning.html
+++ b/grass7/raster/r.object.activelearning/r.object.activelearning.html
@@ -186,4 +186,7 @@ Symposium. doi:10.1109/igarss.2009.5417857<br>
 <h2>AUTHOR</h2> 
 Lucas Lef&egrave;vre (ULB, Brussels, Belgium)
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.object.geometry/r.object.geometry.html
+++ b/grass7/raster/r.object.geometry/r.object.geometry.html
@@ -54,5 +54,7 @@ r.object.geometry input=soilsID output=soils_geom.txt
 Moritz Lennert<br>
 Markus Metz (diagonal clump tracing)
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.object.spatialautocor/r.object.spatialautocor.html
+++ b/grass7/raster/r.object.spatialautocor/r.object.spatialautocor.html
@@ -44,4 +44,7 @@ Geary, R.C., 1954. The Contiguity Ratio and Statistical Mapping. The Incorporate
 
 Moritz Lennert
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.object.thickness/r.object.thickness.html
+++ b/grass7/raster/r.object.thickness/r.object.thickness.html
@@ -74,4 +74,7 @@ Thickness in pixels: min 0.053524  max 103.945479  mean 10.563481
 Paolo Zatelli,
 DICAM, University of Trento, Italy.
 
-<p><i>Last changed: $Date: 2019-07-19 13:15:11 +0100 (Fri, 19 Jul 2019) $</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.out.arc/r.out.arc.html
+++ b/grass7/raster/r.out.arc/r.out.arc.html
@@ -55,4 +55,7 @@ based on r.out.ascii written by <br>
 Michael Shapiro,
 U.S.Army Construction Engineering Research Laboratory
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.out.kde/r.out.kde.html
+++ b/grass7/raster/r.out.kde/r.out.kde.html
@@ -45,4 +45,7 @@ r.out.kde input=schools_density background=relief method=logistic output=output.
 <h2>AUTHORS</h2>
 Anna Petrasova, <a href="http://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll lab</a>
 
-<p><i>Last changed: $Date: 2019-06-12 18:10:36 +0100 (Wed, 12 Jun 2019) $</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.out.legend/r.out.legend.html
+++ b/grass7/raster/r.out.legend/r.out.legend.html
@@ -206,4 +206,7 @@ at a resolution of 150 ppi this is:
 
 Paulo van Breugel, paulo at ecodiv.org
 
-<p><em>Last changed: $Date$</em>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.out.ntv2/r.out.ntv2.html
+++ b/grass7/raster/r.out.ntv2/r.out.ntv2.html
@@ -31,5 +31,7 @@ fields are set to, respectively, current date and time, in YYYYMMDD and HHMMSS f
 <h2>AUTHOR</h2>
 Maciej Sieczka
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.out.tiff/r.out.tiff.html
+++ b/grass7/raster/r.out.tiff/r.out.tiff.html
@@ -41,4 +41,7 @@ Michael Shapiro,
 U.S. Army Construction Engineering Research Laboratory
 <p>GRASS 5.0 team
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.patch.smooth/r.patch.smooth.html
+++ b/grass7/raster/r.patch.smooth/r.patch.smooth.html
@@ -64,4 +64,7 @@ Open Geospatial Data, Software and Standards.
 
 Anna Petrasova, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU OSGeoREL</a><br>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.corearea/r.pi.corearea.html
+++ b/grass7/raster/r.pi/r.pi.corearea/r.pi.corearea.html
@@ -116,5 +116,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.corr.mw/r.pi.corr.mw.html
+++ b/grass7/raster/r.pi/r.pi.corr.mw/r.pi.corr.mw.html
@@ -43,5 +43,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.csr.mw/r.pi.csr.mw.html
+++ b/grass7/raster/r.pi/r.pi.csr.mw/r.pi.csr.mw.html
@@ -58,5 +58,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.energy.pr/r.pi.energy.pr.html
+++ b/grass7/raster/r.pi/r.pi.energy.pr/r.pi.energy.pr.html
@@ -86,5 +86,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.energy/r.pi.energy.html
+++ b/grass7/raster/r.pi/r.pi.energy/r.pi.energy.html
@@ -86,5 +86,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.enn.pr/r.pi.enn.pr.html
+++ b/grass7/raster/r.pi/r.pi.enn.pr/r.pi.enn.pr.html
@@ -46,5 +46,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.enn/r.pi.enn.html
+++ b/grass7/raster/r.pi/r.pi.enn/r.pi.enn.html
@@ -131,5 +131,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.export/r.pi.export.html
+++ b/grass7/raster/r.pi/r.pi.export/r.pi.export.html
@@ -69,5 +69,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.fnn/r.pi.fnn.html
+++ b/grass7/raster/r.pi/r.pi.fnn/r.pi.fnn.html
@@ -127,5 +127,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.graph.dec/r.pi.graph.dec.html
+++ b/grass7/raster/r.pi/r.pi.graph.dec/r.pi.graph.dec.html
@@ -44,5 +44,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.graph.pr/r.pi.graph.pr.html
+++ b/grass7/raster/r.pi/r.pi.graph.pr/r.pi.graph.pr.html
@@ -44,5 +44,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.graph.red/r.pi.graph.red.html
+++ b/grass7/raster/r.pi/r.pi.graph.red/r.pi.graph.red.html
@@ -44,5 +44,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.graph/r.pi.graph.html
+++ b/grass7/raster/r.pi/r.pi.graph/r.pi.graph.html
@@ -56,5 +56,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.grow/r.pi.grow.html
+++ b/grass7/raster/r.pi/r.pi.grow/r.pi.grow.html
@@ -44,5 +44,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.html
+++ b/grass7/raster/r.pi/r.pi.html
@@ -208,5 +208,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.import/r.pi.import.html
+++ b/grass7/raster/r.pi/r.pi.import/r.pi.import.html
@@ -66,5 +66,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.index/r.pi.index.html
+++ b/grass7/raster/r.pi/r.pi.index/r.pi.index.html
@@ -124,5 +124,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.lm/r.pi.lm.html
+++ b/grass7/raster/r.pi/r.pi.lm/r.pi.lm.html
@@ -44,5 +44,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.neigh/r.pi.neigh.html
+++ b/grass7/raster/r.pi/r.pi.neigh/r.pi.neigh.html
@@ -32,5 +32,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.nlm.circ/r.pi.nlm.circ.html
+++ b/grass7/raster/r.pi/r.pi.nlm.circ/r.pi.nlm.circ.html
@@ -79,5 +79,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.nlm.stats/r.pi.nlm.stats.html
+++ b/grass7/raster/r.pi/r.pi.nlm.stats/r.pi.nlm.stats.html
@@ -31,5 +31,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.nlm/r.pi.nlm.html
+++ b/grass7/raster/r.pi/r.pi.nlm/r.pi.nlm.html
@@ -50,5 +50,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.odc/r.pi.odc.html
+++ b/grass7/raster/r.pi/r.pi.odc/r.pi.odc.html
@@ -95,5 +95,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.prob.mw/r.pi.prob.mw.html
+++ b/grass7/raster/r.pi/r.pi.prob.mw/r.pi.prob.mw.html
@@ -44,5 +44,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.prox/r.pi.prox.html
+++ b/grass7/raster/r.pi/r.pi.prox/r.pi.prox.html
@@ -31,5 +31,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.rectangle/r.pi.rectangle.html
+++ b/grass7/raster/r.pi/r.pi.rectangle/r.pi.rectangle.html
@@ -54,6 +54,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
-
+-->

--- a/grass7/raster/r.pi/r.pi.searchtime.mw/r.pi.searchtime.mw.html
+++ b/grass7/raster/r.pi/r.pi.searchtime.mw/r.pi.searchtime.mw.html
@@ -78,5 +78,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.searchtime.pr/r.pi.searchtime.pr.html
+++ b/grass7/raster/r.pi/r.pi.searchtime.pr/r.pi.searchtime.pr.html
@@ -85,5 +85,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.pi/r.pi.searchtime/r.pi.searchtime.html
+++ b/grass7/raster/r.pi/r.pi.searchtime/r.pi.searchtime.html
@@ -103,5 +103,7 @@ University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.popgrowth/r.popgrowth.html
+++ b/grass7/raster/r.popgrowth/r.popgrowth.html
@@ -20,5 +20,7 @@ Johannes Radinger<br>
 Berlin, Germany</i>
 <br>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.quantile.ref/r.quantile.ref.html
+++ b/grass7/raster/r.quantile.ref/r.quantile.ref.html
@@ -63,5 +63,8 @@ The quantile corresponding to the value 5 is 0.8.
 <h2>AUTHOR</h2>
 
 Markus Metz
+
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.random.weight/r.random.weight.html
+++ b/grass7/raster/r.random.weight/r.random.weight.html
@@ -38,5 +38,7 @@ See <a href="https://pvanb.wordpress.com/2014/05/30/weighted_random_sample_of_ra
 
 Paulo van Breugel, paulo at ecodiv.org
 
-<i>Last changed: $Date$</i> 
-
+<!--
+<p>
+<i>Last changed: $Date$</i>
+--> 

--- a/grass7/raster/r.recode.attr/r.recode.attr.html
+++ b/grass7/raster/r.recode.attr/r.recode.attr.html
@@ -38,12 +38,16 @@ ranges of values to one value or a new range of values)
 
  
 <h2>SEE ALSO</h2>
-<em><a href="http://grass.osgeo.org/grass70/manuals/r.reclass.html">r.reclass</a></em>, 
-<em><a href="http://grass.osgeo.org/grass70/manuals/r.recode.html">r.recode</a></em>
+<em>
+<a href="r.reclass.html">r.reclass</a>,
+<a href="r.recode.html">r.recode</a>
+</em>
  
 <h2>AUTHOR</h2>
 
 Paulo van Breugel, paulo at ecodiv.org
 
-<p><i>Last changed: $Date: 2014-12-13 09:11:08 +0100 (za, 13 dec 
-2014)</i></p>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.regression.series/r.regression.series.html
+++ b/grass7/raster/r.regression.series/r.regression.series.html
@@ -113,4 +113,7 @@ r.regression.series x=xone,xtwo,xthree,xfour y=yone,ytwo,ythree,yfour \
 
 Markus Metz
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.resamp.tps/r.resamp.tps.html
+++ b/grass7/raster/r.resamp.tps/r.resamp.tps.html
@@ -87,5 +87,7 @@ TPS interpolation are always completely loaded to memory.
 
 Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.richdem.breachdepressions/r.richdem.breachdepressions.html
+++ b/grass7/raster/r.richdem.breachdepressions/r.richdem.breachdepressions.html
@@ -14,4 +14,7 @@ PLACEHOLDER
 
 Richard Barnes (algorithm and codebase), Andrew D. Wickert (GRASS frontend)<br>
 
-<p><i>Last changed: $Date 2019-06-17$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.richdem.filldepressions/r.richdem.filldepressions.html
+++ b/grass7/raster/r.richdem.filldepressions/r.richdem.filldepressions.html
@@ -14,4 +14,7 @@ PLACEHOLDER
 
 Richard Barnes (algorithm and codebase), Andrew D. Wickert (GRASS frontend)<br>
 
-<p><i>Last changed: $Date 2019-06-17$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.richdem.flowaccumulation/r.richdem.flowaccumulation.html
+++ b/grass7/raster/r.richdem.flowaccumulation/r.richdem.flowaccumulation.html
@@ -14,4 +14,7 @@ PLACEHOLDER
 
 Richard Barnes (algorithm and codebase), Andrew D. Wickert (GRASS frontend)<br>
 
-<p><i>Last changed: $Date 2019-06-17$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.richdem.resolveflats/r.richdem.resolveflats.html
+++ b/grass7/raster/r.richdem.resolveflats/r.richdem.resolveflats.html
@@ -14,4 +14,8 @@ PLACEHOLDER
 
 Richard Barnes (algorithm and codebase), Andrew D. Wickert (GRASS frontend)<br>
 
-<p><i>Last changed: $Date 2019-06-17$</i>
+
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.richdem.terrainattribute/r.richdem.terrainattribute.html
+++ b/grass7/raster/r.richdem.terrainattribute/r.richdem.terrainattribute.html
@@ -14,4 +14,8 @@ PLACEHOLDER
 
 Richard Barnes (algorithm and codebase), Andrew D. Wickert (GRASS frontend)<br>
 
-<p><i>Last changed: $Date 2019-06-17$</i>
+
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.roughness.vector/r.roughness.vector.html
+++ b/grass7/raster/r.roughness.vector/r.roughness.vector.html
@@ -89,4 +89,7 @@ target="_blank">http://carlosgrohmann.com</a>)
 Helmut Kudrnovsky
 <p>
 
+<!--
+<p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.sample.category/r.sample.category.html
+++ b/grass7/raster/r.sample.category/r.sample.category.html
@@ -115,9 +115,11 @@ by this module.
 
 
 <h2>AUTHORS</h2>
-<p>
+
 Vaclav Petras, <a href="http://gis.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>,<br>
 Anna Petrasova, <a href="http://gis.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>
-</p>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.seasons/r.seasons.html
+++ b/grass7/raster/r.seasons/r.seasons.html
@@ -179,4 +179,7 @@ r.colors map=ndvi_season2_start1,ndvi_season2_end1 color=viridis
 
 Markus Metz
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.series.decompose/r.series.decompose.html
+++ b/grass7/raster/r.series.decompose/r.series.decompose.html
@@ -145,4 +145,7 @@ r.mapcals "ndvi03jan = coef.const + coef.time*T +\
 
 Dmitry Kolesov
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.series.diversity/r.series.diversity.html
+++ b/grass7/raster/r.series.diversity/r.series.diversity.html
@@ -195,4 +195,7 @@ max=0.5658
 <h2>AUTHOR</h2>
 Paulo van Breugel, paulo at ecodiv.org
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.series.filter/r.series.filter.html
+++ b/grass7/raster/r.series.filter/r.series.filter.html
@@ -119,4 +119,7 @@ href="https://doi.org/10.1016/j.rse.2004.03.014">10.1016/j.rse.2004.03.014</a>.
 
 Dmitry Kolesov
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.series.lwr/r.series.lwr.html
+++ b/grass7/raster/r.series.lwr/r.series.lwr.html
@@ -260,4 +260,7 @@ doi:<a href="http://dx.doi.org/10.2307/2289282">10.2307/2289282</a>
 
 Markus Metz
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.shaded.pca/r.shaded.pca.html
+++ b/grass7/raster/r.shaded.pca/r.shaded.pca.html
@@ -80,5 +80,7 @@ Devereux, B. J., Amable, G. S., & Crow, P. P. (2008). Visualisation of LiDAR ter
 
 Vaclav Petras, <a href="http://gis.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.shalstab/r.shalstab.html
+++ b/grass7/raster/r.shalstab/r.shalstab.html
@@ -47,4 +47,7 @@ A map for of critical rainfall map (mm/day).
 <p>Montgomery, D. R. and Dietrich, W. E.: A physically based model for the
 topographic control of shallow landsliding,Water Resour. Res., 30, 1153-1171, 1994.</p>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.sim.terrain/r.sim.terrain.html
+++ b/grass7/raster/r.sim.terrain/r.sim.terrain.html
@@ -128,6 +128,8 @@ DOI: <a href="http://dx.doi.org/10.1016/B978-0-12-374739-6.00052-X">http://dx.do
 Brendan A. Harmon<br>
 Louisiana State University<br>
 <i><a href="mailto:brendan.harmon@gmail.com">brendan.harmon@gmail.com</a></i>
-</p>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.sim.water.mp/r.sim.water.mp.html
+++ b/grass7/raster/r.sim.water.mp/r.sim.water.mp.html
@@ -237,4 +237,7 @@ April 2015
 The International Series in Engineering and Computer Science: Volume 773. Springer New York Inc, p. 406.
 </ul>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.skyview/r.skyview.html
+++ b/grass7/raster/r.skyview/r.skyview.html
@@ -43,5 +43,7 @@ r.skyview input=elevation output=elevation_skyview ndir=8
 
 Anna Petrasova, <a href="http://gis.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.slope.direction/r.slope.direction.html
+++ b/grass7/raster/r.slope.direction/r.slope.direction.html
@@ -178,4 +178,7 @@ alt="Slope following street direction for 13 pixels" border="0">
 Stefan Blumentrath, Norwegian Institute for Nature Research, Oslo, Norway<br>
 Written for the INVAFISH project (RCN MILJØFORSK grant 243910)
 
-<p><i>Last changed: $Date: 2018-09-12 14:50:50 +0200 (Wed, 12 Sep 2018) $</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.smooth.seg/r.smooth.seg.html
+++ b/grass7/raster/r.smooth.seg/r.smooth.seg.html
@@ -165,4 +165,7 @@ Alfonso Vitti <br>
 &nbsp; University of Trento - Italy<br>
 &nbsp; alfonso.vitti [at] unitn.it
 
-<p><i>Last changed: $Date: 2015-06-16 12:00:00 +0200 (Tue, 16 Jun 2015)$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.soillossbare/r.soillossbare.html
+++ b/grass7/raster/r.soillossbare/r.soillossbare.html
@@ -20,4 +20,7 @@ http://www4.ncsu.edu/~hmitaso/gmslab/erosion/usle.html
 
 Martin Zbinden
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.soils.texture/r.soils.texture.html
+++ b/grass7/raster/r.soils.texture/r.soils.texture.html
@@ -30,8 +30,8 @@ Gianluca Massei (g_massa@libero.it)
 scheme (guile), and tcl using a floating point numerical test - point inside
 polygon. Applied mathematics and computer technology center alcoa technical
 center. Distribution documents.</p>
-<p>
-<br><br>
-</p>
+
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.stream.basins/r.stream.basins.html
+++ b/grass7/raster/r.stream.basins/r.stream.basins.html
@@ -225,5 +225,8 @@ See also the tutorial: <a href="http://grass.OSGeo.org/wiki/R.stream.*">http://g
 Jarek Jasiewicz, Adam Mickiewicz University, Geoecology and Geoinformation
 Institute.
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->
 

--- a/grass7/raster/r.stream.channel/r.stream.channel.html
+++ b/grass7/raster/r.stream.channel/r.stream.channel.html
@@ -128,5 +128,9 @@ plot(sorted,stdist~stgrad,type="l")
 Jarek Jasiewicz, Adam Mickiewicz University, Geoecology and Geoinformation
 Institute.
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->
+
 

--- a/grass7/raster/r.stream.distance/r.stream.distance.html
+++ b/grass7/raster/r.stream.distance/r.stream.distance.html
@@ -193,6 +193,7 @@ modules</a> wiki page.
 Jarek Jasiewicz, Adam Mickiewicz University, Geoecology and Geoinformation
 Institute.
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
-
+-->

--- a/grass7/raster/r.stream.order/r.stream.order.html
+++ b/grass7/raster/r.stream.order/r.stream.order.html
@@ -355,6 +355,7 @@ modules</a> wiki page.
 
 Jarek Jasiewicz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
-
+-->

--- a/grass7/raster/r.stream.segment/r.stream.segment.html
+++ b/grass7/raster/r.stream.segment/r.stream.segment.html
@@ -230,5 +230,7 @@ modules</a> wiki page.
 Jarek Jasiewicz, Adam Mickiewicz University, Geoecology and Geoinformation
 Institute.
 
-<p><i>Last changed: $Date$</i>
-
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.stream.slope/r.stream.slope.html
+++ b/grass7/raster/r.stream.slope/r.stream.slope.html
@@ -77,5 +77,7 @@ modules</a> wiki page.
 Jarek Jasiewicz, Adam Mickiewicz University, Geoecology and Geoinformation
 Institute.
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.stream.snap/r.stream.snap.html
+++ b/grass7/raster/r.stream.snap/r.stream.snap.html
@@ -131,6 +131,7 @@ modules</a> wiki page.
 Jarek Jasiewicz, Adam Mickiewicz University, Geoecology and Geoinformation
 Institute.
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
-
+-->

--- a/grass7/raster/r.stream.stats/r.stream.stats.html
+++ b/grass7/raster/r.stream.stats/r.stream.stats.html
@@ -214,5 +214,7 @@ modules</a> wiki page.
 <h2>AUTHOR</h2>
 Jarek Jasiewicz, Adam Mickiewicz University, Geoecology and Geoinformation Institute.
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.stream.variables/r.stream.variables.html
+++ b/grass7/raster/r.stream.variables/r.stream.variables.html
@@ -13,5 +13,7 @@ Scientific Data 2, 150073,
 Giuseppe Amatulli<br>
 Sami Domisch
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.stream.watersheds/r.stream.watersheds.html
+++ b/grass7/raster/r.stream.watersheds/r.stream.watersheds.html
@@ -13,5 +13,7 @@ Scientific Data 2, 150073,
 Giuseppe Amatulli<br>
 Sami Domisch
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.subdayprecip.design/r.subdayprecip.design.html
+++ b/grass7/raster/r.subdayprecip.design/r.subdayprecip.design.html
@@ -95,5 +95,7 @@ Republic<br>
 The module is inspired by Python script developed for Esri ArcGIS
 platform by M. Tomasu in 2013.
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.sun.daily/r.sun.daily.html
+++ b/grass7/raster/r.sun.daily/r.sun.daily.html
@@ -45,5 +45,7 @@ r.info beam
 Vaclav Petras, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>,<br>
 Anna Petrasova, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.sun.hourly/r.sun.hourly.html
+++ b/grass7/raster/r.sun.hourly/r.sun.hourly.html
@@ -103,5 +103,7 @@ set one of the values (either shade or sunlight) as NULL.
 Vaclav Petras, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>,<br>
 Anna Petrasova, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.sun.mp/r.sun.mp.html
+++ b/grass7/raster/r.sun.mp/r.sun.mp.html
@@ -380,5 +380,7 @@ Thomas Huld, JRC, Italy <br>
 <a href="MAILTO:suri@geomodel.sk">suri@geomodel.sk</a>
 </address>
 
+<!--
 <p>
-<i>Last changed: $Date$</i> 
+<i>Last changed: $Date$</i>
+--> 

--- a/grass7/raster/r.surf.idw2/r.surf.idw2.html
+++ b/grass7/raster/r.surf.idw2/r.surf.idw2.html
@@ -66,4 +66,7 @@ Module <em>r.surf.idw</em> works only for integer (CELL) raster maps.
 
 Michael Shapiro, U.S.Army Construction Engineering Research Laboratory
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.surf.nnbathy/r.surf.nnbathy.html
+++ b/grass7/raster/r.surf.nnbathy/r.surf.nnbathy.html
@@ -82,5 +82,7 @@ based on v.surf.nnbathy from GRASS 6 by<br>
 Hamish Bowman, Otago University, New Zealand<br>
 Based on <em>r.surf.nnbathy</em> by Maciej Sieczka<br>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.terrain.texture/r.terrain.texture.html
+++ b/grass7/raster/r.terrain.texture/r.terrain.texture.html
@@ -65,4 +65,7 @@ signature. Geomorphology 86, 409-440.
 
 Steven Pawley
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.texture.tiled/r.texture.tiled.html
+++ b/grass7/raster/r.texture.tiled/r.texture.tiled.html
@@ -45,4 +45,7 @@ r.texture.tiled ortho_2001_t792_1m output=ortho_texture method=idm \
 
 Moritz Lennert
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.threshold/r.threshold.html
+++ b/grass7/raster/r.threshold/r.threshold.html
@@ -27,5 +27,7 @@ r.threshold acc=accumulation_map
 <h2>AUTHOR</h2>
 <p>Margherita Di Leo (dileomargherita AT gmail DOT com)
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.to.vect.lines/r.to.vect.lines.html
+++ b/grass7/raster/r.to.vect.lines/r.to.vect.lines.html
@@ -52,5 +52,7 @@ Dept. of Geology<br>
 University of Otago<br>
 Dunedin, New Zealand</i>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.to.vect.tiled/r.to.vect.tiled.html
+++ b/grass7/raster/r.to.vect.tiled/r.to.vect.tiled.html
@@ -22,4 +22,7 @@ The tiles are optionally patched together with the <em>-p</em> flag.
 <h2>AUTHORS</h2>
 Markus Metz
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.traveltime/r.traveltime.html
+++ b/grass7/raster/r.traveltime/r.traveltime.html
@@ -75,5 +75,10 @@ GIS</em>, Journal of the American Water Resources Association, 8,
 </ul>
 
 <h2>AUTHOR</h2>
-Kristian Foerster<br>
-<p><i>Last changed: $Date 2014-09-26$</i>
+Kristian Foerster
+
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->
+

--- a/grass7/raster/r.tri/r.tri.html
+++ b/grass7/raster/r.tri/r.tri.html
@@ -16,4 +16,7 @@ Riley, S. J., S. D. DeGloria and R. Elliot (1999). A terrain ruggedness index th
 <h2>AUTHOR</h2>
 Steven Pawley
 
-<p><em>Last changed: $Date$</em></p>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.univar2/r.univar2.html
+++ b/grass7/raster/r.univar2/r.univar2.html
@@ -133,4 +133,7 @@ Extended statistics by Martin Landa<br>
 Multiple input map support by Ivan Shmakov<br>
 Zonal loop by Markus Metz
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.valley.bottom/r.valley.bottom.html
+++ b/grass7/raster/r.valley.bottom/r.valley.bottom.html
@@ -66,6 +66,7 @@ Water Resources Research, Vol. 39, No. 12, 1347. doi:10.1029/2002WR001426
 
 Helmut Kudrnovsky & Steven Pawley
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
-</p>
+-->

--- a/grass7/raster/r.vect.stats/r.vect.stats.html
+++ b/grass7/raster/r.vect.stats/r.vect.stats.html
@@ -58,5 +58,7 @@ Column and method parameters added by Martin
 Landa, <a href="http://geomatics.fsv.cvut.cz/research/geoforall/">CTU
 GeoForAll Lab</a>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.vector.ruggedness/r.vector.ruggedness.html
+++ b/grass7/raster/r.vector.ruggedness/r.vector.ruggedness.html
@@ -31,4 +31,7 @@ Bighorn Sheep in the Mojave Desert. Journal of Wildlife Management.
 
 Steven Pawley
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.viewshed.cva/r.viewshed.cva.html
+++ b/grass7/raster/r.viewshed.cva/r.viewshed.cva.html
@@ -82,5 +82,7 @@ r.viewshed.cva input=elevation output=peaks_CVA_map \
 
 Isaac Ullah
 
+<!--
 <p>
-<em>Last changed: $Date$</em>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.vif/r.vif.html
+++ b/grass7/raster/r.vif/r.vif.html
@@ -219,4 +219,7 @@ Variance Inflation Factor Cutoff Values. Quality Engineering 14:
 
 Paulo van Breugel, paulo at ecodiv.earth
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.vol.dem/r.vol.dem.html
+++ b/grass7/raster/r.vol.dem/r.vol.dem.html
@@ -132,5 +132,7 @@ Software: Benjamin Ducke
 <p>
 Documentation: Undine Lieberwirth
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.wateroutlet.lessmem/r.wateroutlet.lessmem.html
+++ b/grass7/raster/r.wateroutlet.lessmem/r.wateroutlet.lessmem.html
@@ -22,5 +22,7 @@ to <em><a href="r.water.outlet.html">r.water.outlet</a></em> for more details.
 <br>
 based on <a href="r.water.outlet.html">r.water.outlet</a>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.width.funct/r.width.funct.html
+++ b/grass7/raster/r.width.funct/r.width.funct.html
@@ -74,5 +74,7 @@ n. 9 (2010)</em>
 Margherita Di Leo (grass-dev AT lists DOT osgeo DOT org), Massimo Di 
 Stefano, Francesco Di Stefano
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.zonal.classes/r.zonal.classes.html
+++ b/grass7/raster/r.zonal.classes/r.zonal.classes.html
@@ -107,5 +107,7 @@ Walloon region</a> as part of the WALOUS project.
 
 Tais GRIPPA - Universite Libre de Bruxelles. ANAGEO Lab.
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster3d/r3.count.categories/r3.count.categories.html
+++ b/grass7/raster3d/r3.count.categories/r3.count.categories.html
@@ -27,4 +27,7 @@ between 0 and 100. The values will be then preserved with precision 1
 
 Vaclav Petras, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU GeoForAll Lab</a>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster3d/r3.forestfrag/r3.forestfrag.html
+++ b/grass7/raster3d/r3.forestfrag/r3.forestfrag.html
@@ -88,4 +88,7 @@ Paulo van Breugel,
 main author of the 2D version
 (<em><a href="r.forestfrag.html">r.forestfrag</a></em>)
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster3d/r3.profile/r3.profile.html
+++ b/grass7/raster3d/r3.profile/r3.profile.html
@@ -165,5 +165,7 @@ Approx. transect length: 995.014070 [meters]
 <h2>AUTHOR</h2>
 <a href="mailto:bcovill@tekmap.ns.ca">Bob Covill</a>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster3d/r3.to.group/r3.to.group.html
+++ b/grass7/raster3d/r3.to.group/r3.to.group.html
@@ -28,5 +28,7 @@ r3.to.rast
 
 Vaclav Petras, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU GeoForAll Lab</a><br>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/raster3d/r3.what/r3.what.html
+++ b/grass7/raster3d/r3.what/r3.what.html
@@ -55,4 +55,7 @@ r3.what input=new@user1 coordinates_3d=10,10,1,10,10,11
 <h2>AUTHORS</h2>
 Anna Petrasova, NCSU GeoForAll Lab
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/temporal/t.rast.null/t.rast.null.html
+++ b/grass7/temporal/t.rast.null/t.rast.null.html
@@ -25,5 +25,7 @@ Set specific values (0,-1 and -2) of a space time raster dataset to NULL:
 <h2>AUTHOR</h2>
 Luca Delucchi, Fondazione Edmund Mach
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/temporal/t.rast.what.aggr/t.rast.what.aggr.html
+++ b/grass7/temporal/t.rast.what.aggr/t.rast.what.aggr.html
@@ -146,4 +146,7 @@ cat|station|name|long|lat|fechas|ndvi_mean|ndvi_max|ndvi_16_5600m_minimum|ndvi_1
 
 Luca Delucchi
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/temporal/t.rast.whatcsv/t.rast.whatcsv.html
+++ b/grass7/temporal/t.rast.whatcsv/t.rast.whatcsv.html
@@ -130,4 +130,7 @@ x|y|1990-03-01 00:00:00;1990-04-01 00:00:00|1990-04-01 00:00:00;1990-05-01 00:00
 
 S&ouml;ren Gebbert, Th&uuml;nen Institute of Climate-Smart Agriculture
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.area.weigh/v.area.weigh.html
+++ b/grass7/vector/v.area.weigh/v.area.weigh.html
@@ -46,4 +46,7 @@ v.area.weigh vector=... column=... weight=urban_ngbr5 out=...
 
 Markus Metz
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.build.pg/v.build.pg.html
+++ b/grass7/vector/v.build.pg/v.build.pg.html
@@ -108,5 +108,7 @@ SELECT topology.TopologySummary('topo_bridges')
 
 Martin Landa, Czech Technical University in Prague, Czech Republic
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.centerline/v.centerline.html
+++ b/grass7/vector/v.centerline/v.centerline.html
@@ -124,4 +124,7 @@ Similar addons:
 <h2>AUTHOR</h2>
 Moritz Lennert
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.centerpoint/v.centerpoint.html
+++ b/grass7/vector/v.centerpoint/v.centerpoint.html
@@ -77,4 +77,7 @@ v.centerpoint in=urbanarea out=urbanarea_median acenter=median
 
 Markus Metz
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.class.ml/v.class.ml.html
+++ b/grass7/vector/v.class.ml/v.class.ml.html
@@ -209,5 +209,7 @@ for vector classification which uses <em>mlpy</em>)
 
 Pietro Zambelli, University of Trento
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.class.mlR/v.class.mlR.html
+++ b/grass7/vector/v.class.mlR/v.class.mlR.html
@@ -201,5 +201,7 @@ v.class.mlR segments_file=segstats.csv training_file=training.csv train_class_co
 Moritz Lennert, Université Libre de Bruxelles (ULB)
 based on an initial R-script by Ruben Van De Kerchove, also ULB at the time
 
-
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.class.mlpy/v.class.mlpy.html
+++ b/grass7/vector/v.class.mlpy/v.class.mlpy.html
@@ -111,5 +111,7 @@ D. Albanese, R. Visintainer, S. Merler, S. Riccadonna, G. Jurman, C. Furlanello.
 Vaclav Petras,
 <a href="http://www.cvut.cz">Czech Technical University in Prague</a>, Czech Republic
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.clean.ogr/v.clean.ogr.html
+++ b/grass7/vector/v.clean.ogr/v.clean.ogr.html
@@ -76,5 +76,7 @@ Two new Shapefile layers &quot;research_area_clean&quot; and
 
 Markus Metz<br>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.clip/v.clip.html
+++ b/grass7/vector/v.clip/v.clip.html
@@ -81,5 +81,7 @@ Zofie
 Cimburova, <a href="http://geomatics.fsv.cvut.cz/research/geoforall/">GeoForAll
 Lab</a>, Czech Technical University in Prague, Czech Republic
 
+<!--
 <p>
-<i>Last changed: $Date: 2016-06-28 19:30:00 +0001 (Tue, 28 Jun 2016)$</i>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.colors2/v.colors2.html
+++ b/grass7/vector/v.colors2/v.colors2.html
@@ -95,5 +95,7 @@ d.vect -a tin
 Hamish Bowman<br>
 <i>Dunedin, New Zealand</i>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.concave.hull/v.concave.hull.html
+++ b/grass7/vector/v.concave.hull/v.concave.hull.html
@@ -40,4 +40,7 @@ v.concave.hull in=schools_wake out=schools_wake_concave
 <h2>AUTHOR</h2>
 Markus Metz
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.convert.all/v.convert.all.html
+++ b/grass7/vector/v.convert.all/v.convert.all.html
@@ -40,4 +40,7 @@ v.convert.all
 
 Markus Neteler, ITC-Irst, Trento, Italy
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.convert/v.convert.html
+++ b/grass7/vector/v.convert/v.convert.html
@@ -34,4 +34,7 @@ v.convert in=vectormap_from_50 out=vectormap_60
 
 Radim Blazek, ITC-Irst, Trento, Italy
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.delaunay3d/v.delaunay3d.html
+++ b/grass7/vector/v.delaunay3d/v.delaunay3d.html
@@ -45,5 +45,7 @@ Number of tetrahedrons: 492
 
 Martin Landa, Czech Technical University in Prague, Czech Republic
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.ellipse/v.ellipse.html
+++ b/grass7/vector/v.ellipse/v.ellipse.html
@@ -41,5 +41,7 @@ v.ellipse input=points_of_interest output=ellipse step=1
 
 Tereza Fiedlerova, OSGeoREL, Czech Technical University in Prague, Czech Republic
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.external.all/v.external.all.html
+++ b/grass7/vector/v.external.all/v.external.all.html
@@ -61,5 +61,7 @@ v.external.all -l input=~/geodata/ncshape/
 
 Martin Landa, Czech Technical University in Prague
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.faultdirections/v.faultdirections.html
+++ b/grass7/vector/v.faultdirections/v.faultdirections.html
@@ -43,4 +43,7 @@ v.faultdirections faultmap column=azimuth step=10
 <h2>AUTHOR</h2>
  Moritz Lennert
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.feature.algebra/v.feature.algebra.html
+++ b/grass7/vector/v.feature.algebra/v.feature.algebra.html
@@ -264,5 +264,7 @@ equal sign. The very first expression, hence, will give an error:
 
 Christoph Simon &lt;ciccio at kiosknet com.br&gt;
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.fixed.segmentpoints/v.fixed.segmentpoints.html
+++ b/grass7/vector/v.fixed.segmentpoints/v.fixed.segmentpoints.html
@@ -45,6 +45,7 @@ The <em>category (cat)</em> of the input line is stored in the column
 
 Helmut Kudrnovsky
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
-</p>
+-->

--- a/grass7/vector/v.flexure/v.flexure.html
+++ b/grass7/vector/v.flexure/v.flexure.html
@@ -34,4 +34,7 @@ van Wees, J. D., and S. Cloetingh (1994), A Finite-Difference Technique to Incor
 
 Andrew D. Wickert<br>
 
-<p><i>Last changed: $Date 2015-11-15 (Sun, 15 Nov 2015)$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.gsflow.export/v.gsflow.export.html
+++ b/grass7/vector/v.gsflow.export/v.gsflow.export.html
@@ -27,4 +27,7 @@ Ng, G.-H. C., A. D. Wickert, R. L. McLaughlin, J. La Frenierre, S. Liess, and L.
 
 Andrew D. Wickert<br>
 
-<p><i>Last changed: $Date 2018-04-22$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.gsflow.gravres/v.gsflow.gravres.html
+++ b/grass7/vector/v.gsflow.gravres/v.gsflow.gravres.html
@@ -23,4 +23,7 @@ Francisco, CA.
 
 Andrew D. Wickert<br>
 
-<p><i>Last changed: $Date 2018-04-22$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.gsflow.grid/v.gsflow.grid.html
+++ b/grass7/vector/v.gsflow.grid/v.gsflow.grid.html
@@ -24,4 +24,7 @@ Andrew D. Wickert<br>
 <a href="v.stream.inbasin">v.stream.inbasin</a>,
 <a href="v.stream.network">v.stream.network</a>,
 
-<p><i>Last changed: $Date 2018-04-22$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.gsflow.hruparams/v.gsflow.hruparams.html
+++ b/grass7/vector/v.gsflow.hruparams/v.gsflow.hruparams.html
@@ -23,4 +23,7 @@ Francisco, CA.
 
 Andrew D. Wickert<br>
 
-<p><i>Last changed: $Date 2018-04-22$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.gsflow.mapdata/v.gsflow.mapdata.html
+++ b/grass7/vector/v.gsflow.mapdata/v.gsflow.mapdata.html
@@ -15,14 +15,17 @@ Vector area data with data in the column that is queried that is of "double prec
 Andrew D. Wickert<br>
 
 <h2>SEE ALSO</h2>
-<a href="v.gsflow.export">v.gsflow.export</a><br>
-<a href="v.gsflow.gravres">v.gsflow.gravres</a><br>
-<a href="v.gsflow.grid">v.gsflow.grid</a><br>
-<a href="v.gsflow.hruparams">v.gsflow.hruparams</a><br>
-<a href="v.gsflow.reaches">v.gsflow.reaches</a><br>
-<a href="v.gsflow.segments">v.gsflow.segments</a><br>
-<a href="r.gsflow.hydrodem">r.gsflow.hydrodem</a><br>
-<a href="v.stream.inbasin">v.stream.inbasin</a><br>
+<a href="v.gsflow.export">v.gsflow.export</a>,
+<a href="v.gsflow.gravres">v.gsflow.gravres</a>,
+<a href="v.gsflow.grid">v.gsflow.grid</a>,
+<a href="v.gsflow.hruparams">v.gsflow.hruparams</a>,
+<a href="v.gsflow.reaches">v.gsflow.reaches</a>,
+<a href="v.gsflow.segments">v.gsflow.segments</a>,
+<a href="r.gsflow.hydrodem">r.gsflow.hydrodem</a>,
+<a href="v.stream.inbasin">v.stream.inbasin</a>,
 <a href="v.stream.network">v.stream.network</a>
 
-<p><i>Last changed: $Date 2018-04-22$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.gsflow.reaches/v.gsflow.reaches.html
+++ b/grass7/vector/v.gsflow.reaches/v.gsflow.reaches.html
@@ -23,4 +23,7 @@ Francisco, CA.
 
 Andrew D. Wickert<br>
 
-<p><i>Last changed: $Date 2018-04-22$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.gsflow.segments/v.gsflow.segments.html
+++ b/grass7/vector/v.gsflow.segments/v.gsflow.segments.html
@@ -23,4 +23,7 @@ Francisco, CA.
 
 Andrew D. Wickert<br>
 
-<p><i>Last changed: $Date 2018-04-22$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.habitat.dem/v.habitat.dem.html
+++ b/grass7/vector/v.habitat.dem/v.habitat.dem.html
@@ -242,4 +242,7 @@ Neteler, M. and Mitasova, H. 2008. <a href="http://grassbook.org/">Open Source G
 
 Helmut Kudrnovsky
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.in.gbif/v.in.gbif.html
+++ b/grass7/vector/v.in.gbif/v.in.gbif.html
@@ -53,6 +53,7 @@ instead.
 
 Helmut Kudrnovsky
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
-</p>
+-->

--- a/grass7/vector/v.in.geopaparazzi/v.in.geopaparazzi.html
+++ b/grass7/vector/v.in.geopaparazzi/v.in.geopaparazzi.html
@@ -29,4 +29,7 @@ v.in.geopaparazzi -tz database=/path/to/geopaparazzi.db base=track3d
 
 Luca Delucchi
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.in.gns/v.in.gns.html
+++ b/grass7/vector/v.in.gns/v.in.gns.html
@@ -34,4 +34,7 @@ points map.
 
 Markus Neteler, MPBA Group, ITC-irst, Trento, Italy
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.in.gps/v.in.gps.html
+++ b/grass7/vector/v.in.gps/v.in.gps.html
@@ -95,4 +95,7 @@ happen. We believe that is a <i>gpsbabel</i> trouble in translating
 from <i>garmin</i> to <i>xcsv</i> ... 
 -->
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.in.natura2000/v.in.natura2000.html
+++ b/grass7/vector/v.in.natura2000/v.in.natura2000.html
@@ -96,6 +96,7 @@ output=pa_austria member_state=AT
 
 Helmut Kudrnovsky
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
-</p>
+-->

--- a/grass7/vector/v.in.osm/v.in.osm.html
+++ b/grass7/vector/v.in.osm/v.in.osm.html
@@ -32,5 +32,7 @@ PostgreSQL, PostGIS, <a href="http://wiki.openstreetmap.org/wiki/Osm2pgsql">osm2
 
 Stepan Turek
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.in.ply/v.in.ply.html
+++ b/grass7/vector/v.in.ply/v.in.ply.html
@@ -30,4 +30,7 @@ v.in.ply input=myfile.ply output=myfile
 
 Markus Metz
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.in.redlist/v.in.redlist.html
+++ b/grass7/vector/v.in.redlist/v.in.redlist.html
@@ -41,6 +41,7 @@ One of the species mentioned by <i>-l</i> or <i>-s</i> flag has to be specified 
 
 Helmut Kudrnovsky
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
-</p>
+-->

--- a/grass7/vector/v.in.redwg/v.in.redwg.html
+++ b/grass7/vector/v.in.redwg/v.in.redwg.html
@@ -34,4 +34,7 @@ Not all entity types are supported (warning printed).
 Rodrigo Rodrigues da Silva (pitanga at members dot fsf dot org), São Paulo, Brazil
 <br>based on original code by Radim Blazek, ITC-Irst, Trento, Italy
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.in.survey/v.in.survey.html
+++ b/grass7/vector/v.in.survey/v.in.survey.html
@@ -284,5 +284,7 @@ Engineering. ISSN 1802-2669. pp. tba. doi: tba.
 Eva Stopkova<br>
 functions for DXF conversion are taken from (or based on) the module <i>v.out.dxf</i> (Charles Ehlschlaeger and Radim Blazek)
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.in.wfs2/v.in.wfs2.html
+++ b/grass7/vector/v.in.wfs2/v.in.wfs2.html
@@ -24,5 +24,7 @@ v.in.wfs2 url=http://www2.dmsolutions.ca/cgi-bin/mswfs_gmap output=parks srs=423
 
 Štěpán Turek
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.isochrones/v.isochrones.html
+++ b/grass7/vector/v.isochrones/v.isochrones.html
@@ -96,4 +96,7 @@ v.isochrones map=myroads cost_column=speed start_points=start isochrones=isochro
 <h2>AUTHOR</h2>
 Moritz Lennert
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.krige/v.krige.html
+++ b/grass7/vector/v.krige/v.krige.html
@@ -199,4 +199,7 @@ Isaaks and Srivastava, 1989: "An Introduction to Applied Geostatistics"
 
 Anne Ghisla, Google Summer of Code 2009
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.kriging/v.kriging.html
+++ b/grass7/vector/v.kriging/v.kriging.html
@@ -148,5 +148,8 @@ Eva Stopkova<br>
 functions taken from another modules are cited above the function or at
 the beginning of the file (e.g. <i>quantile.cpp</i> that uses slightly
 modified functions taken from the module <i>r.quantile</i> (Clemens, G.))
+
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.label.sa/v.label.sa.html
+++ b/grass7/vector/v.label.sa/v.label.sa.html
@@ -46,6 +46,10 @@ The algorithm works by the principle of Simulated Annealing.
 
 <h2>AUTHOR</h2>
 Wolf Bergenheim
-<br>
-<p><i>Last changed: $Date$</i>
+
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->
+
 

--- a/grass7/vector/v.lidar.mcc/v.lidar.mcc.html
+++ b/grass7/vector/v.lidar.mcc/v.lidar.mcc.html
@@ -100,5 +100,7 @@ IEEE TRANSACTIONS ON GEOSCIENCE AND REMOTE SENSING 45(4): 1029 - 1038.
 <a href="http://www.fs.fed.us/rm/pubs_other/rmrs_2007_evans_j001.pdf">http://www.fs.fed.us/rm/pubs_other/rmrs_2007_evans_j001.pdf</a><br>
 <a href="http://sourceforge.net/p/mcclidar/wiki/Home/">http://sourceforge.net/p/mcclidar/wiki/Home/</a>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.mapcalc/v.mapcalc.html
+++ b/grass7/vector/v.mapcalc/v.mapcalc.html
@@ -124,5 +124,7 @@ sudo dnf install python-ply
 
 Thomas Leppelt, Soeren Gebbert, Thuenen Institut, Germany <br>
 
-<p><i>Last changed: $Date$</i>
-
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.maxent.swd/v.maxent.swd.html
+++ b/grass7/vector/v.maxent.swd/v.maxent.swd.html
@@ -55,4 +55,7 @@ and subsequently used in other models / functions.
 
 Paulo van Breugel, paulo at ecodiv.earth
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.mrmr/v.mrmr.html
+++ b/grass7/vector/v.mrmr/v.mrmr.html
@@ -56,4 +56,7 @@ Transactions on , vol.27, no.8, pp.1226-1238, Aug. 2005
 
 Steven Pawley
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.neighborhoodmatrix/v.neighborhoodmatrix.html
+++ b/grass7/vector/v.neighborhoodmatrix/v.neighborhoodmatrix.html
@@ -43,4 +43,7 @@ v.neighborhoodmatrix in=census_wake2000 idcolumn=STFID output=census_neighbors.c
 <h2>AUTHOR</h2>
  Moritz Lennert
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.net.curvedarcs/v.net.curvedarcs.html
+++ b/grass7/vector/v.net.curvedarcs/v.net.curvedarcs.html
@@ -73,4 +73,7 @@ d.vect map=points display=shape,cat fill_color=red icon=basic/circle label_bcolo
 
 Moritz Lennert, DGES-ULB
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.net.salesman.opt/v.net.salesman.opt.html
+++ b/grass7/vector/v.net.salesman.opt/v.net.salesman.opt.html
@@ -90,5 +90,7 @@ Radim Blazek, ITC-Irst, Trento, Italy<br>
 Markus Metz<br>
 Documentation: Markus Neteler, Markus Metz
 
-
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.nnstat/v.nnstat.html
+++ b/grass7/vector/v.nnstat/v.nnstat.html
@@ -187,6 +187,7 @@ volume (Minimum Bounding Rectangle area) are based on functions for
 computing convex hull from the module <i>v.hull</i> (Aime, A.,
 Neteler, M., Ducke, B., Landa, M.)
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
-
+-->

--- a/grass7/vector/v.out.gps/v.out.gps.html
+++ b/grass7/vector/v.out.gps/v.out.gps.html
@@ -93,4 +93,7 @@ cs2cs from <a href="http://proj.osgeo.org">PROJ.4</a><br>
 <h2>AUTHOR</h2>
 Hamish Bowman, Dunedin New Zealand
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.out.ply/v.out.ply.html
+++ b/grass7/vector/v.out.ply/v.out.ply.html
@@ -29,4 +29,7 @@ Markus Metz
 <br>
 based on <a href="v.out.ascii.html">v.out.ascii</a>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.out.png/v.out.png.html
+++ b/grass7/vector/v.out.png/v.out.png.html
@@ -26,4 +26,7 @@ georeferencing support using the <b>-w</b> flag.
 Luca Delucchi<br>
 World file support by Anika Bettge and Markus Neteler
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.ply.rectify/v.ply.rectify.html
+++ b/grass7/vector/v.ply.rectify/v.ply.rectify.html
@@ -59,4 +59,7 @@ the georeferenced point cloud shifted to the coordinates' center, and
 
 Markus Metz
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.profile.points/v.profile.points.html
+++ b/grass7/vector/v.profile.points/v.profile.points.html
@@ -54,4 +54,7 @@ v.profile.points input_file=.../points.las output=points_profile width=5 \
 <h2>AUTHOR</h2>
 Vaclav Petras, <a href="https://geospatial.ncsu.edu/osgeorel/">NCSU GeoForAll Lab</a>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.profile/v.profile.html
+++ b/grass7/vector/v.profile/v.profile.html
@@ -82,4 +82,7 @@ issue tracker should be opened.
 
 Maris Nartiss
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.rast.bufferstats/v.rast.bufferstats.html
+++ b/grass7/vector/v.rast.bufferstats/v.rast.bufferstats.html
@@ -64,4 +64,7 @@ https://trac.osgeo.org/grass/ticket/3628
 <h2>AUTHOR</h2>
 Stefan Blumentrath, Norwegian Institute for Nature Research, Oslo, Norway
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.sort.points/v.sort.points.html
+++ b/grass7/vector/v.sort.points/v.sort.points.html
@@ -21,4 +21,7 @@ d.vect -r map=sorted_schools@user1 type=point,line,boundary,area,face width=1 ic
 <h2>AUTHOR</h2>
 Moritz Lennert
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.stats/v.stats.html
+++ b/grass7/vector/v.stats/v.stats.html
@@ -6,4 +6,7 @@ The <em>v.stats</em> calculates vector statistics.
 
  Pietro Zambelli (University of Trento)
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.strds.stats/v.strds.stats.html
+++ b/grass7/vector/v.strds.stats/v.strds.stats.html
@@ -23,5 +23,7 @@ v.strds.stats input=myvector strds=mystrds output=newvector
 
 Luca Delucchi, Fondazione Edmund Mach
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.stream.inbasin/v.stream.inbasin.html
+++ b/grass7/vector/v.stream.inbasin/v.stream.inbasin.html
@@ -18,4 +18,7 @@ Francisco, CA.
 
 Andrew D. Wickert<br>
 
-<p><i>Last changed: $Date 2016-09-27$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.stream.network/v.stream.network.html
+++ b/grass7/vector/v.stream.network/v.stream.network.html
@@ -42,8 +42,11 @@ r.stream_extract(elevation=elevation, accumulation='drainageArea_m2', threshold=
 
 None (yet)
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Andrew D. Wickert<br>
 
-<p><i>Last changed: $Date 2016-09-27$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.stream.order/v.stream.order.html
+++ b/grass7/vector/v.stream.order/v.stream.order.html
@@ -194,5 +194,7 @@ v.db.select stream_network_order | less
 <p>Documentation of the implemented algorithms are in most parts copied from 
    r.stream.order implemented by: Jarek  Jasiewicz and Markus Metz</p>
 
-<p><i>Last changed: $Date$</i>
-
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.stream.profiler/v.stream.profiler.html
+++ b/grass7/vector/v.stream.profiler/v.stream.profiler.html
@@ -18,4 +18,7 @@ None (yet)
 
 Andrew D. Wickert<br>
 
-<p><i>Last changed: $Date 2018-04-22$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.surf.icw/v.surf.icw.html
+++ b/grass7/vector/v.surf.icw/v.surf.icw.html
@@ -137,5 +137,7 @@ Hamish Bowman<br>
 <i>Department of Marine Science,<br>
 Dunedin, New Zealand</i>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.surf.mass/v.surf.mass.html
+++ b/grass7/vector/v.surf.mass/v.surf.mass.html
@@ -84,5 +84,7 @@ Regions. Journal of the American Statistical Association, 74 (367):
 
 Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.surf.nnbathy/v.surf.nnbathy.html
+++ b/grass7/vector/v.surf.nnbathy/v.surf.nnbathy.html
@@ -81,5 +81,7 @@ Based on v.surf.nnbathy from GRASS 6 by:<br>
 Hamish Bowman, Otago University, New Zealand<br>
 Based on <em>r.surf.nnbathy</em> by Maciej Sieczka<br>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.surf.tps/v.surf.tps.html
+++ b/grass7/vector/v.surf.tps/v.surf.tps.html
@@ -137,5 +137,7 @@ optipng -o5 v_surf_tps.png
 
 Markus Metz
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.tin.to.rast/v.tin.to.rast.html
+++ b/grass7/vector/v.tin.to.rast/v.tin.to.rast.html
@@ -9,6 +9,8 @@ TBD
 
 Antonio Alliegro, Alexander Muriy
 
+
+<!--
 <p>
 <i>Last changed: $Date$</i>
-
+-->

--- a/grass7/vector/v.transects/v.transects.html
+++ b/grass7/vector/v.transects/v.transects.html
@@ -105,5 +105,8 @@ v.db.select NH_2008_areas
 
 <h2>AUTHOR</h2>
 Eric Hardin, Helena Mitasova, Updates by John Lloyd 
+
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.vol.idw/v.vol.idw.html
+++ b/grass7/vector/v.vol.idw/v.vol.idw.html
@@ -42,4 +42,7 @@ University of Presov, Presov, Slovakia,
     Anna University, India.
     <a href="mailto:jnoortheen@gmail.com">jnoortheen@gmail.com</a>
 
-<p><i>Last changed: $Date$</i>
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.what.rast.multi/v.what.rast.multi.html
+++ b/grass7/vector/v.what.rast.multi/v.what.rast.multi.html
@@ -56,5 +56,7 @@ v.db.select map=mygeodetic_pts columns=elevatin,slope,aspect separator=comma whe
 <h2>AUTHORS</h2>
 Pierre Roudier<br>
 
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/grass7/vector/v.what.strds.timestamp/v.what.strds.timestamp.html
+++ b/grass7/vector/v.what.strds.timestamp/v.what.strds.timestamp.html
@@ -33,5 +33,8 @@ TBD
 Stefan Blumentrath, Norwegian Institute for Nature Research (NINA)<br>
 Written for the 2018 <a href="irsae.no">IRSAE</a> GRASS GIS course at 
 Studenterhytta, Oslo
-<br>
-<p></p><i>Last changed: $Date$</i>
+
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->


### PR DESCRIPTION
Since the SVN Date tag concept is not supported in git, commented out for now in manual pages.

See related https://github.com/OSGeo/grass/pull/200 (https://github.com/OSGeo/grass/commit/69be6c5f9a8d794ecffb9b8072c6e932984d07e5)