### PR TITLE
r.colors.out_sld: do not write NaN in SLD without -n flag

### DIFF
--- a/grass7/raster/r.colors.out_sld/r.colors.out_sld.html
+++ b/grass7/raster/r.colors.out_sld/r.colors.out_sld.html
@@ -7,6 +7,9 @@ the Styled Layer Description (SLD) format according to OGC standard.
 requires that the input map is read and may thus take a bit longer than the
 export of contious color rules (ramp).
 
+<p> Only if the flag <b>n<\b> is given, the NaN values are written into the
+sld file, otherwise they lead to errors e.g. by unsing the sld in geoserver.
+
 <p>Currently only SLD v1.0.0 is implemented.
 
 <h2>EXAMPLES:</h2>

--- a/grass7/raster/r.colors.out_sld/r.colors.out_sld.html
+++ b/grass7/raster/r.colors.out_sld/r.colors.out_sld.html
@@ -8,7 +8,7 @@ requires that the input map is read and may thus take a bit longer than the
 export of contious color rules (ramp).
 
 <p> Only if the flag <b>n<\b> is given, the NaN values are written into the
-sld file, otherwise they lead to errors e.g. by unsing the sld in geoserver.
+generated SLD file which leads e.g. in GeoServer to an error when using such SLD.
 
 <p>Currently only SLD v1.0.0 is implemented.
 

--- a/grass7/raster/r.colors.out_sld/r.colors.out_sld.py
+++ b/grass7/raster/r.colors.out_sld/r.colors.out_sld.py
@@ -4,7 +4,7 @@
 
 MODULE:       r.colors.out_sld
 AUTHOR(S):    Hamish Bowman
-              Stefan Blumentrath, NINA: Port to GRASS GIS 7 / Python, 
+              Stefan Blumentrath, NINA: Port to GRASS GIS 7 / Python,
               lable and opacity support
 PURPOSE:      Export GRASS raster color table to OGC SLD template v1.0.0
 COPYRIGHT:    (C) 2011 by Hamish Bowman, and the GRASS Development Team
@@ -56,6 +56,11 @@ To Dos:
 #% answer: -
 #%End
 
+#%flag
+#% key: n
+#% description: Propagate NULLs
+#%end
+
 import os
 import sys
 import grass.script as grass
@@ -105,11 +110,11 @@ def main():
 
     # Initialize SLD with header
     sld = u"""<?xml version="1.0" encoding="UTF-8"?>
-<StyledLayerDescriptor version="1.0.0" 
-    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
-    xmlns="http://www.opengis.net/sld" 
-    xmlns:ogc="http://www.opengis.net/ogc" 
-    xmlns:xlink="http://www.w3.org/1999/xlink" 
+<StyledLayerDescriptor version="1.0.0"
+    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+    xmlns="http://www.opengis.net/sld"
+    xmlns:ogc="http://www.opengis.net/ogc"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NamedLayer>
     <Name>{}</Name>""".format(style_name)
@@ -128,7 +133,7 @@ def main():
         # sld+='            <ColorMap type={}>\n'.format('"ramp"')
         ColorMapEntry = '              <ColorMapEntry color="#{0:02x}{1:02x}{2:02x}" quantity="{3}" opacity="{4}" />\n'
 
-    # 
+    #
     for c in color_rules:
         if len(c.split(' ')) == 2 and not c.split(' ')[0] == 'default':
             q = c.split(' ')[0]
@@ -150,9 +155,11 @@ def main():
                     l = 'NoData'
                 else:
                     continue
-                sld+=ColorMapEntry.format(r,g,b,q,l,o)
+                if not q == 'NaN' or flags['n']:
+                    sld+=ColorMapEntry.format(r,g,b,q,l,o)
             else:
-                sld+=ColorMapEntry.format(r,g,b,q,o)
+                if not q == 'NaN' or flags['n']:
+                    sld+=ColorMapEntry.format(r,g,b,q,o)
 
     # write file footer
     sld+="""            </ColorMap>


### PR DESCRIPTION
Using the generated SLD file with currently released version leads to an ERROR in Geoserver:
```
Error rendering coverage on the fast path
java.lang.UnsupportedOperationException: NaN values can only be set inside a single-point Range
NaN values can only be set inside a single-point Range
```
due to the NULL value line in the sld `<sld:ColorMapEntry color="#ffffff" opacity="0" quantity="NaN"/>`.

To avoid this I added a flag `n` which propagates NULL only if `-n` is set.