### PR TITLE
r.confusionmatrix: using stdout instead of stderr for matrix

### DIFF
--- a/grass7/raster/r.confusionmatrix/r.confusionmatrix.py
+++ b/grass7/raster/r.confusionmatrix/r.confusionmatrix.py
@@ -330,7 +330,8 @@ def main():
                 writer.writerow(line)
     if flags['m']:
         for line in lines:
-            grass.message(line)
+            # for stdout using print
+            print(line)
 
     # cleanup
     if options['vector_reference']:


### PR DESCRIPTION
`grass.message` writes the text in `stderr`. The confusion matrix should be printed in `stdout`.