### PR TITLE
tools/check_addons_urls.sh: explicitly set '/bin/bash' shebang

### DIFF
--- a/tools/cronjobs_osgeo_lxd/check_addons_urls.sh
+++ b/tools/cronjobs_osgeo_lxd/check_addons_urls.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Tomas Zigo, 2020
 


### PR DESCRIPTION
Explicitly set '/bin/bash' shebang.

**Error message:**

```
/home/neteler/cronjobs/check_addons_urls.sh: 30: /home/neteler/cronjobs/check_addons_urls.sh: Syntax error: redirection unexpected
```