### PR TITLE
r.pops.spread: Update to PoPS version 1.0.1

### DIFF
--- a/grass7/raster/r.pops.spread/main.cpp
+++ b/grass7/raster/r.pops.spread/main.cpp
@@ -554,7 +554,7 @@ int main(int argc, char *argv[])
             _("The kappa parameter of von Mises distribution"
               " (concentration);"
               " typically the strength of the wind direction");
-    opt.natural_kappa->required = YES;
+    opt.natural_kappa->required = NO;
     opt.natural_kappa->guisection = _("Dispersal");
 
     opt.anthro_kernel = G_define_option();
@@ -774,8 +774,9 @@ int main(int argc, char *argv[])
     else if (opt.natural_kappa->answer)
         config.natural_kappa = std::stod(opt.natural_kappa->answer);
 
-    config.anthro_kernel_type = opt.anthro_kernel->answer;
     config.use_anthropogenic_kernel = false;
+    if (opt.anthro_kernel->answer)
+        config.anthro_kernel_type = opt.anthro_kernel->answer;
     if (kernel_type_from_string(config.anthro_kernel_type) != DispersalKernelType::None)
         config.use_anthropogenic_kernel = true;
 

--- a/grass7/raster/r.pops.spread/testsuite/test_r_pops_spread.py
+++ b/grass7/raster/r.pops.spread/testsuite/test_r_pops_spread.py
@@ -263,6 +263,89 @@ class TestSpread(TestCase):
         values = dict(null_cells=0, min=0, max=7.440, mean=0.947)
         self.assertRasterFitsUnivar(raster='stddev', reference=values, precision=0.001)
 
+    def test_natural_kernel_only(self):
+        """Check with only natural kernel (no anthropogenic kernel)"""
+        start = '2019-01-01'
+        end = '2022-12-31'
+        self.assertModule(
+            'r.pops.spread', host='host', total_plants='max_host', infected='infection',
+            average='average', average_series='average', single_series='single',
+            stddev='stddev', stddev_series='stddev',
+            probability='probability', probability_series='probability',
+            start_date=start, end_date=end, seasonality=[1, 12], step_unit='week',
+            step_num_units=1,
+            reproductive_rate=1, natural_dispersal_kernel='exponential', natural_distance=50,
+            natural_direction='W', natural_direction_strength=3,
+            random_seed=1, runs=5, nprocs=5
+        )
+        self.assertRasterExists('average')
+        self.assertRasterExists('stddev')
+        self.assertRasterExists('probability')
+        end = end[:4]
+        self.assertRasterExists('average' + '_{}_12_31'.format(end))
+        self.assertRasterExists('probability' + '_{}_12_31'.format(end))
+        self.assertRasterExists('single' + '_{}_12_31'.format(end))
+        self.assertRasterExists('stddev' + '_{}_12_31'.format(end))
+
+        ref_float = dict(datatype="DCELL")
+        ref_int = dict(datatype="CELL")
+        self.assertRasterFitsInfo(raster="average", reference=ref_float)
+        self.assertRasterFitsInfo(raster="stddev", reference=ref_float)
+        self.assertRasterFitsInfo(raster="probability", reference=ref_float)
+        self.assertRasterFitsInfo(
+            raster="single" + "_{}_12_31".format(end),
+            reference=ref_int
+        )
+        self.assertRasterFitsInfo(
+            raster="average" + "_{}_12_31".format(end),
+            reference=ref_float
+        )
+        self.assertRasterFitsInfo(
+            raster="probability" + "_{}_12_31".format(end),
+            reference=ref_float
+        )
+        self.assertRasterFitsInfo(
+            raster="stddev" + "_{}_12_31".format(end),
+            reference=ref_float
+        )
+
+        values = dict(null_cells=0, min=0, max=18, mean=0.447)
+        self.assertRasterFitsUnivar(raster='average', reference=values, precision=0.001)
+        values = dict(null_cells=0, min=0, max=100, mean=7.830)
+        self.assertRasterFitsUnivar(raster='probability', reference=values, precision=0.001)
+        values = dict(null_cells=0, min=0, max=6, mean=0.123)
+        self.assertRasterFitsUnivar(raster='stddev', reference=values, precision=0.001)
+
+    def test_minimal_parameters(self):
+        """Check with only minimal set of parameters (optional or with defaults)"""
+        start = '2019-01-01'
+        end = '2022-12-31'
+        self.assertModule(
+            'r.pops.spread', host='host', total_plants='max_host', infected='infection',
+            average='average', average_series='average', single_series='single',
+            stddev='stddev',
+            probability='probability',
+            probability_series='probability',
+            start_date=start, end_date=end,
+            natural_distance=50,
+            random_seed=1
+        )
+        self.assertRasterExists('average')
+        self.assertRasterExists('stddev')
+        self.assertRasterExists('probability')
+
+        ref_float = dict(datatype="DCELL")
+        self.assertRasterFitsInfo(raster="average", reference=ref_float)
+        self.assertRasterFitsInfo(raster="stddev", reference=ref_float)
+        self.assertRasterFitsInfo(raster="probability", reference=ref_float)
+
+        values = dict(null_cells=0, min=0, max=18, mean=2.260)
+        self.assertRasterFitsUnivar(raster='average', reference=values, precision=0.001)
+        values = dict(null_cells=0, min=0, max=100, mean=44.790)
+        self.assertRasterFitsUnivar(raster='probability', reference=values, precision=0.001)
+        values = dict(null_cells=0, min=0, max=0, mean=0)
+        self.assertRasterFitsUnivar(raster='stddev', reference=values, precision=0.001)
+
 
 if __name__ == '__main__':
     test()


### PR DESCRIPTION
Update to PoPS 1.0.1 release, i.e., the tag v1.0.1 in the ncsu-landscape-dynamics/r.pops.spread repo which in turn uses tag v1.0.0 in PoPS Core (no update needed there).

https://github.com/ncsu-landscape-dynamics/r.pops.spread/releases/tag/v1.0.1
https://github.com/ncsu-landscape-dynamics/pops-core/releases/tag/v1.0.0

Fix parameter handling for kernels:
Code no longer fails without an anthropogenic kernel and natural kernel strength (kappa) is no
longer required when direction is not provided (or none).
Adds test for no anthropogenic kernel and minimalistic command line parameters testing against the current values.
