### PR TITLE
Fix v.delaunay3d compilation on FreeBSD

### DIFF
--- a/grass7/vector/v.delaunay3d/Makefile
+++ b/grass7/vector/v.delaunay3d/Makefile
@@ -6,7 +6,12 @@ LIBES = $(GPROJLIB) $(VECTORLIB) $(GISLIB)
 DEPENDENCIES = $(GPROJDEP) $(VECTORDEP) $(GISDEP)
 EXTRA_INC = $(VECT_INC) $(PROJINC)
 EXTRA_CFLAGS = $(VECT_CFLAGS) -frounding-math
-EXTRA_LDFLAGS = -lCGAL -lgmp -lstdc++ -lcxxrt
+ifeq ($(shell uname -s),  FreeBSD)
+EXTRA_LDFLAGS = -lCGAL -lgmp -lcxxrt -lstdc++
+else
+EXTRA_LDFLAGS = -lCGAL -lgmp -lstdc++
+endif
+
 LINK = $(CXX)
 
 include $(MODULE_TOPDIR)/include/Make/Module.make

--- a/grass7/vector/v.delaunay3d/Makefile
+++ b/grass7/vector/v.delaunay3d/Makefile
@@ -1,12 +1,21 @@
 MODULE_TOPDIR = ../..
 
+ifeq '$(findstring ;,$(PATH))' ';'
+    detected_OS := Windows
+else
+    detected_OS := $(shell uname 2>/dev/null || echo Unknown)
+    detected_OS := $(patsubst CYGWIN%,Cygwin,$(detected_OS))
+    detected_OS := $(patsubst MSYS%,MSYS,$(detected_OS))
+    detected_OS := $(patsubst MINGW%,MSYS,$(detected_OS))
+endif
+
 PGM = v.delaunay3d
 
 LIBES = $(GPROJLIB) $(VECTORLIB) $(GISLIB)
 DEPENDENCIES = $(GPROJDEP) $(VECTORDEP) $(GISDEP)
 EXTRA_INC = $(VECT_INC) $(PROJINC)
 EXTRA_CFLAGS = $(VECT_CFLAGS) -frounding-math
-ifeq ($(shell uname -s),  FreeBSD)
+ifeq ($(detected_OS),FreeBSD)
 EXTRA_LDFLAGS = -lCGAL -lgmp -lcxxrt -lstdc++
 else
 EXTRA_LDFLAGS = -lCGAL -lgmp -lstdc++

--- a/grass7/vector/v.delaunay3d/Makefile
+++ b/grass7/vector/v.delaunay3d/Makefile
@@ -6,7 +6,7 @@ LIBES = $(GPROJLIB) $(VECTORLIB) $(GISLIB)
 DEPENDENCIES = $(GPROJDEP) $(VECTORDEP) $(GISDEP)
 EXTRA_INC = $(VECT_INC) $(PROJINC)
 EXTRA_CFLAGS = $(VECT_CFLAGS) -frounding-math
-EXTRA_LDFLAGS = -lCGAL -lgmp -lstdc++
+EXTRA_LDFLAGS = -lCGAL -lgmp -lstdc++ -lcxxrt
 LINK = $(CXX)
 
 include $(MODULE_TOPDIR)/include/Make/Module.make


### PR DESCRIPTION

The v.delaunay3d extension cannot be installed since bin/v.delaunay3d segfault.

```
> g.extension --verbose v.delaunay3d                                                                                                              ✔  10:19:12  
Fetching <v.delaunay3d> from GRASS GIS Addons repository (be patient)...
Downloading source code for <v.delaunay3d> from
<https://github.com/OSGeo/grass-addons/trunk/grass7/vector/v.delaunay3d>
which is identified as 'official' type of source...
A    v.delaunay3d
A    v.delaunay3d/Makefile
A    v.delaunay3d/local_proto.h
A    v.delaunay3d/main.cpp
A    v.delaunay3d/read.cpp
A    v.delaunay3d/v.delaunay3d.html
A    v.delaunay3d/write.cpp
Exporté à la révision 7646.
Compiling...
mkdir -p /tmp/grass7-lbartoletti-89056/tmp5pu0cfi_/v.delaunay3d/bin
mkdir -p /tmp/grass7-lbartoletti-89056/tmp5pu0cfi_/v.delaunay3d/etc
mkdir -p /tmp/grass7-lbartoletti-89056/tmp5pu0cfi_/v.delaunay3d/docs/html
mkdir -p /tmp/grass7-lbartoletti-89056/tmp5pu0cfi_/v.delaunay3d/docs/man
mkdir -p /tmp/grass7-lbartoletti-89056/tmp5pu0cfi_/v.delaunay3d/docs/man/man1
test -d OBJ. || mkdir -p OBJ.
g++9 -DLIBICONV_PLUG -I/usr/local/include -I/usr/local/include  -I/usr/local/include -O2 -pipe  -DLIBICONV_PLUG -fstack-protector-strong -Wl,-rpath=/usr/local/lib/gcc9  -DLIBICONV_PLUG -Wl,-rpath=/usr/local/lib/gcc9  -I/usr/local/include -I/usr/local/grass78/include -I/usr/local/grass78/include   -I/usr/local/include -I/usr/local/include -frounding-math -DPACKAGE=\""grassmods"\"    -I/usr/local/grass78/include -I/usr/local/grass78/include -DRELDIR=\"/tmp/grass7-lbartoletti-89056/tmp5pu0cfi_/v.delaunay3d\" -o OBJ./main.o -c main.cpp
g++9 -DLIBICONV_PLUG -I/usr/local/include -I/usr/local/include  -I/usr/local/include -O2 -pipe  -DLIBICONV_PLUG -fstack-protector-strong -Wl,-rpath=/usr/local/lib/gcc9  -DLIBICONV_PLUG -Wl,-rpath=/usr/local/lib/gcc9  -I/usr/local/include -I/usr/local/grass78/include -I/usr/local/grass78/include   -I/usr/local/include -I/usr/local/include -frounding-math -DPACKAGE=\""grassmods"\"    -I/usr/local/grass78/include -I/usr/local/grass78/include -DRELDIR=\"/tmp/grass7-lbartoletti-89056/tmp5pu0cfi_/v.delaunay3d\" -o OBJ./read.o -c read.cpp
g++9 -DLIBICONV_PLUG -I/usr/local/include -I/usr/local/include  -I/usr/local/include -O2 -pipe  -DLIBICONV_PLUG -fstack-protector-strong -Wl,-rpath=/usr/local/lib/gcc9  -DLIBICONV_PLUG -Wl,-rpath=/usr/local/lib/gcc9  -I/usr/local/include -I/usr/local/grass78/include -I/usr/local/grass78/include   -I/usr/local/include -I/usr/local/include -frounding-math -DPACKAGE=\""grassmods"\"    -I/usr/local/grass78/include -I/usr/local/grass78/include -DRELDIR=\"/tmp/grass7-lbartoletti-89056/tmp5pu0cfi_/v.delaunay3d\" -o OBJ./write.o -c write.cpp
: && gcc9 -L/usr/local/grass78/lib -L/usr/local/grass78/lib -L/usr/local/lib -Wl,-rpath=/usr/local/lib/gcc9  -L/usr/local/lib/gcc9 -B/usr/local/bin -L/usr/local/lib -L/usr/local/lib -fstack-protector-strong -Wl,-rpath=/usr/local/lib/gcc9 -L/usr/local/lib/gcc9  -export-dynamic  -L/usr/local/lib -Wl,-rpath-link,/usr/local/grass78/lib -o /tmp/grass7-lbartoletti-89056/tmp5pu0cfi_/v.delaunay3d/bin/v.delaunay3d OBJ./main.o OBJ./read.o OBJ./write.o    -lgrass_gproj.7.8 -lgrass_vector.7.8 -lgrass_gis.7.8 -lCGAL -lgmp -lstdc++  -lm 
if [ "/tmp/grass7-lbartoletti-89056/tmp5pu0cfi_/v.delaunay3d/bin/v.delaunay3d" != "" ] ; then GISRC=/tmp/grass7-lbartoletti-89056/gisrc GISBASE=/usr/local/grass78 PATH="/usr/local/grass78/bin:/usr/local/grass78/bin:/usr/local/grass78/scripts:$PATH" PYTHONPATH="/usr/local/grass78/etc/python:/usr/local/grass78/gui/wxpython:$PYTHONPATH" LD_LIBRARY_PATH="/tmp/grass7-lbartoletti-89056/tmp5pu0cfi_/v.delaunay3d/bin:/usr/local/grass78/bin:/usr/local/grass78/scripts:/usr/local/grass78/lib:/usr/local/grass78/lib:/usr/local/grass78/lib" LC_ALL=C LANG=C LANGUAGE=C /tmp/grass7-lbartoletti-89056/tmp5pu0cfi_/v.delaunay3d/bin/v.delaunay3d --html-description < /dev/null | grep -v '</body>\|</html>' > v.delaunay3d.tmp.html ; fi
Segmentation fault
gmake: *** [/usr/local/grass78/include/Make/Html.make:14: v.delaunay3d.tmp.html] Error 1
rm v.delaunay3d.tmp.html
ERREUR : Compilation failed, sorry. Please check above error messages.
```

'libcxxrt` was missing (for FreeBSD)