### PR TITLE
wx.metadata/g.gui.metadata: Fix expand wx.SplitterWindow widget to the frame width size

### DIFF
--- a/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
+++ b/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
@@ -933,6 +933,7 @@ class MdMainFrame(wx.Frame):
             self.ntbRight = NotebookRight(self.splitter, self.xmlPath)
             self.splitter.SplitVertically(self.editor, self.ntbRight, sashPosition=0.65)
             self.splitter.SetSashGravity(0.65)
+            self.leftPanel.Hide()
             self.resizeFrame()
             self.Show()
 
@@ -978,6 +979,7 @@ class MdMainFrame(wx.Frame):
 
             self.splitter.SplitVertically(self.editor, self.ntbRight, sashPosition=0.65)
             self.splitter.SetSashGravity(0.65)
+            self.leftPanel.Hide()
             self.Hsizer.Add(self.splitter, proportion=1, flag=wx.EXPAND)
             self.splitter.UpdateSize()
             self.resizeFrame()
@@ -987,6 +989,7 @@ class MdMainFrame(wx.Frame):
             self.second = False
             self.secondAfterChoice = True
             self.splitter.Hide()
+            self.leftPanel.Show()
             self.bttNew.Disable()
             self.bttSave.Disable()
 
@@ -995,6 +998,7 @@ class MdMainFrame(wx.Frame):
         elif self.secondAfterChoice:
             self.secondAfterChoice = False
             self.second = True
+            self.leftPanel.Hide()
             self.splitter.Show()
             self.bttNew.Enable()
             self.bttSave.Enable()


### PR DESCRIPTION
Default layout:

![g_gui_metadata_splitter_window_def_layout](https://user-images.githubusercontent.com/50632337/87039598-afdc0d00-c1ef-11ea-9b55-9471b7b9c0d3.png)

Expected layout:

![g_gui_metadata_splitter_window_exp_layout](https://user-images.githubusercontent.com/50632337/87040095-7a83ef00-c1f0-11ea-8e91-b34a247486d3.png)
