### PR TITLE
cronjob grasslxd: fix broken tar flag order

### DIFF
--- a/tools/cronjobs_osgeo_lxd/cron_grass78_releasebranch_78_build_bins.sh
+++ b/tools/cronjobs_osgeo_lxd/cron_grass78_releasebranch_78_build_bins.sh
@@ -62,6 +62,7 @@ GRASSBUILDDIR=$SOURCE/$BRANCH
 TARGETMAIN=~/var/www/grass/grass-cms
 TARGETDIR=$TARGETMAIN/grass${VERSION}/binary/linux/snapshot
 TARGETHTMLDIR=$TARGETMAIN/grass${VERSION}/manuals/
+# programmer's manual only from master
 
 MYBIN=$MAINDIR/binaries
 
@@ -165,9 +166,10 @@ $MYMAKE sphinxdoclib
 echo "Copy over the manual + pygrass HTML pages:"
 mkdir -p $TARGETHTMLDIR
 # don't destroy the addons
-mv $TARGETHTMLDIR/addons /tmp
-rm -rf $TARGETHTMLDIR/*
-mv /tmp/addons $TARGETHTMLDIR
+\mv $TARGETHTMLDIR/addons /tmp
+rm -f $TARGETHTMLDIR/*.*
+(cd $TARGETHTMLDIR ; rm -rf barscales colortables icons northarrows)
+\mv /tmp/addons $TARGETHTMLDIR
 
 cp -rp dist.$ARCH/docs/html/* $TARGETHTMLDIR/
 echo "Copied pygrass progman to http://grass.osgeo.org/grass${VERSION}/manuals/libpython/"

--- a/tools/cronjobs_osgeo_lxd/cron_grass78_src_relbr78_snapshot.sh
+++ b/tools/cronjobs_osgeo_lxd/cron_grass78_src_relbr78_snapshot.sh
@@ -2,9 +2,9 @@
 
 # script to build GRASS sources package from git relbranch of 7.8
 # (c) GPL 2+ Markus Neteler <neteler@osgeo.org>
-# Markus Neteler 2002, 2003, 2005, 2006, 2007, 2008, 2012, 2014, 2015, 2016, 2017, 2018, 2019
+# Markus Neteler 2002, 2003, 2005, 2006, 2007, 2008, 2012, 2014, 2015, 2016, 2017, 2018, 2019, 2020
 #
-# GRASS Gis github, https://github.com/OSGeo/grass
+# GRASS GIS github, https://github.com/OSGeo/grass
 #
 ## prep, neteler@osgeo6:$
 # mkdir -p ~/src
@@ -21,13 +21,13 @@ GVERSION=$GMAJOR.$GMINOR.git
 DOTVERSION=$GMAJOR.$GMINOR
 GSHORTGVERSION=$GMAJOR$GMINOR
 
-####################
+###################
 # where to find the GRASS sources (git clone):
 SOURCE=$MAINDIR/src/
 BRANCH=releasebranch_${GMAJOR}_${GMINOR}  # or, master
 # where to put the resulting .tar.gz file:
 TARGETMAIN=~/var/www/grass/grass-cms
-TARGET=$TARGETMAIN/grass${GSHORTGVERSION}/source/snapshot
+TARGETDIR=$TARGETMAIN/grass${GSHORTGVERSION}/source/snapshot
 PACKAGENAME=grass-${GVERSION}_
 
 ############################## nothing to change below:
@@ -47,7 +47,7 @@ halt_on_error()
 # create a source code snapshot:
 CWD=`pwd`
 
-mkdir -p $TARGET
+mkdir -p $TARGETDIR
 cd $SOURCE/$BRANCH/
 date
 
@@ -81,28 +81,29 @@ date
 #package it (we rename the directory to have the date inside the package):
 DATE=`date '+_%Y_%m_%d'`
 mv $BRANCH $PACKAGENAME\src_snapshot$DATE
-# exclude version control system directories
-$TAR cfz $PACKAGENAME\src_snapshot$DATE.tar.gz $PACKAGENAME\src_snapshot$DATE --exclude-vcs
+# exclude version control system directories (the flag order matters!)
+$TAR cfz $PACKAGENAME\src_snapshot$DATE.tar.gz --exclude-vcs $PACKAGENAME\src_snapshot$DATE
 mv $PACKAGENAME\src_snapshot$DATE $BRANCH
 
 #remove old snapshot:
-rm -f $TARGET/$PACKAGENAME\src_snapshot*
-rm -f $TARGET/ChangeLog.gz
+rm -f $TARGETDIR/$PACKAGENAME\src_snapshot*
+rm -f $TARGETDIR/ChangeLog.gz
 
 #publish the new one:
 cd $BRANCH/
-cp -p ChangeLog AUTHORS CHANGES CITING COPYING GPL.TXT INSTALL REQUIREMENTS.html $TARGET
+cp -p ChangeLog AUTHORS CHANGES CITING COPYING GPL.TXT INSTALL REQUIREMENTS.html $TARGETDIR
 
 cd ..
-gzip $TARGET/ChangeLog
-cp $PACKAGENAME\src_snapshot$DATE.tar.gz $TARGET
+gzip $TARGETDIR/ChangeLog
+cp $PACKAGENAME\src_snapshot$DATE.tar.gz $TARGETDIR
 rm -f $PACKAGENAME\src_snapshot$DATE.tar.gz
-chmod a+r,g+w $TARGET/* 2> /dev/null
-chgrp grass $TARGET/*   2> /dev/null
+chmod a+r,g+w $TARGETDIR/* 2> /dev/null
+chgrp grass $TARGETDIR/*   2> /dev/null
 
 # link for convenience:
-(cd $TARGET ; rm -f $PACKAGENAME\src_snapshot_latest.tar.gz ; ln -s $PACKAGENAME\src_snapshot$DATE.tar.gz $PACKAGENAME\src_snapshot_latest.tar.gz)
+(cd $TARGETDIR ; rm -f $PACKAGENAME\src_snapshot_latest.tar.gz ; ln -s $PACKAGENAME\src_snapshot$DATE.tar.gz $PACKAGENAME\src_snapshot_latest.tar.gz)
 
-echo "Written: https://grass.osgeo.org/grass${GSHORTGVERSION}/source/snapshot/"
+echo "Written to: $TARGETDIR
+https://grass.osgeo.org/grass${GSHORTGVERSION}/source/snapshot/"
 
 exit 0

--- a/tools/cronjobs_osgeo_lxd/cron_grass7_HEAD_build_bins.sh
+++ b/tools/cronjobs_osgeo_lxd/cron_grass7_HEAD_build_bins.sh
@@ -154,9 +154,10 @@ $MYMAKE sphinxdoclib
 echo "Copy over the manual + pygrass HTML pages:"
 mkdir -p $TARGETHTMLDIR
 # don't destroy the addons
-mv $TARGETHTMLDIR/addons /tmp
-rm -rf $TARGETHTMLDIR/*
-mv /tmp/addons $TARGETHTMLDIR
+\mv $TARGETHTMLDIR/addons /tmp
+rm -f $TARGETHTMLDIR/*.*
+(cd $TARGETHTMLDIR ; rm -rf barscales colortables icons northarrows)
+\mv /tmp/addons $TARGETHTMLDIR
 
 cp -rp dist.$ARCH/docs/html/* $TARGETHTMLDIR/
 echo "Copied pygrass progman to http://grass.osgeo.org/grass${VERSION}/manuals/libpython/"
@@ -169,7 +170,7 @@ cp -p AUTHORS CHANGES CITING COPYING GPL.TXT INSTALL REQUIREMENTS.html $TARGETDI
 (cd $GRASSBUILDDIR/ ; $MYMAKE cleansphinx)
 
 ############
-# generate doxygen manual
+# generate doxygen programmers's manual
 cd $GRASSBUILDDIR/
 #$MYMAKE htmldocs-single > /dev/null || (echo "$0 htmldocs-single: an error occured" ; exit 1)
 $MYMAKE htmldocs-single || (echo "$0 htmldocs-single: an error occured" ; exit 1)

--- a/tools/cronjobs_osgeo_lxd/cron_grass7_HEAD_src_snapshot.sh
+++ b/tools/cronjobs_osgeo_lxd/cron_grass7_HEAD_src_snapshot.sh
@@ -18,13 +18,13 @@ GVERSION=$GMAJOR.$GMINOR.git
 DOTVERSION=$GMAJOR.$GMINOR
 GSHORTGVERSION=$GMAJOR$GMINOR
 
-####################
+###################
 # where to find the GRASS sources (git clone):
 SOURCE=$MAINDIR/src/
 BRANCH=master  # releasebranch_7_8
 # where to put the resulting .tar.gz file:
 TARGETMAIN=~/var/www/grass/grass-cms
-TARGET=$TARGETMAIN/grass${GSHORTGVERSION}/source/snapshot
+TARGETDIR=$TARGETMAIN/grass${GSHORTGVERSION}/source/snapshot
 PACKAGENAME=grass-${GVERSION}_
 
 ############################## nothing to change below:
@@ -44,7 +44,7 @@ halt_on_error()
 # create a source code snapshot:
 CWD=`pwd`
 
-mkdir -p $TARGET
+mkdir -p $TARGETDIR
 cd $SOURCE/$BRANCH/
 date
 
@@ -78,28 +78,29 @@ date
 #package it (we rename the directory to have the date inside the package):
 DATE=`date '+_%Y_%m_%d'`
 mv $BRANCH $PACKAGENAME\src_snapshot$DATE
-# exclude version control system directories
-$TAR cfz $PACKAGENAME\src_snapshot$DATE.tar.gz $PACKAGENAME\src_snapshot$DATE --exclude-vcs
+# exclude version control system directories (the flag order matters!)
+$TAR cfz $PACKAGENAME\src_snapshot$DATE.tar.gz --exclude-vcs $PACKAGENAME\src_snapshot$DATE
 mv $PACKAGENAME\src_snapshot$DATE $BRANCH
 
 #remove old snapshot:
-rm -f $TARGET/$PACKAGENAME\src_snapshot*
-rm -f $TARGET/ChangeLog.gz
+rm -f $TARGETDIR/$PACKAGENAME\src_snapshot*
+rm -f $TARGETDIR/ChangeLog.gz
 
 #publish the new one:
 cd $BRANCH/
-cp -p ChangeLog AUTHORS CHANGES CITING COPYING GPL.TXT INSTALL REQUIREMENTS.html $TARGET
+cp -p ChangeLog AUTHORS CHANGES CITING COPYING GPL.TXT INSTALL REQUIREMENTS.html $TARGETDIR
 
 cd ..
-gzip $TARGET/ChangeLog
-cp $PACKAGENAME\src_snapshot$DATE.tar.gz $TARGET
+gzip $TARGETDIR/ChangeLog
+cp $PACKAGENAME\src_snapshot$DATE.tar.gz $TARGETDIR
 rm -f $PACKAGENAME\src_snapshot$DATE.tar.gz
-chmod a+r,g+w $TARGET/* 2> /dev/null
-chgrp grass $TARGET/*   2> /dev/null
+chmod a+r,g+w $TARGETDIR/* 2> /dev/null
+chgrp grass $TARGETDIR/*   2> /dev/null
 
 # link for convenience:
-(cd $TARGET ; rm -f $PACKAGENAME\src_snapshot_latest.tar.gz ; ln -s $PACKAGENAME\src_snapshot$DATE.tar.gz $PACKAGENAME\src_snapshot_latest.tar.gz)
+(cd $TARGETDIR ; rm -f $PACKAGENAME\src_snapshot_latest.tar.gz ; ln -s $PACKAGENAME\src_snapshot$DATE.tar.gz $PACKAGENAME\src_snapshot_latest.tar.gz)
 
-echo "Written: https://grass.osgeo.org/grass${GSHORTGVERSION}/source/snapshot/"
+echo "Written to: $TARGETDIR
+https://grass.osgeo.org/grass${GSHORTGVERSION}/source/snapshot/"
 
 exit 0


### PR DESCRIPTION
- fixes lack of updates due to wrong position of --exclude-vcs in tar command
- var name sync