### PR TITLE
PEP8: fix flake8 error F403: 'from owslib.iso import *' used; unable to detect undefined names

### DIFF
--- a/grass7/gui/wxpython/wx.metadata/mdlib/mdeditorfactory.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/mdeditorfactory.py
@@ -32,7 +32,11 @@ from wx import EVT_BUTTON
 import wx.lib.scrolledpanel as scrolled
 
 try:
-    from owslib.iso import *
+    from owslib.iso import (
+        CI_Date, CI_OnlineResource, CI_ResponsibleParty, DQ_DataQuality,
+        EX_Extent, EX_GeographicBoundingBox, MD_Distribution,
+        MD_ReferenceSystem,
+    )
 except:
     sys.exit('owslib library is missing. Check requirements on the manual page < https://grasswiki.osgeo.org/wiki/ISO/INSPIRE_Metadata_Support >')
 from .mdjinjaparser import JinjaTemplateParser

--- a/grass7/gui/wxpython/wx.metadata/mdlib/mdgrass.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/mdgrass.py
@@ -18,7 +18,11 @@ This program is free software under the GNU General Public License
 import sys
 import os
 try:
-    from owslib.iso import *
+    from owslib.iso import (
+        CI_Date, CI_OnlineResource, CI_ResponsibleParty, DQ_DataQuality,
+        EX_Extent, EX_GeographicBoundingBox, MD_Distribution,
+        MD_ReferenceSystem,
+    )
 except:
     sys.exit('owslib library is missing. Check requirements on the manual page < https://grasswiki.osgeo.org/wiki/ISO/INSPIRE_Metadata_Support >')
 try:


### PR DESCRIPTION
Fix flake8 error F403: 'from owslib.iso import *' used; unable to detect undefined names