### PR TITLE
Opening in byte creates problems in Python 3

### DIFF
--- a/grass7/imagery/i.segment.stats/i.segment.stats.py
+++ b/grass7/imagery/i.segment.stats/i.segment.stats.py
@@ -331,7 +331,7 @@ def main():
     error_objects = []
 
     if csvfile:
-        with open(csvfile, 'wb') as f:
+        with open(csvfile, 'w') as f:
             f.write(separator.join(output_header)+"\n")
             for key in output_dict:
                 if len(output_dict[key]) + 1 == len(output_header):


### PR DESCRIPTION
I don't remember why the csv output file was opened with 'wb', but in Python 3 this causes a TypeError when one tries to write a string to it.
Don't know if this is the right solution. If someone with more Python string handling notions than me sees an issue with this please shout out. Otherwise I'll commit soon.