### PR TITLE
wx.metadata/mdlib: replace '\' (backslash continuation character) in map history comments

### DIFF
--- a/grass7/gui/wxpython/wx.metadata/mdlib/mdgrass.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/mdgrass.py
@@ -313,6 +313,7 @@ class GrassMD():
         '''
         try:
             self.md_grass['comments'] = self.md_grass['comments'].replace('\n', '; ')
+            self.md_grass['comments'] = self.md_grass['comments'].replace('\\', '')
         except:
             pass
 


### PR DESCRIPTION
**To Reproduce:**

1. Launch `g.gui.metadata`
2. Choose map from tree (bug appear in special cases when backslash continuation character appear in the special position in the map history comments).  I tested on my custom raster map.

My custom raster map history comments:

```
comments="r.proj --quiet location="temp_import_location_21544" mapset="PERMANE\NT" input="dmr" method="nearest" memory=300 resolution=9.99225497862\5072"
```

3. Click on the toolbar pencil icon (Editting)
4. In the right panel hit validate button

**Error message:**

```
Traceback (most recent call last):
  File "/home/tomas/.grass7/addons/scripts/g.gui.metadata", line 1319, in validate
    dispatcher.send(signal='NEW_MD.create')
  File "/usr/lib64/grass79/etc/python/grass/pydispatch/dispatcher.py", line 350, in send
    **named
  File "/usr/lib64/grass79/etc/python/grass/pydispatch/robustapply.py", line 60, in robustApply
    return receiver(*arguments, **named)
  File "/home/tomas/.grass7/addons/scripts/g.gui.metadata", line 757, in initNewMD
    self.md = self.editor.saveMDfromGUI()
  File "/home/tomas/.grass7/addons/etc/wx.metadata/mdlib/mdeditorfactory.py", line 1633, in saveMDfromGUI
    noneStatements()
  File "/home/tomas/.grass7/addons/etc/wx.metadata/mdlib/mdeditorfactory.py", line 1414, in noneStatements
    self.executeStr1(str1, mdDes[self.c])
  File "/home/tomas/.grass7/addons/etc/wx.metadata/mdlib/mdeditorfactory.py", line 1345, in executeStr1
    exec(stri)
  File "<string>", line 1
SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes in position 65-66: malformed \N character escape
```