### PR TITLE
i.zero2null manual: example added

### DIFF
--- a/grass7/imagery/i.zero2null/i.zero2null.html
+++ b/grass7/imagery/i.zero2null/i.zero2null.html
@@ -36,13 +36,17 @@ d.rgb b=T32ULA_20190724T103029_B02_10m green=T32ULA_20190724T103029_B03_10m red=
 i.vi red=T32ULA_20190724T103029_B03_10m nir=T32ULA_20190724T103029_B04_10m vi=ndvi output=s2_ndvi
 d.rast s2_ndvi
 
-# zoom to scene subset
-g.region n=5738180 s=5730360 w=318530 e=332140 res=10 -p
-r.univar -g T32ULA_20190724T103029_B03_10m
+# zoom to scene subset with undesired 0-value pixels
+g.region n=5516940 s=5516840 w=334410 e=334550 res=10
+# visualize pixel values, e.g. in red band
+d.rast T32ULA_20190724T103029_B04_10m
+d.rast.num T32ULA_20190724T103029_B04_10m text_color=blue
 
-# fix no-data pixels
+# fix 0-value pixels
 i.zero2null map=T32ULA_20190724T103029_B02_10m,T32ULA_20190724T103029_B03_10m,T32ULA_20190724T103029_B04_10m,T32ULA_20190724T103029_B08_10m
-r.univar -g T32ULA_20190724T103029_B03_10m_nozero
+# visualize updated pixel values (0 values now replaced), e.g. in red band
+d.rast T32ULA_20190724T103029_B04_10m
+d.rast.num T32ULA_20190724T103029_B04_10m text_color=blue
 </pre></div>
 
 

--- a/grass7/imagery/i.zero2null/i.zero2null.html
+++ b/grass7/imagery/i.zero2null/i.zero2null.html
@@ -9,25 +9,16 @@ in water bodies. These patches are removed and filled with neighboring
 cells.
 
 
-S2B_MSIL2A_20190627T104029_N0212_R008_T32ULC_20190627T135004
-uuid: bb9423ca-e076-41aa-830d-6afa8661df89
-
-i.sentinel.download settings=~/.sentinel_esa uuid=bb9423ca-e076-41aa-830d-6afa8661df89 output=test_s2_scene
-
 <h2>EXAMPLE</h2>
 
-The Sentinel-2 scene <tt>S2B_MSIL2A_20190627T104029_N0212_R008_T32ULC_20190627T135004,
-uuid: TODO</tt> shows unexpected no-data pixels
+The Sentinel-2 scene <tt>S2B_MSIL2A_20190724T103029_N0213_R108_T32ULA_20190724T130550,
+uuid: 0a7cb5ee-80d4-4d15-be19-0b3fdf40791f</tt> shows unexpected no-data pixels
 in lakes.
 
 <div class="code"><pre>
 # download S2 scene affected by no.data pixels within the scene
 i.sentinel.download settings=credentials.txt \
-  uuid=TODO output=test_s2_scene
-
-#i.sentinel.download settings=credentials.txt \
-#  query='filename=S2B_MSIL2A_20190627T104029_N0212_R008_T32ULC_20190627T135004.SAFE' \
-#  output=test_s2_scene
+  uuid=0a7cb5ee-80d4-4d15-be19-0b3fdf40791f output=test_s2_scene
 
 # show lst of granules in scene
 i.sentinel.import -p input=test_s2_scene
@@ -35,23 +26,23 @@ i.sentinel.import -p input=test_s2_scene
 # import selected bands of scene
 i.sentinel.import input=test_s2_scene pattern='B0(2|3|4|8)_10m'
 g.list raster
-g.region raster=T32ULC_20190627T104029_B04_10m -p
+g.region raster=T32ULA_20190724T103029_B04_10m -p
 
 # RGB
-i.colors.enhance b=T32ULC_20190627T104029_B02_10m green=T32ULC_20190627T104029_B03_10m red=T32ULC_20190627T104029_B04_10m
-d.rgb b=T32ULC_20190627T104029_B02_10m green=T32ULC_20190627T104029_B03_10m red=T32ULC_20190627T104029_B04_10m
+i.colors.enhance b=T32ULA_20190724T103029_B02_10m green=T32ULA_20190724T103029_B03_10m red=T32ULA_20190724T103029_B04_10m
+d.rgb b=T32ULA_20190724T103029_B02_10m green=T32ULA_20190724T103029_B03_10m red=T32ULA_20190724T103029_B04_10m
 
 # NDVI
-i.vi red=T32ULC_20190627T104029_B03_10m nir=T32ULC_20190627T104029_B04_10m vi=ndvi output=s2_ndvi
+i.vi red=T32ULA_20190724T103029_B03_10m nir=T32ULA_20190724T103029_B04_10m vi=ndvi output=s2_ndvi
 d.rast s2_ndvi
 
 # zoom to scene subset
 g.region n=5738180 s=5730360 w=318530 e=332140 res=10 -p
-r.univar -g T32ULC_20190627T104029_B03_10m
+r.univar -g T32ULA_20190724T103029_B03_10m
 
 # fix no-data pixels
-i.zero2null map=T32ULC_20190627T104029_B02_10m,T32ULC_20190627T104029_B03_10m,T32ULC_20190627T104029_B04_10m,T32ULC_20190627T104029_B08_10m
-r.univar -g T32ULC_20190627T104029_B03_10m_nozero
+i.zero2null map=T32ULA_20190724T103029_B02_10m,T32ULA_20190724T103029_B03_10m,T32ULA_20190724T103029_B04_10m,T32ULA_20190724T103029_B08_10m
+r.univar -g T32ULA_20190724T103029_B03_10m_nozero
 </pre></div>
 
 

--- a/grass7/imagery/i.zero2null/i.zero2null.html
+++ b/grass7/imagery/i.zero2null/i.zero2null.html
@@ -8,6 +8,53 @@ Sentinel-2 scenes can also have small patches of zero cells, typically
 in water bodies. These patches are removed and filled with neighboring
 cells.
 
+
+S2B_MSIL2A_20190627T104029_N0212_R008_T32ULC_20190627T135004
+uuid: bb9423ca-e076-41aa-830d-6afa8661df89
+
+i.sentinel.download settings=~/.sentinel_esa uuid=bb9423ca-e076-41aa-830d-6afa8661df89 output=test_s2_scene
+
+<h2>EXAMPLE</h2>
+
+The Sentinel-2 scene <tt>S2B_MSIL2A_20190627T104029_N0212_R008_T32ULC_20190627T135004,
+uuid: TODO</tt> shows unexpected no-data pixels
+in lakes.
+
+<div class="code"><pre>
+# download S2 scene affected by no.data pixels within the scene
+i.sentinel.download settings=credentials.txt \
+  uuid=TODO output=test_s2_scene
+
+#i.sentinel.download settings=credentials.txt \
+#  query='filename=S2B_MSIL2A_20190627T104029_N0212_R008_T32ULC_20190627T135004.SAFE' \
+#  output=test_s2_scene
+
+# show lst of granules in scene
+i.sentinel.import -p input=test_s2_scene
+
+# import selected bands of scene
+i.sentinel.import input=test_s2_scene pattern='B0(2|3|4|8)_10m'
+g.list raster
+g.region raster=T32ULC_20190627T104029_B04_10m -p
+
+# RGB
+i.colors.enhance b=T32ULC_20190627T104029_B02_10m green=T32ULC_20190627T104029_B03_10m red=T32ULC_20190627T104029_B04_10m
+d.rgb b=T32ULC_20190627T104029_B02_10m green=T32ULC_20190627T104029_B03_10m red=T32ULC_20190627T104029_B04_10m
+
+# NDVI
+i.vi red=T32ULC_20190627T104029_B03_10m nir=T32ULC_20190627T104029_B04_10m vi=ndvi output=s2_ndvi
+d.rast s2_ndvi
+
+# zoom to scene subset
+g.region n=5738180 s=5730360 w=318530 e=332140 res=10 -p
+r.univar -g T32ULC_20190627T104029_B03_10m
+
+# fix no-data pixels
+i.zero2null map=T32ULC_20190627T104029_B02_10m,T32ULC_20190627T104029_B03_10m,T32ULC_20190627T104029_B04_10m,T32ULC_20190627T104029_B08_10m
+r.univar -g T32ULC_20190627T104029_B03_10m_nozero
+</pre></div>
+
+
 <h2>SEE ALSO</h2>
 
 <em>


### PR DESCRIPTION
TODO: update scene name and UUID to one with no-data pixels

The idea was to use the scene indicated here: https://github.com/OSGeo/grass-addons/pull/123#issuecomment-619857619 
but there is some confusion with S2 name and UUID...