### PR TITLE
i.sentinel.download: enable footprint saving for Sentinel-1 data

### DIFF
--- a/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -358,6 +358,13 @@ class SentinelDownloader(object):
             ("producttype", ogr.OFTString),
             ("identifier", ogr.OFTString)
         ])
+
+        # Sentinel-1 data does not have cloudcoverpercentage
+        prod_types = [type for type in self._products_df_sorted["producttype"]]
+        s1_types = ["SLC", "GRD"]
+        if any(type in prod_types for type in s1_types):
+            del attrs["cloudcoverpercentage"]
+
         for key in attrs.keys():
             field = ogr.FieldDefn(key, attrs[key])
             layer.CreateField(field)


### PR DESCRIPTION
This PR fixes the following issue in `i.sentinel.download`: 
Using `i.sentinel.download` with `producttype=GRD` or `producttype=SLC` (Sentinel-1 product types) and `footprints=...` fails, because a cloud cover percentage parameter is expected in `save_footprints` which is not available for Sentinel-1 data. 
