### PR TITLE
Remove unicode characters that cause installation on Windows to fail

### DIFF
--- a/grass7/raster/r.estimap.recreation/estimap_recreation/algorithm_description
+++ b/grass7/raster/r.estimap.recreation/estimap_recreation/algorithm_description
@@ -1,0 +1,24 @@
+Algorithmic description of the "Contribution of Ecosysten Types"
+
+Related module: supply_and_use.py
+Related function(s): compute_supply()
+Note: the following description deserves some 'proofreading' and likely an
+update.
+
+
+1   B ← {0, .., m-1}     :  Set of aggregational boundaries
+2   T ← {0, .., n-1}     :  Set of land cover types
+3   WE ← 0               :  Set of weighted extents
+4   R ← 0                :  Set of fractions
+5   F ← 0
+6   MASK ← HQR           : High Quality Recreation
+7   foreach {b} ⊆ B do   : for each aggregational boundary 'b'
+8      RB ← 0
+9      foreach {t} ⊆ T do  : for each Land Type
+10         WEt ← Et * Wt   : Weighted Extent = Extent(t) * Weight(t)
+11         WE ← WE⋃{WEt}   : Add to set of Weighted Extents
+12     S ← ∑t∈WEt
+13     foreach t ← T do
+14        Rt ← WEt / ∑WE
+15        R ← R⋃{Rt}
+16     RB ← RB⋃{R}

--- a/grass7/raster/r.estimap.recreation/estimap_recreation/supply_and_use.py
+++ b/grass7/raster/r.estimap.recreation/estimap_recreation/supply_and_use.py
@@ -89,29 +89,6 @@ def compute_supply(
         use_filename=None,
     ):
     """
-     Algorithmic description of the "Contribution of Ecosysten Types"
-
-     # FIXME
-     '''
-     1   B ← {0, .., m-1}     :  Set of aggregational boundaries
-     2   T ← {0, .., n-1}     :  Set of land cover types
-     3   WE ← 0               :  Set of weighted extents
-     4   R ← 0                :  Set of fractions
-     5   F ← 0
-     6   MASK ← HQR           : High Quality Recreation
-     7   foreach {b} ⊆ B do   : for each aggregational boundary 'b'
-     8      RB ← 0
-     9      foreach {t} ⊆ T do  : for each Land Type
-     10         WEt ← Et * Wt   : Weighted Extent = Extent(t) * Weight(t)
-     11         WE ← WE⋃{WEt}   : Add to set of Weighted Extents
-     12     S ← ∑t∈WEt
-     13     foreach t ← T do
-     14        Rt ← WEt / ∑WE
-     15        R ← R⋃{Rt}
-     16     RB ← RB⋃{R}
-     '''
-     # FIXME
-
     Parameters
     ----------
     recreation_spectrum:

--- a/grass7/raster/r.estimap.recreation/estimap_recreation/supply_and_use.py
+++ b/grass7/raster/r.estimap.recreation/estimap_recreation/supply_and_use.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 @author Nikos Alexandris
 """


### PR DESCRIPTION
For details, refer to https://gitlab.com/natcapes/r.estimap.recreation/-/commit/c0e2949d533829ddb42421504042e2918a79866a