### PR TITLE
r.learn.ml: fix deprecated joblib import

### DIFF
--- a/grass7/raster/r.learn.ml/r.learn.ml.py
+++ b/grass7/raster/r.learn.ml/r.learn.ml.py
@@ -639,7 +639,7 @@ def load_training_data(file):
 
 
 def save_model(estimator, X, y, sample_coords, groups, filename):
-    from sklearn.externals import joblib
+    import joblib
     joblib.dump((estimator, X, y, sample_coords, group_id), filename)
 
 


### PR DESCRIPTION
Fixes `DeprecationWarning: sklearn.externals.joblib is deprecated in 0.21 and will be removed in 0.23. Please import this functionality directly from joblib, which can be installed with: pip install joblib. If this warning is raised when loading pickled models, you may need to re-serialize those models with scikit-learn 0.21+.`

Ref:
https://github.com/scikit-optimize/scikit-optimize/pull/776