### PR TITLE
r.green/r.green.hydro: Fix import py modules from libhydro, libgreen lib

### DIFF
--- a/grass7/raster/r.green/r.green.hydro/r.green.hydro.structure/r.green.hydro.structure.py
+++ b/grass7/raster/r.green/r.green.hydro/r.green.hydro.structure/r.green.hydro.structure.py
@@ -136,19 +136,24 @@ from grass.exceptions import ParameterError
 from grass.pygrass.raster import RasterRow
 from grass.script.core import overwrite, parser, warning
 from grass.script.utils import set_path
-from libgreen.checkparameter import check_required_columns, exception2error
-from libhydro.optimal import conv_segpoints
-from libhydro.plant import read_plants, write_structures
 
 try:
     # set python path to the shared r.green libraries
     set_path('r.green', 'libhydro', '..')
     set_path('r.green', 'libgreen', os.path.join('..', '..'))
+    from libhydro.optimal import conv_segpoints
+    from libhydro.plant import read_plants, write_structures
+    from libgreen.checkparameter import check_required_columns, \
+        exception2error
     from libgreen.utils import cleanup
 except ImportError:
     try:
         set_path('r.green', 'libhydro', os.path.join('..', 'etc', 'r.green'))
         set_path('r.green', 'libgreen', os.path.join('..', 'etc', 'r.green'))
+        from libhydro.optimal import conv_segpoints
+        from libhydro.plant import read_plants, write_structures
+        from libgreen.checkparameter import check_required_columns, \
+            exception2error
         from libgreen.utils import cleanup
     except ImportError:
         warning('libgreen and libhydro not in the python path!')


### PR DESCRIPTION
To reproduce:

`g.extension operation=add extension=r.green`

Error message (appear during compilation):

```
Traceback (most recent call last):
  File "/tmp/grass7-tomas-21163/tmp2qtx71zh/r.green/scripts/r.green.hydro.structure", line 139, in <module>
    from libgreen.checkparameter import check_required_columns, exception2error
ModuleNotFoundError: No module named 'libgreen'
```
