### PR TITLE
PEP8: fix flake8 error F632: use ==/!= to compare constant literals (str, bytes, int, float, tuple)

### DIFF
--- a/grass7/gui/wxpython/wx.metadata/mdlib/mdeditorfactory.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/mdeditorfactory.py
@@ -610,7 +610,7 @@ class MdItem(wx.BoxSizer):
                     the GUI generating mechanism will create GUI according to template
                     and all missing tags(xml)-gui(TextCtrls) will be marked by red
         '''
-        if value is None or value is '':
+        if value is None or value == '':
             if self.chckBox:
                 self.chckBoxEdit.SetValue(True)
                 self.isChecked = True


### PR DESCRIPTION
Fix flake8 error F632: use ==/!= to compare constant literals (str, bytes, int, float, tuple)