### PR TITLE
fix i.modis.import on Windows (input parameter)

### DIFF
--- a/grass7/imagery/i.modis/i.modis.import/i.modis.import.py
+++ b/grass7/imagery/i.modis/i.modis.import/i.modis.import.py
@@ -369,7 +369,7 @@ def single(options, remove, an, ow, fil):
         else:
             projwkt = get_proj('w')
             projObj = projection()
-            pref = i.split('/')[-1]
+            pref = i.split(os.path.sep)[-1]
             prod = product().fromcode(pref.split('.')[0])
             spectr = spectral(options, prod, an)
             if projObj.returned() != 'GEO':
@@ -410,7 +410,7 @@ def mosaic(options, remove, an, ow, fil):
     pid = str(os.getpid())
     # for each day
     for dat, listfiles in dictfile.items():
-        pref = listfiles[0].split('/')[-1]
+        pref = listfiles[0].split(os.path.sep)[-1]
         prod = product().fromcode(pref.split('.')[0])
         spectr = spectral(options, prod, an)
         spectr = spectr.lstrip('( ').rstrip(' )')

--- a/grass7/imagery/i.modis/libmodis/rmodislib.py
+++ b/grass7/imagery/i.modis/libmodis/rmodislib.py
@@ -304,9 +304,9 @@ class product:
         elif list(self.products_swath.keys()).count(self.prod) == 1:
             return self.products_swath[self.prod]
         else:
-            grass.fatal(_("The MODIS product inserted is not supported yet. "
+            grass.fatal(_("The MODIS product ({}) inserted is not supported yet. "
                           "Consider to ask on the grass-dev mailing list "
-                          "for future support"))
+                          "for future support").format(self.prod))
 
     def fromcode(self, code):
         for k, v in self.products.items():
@@ -315,9 +315,9 @@ class product:
         for k, v in self.products_swath.items():
             if v['prod'].find(code) != -1:
                 return self.products_swath[k]
-        grass.fatal(_("The MODIS product inserted is not supported yet. "
+        grass.fatal(_("The MODIS product ({}) inserted is not supported yet. "
                       "Consider to ask on the grass-dev mailing list "
-                      "for future support"))
+                      "for future support").format(code))
 
     def color(self, code=None):
         if code:


### PR DESCRIPTION
`i.modis.import` with `input` parameter fails on Windows due to hardcoded Unix-like path separator.

![modis](https://user-images.githubusercontent.com/5683186/83353524-7512c980-a353-11ea-8c36-d12a12c78e9f.png)

