### PR TITLE
i.sentinel.download: -l flag list scene names

### DIFF
--- a/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -294,8 +294,9 @@ class SentinelDownloader(object):
             else:
                 ccp = 'cloudcover_NA'
 
-            print('{0} {1} {2} {3}'.format(
+            print('{0} {1} {2} {3} {4}'.format(
                 self._products_df_sorted['uuid'][idx],
+                self._products_df_sorted['identifier'][idx],
                 self._products_df_sorted['beginposition'][idx].strftime("%Y-%m-%dT%H:%M:%SZ"),
                 ccp,
                 self._products_df_sorted['producttype'][idx],


### PR DESCRIPTION
Since Sentinel scene name lookup from UUID is rather difficult, here a change to also include the names when -l listing Sentinel scenes.

Current version:
```
i.sentinel.download -l settings=~/.sentinel_esa producttype=S2MSI2A start=2018-03-01 end=2019-12-31 cloud=25 sort=ingestiondate map=kleve_krefeld_viersen_wesel_dp -b 
Generating WKT from AOI map (76 vertices)...
Sending WKT from AOI map to ESA...
Querying products: 100%|| 297/297 [00:12<00:00, 22.94 products/s]
297 Sentinel product(s) found
66421c1c-fb97-4379-9ffe-46d9096d5c65 2018-04-06T10:50:29Z  4% S2MSI2A
466c7407-5e0a-4abf-bf05-7bc482a6d8b7 2018-04-06T10:50:29Z  1% S2MSI2A
09d6cdee-77e3-495d-9c2b-228a8f892a81 2018-04-06T10:50:29Z 11% S2MSI2A
4edd776f-276b-4f5d-98f9-0ef7b18aa138 2018-04-06T10:50:29Z 10% S2MSI2A
b3f2b519-39fa-4815-ab2b-081e1fc7cc76 2018-04-18T10:40:21Z 16% S2MSI2A
6b045a93-4f22-46af-b037-c75bbceaa1ac 2018-04-18T10:40:21Z 20% S2MSI2A
...
```

Proposed new version:
```
i.sentinel.download -l settings=~/.sentinel_esa producttype=S2MSI2A start=2018-03-01 end=2019-12-31 cloud=25 sort=ingestiondate map=kleve_krefeld_viersen_wesel_dp -b 
Generating WKT from AOI map (76 vertices)...
Sending WKT from AOI map to ESA...
Querying products: 100%| 297/297 [00:14<00:00, 20.14 products/s]
297 Sentinel product(s) found
66421c1c-fb97-4379-9ffe-46d9096d5c65 S2B_MSIL2A_20180406T105029_N0207_R051_T32ULB_20180406T125448 2018-04-06T10:50:29Z  4% S2MSI2A
466c7407-5e0a-4abf-bf05-7bc482a6d8b7 S2B_MSIL2A_20180406T105029_N0207_R051_T31UGS_20180406T125448 2018-04-06T10:50:29Z  1% S2MSI2A
09d6cdee-77e3-495d-9c2b-228a8f892a81 S2B_MSIL2A_20180406T105029_N0207_R051_T31UGT_20180406T125448 2018-04-06T10:50:29Z 11% S2MSI2A
4edd776f-276b-4f5d-98f9-0ef7b18aa138 S2B_MSIL2A_20180406T105029_N0207_R051_T32ULC_20180406T125448 2018-04-06T10:50:29Z 10% S2MSI2A
b3f2b519-39fa-4815-ab2b-081e1fc7cc76 S2A_MSIL2A_20180418T104021_N0207_R008_T32ULB_20180418T125356 2018-04-18T10:40:21Z 16% S2MSI2A
6b045a93-4f22-46af-b037-c75bbceaa1ac S2A_MSIL2A_20180418T104021_N0207_R008_T31UGS_20180418T125356 2018-04-18T10:40:21Z 20% S2MSI2A
...
```

The code change in this PR is rather trivial...