### PR TITLE
wx.metadata/g.gui.metadata: Fix Spatial/Temporal maps wx.TreeCtrl widget GetSelections method name

### DIFF
--- a/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
+++ b/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
@@ -1205,8 +1205,8 @@ class MdDataCatalog(LocationMapTree):
         if evt is not None:
             item = evt.Item
         else:
-            item = self.GetSelection()
-        name=self.GetItemText(item)
+            item = self.GetSelections()[0]
+        name = self.GetItemText(item)
         parentItem = self.GetItemParent(item)
         mapType = self.GetItemText(parentItem)
         if self.GetChildrenCount(item) == 0 and self.isMapExist(name,mapType):  # is selected map


### PR DESCRIPTION
Fix error message:

```
Traceback (most recent call last):
  File "/home/tomas/.grass7/addons/scripts/g.gui.metadata", line 553, in onNewSession
    self.MdDataCatalogPanelLeft.onChanged(None)
  File "/home/tomas/.grass7/addons/scripts/g.gui.metadata", line 1208, in onChanged
    item = self.GetSelection()
wx._core.wxAssertionError: C++ assertion "!HasFlag(wxTR_MULTIPLE)" failed at /usr/include/wx-3.0-gtk3/wx/generic/treectlg.h(115) in GetSelection(): must use GetSelections() with this control
```