### PR TITLE
hugo deploy script: less downtime

### DIFF
--- a/tools/cronjobs_osgeo_lxd/hugo_clean_and_update_job.sh
+++ b/tools/cronjobs_osgeo_lxd/hugo_clean_and_update_job.sh
@@ -1,22 +1,31 @@
 #!/bin/sh
 
-# 2020 Markus Neteler
+# 2020, Markus Neteler
 # deploy updated web site from github repo
 
-# 1. update local repo from github
-# 2. rm previously built pages
-# 3. built updated pages
-# 4. rm deployed web pages while not deleting src code files in their separate directory (careful!)
-# 5. copy over updated pages to web pages dir
-# 6. copy over Google site ranking token
-# 7. links src code dirs into deployed web pages dir
-# 8. restore link timestamps from their original source time stamps
+# preparation
+#  sudo chown -R neteler.users /var/www
+
+# 0.  change into local git repo copy
+# 1.  update local repo from github
+# 2.  rm previously built pages in local git repo copy
+# 3.  build updated pages with hugo
+# 4.  create tmp target web directory
+# 5.  copy over updated pages to tmp target web directory
+# 6.  rm previously deployed web pages while not deleting src code files in their adjacent directory (careful!)
+# 7.  copy over updated pages from tmp target web directory to server target web directory
+# 8.  links src code dir content into now deployed web directory
+# 9.  rm tmp target web directory
+# 10. restore linked src file timestamps from their original source time stamps
 
 cd /home/neteler/grass-website/ && \
-   git pull origin master &&  \
-   rm -rf /home/neteler/grass-website/public/* &&  \
-   /usr/local/bin/hugo &&  \
-   rm -fr /var/www/html/* &&  \
-   \cp -rp /home/neteler/grass-website/public/* /var/www/html/ &&  \
-   ln -s /var/www/code_and_data/* /var/www/html/ &&  \
+   git pull origin master && \
+   rm -rf /home/neteler/grass-website/public/* && \
+   nice /usr/local/bin/hugo && \
+   mkdir /var/www/html_new && \
+   \cp -rp /home/neteler/grass-website/public/* /var/www/html_new/ && \
+   rm -fr /var/www/html/* && \
+   \mv /var/www/html_new/* /var/www/html/ && \
+   ln -s /var/www/code_and_data/* /var/www/html/ && \
+   rmdir /var/www/html_new && \
    (cd /var/www/html/ ; /home/neteler/bin/fix_link_timestamp.sh .)


### PR DESCRIPTION
Optimize deployment steps for speed to minimize risk that users see a
half-deployed server when visiting https://grass.osgeo.org/ during page redeployment (cronjob).

Change: do not remove, then copy into but prepare in a temp directory, then swap directories.