### PR TITLE
unicode() compatibility fix for Python-2/Python-3 

### DIFF
--- a/grass7/gui/wxpython/wx.stream/gui_modules/rstream_ImageViewer.py
+++ b/grass7/gui/wxpython/wx.stream/gui_modules/rstream_ImageViewer.py
@@ -81,7 +81,7 @@ class ListImg(wx.Listbook):
         old = event.GetOldSelection()
         new = event.GetSelection()
         sel = self.GetSelection()
-        print 'OnPageChanged,  old:%d, new:%d, sel:%d\n' % (old, new, sel)
+        print('OnPageChanged,  old:%d, new:%d, sel:%d\n' % (old, new, sel))
         event.Skip()
 
 
@@ -89,7 +89,7 @@ class ListImg(wx.Listbook):
         old = event.GetOldSelection()
         new = event.GetSelection()
         sel = self.GetSelection()
-        print 'OnPageChanging, old:%d, new:%d, sel:%d\n' % (old, new, sel)
+        print('OnPageChanging, old:%d, new:%d, sel:%d\n' % (old, new, sel))
         event.Skip()
 
 

--- a/grass7/gui/wxpython/wx.wms/Makefile
+++ b/grass7/gui/wxpython/wx.wms/Makefile
@@ -5,7 +5,7 @@ include $(MODULE_TOPDIR)/include/Make/Python.make
 
 ETCDIR = $(ETC)/gui/wxpython/gui_modules/wms
 
-SRCFILES := $(wildcard *.py) serverList.txt
+SRCFILES := $(wildcard *.py) ServersList.xml
 DSTFILES := $(patsubst %,$(ETCDIR)/%,$(SRCFILES)) $(patsubst %.py,$(ETCDIR)/%.pyc,$(filter %.py,$(SRCFILES)))
 
 default: $(DSTFILES)

--- a/grass7/gui/wxpython/wx.wms/ServerInfoAPIs.py
+++ b/grass7/gui/wxpython/wx.wms/ServerInfoAPIs.py
@@ -25,6 +25,10 @@ for details.
 from BeautifulSoup import BeautifulSoup, Tag, BeautifulStoneSoup
 import os.path
 
+# PY2/PY3 compat
+if sys.version_info.major >= 3:
+    unicode = str
+
 class ServerData():
     pass
 

--- a/grass7/gui/wxpython/wx.wms/addserver.py
+++ b/grass7/gui/wxpython/wx.wms/addserver.py
@@ -34,7 +34,9 @@ from ServerInfoAPIs import addServerInfo, removeServerInfo, updateServerInfo, in
 from parse import parsexml, isServiceException, populateLayerTree, isValidResponse
 from LoadConfig import loadConfigFile
 
-
+# PY2/PY3 compat
+if sys.version_info.major >= 3:
+    unicode = str
 
 
 class ServerData():

--- a/grass7/gui/wxpython/wx.wms/parse.py
+++ b/grass7/gui/wxpython/wx.wms/parse.py
@@ -27,6 +27,9 @@ import re
 from xml.dom.minidom import parse, parseString
 from urllib2 import Request, urlopen, URLError, HTTPError
 
+# PY2/PY3 compat
+if sys.version_info.major >= 3:
+    unicode = str
 
 key = 0
 

--- a/grass7/raster/r.connectivity/r.connectivity.corridors/r.connectivity.corridors.py
+++ b/grass7/raster/r.connectivity/r.connectivity.corridors/r.connectivity.corridors.py
@@ -144,6 +144,9 @@ import grass.script.task as task
 from grass.script import vector as vect
 from grass.pygrass.raster.history import History
 from grass.pygrass.modules import Module, ParallelModuleQueue
+# PY2/PY3 compat
+if sys.version_info.major >= 3:
+    unicode = str
 
 ### To do:
 # Distinguish and remove temporary raster maps (single corridors)

--- a/grass7/vector/v.rast.bufferstats/v.rast.bufferstats.py
+++ b/grass7/vector/v.rast.bufferstats/v.rast.bufferstats.py
@@ -147,6 +147,10 @@ from grass.pygrass.gis.region import Region
 from grass.pygrass.modules.interface.module import Module
 from itertools import chain
 
+# PY2/PY3 compat
+if sys.version_info.major >= 3:
+    unicode = str
+
 if not "GISBASE" in os.environ.keys():
     grass.message("You must be in GRASS GIS to run this program.")
     sys.exit(1)


### PR DESCRIPTION
Uses the compatibility test from

https://github.com/OSGeo/grass/blob/0a5097cd0e53f3df8285a3bef68b43e8050d273e/lib/python/script/core.py#L37

(and many other places in GRASS-core)

Fixes #274