### PR TITLE
wx.metadata/g.gui.metadata: Fix profile wx.ComboBox widget layout

### DIFF
--- a/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
+++ b/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
@@ -1034,10 +1034,17 @@ class MdMainFrame(wx.Frame):
 
         self.configPanelLeftSizer = wx.BoxSizer(wx.VERTICAL)
         self.configPanelLeft.SetSizer(self.configPanelLeftSizer)
-        self.configPanelLeftSizer.Add(self.rbGrass)
-        self.configPanelLeftSizer.Add(self.rbExternal)
-        self.configPanelLeftSizer.Add(self.comboBoxProfile)
-        self.configPanelLeft.SetSizer(self.configPanelLeftSizer)
+        self.configPanelLeftSizer.Add(
+            self.rbGrass, proportion=0, flag=wx.LEFT, border=10,
+        )
+        self.configPanelLeftSizer.Add(
+            self.rbExternal, proportion=0, flag=wx.LEFT, border=10,
+        )
+        self.configPanelLeftSizer.Add(
+            self.comboBoxProfile, proportion=0, flag=wx.LEFT | wx.TOP |
+            wx.BOTTOM, border=10,
+        )
+        self.configPanelLeft.SetSizerAndFit(self.configPanelLeftSizer)
 
         self.leftPanelSizer = wx.BoxSizer(wx.VERTICAL)
         self.leftPanel.SetSizer(self.leftPanelSizer)


### PR DESCRIPTION
To reproduce:

1. Launch wxGUI `g.gui.metadata`

2. Check 'Metadata extenal editor' wx.RadioButton widget

3. Check back 'Metadata map editor' wx.RadioButton widget

Default layout:

![g_gui_metadata_config_panel_def_layout](https://user-images.githubusercontent.com/50632337/87053631-7c56ae00-c202-11ea-8099-1dfe9011da47.png)

Expected layout:

![g_gui_metadata_config_panel_exp_layout](https://user-images.githubusercontent.com/50632337/87053735-9db79a00-c202-11ea-8108-419ab751c59d.png)





