### PR TITLE
r.accumulate: Add -N flag for faster flow accumulation (with this flag is slower)

### DIFF
--- a/grass7/raster/r.accumulate/accumulate.c
+++ b/grass7/raster/r.accumulate/accumulate.c
@@ -7,7 +7,8 @@ static double trace_up(struct cell_map *, struct raster_map *,
                        struct raster_map *, char **, char, int, int);
 
 void accumulate(struct cell_map *dir_buf, struct raster_map *weight_buf,
-                struct raster_map *accum_buf, char **done, char neg)
+                struct raster_map *accum_buf, char **done, char neg,
+                char null)
 {
     int row, col;
 
@@ -18,10 +19,10 @@ void accumulate(struct cell_map *dir_buf, struct raster_map *weight_buf,
     for (row = 0; row < nrows; row++) {
         G_percent(row, nrows, 1);
         for (col = 0; col < ncols; col++)
-            if (Rast_is_c_null_value(&dir_buf->c[row][col]))
-                set_null(accum_buf, row, col);
-            else
+            if (!Rast_is_c_null_value(&dir_buf->c[row][col]))
                 trace_up(dir_buf, weight_buf, accum_buf, done, neg, row, col);
+            else if (null)
+                set_null(accum_buf, row, col);
     }
     G_percent(1, 1, 1);
 }

--- a/grass7/raster/r.accumulate/global.h
+++ b/grass7/raster/r.accumulate/global.h
@@ -94,7 +94,7 @@ void add_line(struct line_list *, struct line *);
 
 /* accumulate.c */
 void accumulate(struct cell_map *, struct raster_map *, struct raster_map *,
-                char **, char);
+                char **, char, char);
 
 /* subaccumulate.c */
 void subaccumulate(struct Map_info *, struct cell_map *, struct raster_map *,


### PR DESCRIPTION
By default without the -N flag, flow accumulation is faster than with this flag. Nullifying cells with no flow accumulation (-N flag) adds too much overhead (`Rast_set_[cfd]_null_value` + null file). Subsequent analyses are not affected.