### PR TITLE
i.modis.import: improve error handling input/files

### DIFF
--- a/grass7/imagery/i.modis/i.modis.import/i.modis.import.py
+++ b/grass7/imagery/i.modis/i.modis.import/i.modis.import.py
@@ -362,7 +362,7 @@ def single(options, remove, an, ow, fil):
 
     # for each file
     count = len(listfile)
-    idx = 0
+    idx = 1
     for i in listfile:
         if os.path.exists(i):
             hdf = i
@@ -374,14 +374,14 @@ def single(options, remove, an, ow, fil):
                 continue
 
         grass.message(_("Proccessing <{f}> ({i}/{c})...").format(
-            f=os.path.basename(hdf), i=idx+1, c=count))
+            f=os.path.basename(hdf), i=idx, c=count))
         grass.percent(idx, count, 5)
         idx += 1
 
         try:
             pm = parseModis(hdf)
         except OSError:
-            grass.warning(_("<{}> is not a HDF file. Skipping").format(
+            grass.fatal(_("<{}> is not a HDF file").format(
                 hdf
             ))
             continue
@@ -434,10 +434,10 @@ def mosaic(options, remove, an, ow, fil):
     pid = str(os.getpid())
     # for each day
     count = len(dictfile.keys())
-    idx = 0
+    idx = 1
     for dat, listfiles in dictfile.items():
         grass.message(_("Processing <{d}> ({i}/{c})...").format(
-            d=dat, i=idx+1, c=count
+            d=dat, i=idx, c=count
         ))
         grass.percent(idx, count, 5)
         idx += 1

--- a/grass7/imagery/i.modis/i.modis.import/i.modis.import.py
+++ b/grass7/imagery/i.modis/i.modis.import/i.modis.import.py
@@ -142,6 +142,11 @@ def list_files(opt, mosaik=False):
     # read the file with the list of HDF
     if opt['files'] != '':
         if os.path.exists(opt['files']):
+            if os.path.splitext(opt['files'])[-1].lower() == '.hdf':
+                grass.fatal(_("Option <{}> assumes file with list of HDF files. "
+                              "Use option <{}> to import a single HDF file").format(
+                                  'files', 'input'
+                ))
             listoffile = open(opt['files'], 'r')
             basedir = os.path.split(listoffile.name)[0]
         else:
@@ -163,6 +168,7 @@ def list_files(opt, mosaik=False):
                     filelist[day].append(line.strip())
                 else:
                     filelist[day] = [line.strip()]
+        listoffile.close()
     # create a list for each file
     elif options['input'] != '':
         filelist = [options['input']]
@@ -350,7 +356,13 @@ def single(options, remove, an, ow, fil):
     except:
         grass.fatal("pymodis library is not installed")
     listfile, basedir = list_files(options)
+    if not listfile:
+        grass.warning(_("No HDF files found"))
+        return
+
     # for each file
+    count = len(listfile)
+    idx = 0
     for i in listfile:
         if os.path.exists(i):
             hdf = i
@@ -360,7 +372,19 @@ def single(options, remove, an, ow, fil):
             if not os.path.exists(hdf):
                 grass.warning(_("%s not found" % i))
                 continue
-        pm = parseModis(hdf)
+
+        grass.message(_("Proccessing <{f}> ({i}/{c})...").format(
+            f=os.path.basename(hdf), i=idx+1, c=count))
+        grass.percent(idx, count, 5)
+        idx += 1
+
+        try:
+            pm = parseModis(hdf)
+        except OSError:
+            grass.warning(_("<{}> is not a HDF file. Skipping").format(
+                hdf
+            ))
+            continue
         if options['mrtpath']:
             # create conf file fro mrt tools
             confname = confile(pm, options, an)
@@ -409,7 +433,15 @@ def mosaic(options, remove, an, ow, fil):
     dictfile, targetdir = list_files(options, True)
     pid = str(os.getpid())
     # for each day
+    count = len(dictfile.keys())
+    idx = 0
     for dat, listfiles in dictfile.items():
+        grass.message(_("Processing <{d}> ({i}/{c})...").format(
+            d=dat, i=idx+1, c=count
+        ))
+        grass.percent(idx, count, 5)
+        idx += 1
+
         pref = listfiles[0].split(os.path.sep)[-1]
         prod = product().fromcode(pref.split('.')[0])
         spectr = spectral(options, prod, an)


### PR DESCRIPTION
# Current behaviour

Parameters `input/files` misuse.

```
> i.modis.import files=~/geodata/modis/MCD19A2.A2019030.h18v03.006.2019032034547.hdf 
[no input]

> i.modis.import input=~/geodata/modis/listfileMOD11A1.006.txt --o
WxPython missing, no GUI enabled
Traceback (most recent call last):
  File "/home/martin/src/grass-addons/grass7/imagery/i.modis/i.modis.import/i.modis.import.py", line 621, in <module>
    sys.exit(main())
  File "/home/martin/src/grass-addons/grass7/imagery/i.modis/i.modis.import/i.modis.import.py", line 573, in main
    single(options, remove, analyze, over, outfile)
  File "/home/martin/src/grass-addons/grass7/imagery/i.modis/i.modis.import/i.modis.import.py", line 363, in single
    pm = parseModis(hdf)
  File "/usr/local/lib/python3.8/dist-packages/pymodis/parsemodis.py", line 70, in __init__
    raise IOError('{name}.xml does not exist'.format(name=self.hdfname))
OSError: /home/martin/geodata/modis/listfileMOD11A1.006.txt.xml does not exist
```

# New behaviour

```
> i.modis.import files=~/geodata/modis/MCD19A2.A2019030.h18v03.006.2019032034547.hdf
WxPython missing, no GUI enabled
ERROR: Option <files> assumes file with list of HDF files. Use option
       <input> to import a single HDF file

> i.modis.import input=~/geodata/modis/listfileMOD11A1.006.txt 
WxPython missing, no GUI enabled
ERROR: </home/martin/geodata/modis/listfileMOD11A1.006.txt> is not a HDF file
```

# Notes

This PR also adds progress messages.

```
> GRASS_MESSAGE_FORMAT=plain i.modis.import files=~/geodata/modis/listfileMOD11A1.006.txt
Proccessing <MOD11A1.A2019031.h18v03.006.2019037204216.hdf> (1/17)...
0..
Proccessing <MOD11A1.A2019030.h18v03.006.2019031082924.hdf> (2/17)...
5..
Proccessing <MOD11A1.A2019015.h18v03.006.2019030041445.hdf> (17/17)...
100

> GRASS_MESSAGE_FORMAT=plain i.modis.import files=~/geodata/modis/listfileMOD11A1.006.txt -m
Processing <A2019031> (1/17)...
0..
Processing <A2019030> (2/17)...
5..
Processing <A2019015> (17/17)...
100
```


