### PR TITLE
i.ann.maskrcnn.detect: lazy import skimade and PIL

### DIFF
--- a/grass7/imagery/i.ann.maskrcnn/i.ann.maskrcnn.detect/i.ann.maskrcnn.detect.py
+++ b/grass7/imagery/i.ann.maskrcnn/i.ann.maskrcnn.detect/i.ann.maskrcnn.detect.py
@@ -101,11 +101,6 @@ sys.path.append(path)
 
 def main(options, flags):
 
-    # Lazy imports
-    from skimage.measure import find_contours
-    import skimage.io
-    from PIL import Image
-
     import model as modellib
     from config import ModelConfig
 
@@ -600,4 +595,21 @@ def parse_instances(image,
 
 if __name__ == "__main__":
     options, flags = gscript.parser()
+
+    # import only after the parser finished and the code actually runs
+
+    # Lazy imports
+
+    try:
+        from skimage.measure import find_contours
+        import skimage.io
+    except ImportError:
+        grass.fatal("Cannot import skimage."
+                    " Please install the Python scikit-image package.")
+    try:
+        from PIL import Image
+    except ImportError:
+        grass.fatal("Cannot import PIL."
+                    " Please install the Python pillow package.")
+
     main(options, flags)

--- a/grass7/imagery/i.ann.maskrcnn/i.ann.maskrcnn.detect/i.ann.maskrcnn.detect.py
+++ b/grass7/imagery/i.ann.maskrcnn/i.ann.maskrcnn.detect/i.ann.maskrcnn.detect.py
@@ -84,15 +84,12 @@ import sys
 from io import BytesIO
 
 import numpy as np
-from skimage.measure import find_contours
 import matplotlib.pyplot as plt
 from matplotlib.patches import Polygon
 
 import grass.script as gscript
 from grass.script.utils import get_lib_path
 import grass.script.array as garray
-import skimage.io
-from PIL import Image
 
 from osgeo import gdal, osr
 
@@ -103,6 +100,11 @@ sys.path.append(path)
 
 
 def main(options, flags):
+
+    # Lazy imports
+    from skimage.measure import find_contours
+    import skimage.io
+    from PIL import Image
 
     import model as modellib
     from config import ModelConfig


### PR DESCRIPTION
 i.ann.maskrcnn.detect manuals do not build because skimage is not installed on the build server.
Lazy imports should fix it.
Maybe it should be checked for skimage (and PIL?) in a try-except statement?