### PR TITLE
i.sentinel.import: use footprint to delete nodata border from imported bands

### DIFF
--- a/grass7/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
@@ -500,27 +500,28 @@ class SentinelImporter(object):
                     ))
                 fd.write(os.linesep)
 
-    def set_footprint(self,fp):
-        reg_name = "tmpregion_%s"%(str(os.getpid()))
-        gs.run_command('g.region',save=reg_name)
-        fp_dict={}
-        idlist = [x for x in gs.parse_command('v.db.select',map=fp)]
+    def set_footprint(self, fp):
+        reg_name = "tmpregion_%s" % (str(os.getpid()))
+        gs.run_command('g.region', save=reg_name)
+        fp_dict = {}
+        idlist = [x for x in gs.parse_command('v.db.select', map=fp)]
         cat_idx = idlist[0].split('|').index('cat')
         ident_idx = idlist[0].split('|').index('identifier')
 
         for item in idlist[1:]:
             tmp_key = item.split('|')[ident_idx]
-            key = "%s_%s"%(tmp_key.split('_')[5],tmp_key.split('_')[2])
+            key = "%s_%s" % (tmp_key.split('_')[5], tmp_key.split('_')[2])
             fp_dict[key] = item.split('|')[cat_idx]
-        fp_rast_name = "fp_rast_%s"%(str(os.getpid()))
+        fp_rast_name = "fp_rast_%s" % (str(os.getpid()))
         for map in imported_map_list:
-            gs.run_command('g.region',raster=map)
-            gs.run_command('v.to.rast',input=fp,cats=fp_dict['%s_%s'%(map.split('_')[0],map.split('_')[1])],use="val",value=1,memory=options['memory'], output=fp_rast_name)
-            gs.run_command('r.mapcalc',expression='tmp_%s = if(isnull(%s),null(),%s)'%(map,fp_rast_name,map))
-            gs.run_command('g.rename',raster='tmp_%s,%s'%(map,map))
-            gs.run_command('g.remove',type="raster",name=fp_rast_name,flags='f')
-        gs.run_command('g.region',region=reg_name)
-        gs.run_command('g.remove',type="region",name=reg_name,flags='f')
+            gs.run_command('g.region', raster=map)
+            gs.run_command('v.to.rast', input=fp, cats=fp_dict['%s_%s' % (map.split('_')[0], map.split('_')[1])], use="val",
+                           value=1, memory=options['memory'], output=fp_rast_name)
+            gs.run_command('r.mapcalc', expression='tmp_%s = if(isnull(%s),null(),%s)' % (map, fp_rast_name, map))
+            gs.run_command('g.rename', raster='tmp_%s,%s' % (map, map))
+            gs.run_command('g.remove', type="raster", name=fp_rast_name, flags='f')
+        gs.run_command('g.region', region=reg_name)
+        gs.run_command('g.remove', type="region", name=reg_name, flags='f')
 
 def main():
     global imported_map_list

--- a/grass7/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
@@ -511,12 +511,11 @@ class SentinelImporter(object):
             key = "%s_%s" % (tmp_key.split('_')[5], tmp_key.split('_')[2])
             fp_dict[key] = item.split('|')[cat_idx]
         fp_rast_name = "fp_rast_%s" % (str(os.getpid()))
+        gs.use_temp_region()
         for map in imported_map_list:
             wherestring = "cat = "+ fp_dict['%s_%s'%(map.split('_')[0],map.split('_')[1])]
             reg = gs.parse_command("v.db.select", flags="r", map=fp, where=wherestring)
-            gs.use_temp_region()
             gs.run_command('g.region', align=map, n=reg["n"], s=reg["s"], e=reg["e"], w=reg["w"])
-
             gs.run_command('v.to.rast', input=fp, cats=fp_dict['%s_%s' % (map.split('_')[0], map.split('_')[1])], use="val",
                            value=1, memory=options['memory'], output=fp_rast_name)
             gs.run_command('r.mapcalc', expression='tmp_%s = round(if(isnull(%s),null(),%s))' % (map, fp_rast_name, map))

--- a/grass7/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
@@ -517,8 +517,8 @@ class SentinelImporter(object):
             gs.run_command('g.region', raster=map)
             gs.run_command('v.to.rast', input=fp, cats=fp_dict['%s_%s' % (map.split('_')[0], map.split('_')[1])], use="val",
                            value=1, memory=options['memory'], output=fp_rast_name)
-            gs.run_command('r.mapcalc', expression='tmp_%s = if(isnull(%s),null(),%s)' % (map, fp_rast_name, map))
-            gs.run_command('g.rename', raster='tmp_%s,%s' % (map, map))
+            gs.run_command('r.mapcalc', expression='tmp_%s = round(if(isnull(%s),null(),%s))' % (map, fp_rast_name, map))
+            gs.run_command('g.rename', raster='tmp_%s,%s' % (map, map), overwrite=True)
             gs.run_command('g.remove', type="raster", name=fp_rast_name, flags='f')
         gs.run_command('g.region', region=reg_name)
         gs.run_command('g.remove', type="region", name=reg_name, flags='f')

--- a/grass7/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
@@ -499,25 +499,8 @@ class SentinelImporter(object):
                         br='S2_{}'.format(band_ref)
                     ))
                 fd.write(os.linesep)
-def main():
-    global imported_map_list
 
-    importer = SentinelImporter(options['input'], options['unzip_dir'])
-
-    importer.filter(options['pattern'])
-    if len(importer.files) < 1:
-        gs.fatal(_('Nothing found to import. Please check input and pattern options.'))
-
-    if flags['p']:
-        if options['register_output']:
-            gs.warning(_("Register output file name is not created "
-                         "when -{} flag given").format('p'))
-        importer.print_products()
-        return 0
-
-    importer.import_products(flags['r'], flags['l'], flags['o'])
-    if options['footprints']:
-        fp = options['footprints']
+    def set_footprint(self,fp):
         reg_name = "tmpregion_%s"%(str(os.getpid()))
         gs.run_command('g.region',save=reg_name)
         fp_dict={}
@@ -538,6 +521,27 @@ def main():
             gs.run_command('g.remove',type="raster",name=fp_rast_name,flags='f')
         gs.run_command('g.region',region=reg_name)
         gs.run_command('g.remove',type="region",name=reg_name,flags='f')
+
+def main():
+    global imported_map_list
+
+    importer = SentinelImporter(options['input'], options['unzip_dir'])
+
+    importer.filter(options['pattern'])
+    if len(importer.files) < 1:
+        gs.fatal(_('Nothing found to import. Please check input and pattern options.'))
+
+    if flags['p']:
+        if options['register_output']:
+            gs.warning(_("Register output file name is not created "
+                         "when -{} flag given").format('p'))
+        importer.print_products()
+        return 0
+
+    importer.import_products(flags['r'], flags['l'], flags['o'])
+
+    if options['footprints']:
+        importer.set_footprint(options['footprints'])
 
     importer.write_metadata()
 

--- a/grass7/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
@@ -54,7 +54,7 @@
 #%end
 #%option G_OPT_V_INPUT
 #% key: footprints
-#% description: Name of vector input map with Sentinel-2 footprints to limit import extent to not-null data.
+#% description: Name of vector input map with Sentinel-2 footprints to limit import extent to non NULL data
 #% required: no
 #%end
 #%option


### PR DESCRIPTION
work in progress: adds option to pass a vector footprint which is downloaded from i.sentinel.download. The footprint is then used to remove no-data from the imported bands.