### PR TITLE
Remove '# -*- coding: utf-8 -*-' from supply_and_use.py

### DIFF
--- a/grass7/raster/r.estimap.recreation/estimap_recreation/supply_and_use.py
+++ b/grass7/raster/r.estimap.recreation/estimap_recreation/supply_and_use.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 @author Nikos Alexandris
 """


### PR DESCRIPTION
Apparently this instruction
```
# -*- coding: utf-8 -*-
```
fails to pass through https://github.com/OSGeo/grass/blob/0a4d715a7e975b7508592566cae2aad636e8ac99/scripts/g.extension/g.extension.py#L1057
