### PR TITLE
v.class.ml: fix compile module on OS MS Windows platform

### DIFF
--- a/grass7/vector/v.class.ml/v.class.ml.py
+++ b/grass7/vector/v.class.ml/v.class.ml.py
@@ -362,7 +362,7 @@
 #-----------------------------------------------------
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-import imp
+from importlib.machinery import SourceFileLoader
 import sys
 import os
 from pprint import pprint
@@ -539,7 +539,7 @@ def main(opt, flg):
     # define the classifiers to use/test
     if opt['pyclassifiers'] and opt['pyvar']:
         # import classifiers to use
-        mycls = imp.load_source("mycls", opt['pyclassifiers'])
+        mycls = SourceFileLoader("mycls", opt['pyclassifiers']).load_module()
         classifiers = getattr(mycls, opt['pyvar'])
     else:
         from ml_classifiers import CLASSIFIERS

--- a/grass7/vector/v.class.ml/v.class.ml.py
+++ b/grass7/vector/v.class.ml/v.class.ml.py
@@ -290,7 +290,7 @@
 #% key: svc_kernel
 #% type: string
 #% multiple: no
-#% description: definitive kernel value. Available kernel are: ‘linear’, ‘poly’, ‘rbf’, ‘sigmoid’, ‘precomputed’
+#% description: definitive kernel value. Available kernel are: 'linear', 'poly', 'rbf', 'sigmoid', 'precomputed'
 #% required: no
 #% answer: rbf
 #%end


### PR DESCRIPTION
**Error message**:

```
C:/Users/landa/grass_packager/grass784/x86_64/addons/v.class.ml/scripts/v.class.ml.py:365: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import imp
VERSION_NUMBER=7.8.4 VERSION_DATE=2020 MODULE_TOPDIR=/c/msys64/usr/src/grass784 \
        python3 /usr/src/grass784/dist.x86_64-w64-mingw32/tools/mkhtml.py v.class.ml > /c/Users/landa/grass_packager/grass784/x86_64/addons/v.class.ml/docs/html/v.class.ml.html
Traceback (most recent call last):
  File "C:/msys64/usr/src/grass784/dist.x86_64-w64-mingw32/tools/mkhtml.py", line 286, in <module>
    tmp_data = read_file(tmp_file)
  File "C:/msys64/usr/src/grass784/dist.x86_64-w64-mingw32/tools/mkhtml.py", line 158, in read_file
    return decode(s)
  File "C:/msys64/usr/src/grass784/dist.x86_64-w64-mingw32/tools/mkhtml.py", line 66, in decode
    return bytes_.decode(enc)
  File "C:\\\\OS3944~1\\apps\\Python37\lib\encodings\cp1250.py", line 15, in decode
    return codecs.charmap_decode(input,errors,decoding_table)
UnicodeDecodeError: 'charmap' codec can't decode byte 0x98 in position 8938: character maps to <undefined>
make: *** [/c/msys64/usr/src/grass784/include/Make/Html.make:7: /c/Users/landa/grass_packager/grass784/x86_64/addons/v.class.ml/docs/html/v.class.ml.html] Error 1
rm v.class.ml.tmp.html
```

Wrong single quotes in the 'svc_kernel' parameter description (which caused error message above, during compilation on OS MS Windows platform, on the OS GNU/Linux compilation/instalation work correctly):

Default module manual page:

![v_class_ml_manual_page_default](https://user-images.githubusercontent.com/50632337/95871556-12ecbb00-0d6e-11eb-8f6e-a0d3e576b4d9.png)

Expected module manual page:

![v_class_ml_manual_page_expected](https://user-images.githubusercontent.com/50632337/95871679-36176a80-0d6e-11eb-82c3-8349911e278a.png)

