### PR TITLE
wxGUI wx.metadata: Fix launch g.gui.metadata, g.gui.cswbrowser

### DIFF
--- a/grass7/gui/wxpython/wx.metadata/db.csw.admin/db.csw.admin.py
+++ b/grass7/gui/wxpython/wx.metadata/db.csw.admin/db.csw.admin.py
@@ -120,9 +120,9 @@ import configparser
 import getopt
 
 from grass.script import core as grass
-from grass.pygrass.utils import set_path
+from grass.script.utils import set_path
 
-set_path(modulename='wx.metadata', dirname='mdlib')
+set_path(modulename='wx.metadata', dirname='mdlib', path='..')
 
 from mdlib.cswutil import *
 

--- a/grass7/gui/wxpython/wx.metadata/db.csw.admin/db.csw.admin.py
+++ b/grass7/gui/wxpython/wx.metadata/db.csw.admin/db.csw.admin.py
@@ -126,15 +126,16 @@ set_path(modulename='wx.metadata', dirname='mdlib')
 
 from mdlib.cswutil import *
 
-try:
-    from pycsw.core import admin, config
-
-except:
-    sys.exit(
-        'pycsw library is missing. Check requirements on the manual page < https://grasswiki.osgeo.org/wiki/ISO/INSPIRE_Metadata_Support >')
+MODULE_URL = 'https://grasswiki.osgeo.org/wiki/ISO/INSPIRE_Metadata_Support'
 
 
 class CswAdmin():
+    try:
+        pycsw = __import__('pycsw', ['admin', 'config'])
+    except ImportError:
+        sys.exit('pycsw library is missing. Check requirements on the'
+                 ' manual page < {url} >'.format(url=MODULE_URL))
+
     def __init__(self):
         self.COMMAND = None
         self.XML_DIRPATH = None
@@ -151,7 +152,7 @@ class CswAdmin():
         self.URL = None
         self.HOME = None
         self.TABLE = None
-        self.CONTEXT = config.StaticContext()
+        self.CONTEXT = self.pycsw.core.config.StaticContext()
 
 
     def argParser(self, defaultConf, load_records,
@@ -286,30 +287,30 @@ class CswAdmin():
 
         if self.COMMAND == 'setup_db':
             try:
-                admin.setup_db(self.DATABASE, self.TABLE, self.HOME)
+                self.pycsw.core.admin.setup_db(self.DATABASE, self.TABLE, self.HOME)
             except Exception as err:
                 print(err)
                 print('ERROR: DB creation error.  Database tables already exist')
                 print('Delete tables or database to reinitialize')
 
         elif self.COMMAND == 'load_records':
-            admin.load_records(self.CONTEXT, self.DATABASE, self.TABLE, self.XML_DIRPATH, self.RECURSIVE,
+            self.pycsw.core.admin.load_records(self.CONTEXT, self.DATABASE, self.TABLE, self.XML_DIRPATH, self.RECURSIVE,
                                self.FORCE_CONFIRM)
         elif self.COMMAND == 'export_records':
-            admin.export_records(self.CONTEXT, self.DATABASE, self.TABLE, self.XML_DIRPATH)
+            self.pycsw.core.admin.export_records(self.CONTEXT, self.DATABASE, self.TABLE, self.XML_DIRPATH)
         elif self.COMMAND == 'rebuild_db_indexes':
-            admin.rebuild_db_indexes(self.DATABASE, self.TABLE)
+            self.pycsw.core.admin.rebuild_db_indexes(self.DATABASE, self.TABLE)
         elif self.COMMAND == 'optimize_db':
-            admin.optimize_db(self.CONTEXT, self.DATABASE, self.TABLE)
+            self.pycsw.core.admin.optimize_db(self.CONTEXT, self.DATABASE, self.TABLE)
         elif self.COMMAND == 'refresh_harvested_records':
-            admin.refresh_harvested_records(self.CONTEXT, self.DATABASE, self.TABLE, self.URL)
+            self.pycsw.core.admin.refresh_harvested_records(self.CONTEXT, self.DATABASE, self.TABLE, self.URL)
         elif self.COMMAND == 'gen_sitemap':
-            admin.gen_sitemap(self.CONTEXT, self.DATABASE, self.TABLE, self.URL, self.OUTPUT_FILE)
+            self.pycsw.core.admin.gen_sitemap(self.CONTEXT, self.DATABASE, self.TABLE, self.URL, self.OUTPUT_FILE)
         elif self.COMMAND == 'post_xml':
-            grass.message(admin.post_xml(self.CSW_URL, self.XML, self.TIMEOUT))
+            grass.message(self.pycsw.core.admin.post_xml(self.CSW_URL, self.XML, self.TIMEOUT))
 
         elif self.COMMAND == 'delete_records':
-            admin.delete_records(self.CONTEXT, self.DATABASE, self.TABLE)
+            self.pycsw.core.admin.delete_records(self.CONTEXT, self.DATABASE, self.TABLE)
 
 
 '''#TODO

--- a/grass7/gui/wxpython/wx.metadata/dependency.py
+++ b/grass7/gui/wxpython/wx.metadata/dependency.py
@@ -1,51 +1,103 @@
-owslib=False
-try:
-    import owslib
-    owslib=True
-except:
-    print('owslib library is missing. Check requirements on the manual page < https://grasswiki.osgeo.org/wiki/ISO/INSPIRE_Metadata_Support >')
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
-if owslib:
-    import owslib
-    owsvs= owslib.__version__
+"""
+@module  dependency.py
+@brief   Check wx.metadata py lib dependencies
+
+(C) 2020 by the GRASS Development Team
+This program is free software under the GNU General Public License
+(>=v2). Read the file COPYING that comes with GRASS for details.
+"""
+
+import importlib
+
+URL = 'https://grasswiki.osgeo.org/wiki/ISO/INSPIRE_Metadata_Support'
+MODULES = {
+    'owslib': {
+        'check_version': True,
+        'package': 'owslib.iso',
+        'method': 'MD_Metadata',
+        'version': '>=0.9',
+    },
+    'pycsw': {
+        'check_version': True,
+        'package': 'pycsw.core',
+        'submodule': 'admin',
+        'version': '>=2.0',
+    },
+    'sqlalchemy': {
+        'check_version': False,
+    },
+    'jinja2': {
+        'check_version': False,
+    },
+    'reportlab': {
+        'check_version': False,
+    },
+}
+
+installed_vesion_message = 'Installed version of {} library is <{}>.'
+req_vesion_message = '{name} {version} is required. Check requirements' \
+    'on the manual page <{url}>'
+
+
+def check_dependencies(module_name, check_version=False):
+    module_cfg = MODULES[module_name]
     try:
-        from owslib.iso import *
+        module = importlib.import_module(module_name)
+        if module_cfg['check_version']:
+            package = importlib.import_module(module_cfg['package'])
 
-        MD_Metadata()
-    except:
-        print('Installed version of owslib library is < %s >.'%owsvs)
-        print('owslib >=0.9 is required. Check requirements on the manual page < https://grasswiki.osgeo.org/wiki/ISO/INSPIRE_Metadata_Support >')
+            if module_cfg.get('method'):
+                if not hasattr(package, module_cfg.get('method')):
+                    print(
+                        installed_vesion_message.format(
+                            module_name,
+                            module.__version__,
+                        ),
+                    )
+                    print(
+                        req_vesion_message.format(
+                            name=module_name,
+                            version=module_cfg['version'],
+                            url=URL,
+                        ),
+                    )
+            elif module_cfg.get('module'):
+                try:
+                    importlib.import_module(module_cfg['submodule'])
+                except ModuleNotFoundError:
+                    print(
+                        installed_vesion_message.format(
+                            module_name,
+                            module.__version__,
+                        ),
+                    )
+                    print(
+                        req_vesion_message.format(
+                            name=module_name,
+                            version=module_cfg['version'],
+                            url=URL,
+                        ),
+                    )
+
+        return True
+    except ModuleNotFoundError:
+        print(
+            '{name} library is missing. Check requirements on the'
+            ' manual page <{url}>'.format(
+                name=module_name,
+                url=URL,
+            ),
+        )
 
 
-try:
-    import jinja2
-except:
-    print('jinja2 library is missing. Check requirements on the manual page < https://grasswiki.osgeo.org/wiki/ISO/INSPIRE_Metadata_Support >')
-pycsw=False
-
-try:
-    import pycsw
-    pycsw=True
-except:
-    print('pycsw library is missing. Check requirements on the manual page < https://grasswiki.osgeo.org/wiki/ISO/INSPIRE_Metadata_Support >')
-
-try:
-    import reportlab
-except:
-    print('python-import reportlab library is missing. Check requirements on the manual page < https://grasswiki.osgeo.org/wiki/ISO/INSPIRE_Metadata_Support >')
-
-if pycsw:
-    import pycsw
-    cswvs= pycsw.__version__
-    try:
-        from pycsw.core import admin
-    except:
-        print('Installed version of pycsw library is < %s >.'%cswvs)
-        print('pycsw >=2.0 is required. Check requirements on the manual page < https://grasswiki.osgeo.org/wiki/ISO/INSPIRE_Metadata_Support >')
+def main():
+    for module in MODULES:
+        if check_dependencies(module):
+            print('{name} is installed.'.format(name=module))
 
 
-from owslib.iso import *
-import jinja2
-from pycsw.core import admin
-import reportlab
-
+if __name__ == "__main__":
+    main()

--- a/grass7/gui/wxpython/wx.metadata/g.gui.cswbrowser/g.gui.cswbrowser.py
+++ b/grass7/gui/wxpython/wx.metadata/g.gui.cswbrowser/g.gui.cswbrowser.py
@@ -9,17 +9,18 @@ This program is free software under the GNU General Public License
 
 @author Matej Krejci <matejkrejci gmail.com> (GSoC 2015)
 """
-import grass.script as grass
 
-from grass.pygrass.utils import set_path
-set_path(modulename='wx.metadata', dirname='mdlib')
+import grass.script as grass
+from grass.script.setup import set_gui_path
+
+grass.utils.set_path(modulename='wx.metadata', dirname='mdlib', path='..')
+
+from mdlib.cswlib import CSWBrowserPanel, CSWConnectionPanel
 
 import wx
 
-from grass.script.setup import set_gui_path
 set_gui_path()
 
-from mdlib.cswlib import CSWBrowserPanel, CSWConnectionPanel
 
 class CswBrowserMainDialog(wx.Frame):
     def __init__(self,giface=None):

--- a/grass7/gui/wxpython/wx.metadata/g.gui.cswbrowser/g.gui.cswbrowser.py
+++ b/grass7/gui/wxpython/wx.metadata/g.gui.cswbrowser/g.gui.cswbrowser.py
@@ -10,6 +10,13 @@ This program is free software under the GNU General Public License
 @author Matej Krejci <matejkrejci gmail.com> (GSoC 2015)
 """
 
+#%module
+#% description: Graphical CSW metadata browser.
+#% keyword: general
+#% keyword: GUI
+#% keyword: metadata
+#%end
+
 import grass.script as grass
 from grass.script.setup import set_gui_path
 

--- a/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
+++ b/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
@@ -973,7 +973,7 @@ class MdMainFrame(wx.Frame):
             self.splitter.SplitVertically(self.editor, self.ntbRight, sashPosition=0.65)
             self.splitter.SetSashGravity(0.65)
             self.Hsizer.Add(self.splitter, proportion=1, flag=wx.EXPAND)
-            self.splitter.SizeWindows()
+            self.splitter.UpdateSize()
             self.resizeFrame()
             self.Show()
 

--- a/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
+++ b/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
@@ -764,7 +764,6 @@ class MdMainFrame(wx.Frame):
         '''In editing mode config panel is hidden
         '''
         self.bttNew.Enable()
-        self.Hsizer.Remove(self.leftPanel)
         self.Hsizer.Layout()
         self.leftPanel.SetSize((1, 1))
 
@@ -985,7 +984,6 @@ class MdMainFrame(wx.Frame):
             self.bttNew.Disable()
             self.bttSave.Disable()
 
-            self.Hsizer.Insert(0, self.leftPanel, proportion=1, flag=wx.EXPAND)
             self.resizeFrame()
 
         elif self.secondAfterChoice:

--- a/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
+++ b/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
@@ -285,6 +285,7 @@ class MdMainFrame(wx.Frame):
         wx.Frame.__init__(self, None, title="Metadata Editor", size=(650, 500))
         self.initDefaultPathStorageMetadata()
 
+        self.config = wx.Config("g.gui.metadata")
         self.jinjaPath = jinjaPath
         self.xmlPath = xmlPath
         self.first = True

--- a/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
+++ b/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
@@ -1396,7 +1396,7 @@ class TreeBrowser(wx.TreeCtrl):
                     text = e.text
                 if text:
                     val = tree.AppendItem(item, text)
-                    tree.SetPyData(val, e)
+                    tree.SetItemData(val, e)
 
                 add(item, e)
 

--- a/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
+++ b/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
@@ -451,7 +451,6 @@ class MdMainFrame(wx.Frame):
         dbSizer = wx.BoxSizer(wx.VERTICAL)
         dbSizer.Add(self.cswPanel, flag=wx.EXPAND, proportion=1)
         self.cswDialog.SetSizer(dbSizer)
-        self.cswDialog.SetBestFittingSize()
         self.cswDialog.ShowModal()
         self.cswDialog.Destroy()
 

--- a/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
+++ b/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
@@ -21,6 +21,13 @@ This program is free software under the GNU General Public License
 @author Matej Krejci <matejkrejci gmail.com> (GSoC 2014) (GSoC 2015)
 """
 
+#%module
+#% description: Graphical ISO/INSPIRE metadata editor.
+#% keyword: general
+#% keyword: GUI
+#% keyword: metadata
+#%end
+
 import os
 import sys
 import tempfile

--- a/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
+++ b/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
@@ -21,41 +21,40 @@ This program is free software under the GNU General Public License
 @author Matej Krejci <matejkrejci gmail.com> (GSoC 2014) (GSoC 2015)
 """
 
-import sys
 import os
+import sys
+import tempfile
+import webbrowser
+from functools import reduce
 
-from grass.pygrass.utils import set_path
+from lxml import etree
+
 import grass.script as grass
+import grass.temporal as tgis
 from grass.pydispatch import dispatcher
 from grass.pydispatch.signal import Signal
-import grass.temporal as tgis
-
 from grass.script.setup import set_gui_path
-from functools import reduce
+
 set_gui_path()
-
-from core.gcmd import RunCommand, GError, GMessage
-#from datacatalog.tree import LocationMapTree
-from core.utils import GetListOfLocations, ListOfMapsets
 from core.debug import Debug
+from core.gcmd import GError, GMessage, RunCommand
+# from datacatalog.tree import LocationMapTree
+from core.utils import GetListOfLocations, ListOfMapsets
 
-set_path(modulename='wx.metadata', dirname='mdlib')
+grass.utils.set_path(modulename='wx.metadata', dirname='mdlib', path='..')
 
 from mdlib import mdgrass
 from mdlib import mdutil
-from mdlib.mdpdffactory import PdfCreator
 from mdlib.cswlib import CSWConnectionPanel
 from mdlib.mdeditorfactory import MdMainEditor
+from mdlib.mdpdffactory import PdfCreator
 
-from lxml import etree
 import wx
-from wx.lib.buttons import ThemedGenBitmapTextButton as BitmapBtnTxt
 from wx import SplitterWindow
+from wx.lib.buttons import ThemedGenBitmapTextButton as BitmapBtnTxt
 
-#from pydispatch import dispatcher
+# from pydispatch import dispatcher
 
-import webbrowser
-import tempfile
 #===============================================================================
 # MAIN FRAME
 #===============================================================================

--- a/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
+++ b/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
@@ -131,7 +131,7 @@ class LocationMapTree(wx.TreeCtrl):
                 self.AppendItem(vartype, mlayer)
 
         self.RestoreBackup()
-        Debug.msg(1, "Tree filled")    
+        Debug.msg(1, "Tree filled")
 
     def InitTreeItems(self):
         """Create popup menu for layers"""
@@ -196,7 +196,7 @@ class LocationMapTree(wx.TreeCtrl):
             if self.GetItemText(item) == match:
                 return True
             item, cookie = self.GetNextChild(root, cookie)
-        return False       
+        return False
 
     def UpdateTree(self):
         """Update whole tree."""
@@ -215,7 +215,7 @@ class LocationMapTree(wx.TreeCtrl):
         if(self.selected_layer):
             self._popupMenuLayer()
         elif(self.selected_mapset and self.selected_type==None):
-            self._popupMenuMapset() 
+            self._popupMenuMapset()
 
     def OnDoubleClick(self, event):
         """Double click"""
@@ -468,7 +468,7 @@ class MdMainFrame(wx.Frame):
                             defaultDir=self.mdDestination,
                             defaultFile=XMLtail.split('.')[0] + '.pdf',
                             wildcard="*.pdf",
-                            style=wx.SAVE | wx.FD_OVERWRITE_PROMPT)
+                            style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT)
 
         if dlg.ShowModal() == wx.ID_OK:
             outPath = dlg.GetDirectory()
@@ -552,7 +552,7 @@ class MdMainFrame(wx.Frame):
                             self.mdDestination,
                             "",
                             "*.xml",
-                            wx.OPEN)
+                            wx.FD_OPEN)
 
         if dlg.ShowModal() == wx.ID_OK:
             self.xmlPath = dlg.GetPath()
@@ -567,7 +567,7 @@ class MdMainFrame(wx.Frame):
                             self.mdDestination,
                             "",
                             "*.xml",
-                            wx.SAVE)
+                            wx.FD_SAVE)
 
         if dlg.ShowModal() == wx.ID_OK:
             self.onExportTemplate(outPath=dlg.GetDirectory(),
@@ -579,7 +579,7 @@ class MdMainFrame(wx.Frame):
                             self.mdDestination,
                             "",
                             "*.xml",
-                            wx.OPEN)
+                            wx.FD_OPEN)
 
         if dlg.ShowModal() == wx.ID_OK:
             self.jinjaPath = dlg.GetPath()
@@ -596,7 +596,7 @@ class MdMainFrame(wx.Frame):
                                 defaultDir=self.mdDestination,
                                 defaultFile=self.XMLtail,
                                 wildcard="*.xml",
-                                style=wx.SAVE | wx.FD_OVERWRITE_PROMPT)
+                                style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT)
 
             if dlg.ShowModal() == wx.ID_OK:
                 self.exportXML(outPath=dlg.GetDirectory(), outFileName=dlg.GetFilename())
@@ -855,7 +855,8 @@ class MdMainFrame(wx.Frame):
         if self.profileChoice == 'Load custom' and self.numOfMap != 0:
             # load profile. IF - just one map, ELSE - multiple editing
             if multipleEditing is False:
-                dlg = wx.FileDialog(self, "Select profile", os.getcwd(), "", "*.xml", wx.OPEN)
+                dlg = wx.FileDialog(self, "Select profile", os.getcwd(),
+                                    "", "*.xml", wx.FD_OPEN)
                 if dlg.ShowModal() == wx.ID_OK:
                     self.mdCreator = mdgrass.GrassMD(self.ListOfMapTypeDict[-1][list(self.ListOfMapTypeDict[-1].keys())[0]],
                                                      list(self.ListOfMapTypeDict[-1].keys())[0])

--- a/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
+++ b/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
@@ -1024,7 +1024,7 @@ class MdMainFrame(wx.Frame):
         self.mainSizer.Add(self.toolbar, flag=wx.EXPAND)
 
         self.mainSizer.Add(wx.StaticLine(self, -1, style=wx.LI_HORIZONTAL, size=(10000, 5)))
-        self.mainSizer.AddSpacer(5, 5, 1, wx.EXPAND)
+        self.mainSizer.Add(5, 5, 1, wx.EXPAND)
 
         self.configPanelLeftSizer = wx.BoxSizer(wx.VERTICAL)
         self.configPanelLeft.SetSizer(self.configPanelLeftSizer)
@@ -1036,7 +1036,7 @@ class MdMainFrame(wx.Frame):
         self.leftPanelSizer = wx.BoxSizer(wx.VERTICAL)
         self.leftPanel.SetSizer(self.leftPanelSizer)
         self.leftPanelSizer.Add(self.configPanelLeft, proportion=0, flag=wx.EXPAND)
-        self.leftPanelSizer.AddSpacer(5, 5, 1, wx.EXPAND)
+        self.leftPanelSizer.Add(5, 5, 1, wx.EXPAND)
         self.leftPanelSizer.Add(self.MdDataCatalogPanelLeft, proportion=1, flag=wx.EXPAND)
 
         self.Hsizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -1481,7 +1481,7 @@ class CswPublisher(CSWConnectionPanel):
     def __init__(self, parent, main):
         super(CswPublisher, self).__init__(parent, main, cswBrowser=False)
         self.publishBtt = wx.Button(self.panelLeft, label='Publish')
-        self.configureSizer.AddSpacer(40, 10, 1, wx.EXPAND)
+        self.configureSizer.Add(40, 10, 1, wx.EXPAND)
         self.configureSizer.Add(self.publishBtt, 0, wx.EXPAND)
         self.publishBtt.SetBackgroundColour((255, 127, 80))
 

--- a/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
+++ b/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
@@ -1025,7 +1025,7 @@ class MdMainFrame(wx.Frame):
         self.mainSizer.Add(self.toolbar, flag=wx.EXPAND)
 
         self.mainSizer.Add(wx.StaticLine(self, -1, style=wx.LI_HORIZONTAL, size=(10000, 5)))
-        self.mainSizer.Add(5, 5, 1, wx.EXPAND)
+        self.mainSizer.AddSpacer(5)
 
         self.configPanelLeftSizer = wx.BoxSizer(wx.VERTICAL)
         self.configPanelLeft.SetSizer(self.configPanelLeftSizer)
@@ -1037,7 +1037,7 @@ class MdMainFrame(wx.Frame):
         self.leftPanelSizer = wx.BoxSizer(wx.VERTICAL)
         self.leftPanel.SetSizer(self.leftPanelSizer)
         self.leftPanelSizer.Add(self.configPanelLeft, proportion=0, flag=wx.EXPAND)
-        self.leftPanelSizer.Add(5, 5, 1, wx.EXPAND)
+        self.leftPanelSizer.AddSpacer(5)
         self.leftPanelSizer.Add(self.MdDataCatalogPanelLeft, proportion=1, flag=wx.EXPAND)
 
         self.Hsizer = wx.BoxSizer(wx.HORIZONTAL)

--- a/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
+++ b/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
@@ -74,7 +74,7 @@ class LocationMapTree(wx.TreeCtrl):
         self._initVariables()
         self.MakeBackup()
 
-        wx.EVT_TREE_ITEM_RIGHT_CLICK(self, wx.ID_ANY, self.OnRightClick)
+        self.Bind(wx.EVT_TREE_ITEM_RIGHT_CLICK, self.OnRightClick)
 
         self.Bind(wx.EVT_LEFT_DCLICK, self.OnDoubleClick)
         self.Bind(wx.EVT_KEY_DOWN, self.OnKeyDown)

--- a/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
+++ b/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
@@ -786,7 +786,7 @@ class MdMainFrame(wx.Frame):
             self.MdDataCatalogPanelLeft.UnselectAll()
 
     def chckProfileSelection(self, type):
-        parent = self.MdDataCatalogPanelLeft.GetSelection()
+        parent = self.MdDataCatalogPanelLeft.GetSelections()[0]
         while True:
             text = self.MdDataCatalogPanelLeft.GetItemText(parent)
             if text == 'Temporal maps':

--- a/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
@@ -39,6 +39,8 @@ from subprocess import PIPE
 from grass.pygrass.modules import Module
 from grass.script import parse_key_val
 
+from .mdeditorfactory import ADD_RM_BUTTON_SIZE
+
 
 class ConstraintsBuilder(wx.Panel):
     def __init__(self, parent, settings=''):
@@ -118,7 +120,8 @@ class CSWBrowserPanel(wx.Panel):
         self.numResultsSpin = wx.SpinCtrl(self.pnlLeft, min=1, max=100, initial=20, size=(sizeConst, self.h),
                                           style=wx.ALIGN_RIGHT | wx.SP_ARROW_KEYS)
 
-        self.addKeywordCtr = wx.Button(self.pnlLeft, -1, '+', size=(self.h, self.h))
+        self.addKeywordCtr = wx.Button(self.pnlLeft, -1, '+',
+                                       size=ADD_RM_BUTTON_SIZE)
         self.addKeywordCtr.Bind(wx.EVT_BUTTON, self.addKeyWidget)
         self.findBtt = wx.Button(self.pnlLeft, size=(sizeConst, self.h), label='Search')
         self.findBtt.SetBackgroundColour((255, 127, 80))
@@ -235,7 +238,8 @@ class CSWBrowserPanel(wx.Panel):
         name = evt.GetEventObject().GetLabel()
         if name == '+':
             kw = wx.TextCtrl(self.pnlLeft)
-            addKeywordCtr = wx.Button(self.pnlLeft, -1, '-', size=(self.h, self.h))
+            addKeywordCtr = wx.Button(self.pnlLeft, -1, '-',
+                                      size=ADD_RM_BUTTON_SIZE)
             addKeywordCtr.Bind(wx.EVT_BUTTON, self.addKeyWidget)
 
             self.constraintsWidgets.append(kw)

--- a/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
@@ -927,7 +927,6 @@ class CSWBrowserPanel(wx.Panel):
         leftPanelSizer.Add(findPanelSizer, 0, wx.EXPAND)
         leftPanelSizer.Add(self.findResNumLbl, 0)
         leftPanelSizer.Add(self.resultList, 1, wx.EXPAND)
-        leftPanelSizer.Add(10, 10, 1, wx.EXPAND)
 
         listerSizer = wx.BoxSizer(wx.HORIZONTAL)
 

--- a/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
@@ -71,13 +71,13 @@ Examples\n\
     def _layout(self):
         panelSizer = wx.BoxSizer(wx.VERTICAL)
         panelSizer.Add(self.label)
-        panelSizer.AddSpacer(10, 10, 1, wx.EXPAND)
+        panelSizer.Add(10, 10, 1, wx.EXPAND)
         panelSizer.Add(self.constrCtrl, 1, wx.EXPAND)
 
         horSizer = wx.BoxSizer(wx.HORIZONTAL)
         horSizer.Add(self.applyBtt)
         horSizer.Add(self.cancelBtt)
-        panelSizer.AddSpacer(10, 10, 1, wx.EXPAND)
+        panelSizer.Add(10, 10, 1, wx.EXPAND)
         panelSizer.Add(horSizer)
         self.SetSizerAndFit(panelSizer)
 
@@ -825,7 +825,7 @@ class CSWBrowserPanel(wx.Panel):
 
         self.leftSearchSizer.Add(self.keywordLbl, 0)
 
-        self.rightSearchSizer.AddSpacer(4, 0, 1, wx.EXPAND)
+        self.rightSearchSizer.Add(4, 0, 1, wx.EXPAND)
         self.rightSearchSizer.Add(self.advanceChck, 0)
 
         self.leftSearchSizer.Add(self.keywordCtr, 0, wx.EXPAND)
@@ -842,18 +842,18 @@ class CSWBrowserPanel(wx.Panel):
         bb3sizer = wx.BoxSizer(wx.HORIZONTAL)
         self.stBox2Sizer = wx.StaticBoxSizer(self.stbBB, wx.VERTICAL)
         bb1sizer.Add(self.bbWestLb)
-        bb1sizer.AddSpacer(14, 10, 1, wx.EXPAND)
+        bb1sizer.Add(14, 10, 1, wx.EXPAND)
         bb1sizer.Add(self.bbWest, 1, wx.EXPAND)
-        bb1sizer.AddSpacer(20, 10, 1, wx.EXPAND)
+        bb1sizer.Add(20, 10, 1, wx.EXPAND)
         bb1sizer.Add(self.bbSouthLb)
-        bb1sizer.AddSpacer(14, 10, 1, wx.EXPAND)
+        bb1sizer.Add(14, 10, 1, wx.EXPAND)
         bb1sizer.Add(self.bbSouth, 1, wx.EXPAND)
         bb2sizer.Add(self.bbEastLb)
-        bb2sizer.AddSpacer(10, 10, 1, wx.EXPAND)
+        bb2sizer.Add(10, 10, 1, wx.EXPAND)
         bb2sizer.Add(self.bbEast, 1, wx.EXPAND)
-        bb2sizer.AddSpacer(20, 10, 1, wx.EXPAND)
+        bb2sizer.Add(20, 10, 1, wx.EXPAND)
         bb2sizer.Add(self.bbNorthLb)
-        bb2sizer.AddSpacer(10, 10, 1, wx.EXPAND)
+        bb2sizer.Add(10, 10, 1, wx.EXPAND)
         bb2sizer.Add(self.bbNorth, 1, wx.EXPAND)
         bb3sizer.Add(self.bbSetGlobalBtt1, wx.EXPAND)
         bb3sizer.Add(self.bbSetMapExtendBtt1, wx.EXPAND)
@@ -863,13 +863,13 @@ class CSWBrowserPanel(wx.Panel):
         # bounding box sizer---------------end
         stbBox0Sizer.Add(self.catalogLbl, 0)
         stbBox0Sizer.Add(self.catalogCmb, 1, wx.EXPAND)
-        stbBox0Sizer.AddSpacer(10, 10, 1, wx.EXPAND)
+        stbBox0Sizer.Add(10, 10, 1, wx.EXPAND)
 
         stbBox0Sizer.Add(self.stBox1Sizer, 0, wx.EXPAND)
-        stbBox0Sizer.AddSpacer(10, 10, 1, wx.EXPAND)
+        stbBox0Sizer.Add(10, 10, 1, wx.EXPAND)
         stbBox0Sizer.Add(self.stBox2Sizer, 0, wx.EXPAND)
         leftPanelSizer.Add(stbBox0Sizer, 0, wx.EXPAND)
-        leftPanelSizer.AddSpacer(10, 10, 1, wx.EXPAND)
+        leftPanelSizer.Add(10, 10, 1, wx.EXPAND)
 
         findPanelSizer = wx.BoxSizer(wx.HORIZONTAL)
 
@@ -880,7 +880,7 @@ class CSWBrowserPanel(wx.Panel):
         leftPanelSizer.Add(findPanelSizer, 0, wx.EXPAND)
         leftPanelSizer.Add(self.findResNumLbl, 0)
         leftPanelSizer.Add(self.resultList, 1, wx.EXPAND)
-        leftPanelSizer.AddSpacer(10, 10, 1, wx.EXPAND)
+        leftPanelSizer.Add(10, 10, 1, wx.EXPAND)
 
         listerSizer = wx.BoxSizer(wx.HORIZONTAL)
 
@@ -1219,14 +1219,14 @@ class CSWConnectionPanel(wx.Panel):
         self.configureSizer = wx.BoxSizer(wx.VERTICAL)
         self.stBoxConnectionsSizer = wx.StaticBoxSizer(self.stBoxConnections, wx.VERTICAL)
         self.stBoxConnectionsSizer.Add(self.connectionLBox, 1, wx.EXPAND)
-        self.stBoxConnectionsSizer.AddSpacer(20, 10, 1, wx.EXPAND)
+        self.stBoxConnectionsSizer.Add(20, 10, 1, wx.EXPAND)
         self.stBoxConnectionsSizer.Add(wx.StaticText(self.panelLeft, label='Timeout'), 0)
         self.stBoxConnectionsSizer.Add(self.timeoutSpin, 0)
 
         self.stBoxConnectionsSizer.Add(self.serviceInfoBtt, 0, wx.EXPAND)
         self.configureSizer.Add(self.stBoxConnectionsSizer, 1, wx.EXPAND)
 
-        self.configureSizer.AddSpacer(20, 10, 1, wx.EXPAND)
+        self.configureSizer.Add(20, 10, 1, wx.EXPAND)
         self.stBoxConnections1Sizer = wx.StaticBoxSizer(self.stBoxConnections1, wx.VERTICAL)
         self.stBoxConnections1Sizer.Add(self.newBtt, 0, wx.EXPAND)
         self.stBoxConnections1Sizer.Add(self.removeBtt, 0, wx.EXPAND)

--- a/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
@@ -837,7 +837,7 @@ class CSWBrowserPanel(wx.Panel):
                 self.resultList.InsertItem(
                     index, normalize_text(self.catalog.records[rec].type))
             else:
-                self.resultList.SetItem(index, 0, 'unknown')
+                self.resultList.InsertItem(index, 'unknown')
             if self.catalog.records[rec].title:
                 self.resultList.SetItem(
                     index, 1, normalize_text(self.catalog.records[rec].title))

--- a/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
@@ -256,6 +256,7 @@ class CSWBrowserPanel(wx.Panel):
 
             self.leftSearchSizer.Remove(sizeLeft)
             self.rightSearchSizer.Remove(sizeRight)
+
         self.Fit()
 
     def OnShowReguest(self, evt):
@@ -779,11 +780,13 @@ class CSWBrowserPanel(wx.Panel):
         for rec in self.catalog.records:
             if self.catalog.records[rec].type:
                 item = wx.ListItem()
-                self.resultList.InsertStringItem(index, normalize_text(self.catalog.records[rec].type))
+                self.resultList.InsertItem(
+                    index, normalize_text(self.catalog.records[rec].type))
             else:
                 self.resultList.SetStringItem(index, 0, 'unknown')
             if self.catalog.records[rec].title:
-                self.resultList.SetStringItem(index, 1, normalize_text(self.catalog.records[rec].title))
+                self.resultList.SetItem(
+                    index, 1, normalize_text(self.catalog.records[rec].title))
 
             if self.catalog.records[rec].identifier:
                 self.set_item_data(index, 'identifier',

--- a/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
@@ -35,6 +35,8 @@ from wx.html import EVT_HTML_LINK_CLICKED, HW_DEFAULT_STYLE, HW_SCROLLBAR_AUTO
 from owslib.csw import CatalogueServiceWeb
 from owslib.fes import BBox, PropertyIsLike
 from owslib.ows import ExceptionReport
+from grass.script.setup import set_gui_path
+set_gui_path()
 from gui_core.forms import GUI
 from core.gcmd import GError, GMessage, GWarning
 from subprocess import PIPE

--- a/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
@@ -73,15 +73,21 @@ Examples\n\
 
     def _layout(self):
         panelSizer = wx.BoxSizer(wx.VERTICAL)
-        panelSizer.Add(self.label)
-        panelSizer.Add(10, 10, 1, wx.EXPAND)
-        panelSizer.Add(self.constrCtrl, 1, wx.EXPAND)
+        sb = wx.StaticBox(self, label='Constraints')
+        sbs = wx.StaticBoxSizer(sb, orient=wx.VERTICAL)
+        sbs.Add(self.label, flag=wx.TOP | wx.LEFT | wx.RIGHT, border=10)
+        sbs.Add(10, 10, 1, wx.EXPAND)
+        sbs.Add(self.constrCtrl, 1, flag=wx.EXPAND | wx.LEFT | wx.RIGHT |
+                wx.BOTTOM, border=10)
+        panelSizer.Add(sbs, flag=wx.ALL, border=10)
 
         horSizer = wx.BoxSizer(wx.HORIZONTAL)
         horSizer.Add(self.applyBtt)
-        horSizer.Add(self.cancelBtt)
+        horSizer.Add(self.cancelBtt, flag=wx.LEFT, border=5)
         panelSizer.Add(10, 10, 1, wx.EXPAND)
-        panelSizer.Add(horSizer)
+        panelSizer.Add(horSizer, flag=wx.ALIGN_CENTER | wx.TOP | wx.BOTTOM,
+                       border=10)
+
         self.SetSizerAndFit(panelSizer)
 
 
@@ -213,8 +219,7 @@ class CSWBrowserPanel(wx.Panel):
             self.constrPnl.cancelBtt.Bind(wx.EVT_BUTTON, self._destroyDialog)
             dbSizer = wx.BoxSizer(wx.VERTICAL)
             dbSizer.Add(self.constrPnl, flag=wx.EXPAND)
-            self.geDialog.SetSizer(dbSizer)
-            self.geDialog.SetBestFittingSize()
+            self.geDialog.SetSizerAndFit(dbSizer)
             self.geDialog.ShowModal()
 
     def _destroyDialog(self, evt):

--- a/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
@@ -498,10 +498,10 @@ class CSWBrowserPanel(wx.Panel):
 
     def setTooltip(self, evt):
         index = evt.GetIndex()
-        text = self.resultList.GetItem(index, 1)
-        text = text.GetText()
-
-        self.resultList.SetToolTip(wx.ToolTip(text))
+        if index > -1:
+            text = self.resultList.GetItem(index, 1)
+            text = text.GetText()
+            self.resultList.SetToolTip(wx.ToolTip(text))
 
     def setBBoxGRASS(self, evt=None):
         vdb = Module('g.region', flags='bg', stdout_=PIPE)

--- a/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
@@ -575,6 +575,9 @@ class CSWBrowserPanel(wx.Panel):
             GMessage(_("No access to layer tree. Run g.gui.cswbroswer from g.gui"))
 
     def OnService(self, evt):
+        def strip_str(s):
+            return s.strip().replace('"', '').replace('\'', '')
+
         name = evt.GetEventObject().GetLabel()
         idx = self.resultList.GetNextItem(0, wx.LIST_NEXT_ALL,
                                           wx.LIST_STATE_SELECTED)
@@ -582,7 +585,14 @@ class CSWBrowserPanel(wx.Panel):
             return
         cmd = []
         item_data = "item_data=" + self.get_item_data(idx, 'link')
-        exec (item_data)
+        # Strip { }
+        data = self.get_item_data(idx, 'link')[1:-2]
+        item_data = dict(
+            (strip_str(k), strip_str(v))
+            for k, v in (item.split(':', 1)
+                         for item in
+                         data.split(', ')))
+
         if name == "Add WMS":
             data_url = item_data['wms']
             service = ['r.in.wms', 'Add web service layer']

--- a/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
@@ -10,6 +10,8 @@ This program is free software under the GNU General Public License
 
 @author Matej Krejci <matejkrejci gmail.com> (GSoC 2015)
 """
+
+import os
 import sys
 
 try:
@@ -37,6 +39,7 @@ from gui_core.forms import GUI
 from core.gcmd import GError, GMessage, GWarning
 from subprocess import PIPE
 from grass.pygrass.modules import Module
+import grass.script as grass
 from grass.script import parse_key_val
 
 from .mdeditorfactory import ADD_RM_BUTTON_SIZE
@@ -262,26 +265,28 @@ class CSWBrowserPanel(wx.Panel):
     def OnShowReguest(self, evt):
         # request_html = encodeString(highlight_xml(self.context, self.catalog.request,False))
         path = os.path.join(tempfile.gettempdir(), 'htmlRequest.xml')
+        request = grass.decode(self.catalog.request)
         if os.path.exists(path): os.remove(path)
         f = open(path, 'w')
-        f.writelines(self.catalog.request)
+        f.writelines(request)
         f.close()
         if yesNo(self, 'Do you want to open <request> in default browser', 'Open file'):
             open_url(path)
         else:
-            self.htmlView.SetPage((renderXML(self.context, self.catalog.request)))
+            self.htmlView.SetPage((renderXML(self.context, request)))
 
     def OnShowResponse(self, evt):
         # response_html = encodeString(highlight_xml(self.context, self.catalog.response,False))
         path = os.path.join(tempfile.gettempdir(), 'htmlResponse.xml')
+        response = grass.decode(self.catalog.response)
         if os.path.exists(path): os.remove(path)
         f = open(path, 'w')
-        f.write(self.catalog.response)
+        f.write(response)
         f.close()
         if yesNo(self, 'Do you want to open <response> in default browser', 'Open file'):
             open_url(path)
         else:
-            self.htmlView.SetPage((renderXML(self.context, self.catalog.response)))
+            self.htmlView.SetPage((renderXML(self.context, response)))
 
     def getTmpConnection(self, name):
         key = '/connections/%s/url' % name

--- a/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
@@ -675,6 +675,7 @@ class CSWBrowserPanel(wx.Panel):
     def OnSearch(self, evt):
         """execute search"""
 
+        wx.BeginBusyCursor()
         self.refreshResultList()
         self.catalog = None
         self.loadConstraints()
@@ -685,6 +686,7 @@ class CSWBrowserPanel(wx.Panel):
         current_text = self.catalogCmb.GetValue()
         if current_text == '':
             GMessage('Please set catalog')
+            wx.EndBusyCursor()
             return
 
         self.catalog_url = self.getTmpConnection(current_text)
@@ -707,6 +709,7 @@ class CSWBrowserPanel(wx.Panel):
             self.constraints.append(BBox(bbox))
 
         if not self._get_csw():
+            wx.EndBusyCursor()
             return
 
         # TODO: allow users to select resources types
@@ -717,9 +720,11 @@ class CSWBrowserPanel(wx.Panel):
             self.outpoutschema = 'dc'
         except ExceptionReport as err:
             GError('Search error: %s' % err)
+            wx.EndBusyCursor()
             return
         except Exception as err:
             GError('Connection error: %s' % err)
+            wx.EndBusyCursor()
             return
 
         ###work around for GMD records
@@ -736,9 +741,11 @@ class CSWBrowserPanel(wx.Panel):
 
             except ExceptionReport as err:
                 GError('Search error: %s' % err)
+                wx.EndBusyCursor()
                 return
             except Exception as err:
                 GError('Connection error: %s' % err)
+                wx.EndBusyCursor()
                 return
         ###work around for GMD records- END
 
@@ -754,6 +761,7 @@ class CSWBrowserPanel(wx.Panel):
             return
 
         self.displyResults()
+        wx.EndBusyCursor()
 
     def get_item_data(self, index, field):
         if field == 'identifier':

--- a/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
@@ -614,7 +614,6 @@ class CSWBrowserPanel(wx.Panel):
         if not idx:
             return
         cmd = []
-        item_data = "item_data=" + self.get_item_data(idx, 'link')
         # Strip { }
         data = self.get_item_data(idx, 'link')[1:-1]
         item_data = dict(

--- a/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
@@ -226,18 +226,43 @@ class CSWBrowserPanel(wx.Panel):
         self.advanceChck.SetValue(False)
         self.geDialog.Destroy()
 
+    def check_char_pair(self, s, start_char='[', end_char=']',
+                        same_char=False):
+        """Check char pair count in the string
+
+        param s: string
+        param start_char: start char
+        param end_char: end char
+        param same_char: bool
+
+        :return: bool (count of start char is equal or not equal to
+        the count of end char)
+        """
+        a = 0
+        for i in range(len(s)):
+            if s[i] == start_char:
+                a += 1
+            elif s[i] == end_char:
+                a -= 1
+        if not same_char:
+            return a == 0
+        else:
+            return True if a % 2 == 0 else False
+
     def OnSetAdvancedConstraints(self, evt):
+        error_message = 'Constraints syntax error'
         self.constString = self.constrPnl.constrCtrl.GetValue()
-        if self.constString == '':
+        if (self.constString == '' or not
+            (self.constString.startswith('[')
+             and self.constString.endswith(']'))):
+            GMessage(error_message)
             return
-        constString = 'self.constraints=' + self.constString
-        try:
-            exec (constString)
-            if type(self.constraints != type(list())):
-                GMessage('Constraints syntax error')
-                return
-        except:
-            GMessage('Constraints syntax error')
+        if not self.check_char_pair(self.constString):
+            GMessage(error_message)
+            return
+        if not self.check_char_pair(self.constString, start_char='\'',
+                                    end_char='\'', same_char=True):
+            GMessage(error_message)
             return
         self.constraintsAdvanced = True
         self.geDialog.Destroy()

--- a/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
@@ -807,9 +807,9 @@ class CSWBrowserPanel(wx.Panel):
                 self.resultList.InsertStringItem(index,
                                                  normalize_text(self.catalog.records[rec].identification.identtype))
             else:
-                self.resultList.SetStringItem(index, 0, 'unknown')
+                self.resultList.SetItem(index, 0, 'unknown')
             if self.catalog.records[rec].identification.title:
-                self.resultList.SetStringItem(index, 1, normalize_text(self.catalog.records[rec].identification.title))
+                self.resultList.SetItem(index, 1, normalize_text(self.catalog.records[rec].identification.title))
 
             if self.catalog.records[rec].identification.title:
                 self.set_item_data(index, 'identifier',
@@ -837,7 +837,7 @@ class CSWBrowserPanel(wx.Panel):
                 self.resultList.InsertItem(
                     index, normalize_text(self.catalog.records[rec].type))
             else:
-                self.resultList.SetStringItem(index, 0, 'unknown')
+                self.resultList.SetItem(index, 0, 'unknown')
             if self.catalog.records[rec].title:
                 self.resultList.SetItem(
                     index, 1, normalize_text(self.catalog.records[rec].title))

--- a/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
@@ -616,7 +616,7 @@ class CSWBrowserPanel(wx.Panel):
         cmd = []
         item_data = "item_data=" + self.get_item_data(idx, 'link')
         # Strip { }
-        data = self.get_item_data(idx, 'link')[1:-2]
+        data = self.get_item_data(idx, 'link')[1:-1]
         item_data = dict(
             (strip_str(k), strip_str(v))
             for k, v in (item.split(':', 1)

--- a/grass7/gui/wxpython/wx.metadata/mdlib/mdeditorfactory.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/mdeditorfactory.py
@@ -725,7 +725,6 @@ class MdNotebookPage(scrolled.ScrolledPanel):
     def __init__(self, parent):
         scrolled.ScrolledPanel.__init__(self, parent=parent, id=wx.ID_ANY)
         self.items = []
-        self.SetupScrolling()
         self._addNotebookPageLay()
         self.sizerIndexDict = {}
         self.sizerIndex = 0
@@ -768,8 +767,10 @@ class MdNotebookPage(scrolled.ScrolledPanel):
         self.items.append(item)
         posIndex = self.sizerIndexDict[mId]
         self.mainSizer.Insert(posIndex, item, proportion=0, flag=wx.EXPAND)
-        self.SetSizerAndFit(self.mainSizer)
         self.GetParent().Refresh()
+        self.Layout()
+        self.SetupScrolling()
+
 
     def removeBox(self, box):
         box.Destroy()

--- a/grass7/gui/wxpython/wx.metadata/mdlib/mdeditorfactory.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/mdeditorfactory.py
@@ -220,7 +220,7 @@ class MdBox(wx.Panel):
             self.rmBoxButt = wx.Button(self, id=ID_ANY, size=(30, 30), label='-')
             self.boxButtonSizer.Add(self.rmBoxButt, 0)
             self.rmBoxButt.Bind(EVT_BUTTON, self.removeBox)
-        
+
     def addDuplicatedItem(self, item):
         self.stBoxSizer.Add(item, flag=wx.EXPAND, proportion=1)
         self.stBoxSizer.AddSpacer(5, 5, 1, wx.EXPAND)
@@ -662,8 +662,8 @@ class MdItem(wx.BoxSizer):
         if self.chckBox:
             self.textFieldSizer.Add(self.chckBoxEdit, 0)
 
-        self.Add(item=self.tagText, proportion=0)
-        self.Add(item=self.textFieldSizer, proportion=0, flag=wx.EXPAND)
+        self.Add(self.tagText, proportion=0)
+        self.Add(self.textFieldSizer, proportion=0, flag=wx.EXPAND)
 
 
 class MdItemKeyword(wx.BoxSizer):

--- a/grass7/gui/wxpython/wx.metadata/mdlib/mdeditorfactory.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/mdeditorfactory.py
@@ -53,6 +53,7 @@ from grass.pygrass.modules import Module
 #=========================================================================
 # MD filework
 #=========================================================================
+ADD_RM_BUTTON_SIZE = (35, 35)
 
 class MdFileWork():
 
@@ -212,12 +213,14 @@ class MdBox(wx.Panel):
             self.stBoxSizer.AddSpacer(5, 5, 1, wx.EXPAND)
 
         if multi:
-            self.addBoxButt = wx.Button(self, id=ID_ANY, size=(30, 30), label='+')
+            self.addBoxButt = wx.Button(self, id=ID_ANY, size=ADD_RM_BUTTON_SIZE,
+                                        label='+')
             self.boxButtonSizer.Add(self.addBoxButt, 0)
             self.addBoxButt.Bind(EVT_BUTTON, self.duplicateBox)
 
         if rmMulti:
-            self.rmBoxButt = wx.Button(self, id=ID_ANY, size=(30, 30), label='-')
+            self.rmBoxButt = wx.Button(self, id=ID_ANY, size=ADD_RM_BUTTON_SIZE,
+                                       label='-')
             self.boxButtonSizer.Add(self.rmBoxButt, 0)
             self.rmBoxButt.Bind(EVT_BUTTON, self.removeBox)
 
@@ -424,11 +427,13 @@ class MdItem(wx.BoxSizer):
         self.valueCtrl.SetExtraStyle(wx.WS_EX_VALIDATE_RECURSIVELY)
 
         if self.multiple:
-            self.addItemButt = wx.Button(parent, -1, size=(30, 30), label='+')
+            self.addItemButt = wx.Button(parent, -1, size=ADD_RM_BUTTON_SIZE,
+                                         label='+')
             self.addItemButt.Bind(EVT_BUTTON, self.duplicateItem)
 
         if rmMulti:
-            self.rmItemButt = wx.Button(parent, -1, size=(30, 30), label='-')
+            self.rmItemButt = wx.Button(parent, -1, size=ADD_RM_BUTTON_SIZE,
+                                        label='-')
             self.rmItemButt.Bind(EVT_BUTTON, self.removeItem)
 
         if self.chckBox:
@@ -674,7 +679,8 @@ class MdItemKeyword(wx.BoxSizer):
         self.keywordObj=keywordObj
         self.text = wx.StaticText(parent=parent, id=ID_ANY, label=text)
         self.parent=parent
-        self.rmItemButt = wx.Button(parent, -1, size=(30, 30), label='-')
+        self.rmItemButt = wx.Button(parent, -1, size=ADD_RM_BUTTON_SIZE,
+                                    label='-')
         self.rmItemButt.Bind(EVT_BUTTON, self.removeItem)
         self.keyword=keyword
         self.title=title

--- a/grass7/gui/wxpython/wx.metadata/mdlib/mdeditorfactory.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/mdeditorfactory.py
@@ -201,7 +201,7 @@ class MdBox(wx.Panel):
 
         self.boxButtonSizer = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.panelSizer.Add(10, 10, 1, wx.EXPAND)
+        self.panelSizer.AddSpacer(5)
         self.panelSizer.Add(self.boxButtonSizer, flag=wx.EXPAND, proportion=1)
 
         self.stBoxSizer = wx.StaticBoxSizer(self.stbox, orient=wx.VERTICAL)
@@ -210,7 +210,7 @@ class MdBox(wx.Panel):
         for item in items:
             self.mdItems.append(item)
             self.stBoxSizer.Add(item, flag=wx.EXPAND, proportion=1)
-            self.stBoxSizer.Add(5, 5, 1, wx.EXPAND)
+            self.stBoxSizer.AddSpacer(5)
 
         if multi:
             self.addBoxButt = wx.Button(self, id=ID_ANY, size=ADD_RM_BUTTON_SIZE,
@@ -226,7 +226,7 @@ class MdBox(wx.Panel):
 
     def addDuplicatedItem(self, item):
         self.stBoxSizer.Add(item, flag=wx.EXPAND, proportion=1)
-        self.stBoxSizer.Add(5, 5, 1, wx.EXPAND)
+        self.stBoxSizer.AddSpacer(5)
         self.GetParent().Layout()
 
     def getCtrlID(self):

--- a/grass7/gui/wxpython/wx.metadata/mdlib/mdeditorfactory.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/mdeditorfactory.py
@@ -201,7 +201,7 @@ class MdBox(wx.Panel):
 
         self.boxButtonSizer = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.panelSizer.AddSpacer(10, 10, 1, wx.EXPAND)
+        self.panelSizer.Add(10, 10, 1, wx.EXPAND)
         self.panelSizer.Add(self.boxButtonSizer, flag=wx.EXPAND, proportion=1)
 
         self.stBoxSizer = wx.StaticBoxSizer(self.stbox, orient=wx.VERTICAL)
@@ -210,7 +210,7 @@ class MdBox(wx.Panel):
         for item in items:
             self.mdItems.append(item)
             self.stBoxSizer.Add(item, flag=wx.EXPAND, proportion=1)
-            self.stBoxSizer.AddSpacer(5, 5, 1, wx.EXPAND)
+            self.stBoxSizer.Add(5, 5, 1, wx.EXPAND)
 
         if multi:
             self.addBoxButt = wx.Button(self, id=ID_ANY, size=ADD_RM_BUTTON_SIZE,
@@ -226,7 +226,7 @@ class MdBox(wx.Panel):
 
     def addDuplicatedItem(self, item):
         self.stBoxSizer.Add(item, flag=wx.EXPAND, proportion=1)
-        self.stBoxSizer.AddSpacer(5, 5, 1, wx.EXPAND)
+        self.stBoxSizer.Add(5, 5, 1, wx.EXPAND)
         self.GetParent().Layout()
 
     def getCtrlID(self):
@@ -269,7 +269,7 @@ class MdBoxKeywords(MdBox):
         self.boxButtonSizer = wx.BoxSizer(wx.HORIZONTAL)
         self.parent2=parent2
 
-        self.panelSizer.AddSpacer(10, 10, 1, wx.EXPAND)
+        self.panelSizer.Add(10, 10, 1, wx.EXPAND)
         self.panelSizer.Add(self.boxButtonSizer, flag=wx.EXPAND, proportion=1)
         self.parent=parent
         self.stBoxSizer = wx.StaticBoxSizer(self.stbox, orient=wx.VERTICAL)
@@ -913,7 +913,7 @@ class MdKeywords(wx.BoxSizer):
         self.Add(self.box,flag=wx.EXPAND)
         self.Add(self.comboKeysLabel,flag=wx.EXPAND)
         self.Add(self.comboKeys,flag=wx.EXPAND)
-        self.AddSpacer(10, 10, 1, wx.EXPAND)
+        self.Add(10, 10, 1, wx.EXPAND)
 
         self.Add(self.keysList,proportion=1,flag=wx.EXPAND)
 

--- a/grass7/gui/wxpython/wx.metadata/mdlib/mdgrass.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/mdgrass.py
@@ -88,7 +88,8 @@ class GrassMD():
     def parseTemporal(self):
         env = grass.gisenv()
         mapset = env['MAPSET']
-        self.map="%s@%s"%(self.map,mapset)
+        if self.map.find("@") < 0:
+            self.map = "{}@{}".format(self.map, mapset)
         tinfo = Module('t.info',
                         self.map,
                         flags='g',

--- a/grass7/gui/wxpython/wx.metadata/mdlib/mdgrass.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/mdgrass.py
@@ -482,7 +482,7 @@ class GrassMD():
 
     def readXML(self, xml_file):
         '''create instance of metadata(owslib) from xml file'''
-        self.md = util.MD_MetadataMOD(etree.parse(xml_file))
+        self.md = mdutil.MD_MetadataMOD(etree.parse(xml_file))
 
 
     def getMapInfo(self):
@@ -554,17 +554,17 @@ class GrassMD():
                 else:
                     Module('g.message', message='For overwriting use flag -overwrite')
                     return False
-            else: 
+            else:
                 try:
                     xml_file = open(path, "w")
                     xml_file.write(iso_xml)
                     xml_file.close()
                     Module('g.message', message='Metadata file has been exported')
                     return path
-                    
+
                 except IOError as e:
                     print("I/O error({0}): {1}".format(e.errno, e.strerror))
-                    grass.fatal('error: cannot write xml to file')                
+                    grass.fatal('error: cannot write xml to file')
 
     def validate_inspire(self):
         return mdutil.isnpireValidator(self.md)

--- a/grass7/gui/wxpython/wx.metadata/mdlib/mdjinjaparser.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/mdjinjaparser.py
@@ -91,7 +91,7 @@ class MdDescription():
         try:
             for k, oldListItem in enumerate(self.mdItem):
                 for i in oldListItem:
-                    if i == item:
+                    if oldListItem == item:
                         self.mdItem[k].remove(item)
         except:
             self.mdItem.remove(item)

--- a/grass7/gui/wxpython/wx.metadata/mdlib/mdjinjaparser.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/mdjinjaparser.py
@@ -165,7 +165,7 @@ class JinjaTemplateParser():
                             values += ",selfInfoString='''{{" + values2 + "#}'''"
 
                         exe_str = "self.mdDescription.append(MdDescription(%s))" % values
-                        exe_str = exe_str.decode("utf-8", 'ignore')
+                        exe_str = exe_str.encode("utf-8", 'ignore')
                         eval(exe_str)
         except:
             GError('Cannot open jinja template')

--- a/grass7/gui/wxpython/wx.metadata/mdlib/mdpdffactory.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/mdpdffactory.py
@@ -19,6 +19,7 @@ import tempfile
 
 from core.gcmd import GWarning
 
+from grass.pygrass.modules.interface.env import G_debug
 from grass.pygrass.utils import set_path
 from grass.script import core as grass
 from grass.script.utils import get_lib_path
@@ -571,7 +572,7 @@ class MapBBFactory():
     def buildLink(self, center, zoom, corners):
         size = str(self.size[0]) + 'x' + str(self.size[1])
 
-        pic = ("{service_url}?"
+        pic0 = ("{service_url}?"
                "geojson={geojson}&"
                "center={lat},{lng}&"
                "zoom={zoom}&"
@@ -582,7 +583,8 @@ class MapBBFactory():
                    lng=center['lng'],
                    zoom=zoom,
                    size=size))
-        pic = pic.replace(' ', '')
+        pic0 = pic0.replace(' ', '')
+        G_debug(3, 'Static map img url: {}'.format(pic0))
 
         pic1 = ("{service_url}?"
                 "geojson={geojson}&"
@@ -596,8 +598,9 @@ class MapBBFactory():
                     zoom=zoom - 4,
                     size=size))
         pic1 = pic1.replace(' ', '')
+        G_debug(3, 'Static map (reduced zoom) img url: {}'.format(pic1))
 
-        return pic, pic1
+        return pic0, pic1
 
     def CalcCenterFromBounds(self, bounds, output_coord=None):
         """Calculates the center point given southwest/northeast lat/lng

--- a/grass7/gui/wxpython/wx.metadata/mdlib/mdpdffactory.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/mdpdffactory.py
@@ -1,19 +1,34 @@
-try:
-    from owslib.iso import *
-except:
-    sys.exit('owslib library is missing. Check requirements on the manual page < https://grasswiki.osgeo.org/wiki/ISO/INSPIRE_Metadata_Support >')
-import tempfile, sys, subprocess, os
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+@module  mdpdffactory
+@brief   Pdf creator
+
+Classes:
+ - mdpdffactory::MapBBFactory
+ - mdpdffactory::MyTheme
+ - mdpdffactory::MD_ITEM
+ - mdpdffactory::PdfCreator
+ - mdpdffactory::Point
+"""
+
+import math
+import os
+import subprocess
+import tempfile
+
+from core.gcmd import GWarning
+
 from grass.pygrass.utils import set_path
 from grass.script import core as grass
 from grass.script.utils import get_lib_path
-from core.gcmd import GError, GMessage, GWarning
+
+from reportlab.platypus import Image, Paragraph, Table
+from reportlab.platypus import PageBreak
 
 set_path(modulename='wx.metadata', dirname='mdlib')
-
-import math
-from reportlab.platypus import Paragraph, Image, Table
-from reportlab.platypus import PageBreak
-from .mdpdftheme import *
+from .mdpdftheme import CENTER, DefaultTheme, H1, H4, LEFT, Pdf, T1, \
+    T2, T3
 
 
 class MyTheme(DefaultTheme):

--- a/grass7/gui/wxpython/wx.metadata/mdlib/mdpdffactory.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/mdpdffactory.py
@@ -489,7 +489,8 @@ class MapBBFactory():
         self.pixel_range = []
         self.pixels = 256
         self.size = size
-        zoom_levels = list(range(0, 20))
+        self.zoom_max = 17
+        zoom_levels = list(range(0, self.zoom_max))
         for z in zoom_levels:
             origin = self.pixels / 2
             self.pixels_per_lon_degree.append(self.pixels / 360)
@@ -656,7 +657,7 @@ class MapBBFactory():
         Returns:
           An int zoom level.
         """
-        zmax = 20
+        zmax = self.zoom_max
         zmin = 0
         bottom_left = bounds[0]
         top_right = bounds[1]

--- a/grass7/gui/wxpython/wx.metadata/mdlib/mdpdffactory.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/mdpdffactory.py
@@ -3,8 +3,9 @@ try:
 except:
     sys.exit('owslib library is missing. Check requirements on the manual page < https://grasswiki.osgeo.org/wiki/ISO/INSPIRE_Metadata_Support >')
 import tempfile, sys, os
-from grass.pygrass.utils import set_path,get_lib_path
+from grass.pygrass.utils import set_path
 from grass.script import core as grass
+from grass.script.utils import get_lib_path
 from core.gcmd import GError, GMessage, GWarning
 
 set_path(modulename='wx.metadata', dirname='mdlib')
@@ -136,8 +137,10 @@ class PdfCreator(object):
 
         self.doc.set_theme(MyTheme)
 
-        logo_path = get_lib_path("wx.metadata",'config')
-        logo_path = os.path.join(logo_path,'logo_variant_bg.png')
+        lib_name = 'config'
+        logo_path = get_lib_path("wx.metadata", lib_name)
+
+        logo_path = os.path.join(logo_path, lib_name, 'logo_variant_bg.png')
         self.doc.add_image(logo_path, 57, 73, LEFT)
 
         if self.map is None:
@@ -641,4 +644,3 @@ class MapBBFactory():
         north = max(flats)
         south = min(flats)
         return [[south, west], [north, east]]
-

--- a/grass7/gui/wxpython/wx.metadata/mdlib/mdpdffactory.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/mdpdffactory.py
@@ -422,8 +422,8 @@ class PdfCreator(object):
     def savePDF(self, doc, pathToPdf=None):
         if pathToPdf is None:
             pathToPdf = self.pdf_file
-        out = open(pathToPdf, 'w+')
-        out.writelines(doc)
+        out = open(pathToPdf, 'wb+')
+        out.write(doc)
         out.close()
         return pathToPdf
 

--- a/grass7/gui/wxpython/wx.metadata/mdlib/mdpdftheme.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/mdpdftheme.py
@@ -324,7 +324,7 @@ class Pdf(object):
         self.add(img)
 
     def render(self):
-        buffer = io.StringIO()
+        buffer = io.BytesIO()
         doc_template_args = self.theme.doc_template_args()
         doc = SimpleDocTemplate(buffer, title=self.title, author=self.author,
                                 **doc_template_args)

--- a/grass7/gui/wxpython/wx.metadata/mdlib/mdutil.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/mdutil.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# -*- coding: utf-8
+# -*- coding: utf-8 -*-
+
 """
 @package mdgrass
 @module  v.info.iso, r.info.iso, g.gui.metadata
@@ -20,21 +21,29 @@ This program is free software under the GNU General Public License
 
 @author Matej Krejci <matejkrejci gmail.com> (GSoC 2014)
 """
+
 import os
+import string
 import sys
+from subprocess import PIPE
 
 try:
-    from owslib.iso import *
-except:
-    sys.exit(
-        'owslib library is missing. Check requirements on the manual page < https://grasswiki.osgeo.org/wiki/ISO/INSPIRE_Metadata_Support >')
+    from owslib.iso import (
+        MD_DataIdentification, MD_Metadata, namespaces,
+        SV_ServiceIdentification,
+    )
+except ImportError:
+    sys.exit('owslib library is missing. Check requirements on the '
+             'manual page < https://grasswiki.osgeo.org/wiki/ISO/INSPIRE '
+             'Metadata_Support >')
+
+from grass.pygrass.modules import Module
+from grass.pygrass.utils import get_lib_path
+from grass.script import core as grass
+
 
 from owslib import util
-import string
-from grass.script import core as grass
-from grass.pygrass.modules import Module
-from subprocess import PIPE
-from grass.pygrass.utils import get_lib_path
+
 import wx
 
 
@@ -42,24 +51,42 @@ class StaticContext(object):
     def __init__(self):
         self.ppath = os.path.dirname(os.path.abspath(__file__))
 
-        self.confDirPath = os.path.join(os.getenv('GRASS_ADDON_BASE'), 'etc', 'wx.metadata', 'config')
+        self.confDirPath = os.path.join(
+            os.getenv('GRASS_ADDON_BASE'),
+            'etc', 'wx.metadata', 'config',
+        )
         path = os.path.join('wx.metadata', 'config')
-        self.connResources = get_lib_path(modname=path, libname='connections_resources.xml')
+        self.connResources = get_lib_path(
+            modname=path, libname='connections_resources.xml',
+        )
         if self.connResources is None:
-            grass.fatal("Fatal error: library < %s > not found" % path)
+            grass.fatal(
+                "Fatal error: library < {} > not found".format(
+                    path),
+            )
         else:
-            self.connResources = os.path.join(self.connResources, 'connections_resources.xml')
+            self.connResources = os.path.join(
+                self.connResources, 'connections_resources.xml',
+            )
 
-        self.configureLibPath = get_lib_path(modname=path, libname='init_md.txt')
+        self.configureLibPath = get_lib_path(
+            modname=path, libname='init_md.txt',
+        )
         if self.configureLibPath is None:
-            grass.fatal("Fatal error: library < %s > not found" % path)
+            grass.fatal(
+                "Fatal error: library < {} > not found".format(path),
+            )
 
         path = os.path.join('wx.metadata', 'profiles')
-        self.profilesLibPath = get_lib_path(modname=path, libname='basicProfile.xml')
+        self.profilesLibPath = get_lib_path(
+            modname=path, libname='basicProfile.xml',
+        )
         if self.profilesLibPath is None:
             grass.fatal("Fatal error: library < %s > not found" % path)
 
-        self.lib_path = os.path.normpath(self.configureLibPath + os.sep + os.pardir)
+        self.lib_path = os.path.normpath(
+            os.path.join(self.configureLibPath, os.pardir),
+        )
 
 
 def isTableExists(name):
@@ -78,7 +105,10 @@ def removeNonAscii(s):
 
 
 def yesNo(parent, question, caption='Yes or no?'):
-    dlg = wx.MessageDialog(parent, question, caption, wx.YES_NO | wx.ICON_QUESTION)
+    dlg = wx.MessageDialog(
+        parent, question, caption,
+        wx.YES_NO | wx.ICON_QUESTION,
+    )
     result = dlg.ShowModal() == wx.ID_YES
     dlg.Destroy()
     return result
@@ -89,7 +119,7 @@ def findBetween(s, first, last):
         start = s.index(first) + len(first)
         end = s.index(last, start)
         return s[start:end]
-    except:
+    except ValueError:
         return ""
 
 
@@ -106,11 +136,15 @@ def replaceXMLReservedChar(inp):
 
 def pathToMapset():
     gisenvDict = grass.gisenv()
-    return os.path.join(gisenvDict['GISDBASE'], gisenvDict['LOCATION_NAME'], gisenvDict['MAPSET'])
+    return os.path.join(
+        gisenvDict['GISDBASE'],
+        gisenvDict['LOCATION_NAME'],
+        gisenvDict['MAPSET'],
+    )
 
 
 def grassProfileValidator(md):
-    '''function for validation of GRASS BASIC XML-OWSLib  file-object'''
+    '''Validation of GRASS BASIC XML-OWSLib  file-object'''
 
     result = {}
     result["status"] = "succeded"
@@ -119,71 +153,97 @@ def grassProfileValidator(md):
     errors = 0
 
     if md.identification is None:
-        result["errors"].append("gmd:CI_ResponsibleParty: Organization name is missing")
+        result["errors"].append(
+            "gmd:CI_ResponsibleParty: Organization name is missing")
         result["errors"].append("gmd:CI_ResponsibleParty: E-mail is missing")
         result["errors"].append("gmd:CI_ResponsibleParty: Role is missing")
         result["errors"].append("gmd:md_DataIdentification: Title is missing")
-        result["errors"].append("gmd:md_DataIdentification: Abstract is missing")
+        result["errors"].append(
+            "gmd:md_DataIdentification: Abstract is missing")
         result["errors"].append("gmd:md_ScopeCode: Resource type is missing")
-        result["errors"].append("gmd:RS_Identifier: Unique Resource Identifier is missing")
+        result["errors"].append(
+            "gmd:RS_Identifier: Unique Resource Identifier is missing")
         result["errors"].append("gmd:EX_Extent: Extent element is missing")
-        result["errors"].append("gmd:EX_GeographicBoundingBox: Bounding box is missing")
-        result["errors"].append("Both gmd:EX_TemporalExtent and gmd:CI_Date are missing")
+        result["errors"].append(
+            "gmd:EX_GeographicBoundingBox: Bounding box is missing")
+        result["errors"].append(
+            "Both gmd:EX_TemporalExtent and gmd:CI_Date are missing")
         result["errors"].append("gmd:useLimitation is missing")
         errors += 20
     else:
-        if len(md.identification.contact) < 1 or md.identification.contact is None:
-            result["errors"].append("gmd:CI_ResponsibleParty: Organization name is missing")
-            result["errors"].append("gmd:CI_ResponsibleParty: E-mail is missing")
-            result["errors"].append("gmd:CI_ResponsibleParty: Role is missing")
+        if len(md.identification.contact) < 1 or \
+           md.identification.contact is None:
+            result["errors"].append(
+                "gmd:CI_ResponsibleParty: Organization name is missing")
+            result["errors"].append(
+                "gmd:CI_ResponsibleParty: E-mail is missing")
+            result["errors"].append(
+                "gmd:CI_ResponsibleParty: Role is missing")
             errors += 3
         else:
             if md.identification.contact[0].organization is (None or ''):
-                result["errors"].append("gmd:CI_ResponsibleParty: Organization name is missing")
+                result["errors"].append(
+                    "gmd:CI_ResponsibleParty: Organization name is missing")
                 errors += 1
 
             if md.identification.contact[0].email is (None or ''):
-                result["errors"].append("gmd:CI_ResponsibleParty: E-mail is missing")
+                result["errors"].append(
+                    "gmd:CI_ResponsibleParty: E-mail is missing")
                 errors += 1
 
             if md.identification.contact[0].role is (None or ''):
-                result["errors"].append("gmd:CI_ResponsibleParty: Role is missing")
+                result["errors"].append(
+                    "gmd:CI_ResponsibleParty: Role is missing")
                 errors += 1
 
         if md.identification.title is (None or ''):
-            result["errors"].append("gmd:md_DataIdentification: Title is missing")
+            result["errors"].append(
+                "gmd:md_DataIdentification: Title is missing")
             errors += 1
         if md.identification.abstract is (None or ''):
-            result["errors"].append("gmd:md_DataIdentification: Abstract is missing")
+            result["errors"].append(
+                "gmd:md_DataIdentification: Abstract is missing")
             errors += 1
-        if md.identification.identtype is '':
-            result["errors"].append("gmd:md_ScopeCode: Resource type is missing")
+        if md.identification.identtype == '':
+            result["errors"].append(
+                "gmd:md_ScopeCode: Resource type is missing")
             errors += 1
 
         if md.identification.extent is None:
-            result["errors"].append("gmd:EX_Extent: Extent element is missing")
+            result["errors"].append(
+                "gmd:EX_Extent: Extent element is missing")
             errors += 4
         else:
             if md.identification.extent.boundingBox is None:
-                result["errors"].append("gmd:EX_GeographicBoundingBox: Bounding box is missing")
+                result["errors"].append(
+                    "gmd:EX_GeographicBoundingBox: Bounding box is missing")
                 errors += 4
             else:
                 if md.identification.extent.boundingBox.minx is (None or ''):
-                    result["errors"].append("gmd:westBoundLongitude: minx is missing")
+                    result["errors"].append(
+                        "gmd:westBoundLongitude: minx is missing")
                     errors += 1
                 if md.identification.extent.boundingBox.maxx is (None or ''):
-                    result["errors"].append("gmd:eastBoundLongitude: maxx is missing")
+                    result["errors"].append(
+                        "gmd:eastBoundLongitude: maxx is missing")
                     errors += 1
                 if md.identification.extent.boundingBox.miny is (None or ''):
-                    result["errors"].append("gmd:southBoundLatitude: miny is missing")
+                    result["errors"].append(
+                        "gmd:southBoundLatitude: miny is missing")
                     errors += 1
                 if md.identification.extent.boundingBox.maxy is (None or ''):
-                    result["errors"].append("gmd:northBoundLatitude: maxy is missing")
+                    result["errors"].append(
+                        "gmd:northBoundLatitude: maxy is missing")
                     errors += 1
 
-        if len(md.identification.date) < 1 or (md.identification.temporalextent_start is (
-                    None or '') or md.identification.temporalextent_end is (None or '')):
-            result["errors"].append("Both gmd:EX_TemporalExtent and gmd:CI_Date are missing")
+        if (len(md.identification.date) < 1 or
+           (
+               md.identification.temporalextent_start is (None or '') or
+               md.identification.temporalextent_end is (None or '')
+           )):
+
+            result["errors"].append(
+                "Both gmd:EX_TemporalExtent and gmd:CI_Date are missing")
             errors += 1
 
     if md.datestamp is (None or ''):
@@ -201,7 +261,8 @@ def grassProfileValidator(md):
         errors += 3
     else:
         if md.contact[0].organization is (None or ''):
-            result["errors"].append("gmd:contact: Organization name is missing")
+            result["errors"].append(
+                "gmd:contact: Organization name is missing")
             errors += 1
 
         if md.contact[0].email is (None or ''):
@@ -219,7 +280,7 @@ def grassProfileValidator(md):
 
 
 def isnpireValidator(md):
-    '''function for validation INSPIRE  XML-OWSLib  file-object'''
+    '''Validation INSPIRE  XML-OWSLib file-object'''
 
     result = {}
     result["status"] = "succeded"
@@ -228,108 +289,152 @@ def isnpireValidator(md):
     errors = 0
 
     if md.identification is None:
-        result["errors"].append("gmd:CI_ResponsibleParty: Organization name is missing")
+        result["errors"].append(
+            "gmd:CI_ResponsibleParty: Organization name is missing")
         result["errors"].append("gmd:CI_ResponsibleParty: E-mail is missing")
         result["errors"].append("gmd:CI_ResponsibleParty: Role is missing")
         result["errors"].append("gmd:md_DataIdentification: Title is missing")
-        result["errors"].append("gmd:md_DataIdentification: Abstract is missing")
+        result["errors"].append(
+            "gmd:md_DataIdentification: Abstract is missing")
         result["errors"].append("gmd:md_ScopeCode: Resource type is missing")
         result["errors"].append("gmd:language: Resource language is missing")
-        result["errors"].append("gmd:RS_Identifier: Unique Resource Identifier is missing")
+        result["errors"].append(
+            "gmd:RS_Identifier: Unique Resource Identifier is missing")
         result["errors"].append("gmd:topicCategory: TopicCategory is missing")
         result["errors"].append("gmd:md_Keywords: Keywords are missing")
-        result["errors"].append("gmd:thesaurusName: Thesaurus title is missing")
+        result["errors"].append(
+            "gmd:thesaurusName: Thesaurus title is missing")
         result["errors"].append("gmd:thesaurusName: Thesaurus date is missing")
-        result["errors"].append("gmd:thesaurusName: Thesaurus date type is missing")
+        result["errors"].append(
+            "gmd:thesaurusName: Thesaurus date type is missing")
         result["errors"].append("gmd:EX_Extent: Extent element is missing")
-        result["errors"].append("gmd:EX_GeographicBoundingBox: Bounding box is missing")
-        result["errors"].append("Both gmd:EX_TemporalExtent and gmd:CI_Date are missing")
+        result["errors"].append(
+            "gmd:EX_GeographicBoundingBox: Bounding box is missing")
+        result["errors"].append(
+            "Both gmd:EX_TemporalExtent and gmd:CI_Date are missing")
         result["errors"].append("gmd:useLimitation is missing")
         result["errors"].append("gmd:accessConstraints is missing")
         result["errors"].append("gmd:otherConstraints is missing")
         errors += 20
     else:
-        if md.identification.contact is None or len(md.identification.contact) < 1:
-            result["errors"].append("gmd:CI_ResponsibleParty: Organization name is missing")
-            result["errors"].append("gmd:CI_ResponsibleParty: E-mail is missing")
+        if md.identification.contact is None or \
+           len(md.identification.contact) < 1:
+
+            result["errors"].append(
+                "gmd:CI_ResponsibleParty: Organization name is missing")
+            result["errors"].append(
+                "gmd:CI_ResponsibleParty: E-mail is missing")
             result["errors"].append("gmd:CI_ResponsibleParty: Role is missing")
             errors += 3
-        else:
 
+        else:
             if md.identification.contact[0].organization is (None or ''):
-                result["errors"].append("gmd:CI_ResponsibleParty: Organization name is missing")
+                result["errors"].append(
+                    "gmd:CI_ResponsibleParty: Organization name is missing")
                 errors += 1
 
             if md.identification.contact[0].email is (None or ''):
-                result["errors"].append("gmd:CI_ResponsibleParty: E-mail is missing")
+                result["errors"].append(
+                    "gmd:CI_ResponsibleParty: E-mail is missing")
                 errors += 1
 
             if md.identification.contact[0].role is (None or ''):
-                result["errors"].append("gmd:CI_ResponsibleParty: Role is missing")
+                result["errors"].append(
+                    "gmd:CI_ResponsibleParty: Role is missing")
                 errors += 1
 
         if md.identification.title is (None or ''):
-            result["errors"].append("gmd:md_DataIdentification: Title is missing")
+            result["errors"].append(
+                "gmd:md_DataIdentification: Title is missing")
             errors += 1
         if md.identification.abstract is (None or ''):
-            result["errors"].append("gmd:md_DataIdentification: Abstract is missing")
+            result["errors"].append(
+                "gmd:md_DataIdentification: Abstract is missing")
             errors += 1
         if md.identification.identtype is (None or ''):
-            result["errors"].append("gmd:md_ScopeCode: Resource type is missing")
+            result["errors"].append(
+                "gmd:md_ScopeCode: Resource type is missing")
             errors += 1
 
         if md.identification.resourcelanguage is None:
             errors += 1
-            result["errors"].append("gmd:language: Resource language is missing")
+            result["errors"].append(
+                "gmd:language: Resource language is missing")
         else:
-            if len(md.identification.resourcelanguage) < 1 or md.identification.resourcelanguage[0] == '':
-                result["errors"].append("gmd:language: Resource language is missing")
+            if len(md.identification.resourcelanguage) < 1 or \
+               md.identification.resourcelanguage[0] == '':
+                result["errors"].append(
+                    "gmd:language: Resource language is missing")
                 errors += 1
 
         if md.identification.uricode is None:
-            result["errors"].append("gmd:RS_Identifier: Unique Resource Identifier is missing")
+            result["errors"].append(
+                "gmd:RS_Identifier: Unique Resource Identifier is missing")
             errors += 1
         else:
-            if len(md.identification.uricode) < 1 or md.identification.uricode[0] == '':
-                result["errors"].append("gmd:RS_Identifier: Unique Resource Identifier is missing")
+            if len(md.identification.uricode) < 1 or \
+               md.identification.uricode[0] == '':
+                result["errors"].append(
+                    "gmd:RS_Identifier: Unique Resource Identifier is missing")
                 errors += 1
 
         if md.identification.topiccategory is None:
-            result["errors"].append("gmd:topicCategory: TopicCategory is missing")
+            result["errors"].append(
+                "gmd:topicCategory: TopicCategory is missing")
             errors += 1
         else:
-            if len(md.identification.topiccategory) < 1 or md.identification.topiccategory[0] == '':
-                result["errors"].append("gmd:topicCategory: TopicCategory is missing")
+            if len(md.identification.topiccategory) < 1 or \
+               md.identification.topiccategory[0] == '':
+                result["errors"].append(
+                    "gmd:topicCategory: TopicCategory is missing")
                 errors += 1
 
-        if md.identification.keywords is None or len(md.identification.keywords) < 1:
+        if md.identification.keywords is None or \
+           len(md.identification.keywords) < 1:
+
             result["errors"].append("gmd:MD_Keywords: Keywords are missing")
-            result["errors"].append("gmd:thesaurusName: Thesaurus title is missing")
-            result["errors"].append("gmd:thesaurusName: Thesaurus date is missing")
-            result["errors"].append("gmd:thesaurusName: Thesaurus date type is missing")
+            result["errors"].append(
+                "gmd:thesaurusName: Thesaurus title is missing")
+            result["errors"].append(
+                "gmd:thesaurusName: Thesaurus date is missing")
+            result["errors"].append(
+                "gmd:thesaurusName: Thesaurus date type is missing")
             errors += 4
+
         else:
-            if md.identification.keywords[0]['keywords'] is None or len(md.identification.keywords[0]['keywords']) < 1 \
-                    or str(md.identification.keywords[0]['keywords']) == "[u'']":
-                result["errors"].append("gmd:MD_Keywords: Keywords are missing")
+            if (
+                md.identification.keywords[0]['keywords'] is None or
+                len(md.identification.keywords[0]['keywords']) < 1 or
+                str(md.identification.keywords[0]['keywords']) == "[u'']"
+            ):
+
+                result["errors"].append(
+                    "gmd:MD_Keywords: Keywords are missing")
                 errors += 1
             if md.identification.keywords[0]['thesaurus'] is None:
-                result["errors"].append("gmd:thesaurusName: Thesaurus title is missing")
-                result["errors"].append("gmd:thesaurusName: Thesaurus date is missing")
-                result["errors"].append("gmd:thesaurusName: Thesaurus date type is missing")
+                result["errors"].append(
+                    "gmd:thesaurusName: Thesaurus title is missing")
+                result["errors"].append(
+                    "gmd:thesaurusName: Thesaurus date is missing")
+                result["errors"].append(
+                    "gmd:thesaurusName: Thesaurus date type is missing")
                 errors += 3
             else:
-                if md.identification.keywords[0]['thesaurus']['title'] is None \
-                        or len(md.identification.keywords[0]['thesaurus']['title']) < 1:
-                    result["errors"].append("gmd:thesaurusName: Thesaurus title is missing")
+                title = md.identification.keywords[0]['thesaurus']['title']
+                if (title is None or len(title) < 1):
+                    result["errors"].append(
+                        "gmd:thesaurusName: Thesaurus title is missing")
                     errors += 1
-                if md.identification.keywords[0]['thesaurus']['date'] is None \
-                        or len(md.identification.keywords[0]['thesaurus']['date']) < 1:
-                    result["errors"].append("gmd:thesaurusName: Thesaurus date is missing")
+                date = md.identification.keywords[0]['thesaurus']['date']
+                if date is None or len(date) < 1:
+                    result["errors"].append(
+                        "gmd:thesaurusName: Thesaurus date is missing")
                     errors += 1
-                if md.identification.keywords[0]['thesaurus']['datetype'] is None \
-                        or len(md.identification.keywords[0]['thesaurus']['datetype']) < 1:
-                    result["errors"].append("gmd:thesaurusName: Thesaurus date type is missing")
+                datetype = (md.identification.keywords[0]['thesaurus']
+                            ['datetype'])
+                if datetype is None or len(datetype) < 1:
+                    result["errors"].append(
+                        "gmd:thesaurusName: Thesaurus date type is missing")
                     errors += 1
 
         if md.identification.extent is None:
@@ -342,30 +447,43 @@ def isnpireValidator(md):
                 errors += 1
             else:
                 if md.identification.extent.boundingBox.minx is (None or ''):
-                    result["errors"].append("gmd:westBoundLongitude: minx is missing")
+                    result["errors"].append(
+                        "gmd:westBoundLongitude: minx is missing")
                     errors += 1
                 if md.identification.extent.boundingBox.maxx is (None or ''):
-                    result["errors"].append("gmd:eastBoundLongitude: maxx is missing")
+                    result["errors"].append(
+                        "gmd:eastBoundLongitude: maxx is missing")
                     errors += 1
                 if md.identification.extent.boundingBox.miny is (None or ''):
-                    result["errors"].append("gmd:southBoundLatitude: miny is missing")
+                    result["errors"].append(
+                        "gmd:southBoundLatitude: miny is missing")
                     errors += 1
                 if md.identification.extent.boundingBox.maxy is (None or ''):
-                    result["errors"].append("gmd:northBoundLatitude: maxy is missing")
+                    result["errors"].append(
+                        "gmd:northBoundLatitude: maxy is missing")
                     errors += 1
 
-        if len(md.identification.date) < 1 or (md.identification.temporalextent_start is (
-                    None or '') or md.identification.temporalextent_end is (None or '')):
-            result["errors"].append("Both gmd:EX_TemporalExtent and gmd:CI_Date are missing")
+        if (
+                len(md.identification.date) < 1 or
+                (
+                    md.identification.temporalextent_start is (None or '') or
+                    md.identification.temporalextent_end is (None or '')
+                )
+        ):
+            result["errors"].append(
+                "Both gmd:EX_TemporalExtent and gmd:CI_Date are missing")
             errors += 1
 
-        if len(md.identification.uselimitation) < 1 or md.identification.uselimitation[0] == '':
+        if len(md.identification.uselimitation) < 1 or \
+           md.identification.uselimitation[0] == '':
             result["errors"].append("gmd:useLimitation is missing")
             errors += 1
-        if len(md.identification.accessconstraints) < 1 or md.identification.accessconstraints[0] == '':
+        if len(md.identification.accessconstraints) < 1 or \
+           md.identification.accessconstraints[0] == '':
             result["errors"].append("gmd:accessConstraints is missing")
             errors += 1
-        if len(md.identification.otherconstraints) < 1 or md.identification.otherconstraints[0] == '':
+        if len(md.identification.otherconstraints) < 1 or \
+           md.identification.otherconstraints[0] == '':
             result["errors"].append("gmd:otherConstraints is missing")
             errors += 1
 
@@ -381,8 +499,10 @@ def isnpireValidator(md):
     if md.dataquality is (None or ''):
         result["errors"].append("gmd:LI_Lineage is missing")
         result["errors"].append("gmd:DQ_ConformanceResult: Date is missing")
-        result["errors"].append("gmd:DQ_ConformanceResult: Date type is missing")
-        # result["errors"].append("gmd:DQ_ConformanceResult: Degree is missing")
+        result["errors"].append(
+            "gmd:DQ_ConformanceResult: Date type is missing")
+        # result["errors"].append(
+        #     "gmd:DQ_ConformanceResult: Degree is missing")
         result["errors"].append("gmd:DQ_ConformanceResult: Title is missing")
         errors += 4
     else:
@@ -390,17 +510,24 @@ def isnpireValidator(md):
         if md.dataquality.lineage is (None or ''):
             result["errors"].append("gmd:LI_Lineage is missing")
             errors += 1
-        if len(md.dataquality.conformancedate) < 1 or md.dataquality.conformancedate[0] == '':
-            result["errors"].append("gmd:DQ_ConformanceResult: Date is missing")
+        if len(md.dataquality.conformancedate) < 1 or \
+           md.dataquality.conformancedate[0] == '':
+            result["errors"].append(
+                "gmd:DQ_ConformanceResult: Date is missing")
             errors += 1
-        if len(md.dataquality.conformancedatetype) < 1 or md.dataquality.conformancedatetype[0] == '':
-            result["errors"].append("gmd:DQ_ConformanceResult: Date type is missing")
+        if len(md.dataquality.conformancedatetype) < 1 or \
+           md.dataquality.conformancedatetype[0] == '':
+            result["errors"].append(
+                "gmd:DQ_ConformanceResult: Date type is missing")
             errors += 1
         # if len(md.dataquality.conformancedegree) < 1:
-        #     result["errors"].append("gmd:DQ_ConformanceResult: Degree is missing")
+        #     result["errors"].append(
+        #         "gmd:DQ_ConformanceResult: Degree is missing")
         #     errors += 1
-        if len(md.dataquality.conformancetitle) < 1 or md.dataquality.conformancetitle[0] == '':
-            result["errors"].append("gmd:DQ_ConformanceResult: Title is missing")
+        if len(md.dataquality.conformancetitle) < 1 or \
+           md.dataquality.conformancetitle[0] == '':
+            result["errors"].append(
+                "gmd:DQ_ConformanceResult: Title is missing")
             errors += 1
 
     if md.contact is None or len(md.contact) < 1:
@@ -411,7 +538,8 @@ def isnpireValidator(md):
     else:
 
         if md.contact[0].organization is (None or ''):
-            result["errors"].append("gmd:contact: Organization name is missing")
+            result["errors"].append(
+                "gmd:contact: Organization name is missing")
             errors += 1
 
         if md.contact[0].email is (None or ''):
@@ -443,30 +571,63 @@ class MD_DataIdentification_MOD(MD_DataIdentification):
             val1 = None
             val3 = None
             val4 = None
-            extents = md.findall(util.nspath_eval('gmd:extent', namespaces))
-            extents.extend(md.findall(util.nspath_eval('srv:extent', namespaces)))
+            extents = md.findall(
+                util.nspath_eval('gmd:extent', namespaces),
+            )
+            extents.extend(
+                md.findall(
+                    util.nspath_eval('srv:extent', namespaces),
+                ),
+            )
             for extent in extents:
                 if val2 is None:
-                    val2 = extent.find(util.nspath_eval(
-                        'gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TM_PeriodDuration/gml:duration',
-                        namespaces))  # TODO
+                    duration = ('gmd:EX_Extent/gmd:temporalElement/'
+                                'gmd:EX_TemporalExtent/gmd:extent/'
+                                'gml:TM_PeriodDuration/gml:duration')
+                    val2 = extent.find(
+                        util.nspath_eval(
+                            duration,
+                            namespaces,
+                        ),
+                    )  # TODO
                 self.temporalType = util.testXMLValue(val2)
 
                 if val1 is None:
-                    val1 = extent.find(util.nspath_eval(
-                        'gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:timeLength/gml:timeInterval/gml:unit/gml:TimeUnitType',
-                        namespaces))
+                    time_unit_type = ('gmd:EX_Extent/gmd:temporalElement/'
+                                      'gmd:EX_TemporalExtent/gmd:extent/'
+                                      'gml:timeLength/gml:timeInterval/'
+                                      'gml:unit/gml:TimeUnitType')
+                    val1 = extent.find(
+                        util.nspath_eval(
+                            time_unit_type,
+                            namespaces,
+                        ),
+                    )
                 self.timeUnit = util.testXMLValue(val1)
                 if val3 is None:
-                    val3 = extent.find(util.nspath_eval(
-                        'gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:timeLength/gml:timeInterval/gml:radix/gco:positiveInteger',
-                        namespaces))
+                    positive_int = ('gmd:EX_Extent/gmd:temporalElement/'
+                                    'gmd:EX_TemporalExtent/gmd:extent/'
+                                    'gml:timeLength/gml:timeInterval/'
+                                    'gml:radix/gco:positiveInteger')
+                    val3 = extent.find(
+                        util.nspath_eval(
+                            positive_int,
+                            namespaces,
+                        ),
+                    )
                 self.radixT = util.testXMLValue(val3)
 
                 if val4 is None:
-                    val4 = extent.find(util.nspath_eval(
-                        'gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:timeLength/gml:timeInterval/gml:factor/gco:Integer',
-                        namespaces))
+                    integer = ('gmd:EX_Extent/gmd:temporalElement/'
+                               'gmd:EX_TemporalExtent/gmd:extent/'
+                               'gml:timeLength/gml:timeInterval/'
+                               'gml:factor/gco:Integer')
+                    val4 = extent.find(
+                        util.nspath_eval(
+                            integer,
+                            namespaces,
+                        ),
+                    )
                 self.factor = util.testXMLValue(val4)
 
 
@@ -476,28 +637,56 @@ class MD_MetadataMOD(MD_Metadata):
     def __init__(self, md=None):
         MD_Metadata.__init__(self, md)
         if md is not None:
-            val = md.find(util.nspath_eval('gmd:identificationInfo/gmd:MD_DataIdentification', namespaces))
-            val2 = md.find(util.nspath_eval('gmd:identificationInfo/srv:SV_ServiceIdentification', namespaces))
+            val = md.find(
+                util.nspath_eval(
+                    'gmd:identificationInfo/gmd:MD_DataIdentification',
+                    namespaces,
+                ),
+            )
+            val2 = md.find(
+                util.nspath_eval(
+                    'gmd:identificationInfo/srv:SV_ServiceIdentification',
+                    namespaces,
+                ),
+            )
 
             if val is not None:
                 self.identification = MD_DataIdentification_MOD(val, 'dataset')
                 self.serviceidentification = None
             elif val2 is not None:
-                self.identification = MD_DataIdentification_MOD(val2, 'service')
+                self.identification = MD_DataIdentification_MOD(
+                    val2, 'service',
+                )
                 self.serviceidentification = SV_ServiceIdentification(val2)
             else:
                 self.identification = None
                 self.serviceidentification = None
 
             self.identificationinfo = []
-            for idinfo in md.findall(util.nspath_eval('gmd:identificationInfo', namespaces)):
+            for idinfo in md.findall(
+                    util.nspath_eval(
+                        'gmd:identificationInfo',
+                        namespaces,
+                    ),
+            ):
                 val = list(idinfo)[0]
                 tagval = util.xmltag_split(val.tag)
                 if tagval == 'MD_DataIdentification':
-                    self.identificationinfo.append(MD_DataIdentification_MOD(val, 'dataset'))
+                    self.identificationinfo.append(
+                        MD_DataIdentification_MOD(val, 'dataset'),
+                    )
                 elif tagval == 'MD_ServiceIdentification':
-                    self.identificationinfo.append(MD_DataIdentification_MOD(val, 'service'))
+                    self.identificationinfo.append(
+                        MD_DataIdentification_MOD(val, 'service'),
+                    )
                 elif tagval == 'SV_ServiceIdentification':
-                    self.identificationinfo.append(SV_ServiceIdentification(val))
+                    self.identificationinfo.append(
+                        SV_ServiceIdentification(val),
+                    )
 
-            val = md.find(util.nspath_eval('gmd:distributionInfo/gmd:MD_Distribution', namespaces))
+            val = md.find(
+                util.nspath_eval(
+                    'gmd:distributionInfo/gmd:MD_Distribution',
+                    namespaces,
+                ),
+            )

--- a/grass7/gui/wxpython/wx.metadata/mdlib/mdutil.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/mdutil.py
@@ -74,7 +74,7 @@ def removeNonAscii(s):
     '''Removed non ASCII chars
     '''
     s = [x for x in s if x in string.printable]
-    return s
+    return ''.join(s)
 
 
 def yesNo(parent, question, caption='Yes or no?'):

--- a/grass7/gui/wxpython/wx.metadata/r.info.iso/r.info.iso.py
+++ b/grass7/gui/wxpython/wx.metadata/r.info.iso/r.info.iso.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# -*- coding: utf-8
+# -*- coding: utf-8 -*-
+
 """
 @module  r.info.iso
 @brief   Module for creating metadata based on ISO for raster maps
@@ -33,17 +34,17 @@ This program is free software under the GNU General Public License
 #% required: no
 #%end
 
-
 import os
 import sys
 
-from grass.script import parser, fatal
-from grass.pygrass.utils import set_path
+from grass.script import parser
+from grass.script.utils import set_path
 
 set_path(modulename='wx.metadata', dirname='mdlib')
 
+
 def main():
-    # load metadata library
+    # Load metadata library
     from mdlib.mdgrass import GrassMD
 
     if not options['output']:
@@ -55,9 +56,11 @@ def main():
     md = GrassMD(options['map'], 'raster')
     if options['profile'] == 'inspire':
         md.createGrassInspireISO()
-        xml_file = md.saveXML(path=destination,
-                              xml_out_name=name,
-                              overwrite=os.getenv('GRASS_OVERWRITE', False))
+        xml_file = md.saveXML(
+            path=destination,
+            xml_out_name=name,
+            overwrite=os.getenv('GRASS_OVERWRITE', False),
+        )
 
         if xml_file is not False:
             md.readXML(xml_file)
@@ -65,9 +68,11 @@ def main():
 
     else:
         md.createGrassBasicISO()
-        xml_file = md.saveXML(path=destination,
-                              xml_out_name=name,
-                              overwrite=os.getenv('GRASS_OVERWRITE', False))
+        xml_file = md.saveXML(
+            path=destination,
+            xml_out_name=name,
+            overwrite=os.getenv('GRASS_OVERWRITE', False),
+        )
 
         if xml_file is not False:
             md.readXML(xml_file)
@@ -76,5 +81,4 @@ def main():
 
 if __name__ == "__main__":
     options, flags = parser()
-    main()
-
+    sys.exit(main())

--- a/grass7/gui/wxpython/wx.metadata/t.info.iso/t.info.iso.py
+++ b/grass7/gui/wxpython/wx.metadata/t.info.iso/t.info.iso.py
@@ -48,9 +48,9 @@ def main():
 
     if not options['output']:
         destination = None
-        name = None
+        output_name = None
     else:
-        destination, name = os.path.split(options['output'])
+        destination, output_name = os.path.split(options['output'])
 
     name = options["input"]
     type_ = options["type"]
@@ -76,7 +76,7 @@ def main():
     md.createTemporalISO()
     md.saveXML(
         path=destination,
-        xml_out_name=name,
+        xml_out_name=output_name,
         overwrite=os.getenv('GRASS_OVERWRITE', False),
     )
 

--- a/grass7/gui/wxpython/wx.metadata/t.info.iso/t.info.iso.py
+++ b/grass7/gui/wxpython/wx.metadata/t.info.iso/t.info.iso.py
@@ -31,16 +31,15 @@ This program is free software under the GNU General Public License
 #% required: no
 #%end
 
-
 import os
 import sys
 
-import grass.temporal as tgis
 import grass.script as grass
-from grass.script import parser, fatal
-from grass.pygrass.utils import set_path
+import grass.temporal as tgis
+from grass.script import parser
 
-set_path(modulename='wx.metadata', dirname='mdlib')
+grass.utils.set_path(modulename='wx.metadata', dirname='mdlib', path='..')
+
 
 def main():
     # load metadata library
@@ -80,4 +79,4 @@ def main():
 
 if __name__ == "__main__":
     options, flags = parser()
-    main()
+    sys.exit(main())

--- a/grass7/gui/wxpython/wx.metadata/t.info.iso/t.info.iso.py
+++ b/grass7/gui/wxpython/wx.metadata/t.info.iso/t.info.iso.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8
+# -*- coding: utf-8 -*-
 """
 @module  r.info.iso
 @brief   Module for creating metadata based on ISO for raster maps
@@ -10,6 +10,7 @@ This program is free software under the GNU General Public License
 
 @author Matej Krejci <matejkrejci gmail.com> (GSoC 2015)
 """
+
 #%module
 #% description: Lists information about space time datasets and maps.
 #% keyword: temporal
@@ -42,7 +43,7 @@ grass.utils.set_path(modulename='wx.metadata', dirname='mdlib', path='..')
 
 
 def main():
-    # load metadata library
+    # Load metadata library
     from mdlib.mdgrass import GrassMD
 
     if not options['output']:
@@ -54,7 +55,6 @@ def main():
     name = options["input"]
     type_ = options["type"]
 
-
     # Make sure the temporal database exists
     tgis.init()
 
@@ -63,18 +63,22 @@ def main():
     if name.find("@") >= 0:
         id_ = name
     else:
-        id_ = name + "@" + grass.gisenv()["MAPSET"]
+        id_ = "{}@{}".format(name, grass.gisenv()["MAPSET"])
 
     dataset = tgis.dataset_factory(type_, id_)
 
-    if dataset.is_in_db(dbif) == False:
-        grass.fatal(_("Dataset <%s> not found in temporal database") % (id_))
+    if not dataset.is_in_db(dbif):
+        grass.fatal(
+            _("Dataset <%s> not found in temporal database") % (id_),
+        )
 
     md = GrassMD(id_, type=type_)
     md.createTemporalISO()
-    md.saveXML(path=destination,
-               xml_out_name=name,
-               overwrite=os.getenv('GRASS_OVERWRITE', False))
+    md.saveXML(
+        path=destination,
+        xml_out_name=name,
+        overwrite=os.getenv('GRASS_OVERWRITE', False),
+    )
 
 
 if __name__ == "__main__":

--- a/grass7/gui/wxpython/wx.metadata/v.info.iso/v.info.iso.py
+++ b/grass7/gui/wxpython/wx.metadata/v.info.iso/v.info.iso.py
@@ -36,10 +36,10 @@ This program is free software under the GNU General Public License
 import os
 import sys
 
-from grass.script import parser, fatal
-from grass.pygrass.utils import set_path
+from grass.script import parser
+from grass.script.utils import set_path
 
-set_path(modulename='wx.metadata', dirname='mdlib')
+set_path(modulename='wx.metadata', dirname='mdlib', path='..')
 
 def main():
     # load metadata library
@@ -75,4 +75,4 @@ def main():
 
 if __name__ == "__main__":
     options, flags = parser()
-    main()
+    sys.exit(main())

--- a/grass7/gui/wxpython/wx.metadata/v.info.iso/v.info.iso.py
+++ b/grass7/gui/wxpython/wx.metadata/v.info.iso/v.info.iso.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8
+# -*- coding: utf-8 -*-
 """
 @module  v.info.iso
 @brief   Module for creating metadata based on ISO for vector maps
@@ -41,8 +41,9 @@ from grass.script.utils import set_path
 
 set_path(modulename='wx.metadata', dirname='mdlib', path='..')
 
+
 def main():
-    # load metadata library
+    # Load metadata library
     from mdlib.mdgrass import GrassMD
 
     if not options['output']:
@@ -54,9 +55,11 @@ def main():
     md = GrassMD(options['map'], 'vector')
     if options['profile'] == 'inspire':
         md.createGrassInspireISO()
-        xml_file = md.saveXML(path=destination,
-                              xml_out_name=name,
-                              overwrite=os.getenv('GRASS_OVERWRITE', False))
+        xml_file = md.saveXML(
+            path=destination,
+            xml_out_name=name,
+            overwrite=os.getenv('GRASS_OVERWRITE', False),
+        )
 
         if xml_file is not False:
             md.readXML(xml_file)
@@ -64,9 +67,11 @@ def main():
 
     else:
         md.createGrassBasicISO()
-        xml_file = md.saveXML(path=destination,
-                              xml_out_name=name,
-                              overwrite=os.getenv('GRASS_OVERWRITE', False))
+        xml_file = md.saveXML(
+            path=destination,
+            xml_out_name=name,
+            overwrite=os.getenv('GRASS_OVERWRITE', False),
+        )
 
         if xml_file is not False:
             md.readXML(xml_file)


### PR DESCRIPTION
1. wxGUI `g.gui.metadata`:

![g_gui_metadata](https://user-images.githubusercontent.com/50632337/85323244-f62f2d80-b4c7-11ea-875f-d7bfaa59f446.jpeg)

with csw dialog:

![g_gui_metadata_with_csw_dialog](https://user-images.githubusercontent.com/50632337/85323285-021aef80-b4c8-11ea-875f-0b6ca1ff425e.jpeg)

Exporting metadata reports to format PDF:

I changed the api to get static map img from google maps api to [osm api](https://github.com/jperelli/osm-static-maps) (sometimes the service `https://osm-static-maps.herokuapp.com` is unavailable for a short time). Currently only static map img url query `zoom` param argument is not correctly derived.

Example raster Basins maps (nc_basic_spm_grass7 location) url to get [static map img ](https://osm-static-maps.herokuapp.com/?geojson=[{'type':'Feature','geometry':{'type':'Polygon','coordinates':[[[-78.77462049,35.68792712],[-78.60889171,35.6875073],[-78.60830318,35.80918894],[-78.77428134,35.80960938],[-78.77462049,35.68792712]]]}}]&center=-78.69152414,35.74858701&zoom=12&size=200x200`) (Geographic Location section in the pdf doc):
```https://osm-static-maps.herokuapp.com/?geojson=[{'type':'Feature','geometry':{'type':'Polygon','coordinates':[[[-78.77462049,35.68792712],[-78.60889171,35.6875073],[-78.60830318,35.80918894],[-78.77428134,35.80960938],[-78.77462049,35.68792712]]]}}]&center=-78.69152414,35.74858701&zoom=12&size=200x200```

2. wxGUI `g.gui.cswbrowser`:

![g_gui_cswbrowser](https://user-images.githubusercontent.com/50632337/85325688-50ca8880-b4cc-11ea-9d17-6f62477508a3.jpeg)

Additional info:

Tested with:

```
wx.version()
4.0.7.post2 gtk3 (phoenix) wxWidgets 3.0.4'
```
