### PR TITLE
i.modis: fix python3 issues

### DIFF
--- a/grass7/imagery/i.modis/i.modis.import/i.modis.import.py
+++ b/grass7/imagery/i.modis/i.modis.import/i.modis.import.py
@@ -107,7 +107,6 @@
 
 import os
 import sys
-import string
 import glob
 import shutil
 import grass.script as grass
@@ -155,10 +154,10 @@ def list_files(opt, mosaik=False):
             filelist = []
         # append hdf files
         for line in listoffile:
-            if string.find(line, 'xml') == -1 and mosaik is False:
+            if line.find('xml') == -1 and mosaik is False:
                 filelist.append(line.strip())
             # for mosaic create a list of hdf files for each day
-            elif string.find(line, 'xml') == -1 and mosaik is True:
+            elif line.find('xml') == -1 and mosaik is True:
                 day = line.split('/')[-1].split('.')[1]
                 if day in filelist:
                     filelist[day].append(line.strip())
@@ -410,7 +409,7 @@ def mosaic(options, remove, an, ow, fil):
     dictfile, targetdir = list_files(options, True)
     pid = str(os.getpid())
     # for each day
-    for dat, listfiles in dictfile.iteritems():
+    for dat, listfiles in dictfile.items():
         pref = listfiles[0].split('/')[-1]
         prod = product().fromcode(pref.split('.')[0])
         spectr = spectral(options, prod, an)

--- a/grass7/imagery/i.modis/libmodis/rmodislib.py
+++ b/grass7/imagery/i.modis/libmodis/rmodislib.py
@@ -299,9 +299,9 @@ class product:
                                }
 
     def returned(self):
-        if self.products.keys().count(self.prod) == 1:
+        if list(self.products.keys()).count(self.prod) == 1:
             return self.products[self.prod]
-        elif self.products_swath.keys().count(self.prod) == 1:
+        elif list(self.products_swath.keys()).count(self.prod) == 1:
             return self.products_swath[self.prod]
         else:
             grass.fatal(_("The MODIS product inserted is not supported yet. "
@@ -343,9 +343,9 @@ class product:
     def __str__(self):
         prod = self.returned()
         string = "product: " + prod['prod'] + ", url: " + prod['url']
-        if prod.keys().count('spec') == 1:
+        if list(prod.keys()).count('spec') == 1:
             string += ", spectral_subset: " + prod['spec']
-        if prod.keys().count('spec_qa') == 1:
+        if list(prod.keys()).count('spec_qa') == 1:
             if prod['spec_qa'] != None:
                 string += ", spectral_subset_qa:" + prod['spec_qa']
         return string

--- a/grass7/imagery/i.modis/libmodis/rmodislib.py
+++ b/grass7/imagery/i.modis/libmodis/rmodislib.py
@@ -309,12 +309,11 @@ class product:
                           "for future support"))
 
     def fromcode(self, code):
-        import string
-        for k, v in self.products.iteritems():
-            if string.find(v['prod'], code) != -1:
+        for k, v in self.products.items():
+            if v['prod'].find(code) != -1:
                 return self.products[k]
-        for k, v in self.products_swath.iteritems():
-            if string.find(v['prod'], code) != -1:
+        for k, v in self.products_swath.items():
+            if v['prod'].find(code) != -1:
                 return self.products_swath[k]
         grass.fatal(_("The MODIS product inserted is not supported yet. "
                       "Consider to ask on the grass-dev mailing list "


### PR DESCRIPTION
This PR fixes Python3-related issue of rmodislib. Currently `i.modis.download` fails with

```
Traceback (most recent call last):
  File "/home/martin/.grass7/addons/scripts/i.modis.download", line 274, in <module>
    sys.exit(main())
  File "/home/martin/.grass7/addons/scripts/i.modis.download", line 246, in main
    prod = product(produ).returned()
  File "/home/martin/.grass7/addons/etc/i.modis/rmodislib.py", line 302, in returned
    if self.products.keys().count(self.prod) == 1:
AttributeError: 'dict_keys' object has no attribute 'count'
```

Summary:

* dict_keys -> list
* string.find() to var.find()
* iteritems() -> items()