### PR TITLE
Fix trac #3818 (bug in modules.xml: double man1 in path), possibly

### DIFF
--- a/tools/addons/compile.sh
+++ b/tools/addons/compile.sh
@@ -96,7 +96,7 @@ for c in "db" "display" "general" "gui/wxpython" "imagery" "misc" "raster" "rast
 	make MODULE_TOPDIR="$TOPDIR" \
 	    BIN="$path/bin" \
 	    HTMLDIR="$path/docs/html" \
-	    MANBASEDIR="$path/docs/man/man1" \
+	    MANBASEDIR="$path/docs/man" \
 	    SCRIPTDIR="$path/scripts" \
 	    ETC="$path/etc" \
             SOURCE_URL="https://github.com/OSGeo/grass-addons/tree/master/grass${GRASS_VERSION}/" > \


### PR DESCRIPTION
This might fix [#3818](https://trac.osgeo.org/grass/ticket/3818). I can't test this fix, but reviewing the code behind https://grass.osgeo.org/addons/grass7/modules.xml and comparing with similar code in  [g.extension.py:1317](https://github.com/OSGeo/grass/blob/ac8bd2777492fa11e3ab46b418f70fc01c5714a4/scripts/g.extension/g.extension.py#L1317) make me believe this can be the cause of the problem.

The modules.xml is generated along addon compilation on server, with log file inluding this double-man1 directory, see eg. https://grass.osgeo.org/addons/grass7/logs/db.join.log:
```
...
mkdir -p /tmp/.grass7/addons/db.join/docs/html
mkdir -p /tmp/.grass7/addons/db.join/docs/man/man1
mkdir -p /tmp/.grass7/addons/db.join/docs/man/man1/man1
mkdir -p /tmp/.grass7/addons/db.join/scripts
...
VERSION_NUMBER=7.8.3dev /work/src/grass78/dist.x86_64-pc-linux-gnu/tools/g.html2man.py \
"/tmp/.grass7/addons/db.join/docs/html/db.join.html" \ 
"/tmp/.grass7/addons/db.join/docs/man/man1/man1/db.join.1"
...
```
