### PR TITLE
PEP8: fix flake8 error F403: 'from mdlib.cswutil import *' used; unable to detect undefined names

### DIFF
--- a/grass7/gui/wxpython/wx.metadata/db.csw.admin/db.csw.admin.py
+++ b/grass7/gui/wxpython/wx.metadata/db.csw.admin/db.csw.admin.py
@@ -123,8 +123,6 @@ from grass.script.utils import set_path
 
 set_path(modulename='wx.metadata', dirname='mdlib', path='..')
 
-from mdlib.cswutil import *
-
 MODULE_URL = 'https://grasswiki.osgeo.org/wiki/ISO/INSPIRE_Metadata_Support'
 
 
@@ -154,7 +152,6 @@ class CswAdmin():
         self.HOME = None
         self.TABLE = None
         self.CONTEXT = self.pycsw_config.StaticContext()
-
 
     def argParser(self, defaultConf, load_records,
                   loadRecurs, setupDB,

--- a/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
@@ -20,7 +20,10 @@ except:
     sys.exit(
         'owslib python library is missing. Check requirements on the manual page < https://grasswiki.osgeo.org/wiki/ISO/INSPIRE_Metadata_Support >')
 import tempfile
-from .cswutil import *
+from .cswutil import (
+    get_connections_from_file, normalize_text, open_url, renderXML,
+    render_template,
+)
 from .mdutil import yesNo, StaticContext
 import json
 import wx


### PR DESCRIPTION
Fix flake8 error F403: 'from mdlib.cswutil import *' used; unable to detect undefined names