### PR TITLE
i.modis.import creates temporary data in current directory

### DIFF
--- a/grass7/imagery/i.modis/i.modis.import/i.modis.import.py
+++ b/grass7/imagery/i.modis/i.modis.import/i.modis.import.py
@@ -382,6 +382,9 @@ def single(options, remove, an, ow, fil):
             outname = outname.replace(' ', '_')
             execmodis = convertModisGDAL(str(hdf), outname, spectr, res,
                                          wkt=str(projwkt))
+
+        # produce temporary files in input folder
+        os.chdir(basedir)
         try:
             execmodis.run(quiet=True)
         except:
@@ -462,6 +465,9 @@ def mosaic(options, remove, an, ow, fil):
                     res = None
                 execmodis = convertModisGDAL(str(hdf), out, spectr, res,
                                              wkt=str(projwkt), vrt=True)
+
+            # produce temporary files in input folder
+            os.chdir(basedir)
             try:
                 execmodis.run(quiet=True)
             except:


### PR DESCRIPTION
## To reproduce

```
i.modis.import input=~/geodata/modis/MCD19A2.A2019031.h18v03.006.2019036210121.hdf -t --o
ls *.tif -w1
MCD19A2.A2019031.h18v03.single_AOD_QA.tif
MCD19A2.A2019031.h18v03.single_Optical_Depth_055.tif
```
## Important on Windows

This is causing serious problem on Windows (here current working directory is set to C:\ by default).

![i-modis-win-bug](https://user-images.githubusercontent.com/5683186/83955407-eae6cb80-a852-11ea-8359-9b67ce43913a.png)
