### PR TITLE
r.richdem.*: lazy import RICHDEM so manuals get built

### DIFF
--- a/grass7/raster/r.richdem.breachdepressions/r.richdem.breachdepressions.py
+++ b/grass7/raster/r.richdem.breachdepressions/r.richdem.breachdepressions.py
@@ -16,7 +16,7 @@
 #############################################################################
 #
 # REQUIREMENTS: richdem
- 
+
 # More information
 # Started June 2019
 
@@ -57,14 +57,7 @@ import numpy as np
 from grass import script as gscript
 from grass.script import array as garray
 from grass.pygrass.modules.shortcuts import general as g
-# RICHDEM
-try:
-    import richdem as rd
-except:
-    g.message(flags='e', message=('RichDEM not detected. Install pip3 and '+
-                                  'then type at the command prompt: '+
-                                  '"pip3 install richdem".'))
-        
+
 ###############
 # MAIN MODULE #
 ###############
@@ -73,22 +66,28 @@ def main():
     """
     RichDEM depression breaching
     """
-    
+    # lazy import RICHDEM
+    try:
+        import richdem as rd
+    except:
+        g.message(flags='e', message=('RichDEM not detected. Install pip3 and '+
+                                      'then type at the command prompt: '+
+                                      '"pip3 install richdem".'))
+
     options, flags = gscript.parser()
     _input = options['input']
     _output = options['output']
     _topology = options['topology']
-    
+
     dem = garray.array()
     dem.read(_input, null=np.nan)
-    
+
     rd_inout = rd.rdarray(dem, no_data=np.nan)
     rd.BreachDepressions(dem=rd_inout, in_place=True,
                        topology=_topology)
-    
+
     dem[:] = rd_inout[:]
     dem.write(_output, overwrite=gscript.overwrite())
 
 if __name__ == "__main__":
     main()
-    

--- a/grass7/raster/r.richdem.filldepressions/r.richdem.filldepressions.py
+++ b/grass7/raster/r.richdem.filldepressions/r.richdem.filldepressions.py
@@ -16,7 +16,7 @@
 #############################################################################
 #
 # REQUIREMENTS: richdem
- 
+
 # More information
 # Started June 2019
 
@@ -69,14 +69,7 @@ import numpy as np
 from grass import script as gscript
 from grass.script import array as garray
 from grass.pygrass.modules.shortcuts import general as g
-# RICHDEM
-try:
-    import richdem as rd
-except:
-    g.message(flags='e', message=('RichDEM not detected. Install pip3 and '+
-                                  'then type at the command prompt: '+
-                                  '"pip3 install richdem".'))
-        
+
 ###############
 # MAIN MODULE #
 ###############
@@ -85,13 +78,20 @@ def main():
     """
     RichDEM depression filling
     """
-    
+    # lazy import RICHDEM
+    try:
+        import richdem as rd
+    except:
+        g.message(flags='e', message=('RichDEM not detected. Install pip3 and '+
+                                      'then type at the command prompt: '+
+                                      '"pip3 install richdem".'))
+
     options, flags = gscript.parser()
     _input = options['input']
     _output = options['output']
     _epsilon = options['epsilon']
     _topology = options['topology']
-    
+
     if _epsilon == 'true':
         epsilon = True
     else:
@@ -99,14 +99,13 @@ def main():
 
     dem = garray.array()
     dem.read(_input, null=np.nan)
-    
+
     rd_inout = rd.rdarray(dem, no_data=np.nan)
     rd.FillDepressions(dem=rd_inout, epsilon=epsilon, in_place=True,
                        topology=_topology)
-    
+
     dem[:] = rd_inout[:]
     dem.write(_output, overwrite=gscript.overwrite())
 
 if __name__ == "__main__":
     main()
-    

--- a/grass7/raster/r.richdem.flowaccumulation/r.richdem.flowaccumulation.py
+++ b/grass7/raster/r.richdem.flowaccumulation/r.richdem.flowaccumulation.py
@@ -16,7 +16,7 @@
 #############################################################################
 #
 # REQUIREMENTS: richdem
- 
+
 # More information
 # Started June 2019
 
@@ -70,14 +70,7 @@ import numpy as np
 from grass import script as gscript
 from grass.script import array as garray
 from grass.pygrass.modules.shortcuts import general as g
-# RICHDEM
-try:
-    import richdem as rd
-except:
-    g.message(flags='e', message=('RichDEM not detected. Install pip3 and '+
-                                  'then type at the command prompt: '+
-                                  '"pip3 install richdem".'))
-        
+
 ###############
 # MAIN MODULE #
 ###############
@@ -86,14 +79,21 @@ def main():
     """
     RichDEM flat resolution: give a gentle slope
     """
-    
+    # lazy import RICHDEM
+    try:
+        import richdem as rd
+    except:
+        g.message(flags='e', message=('RichDEM not detected. Install pip3 and '+
+                                      'then type at the command prompt: '+
+                                      '"pip3 install richdem".'))
+
     options, flags = gscript.parser()
     _input = options['input']
     _output = options['output']
     _method = options['method']
     _exponent = options['exponent']
     _weights = options['weights']
-    
+
     if (_method == 'Holmgren') or (_method == 'Freeman'):
         if _exponent == '':
             g.message(flags='w', message=('Exponent must be defined for '+
@@ -103,32 +103,31 @@ def main():
         else:
             _exponent = float(_exponent)
     else:
-        _exponent = None 
-    
+        _exponent = None
+
     if _weights == '':
-        rd_weights = None 
+        rd_weights = None
     else:
         g_weights = garray.array()
         g_weights.read(_weights, null=np.nan)
         rd_weights = rd.rdarray(g_weights, no_data=np.nan)
-        
-    
+
+
     dem = garray.array()
     dem.read(_input, null=np.nan)
-    
+
     mask = dem*0 + 1
-    
+
     rd_input = rd.rdarray(dem, no_data=np.nan)
     del dem
     rd_output = rd.FlowAccumulation(dem=rd_input, method=_method,
                         exponent=_exponent, weights=rd_weights, in_place=False)
-    
+
     rd_output *= mask
-    
+
     accum = garray.array()
     accum[:] = rd_output[:]
     accum.write(_output, overwrite=gscript.overwrite())
 
 if __name__ == "__main__":
     main()
-    

--- a/grass7/raster/r.richdem.resolveflats/r.richdem.resolveflats.py
+++ b/grass7/raster/r.richdem.resolveflats/r.richdem.resolveflats.py
@@ -16,7 +16,7 @@
 #############################################################################
 #
 # REQUIREMENTS: richdem
- 
+
 # More information
 # Started June 2019
 
@@ -47,14 +47,7 @@ import numpy as np
 from grass import script as gscript
 from grass.script import array as garray
 from grass.pygrass.modules.shortcuts import general as g
-# RICHDEM
-try:
-    import richdem as rd
-except:
-    g.message(flags='e', message=('RichDEM not detected. Install pip3 and '+
-                                  'then type at the command prompt: '+
-                                  '"pip3 install richdem".'))
-        
+
 ###############
 # MAIN MODULE #
 ###############
@@ -63,7 +56,14 @@ def main():
     """
     RichDEM flat resolution: give a gentle slope
     """
-    
+    # lazy import RICHDEM
+    try:
+        import richdem as rd
+    except:
+        g.message(flags='e', message=('RichDEM not detected. Install pip3 and '+
+                                      'then type at the command prompt: '+
+                                      '"pip3 install richdem".'))
+
     options, flags = gscript.parser()
     _input = options['input']
     _output = options['output']
@@ -72,16 +72,15 @@ def main():
     _rasters = np.array(gscript.parse_command('g.list', type='raster').keys())
     if (_rasters == _output).any():
         g.message(flags='e', message="output would overwrite "+_output)
-    
+
     dem = garray.array()
     dem.read(_input, null=np.nan)
-    
+
     rd_input = rd.rdarray(dem, no_data=np.nan)
     rd_output = rd.ResolveFlats(rd_input)
-    
+
     dem[:] = rd_output[:]
     dem.write(_output, overwrite=gscript.overwrite())
 
 if __name__ == "__main__":
     main()
-    

--- a/grass7/raster/r.richdem.terrainattribute/r.richdem.terrainattribute.py
+++ b/grass7/raster/r.richdem.terrainattribute/r.richdem.terrainattribute.py
@@ -16,7 +16,7 @@
 #############################################################################
 #
 # REQUIREMENTS: richdem
- 
+
 # More information
 # Started June 2019
 
@@ -64,14 +64,7 @@ import numpy as np
 from grass import script as gscript
 from grass.script import array as garray
 from grass.pygrass.modules.shortcuts import general as g
-# RICHDEM
-try:
-    import richdem as rd
-except:
-    g.message(flags='e', message=('RichDEM not detected. Install pip3 and '+
-                                  'then type at the command prompt: '+
-                                  '"pip3 install richdem".'))
-        
+
 ###############
 # MAIN MODULE #
 ###############
@@ -80,25 +73,31 @@ def main():
     """
     RichDEM flat resolution: give a gentle slope
     """
-    
+    # lazy import RICHDEM
+    try:
+        import richdem as rd
+    except:
+        g.message(flags='e', message=('RichDEM not detected. Install pip3 and '+
+                                      'then type at the command prompt: '+
+                                      '"pip3 install richdem".'))
+
     options, flags = gscript.parser()
     _input = options['input']
     _output = options['output']
     _attribute = options['attribute']
     _zscale = float(options['zscale'])
-    
+
     dem = garray.array()
     dem.read(_input, null=np.nan)
-    
+
     rd_input = rd.rdarray(dem, no_data=np.nan)
     del dem
     rd_output = rd.TerrainAttribute(dem=rd_input, attrib=_attribute,
                                     zscale=_zscale)
-    
+
     outarray = garray.array()
     outarray[:] = rd_output[:]
     outarray.write(_output, overwrite=gscript.overwrite())
 
 if __name__ == "__main__":
     main()
-    


### PR DESCRIPTION
Currently, manuals for r.richdem.* are not built because richdem cannot be imported on built server.
Lazy importing richdem should solve this...