### PR TITLE
g.download.location: Make unzip, untar more robust

### DIFF
--- a/grass7/general/g.download.location/g.download.location.html
+++ b/grass7/general/g.download.location/g.download.location.html
@@ -1,8 +1,14 @@
 <h2>DESCRIPTION</h2>
 
-<em>g.download.location</em> downloads a location from a given URL
+<em>g.download.location</em> downloads an archived (e.g.,
+<code>.zip</code> or <code>.tar.gz</code>) location from a given URL
 and unpacks it to a specified or current GRASS GIS Spatial Database.
 URL can be also a local file on the disk.
+
+If the archive contains a directory which contains a location, the module
+will recognize that and use the location automatically.
+First directory which is a location is used.
+Other locations or any other files are ignored.
 
 <h2>SEE ALSO</h2>
 
@@ -11,7 +17,7 @@ URL can be also a local file on the disk.
   <a href="https://grass.osgeo.org/grass-stable/manuals/g.mapsets.html">g.mapsets</a>,
   <a href="https://grass.osgeo.org/grass-stable/manuals/r.proj.html">r.proj</a>,
   <a href="https://grass.osgeo.org/grass-stable/manuals/v.proj.html">v.proj</a>,
-  <a href="g.proj.all.html">g.proj.all</a>,
+  <a href="g.proj.all.html">g.proj.all</a>
 </em>
 
 <h2>AUTHORS</h2>


### PR DESCRIPTION
The module can now deal with location being only one of the nested directories for cases
when archiving program creates one extra. It recurses one level into the structure
(can be modified in the code) which adds additional level to what the Python libraries are doing
(which actually makes the code more complex for us).

xz is among the recognized extensions.

Several special cases and error are now handled gracefully with error being reported
for single file in an archive (typically another archive, but leaving that aside)
and for file being incomplete (likely not fully downloaded).

Functions raise an unified exception, main code now calls fatal when that happens.

Filenames without extension don't cause traceback, but cause an error to be reported.
