### PR TITLE
i.cutlines: no 0 vertical or horizontal number of lines

### DIFF
--- a/grass7/imagery/i.cutlines/i.cutlines.py
+++ b/grass7/imagery/i.cutlines/i.cutlines.py
@@ -301,10 +301,10 @@ def main():
 
     if nsrange > ewrange:
         hnumber_lines = number_lines
-        vnumber_lines = int(number_lines * (ewrange / nsrange))
+        vnumber_lines = max(int(number_lines * (ewrange / nsrange)), 1)
     else:
         vnumber_lines = number_lines
-        hnumber_lines = int(number_lines * (nsrange / ewrange))
+        hnumber_lines = max(int(number_lines * (nsrange / ewrange)), 1)
 
     # Create the lines in horizonal direction
     nsstep = float(region.n - region.s - region.nsres) / hnumber_lines


### PR DESCRIPTION
In the moment it is possible that `hnumber_lines` or `hnumber_lines` can get 0. E.g. if `number_lines * (nsrange / ewrange) = 0.815` and then i.cutlines results in an error:
```
...
Finding cutlines in both directions
Traceback (most recent call last): 
  File "/usr/local/grass78/scripts/i.cutlines", line 640, in <module>
    main()
  File "/usr/local/grass78/scripts/i.cutlines", line 310, in main
    nsstep = float(region.n - region.s - region.nsres) / hnumber_lines
ZeroDivisionError: float division by zero
Erasing temporary files...
```
To avoid this I added that `hnumber_lines` or `hnumber_lines` must be at least 1.