### PR TITLE
wx.metadata: Add missing default dependencies py modules

### DIFF
--- a/grass7/gui/wxpython/wx.metadata/dependency.py
+++ b/grass7/gui/wxpython/wx.metadata/dependency.py
@@ -14,6 +14,9 @@ import importlib
 
 URL = 'https://grasswiki.osgeo.org/wiki/ISO/INSPIRE_Metadata_Support'
 MODULES = {
+    'lxml': {
+        'check_version': False,
+    },
     'owslib': {
         'check_version': True,
         'package': 'owslib.iso',
@@ -25,6 +28,9 @@ MODULES = {
         'package': 'pycsw.core',
         'submodule': 'admin',
         'version': '>=2.0',
+    },
+    'pygments': {
+        'check_version': False,
     },
     'sqlalchemy': {
         'check_version': False,

--- a/grass7/gui/wxpython/wx.metadata/dependency.py
+++ b/grass7/gui/wxpython/wx.metadata/dependency.py
@@ -14,6 +14,9 @@ import importlib
 
 URL = 'https://grasswiki.osgeo.org/wiki/ISO/INSPIRE_Metadata_Support'
 MODULES = {
+    'jinja2': {
+        'check_version': False,
+    },
     'lxml': {
         'check_version': False,
     },
@@ -32,13 +35,10 @@ MODULES = {
     'pygments': {
         'check_version': False,
     },
-    'sqlalchemy': {
-        'check_version': False,
-    },
-    'jinja2': {
-        'check_version': False,
-    },
     'reportlab': {
+        'check_version': False,
+    },
+    'sqlalchemy': {
         'check_version': False,
     },
 }


### PR DESCRIPTION
Add missing default dependencies py modules:

1.  `lxml`

2.  `pygments`