### PR TITLE
i.sentinel.import: fix invalid format

### DIFF
--- a/grass7/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
@@ -451,7 +451,10 @@ class SentinelImporter(object):
                     continue
 
                 timestamp = meta['timestamp']
-                timestamp_str = timestamp.strftime("%-d %b %Y %H:%M:%S.%f")
+                try:
+                    timestamp_str = timestamp.strftime("%d %b %Y %H:%M:%S.%f")
+                except ValueError as e:
+                    gs.fatal("{}: {}".format(timestamp, e))
                 descr_list = []
                 for dkey in meta.keys():
                     if dkey != 'timestamp':


### PR DESCRIPTION
`i.sentinel.import` fails with

```
Writing metadata to maps...
Traceback (most recent call last):
  File "C:\Users\martin\AppData\Roaming\GRASS7\addons/scripts/i.sentinel.import.py", line 561, in <module>
    sys.exit(main())
  File "C:\Users\martin\AppData\Roaming\GRASS7\addons/scripts/i.sentinel.import.py", line 545, in main
    importer.write_metadata()
  File "C:\Users\martin\AppData\Roaming\GRASS7\addons/scripts/i.sentinel.import.py", line 454, in write_metadata
    timestamp_str = timestamp.strftime("%-d %b %Y %H:%M:%S.%f")
ValueError: Invalid format string
```