### PR TITLE
i.modis: support for MCD19A2 v006

### DIFF
--- a/grass7/imagery/i.modis/i.modis.download/i.modis.download.py
+++ b/grass7/imagery/i.modis/i.modis.download/i.modis.download.py
@@ -50,7 +50,7 @@
 #% label: Name of MODIS product(s)
 #% multiple: yes
 #% required: no
-#% options: lst_terra_daily_1000, lst_aqua_daily_1000, lst_terra_eight_1000, lst_aqua_eight_1000, lst_terra_daily_5600, lst_aqua_daily_5600, lst_terra_monthly_5600, lst_aqua_monthly_5600, ndvi_terra_sixteen_250, ndvi_aqua_sixteen_250, ndvi_terra_sixteen_500, ndvi_aqua_sixteen_500, ndvi_terra_sixteen_1000, ndvi_aqua_sixteen_1000, ndvi_terra_sixteen_5600, ndvi_aqua_sixteen_5600, ndvi_terra_monthly_5600, ndvi_aqua_monthly_5600, snow_terra_daily_500, snow_aqua_daily_500, snow_terra_eight_500, snow_aqua_eight_500, surfreflec_terra_daily_500, surfreflec_aqua_daily_500, surfreflec_terra_eight_500, surfreflec_aqua_eight_500, water_terra_250
+#% options: lst_terra_daily_1000, lst_aqua_daily_1000, lst_terra_eight_1000, lst_aqua_eight_1000, lst_terra_daily_5600, lst_aqua_daily_5600, lst_terra_monthly_5600, lst_aqua_monthly_5600, ndvi_terra_sixteen_250, ndvi_aqua_sixteen_250, ndvi_terra_sixteen_500, ndvi_aqua_sixteen_500, ndvi_terra_sixteen_1000, ndvi_aqua_sixteen_1000, ndvi_terra_sixteen_5600, ndvi_aqua_sixteen_5600, ndvi_terra_monthly_5600, ndvi_aqua_monthly_5600, snow_terra_daily_500, snow_aqua_daily_500, snow_terra_eight_500, snow_aqua_eight_500, surfreflec_terra_daily_500, surfreflec_aqua_daily_500, surfreflec_terra_eight_500, surfreflec_aqua_eight_500, water_terra_250, aerosol_terra_aqua_daily_1000
 #% answer: lst_terra_daily_1000
 #%end
 #%option

--- a/grass7/imagery/i.modis/i.modis.html
+++ b/grass7/imagery/i.modis/i.modis.html
@@ -189,6 +189,31 @@ These products are currently supported:
       product pages)</li>
 </ul>
 
+<h3>MODIS AOD - Aerosol Optical Depth</h3>
+<ul>
+  <li><b>Aerosol optical depth daily 1 Km (Terra+Aqua)</b>: MCD19A2 is
+    the short name for the Multi-Angle Implementation of Atmospheric
+    Correction (MAIAC) algorithm-based Level-2 gridded (L2G) aerosol
+    optical thickness over land surfaces product. This product is
+    derived using both Terra and Aqua MODIS inputs, and produced daily
+    at 1 km pixel resolution in a Sinusoidal projection. MCD19A2 has
+    achieved Stage-3 validation, and each Hierarchical Data Format 4
+    (HDF4) file contains two data groups with the following Science
+    Data Set parameters: Grid 1km: 1. Aerosol Optical Depth at 047
+    micron / 2. Aerosol Optical Depth at 055 micron / 3. AOD
+    Uncertainty at 047 micron / 4. Fine-Mode Fraction for Ocean /
+    5. Column Water Vapor in cm liquid water / 6. AOD QA / 7. AOD
+    Model (Regional background model used) / 8. Injection Height
+    (Smoke injection height over local surface height) Grid 5km:
+    9. Cosine of Solar Zenith Angle / 10. Cosine of View Zenith Angle
+    / 11. Relative Azimuth Angle / 12. Scattering Angle / 13. Glint
+    Angle. See the validation webpage for details on the validation
+    and validation definitions
+    (related <a href="https://lpdaac.usgs.gov/products/mcd19a2v006/">MCD19A2</a>
+    product pages).
+  </li>
+</ul>
+
 <h2>NOTES</h2>
 
 The <em>i.modis</em> modules need the <a href="http://www.pymodis.org">pyModis</a>

--- a/grass7/imagery/i.modis/i.modis.import/i.modis.import.html
+++ b/grass7/imagery/i.modis/i.modis.import/i.modis.import.html
@@ -36,6 +36,32 @@ obtaining a successful result.
 NOTE: In order to work with the temporal framework of GRASS GIS the flag
 <em>w</em> must be set during the import with <em>i.modis.import</em>.
 
+<h3>Default subset of layers to import</h3>
+
+User-defined subset of layers can be specified by <b>spectral</b>
+option. If not given, default values are applied.
+
+<h4> MODIS AOD - Aerosol Optical Depth</h4>
+
+<table>
+  <tr>
+    <td>SDS layer</td><td>Spectral</td><td>Spectral QA</td>
+  </tr>
+  <tr><td>Aerosol Optical Depth at 047 micron</td><td>0</td><td>0</td></tr>
+  <tr><td>Aerosol Optical Depth at 055 micron</td><td>1</td><td>1</td></tr>
+  <tr><td>AOD Uncertainty at 047 micron</td><td>0</td><td>0</td></tr>
+  <tr><td>Fine-Mode Fraction for Ocean</td><td>0</td><td>0</td></tr>
+  <tr><td>Column Water Vapor in cm liquid water</td><td>0</td><td>0</td></tr>
+  <tr><td>AOD QA</td><td>0</td><td>1</td></tr>
+  <tr><td>AOD Model (Regional background model used)</td><td>0</td><td>0</td></tr>
+  <tr><td>Injection Height (Smoke injection height over local surface height) Grid 5km</td><td>0</td><td>0</td></tr>
+  <tr><td>Cosine of Solar Zenith Angle</td><td>0</td><td>0</td></tr>
+  <tr><td>Cosine of View Zenith Angle</td><td>0</td><td>0</td></tr>
+  <tr><td>Relative Azimuth Angle</td><td>0</td><td>0</td></tr>
+  <tr><td>Scattering Angle</td><td>0</td><td>0</td></tr>
+  <tr><td>Glint Angle</td><td>0</td><td>0</td></tr>
+</table>
+
 <h2>EXAMPLES</h2>
 
 <h3>General examples</h3>

--- a/grass7/imagery/i.modis/libmodis/rmodislib.py
+++ b/grass7/imagery/i.modis/libmodis/rmodislib.py
@@ -115,6 +115,11 @@ class product:
         water_spec = ('( 1 )')
         water_specqa = ('( 1 1 )')
         water_suff = {'.water_mask': '.water_mask_QA'}
+        # value for aerosol product
+        aerosol_spec = '( 0 1 0 0 0 0 0 0 0 0 0 0 0 )'
+        aerosol_specqa = '( 0 1 0 0 0 1 0 0 0 0 0 0 0 )'
+        aerosol1km_suff = {'.Optical_Depth_055': '.AOD_QA'}
+        aerosol_color = 'bcyr'
 
         # granularity
         daily = 1
@@ -282,12 +287,19 @@ class product:
                                      'suff': water_suff, 'days': daily,
                                      'color': snow_color}
                 }
+        aerosol = {'aerosol_terra_aqua_daily_1000': {'url': urlbase, 'folder': 'MOTA/',
+                                                     'prod': 'MCD19A2.006', 'days': daily,
+                                                     'spec': aerosol_spec, 'spec_qa': aerosol_specqa,
+                                                     'suff': aerosol1km_suff, 'res': 1000,
+                                                     'color': aerosol_color}
+                }
         self.products = {}
         self.products.update(lst)
         self.products.update(vi)
         self.products.update(snow)
         self.products.update(surf_refl)
         self.products.update(water)
+        self.products.update(aerosol)
         self.products_swath = {'lst_terra_daily': {'url': urlbase,
                                                    'folder': 'MOLT/',
                                                    'prod': 'MOD11_L2.006',


### PR DESCRIPTION
This PR adds support for https://lpdaac.usgs.gov/products/mcd19a2v006/

The input subsets in case of MCD19A2 contain multiple bands. 

Input data:
```
gdalinfo HDF4_EOS:EOS_GRID:"MCD19A2.A2020052.h18v03.006.2020056023047.hdf":grid1km:Optical_Depth_055
...
Band 1 Block=1200x833 Type=Int16, ColorInterp=Gray
  Description = AOD at 0.55 micron
    Computed Min/Max=0.000,597.000
  NoData Value=-28672
  Offset: 0,   Scale:0.001
Band 2 Block=1200x833 Type=Int16, ColorInterp=Gray
  Description = AOD at 0.55 micron
    Computed Min/Max=0.000,575.000
  NoData Value=-28672
  Offset: 0,   Scale:0.001
Band 3 Block=1200x833 Type=Int16, ColorInterp=Gray
  Description = AOD at 0.55 micron
    Computed Min/Max=0.000,519.000
  NoData Value=-28672
  Offset: 0,   Scale:0.001
Band 4 Block=1200x833 Type=Int16, ColorInterp=Gray
  Description = AOD at 0.55 micron
ERROR 1: HDF4_EOS:EOS_GRID:MCD19A2.A2020052.h18v03.006.2020056023047.hdf:grid1km:Optical_Depth_055, band 4: Failed to compute min/max, no valid pixels found in sampling.
  
  NoData Value=-28672
  Offset: 0,   Scale:0.001
Band 5 Block=1200x833 Type=Int16, ColorInterp=Gray
  Description = AOD at 0.55 micron
    Computed Min/Max=0.000,457.000
  NoData Value=-28672
  Offset: 0,   Scale:0.001
```

`i.modis.import` seems to import only the first channel

```
r.info -r MCD19A2.A2020052.h18v03.single_Optical_Depth_055
min=0
max=597
```
This PR allows to import all bands into GRASS.

```
g.list rast
MCD19A2.A2020052.h18v03.single_Optical_Depth_055.1
MCD19A2.A2020052.h18v03.single_Optical_Depth_055.2
MCD19A2.A2020052.h18v03.single_Optical_Depth_055.3
MCD19A2.A2020052.h18v03.single_Optical_Depth_055.4
MCD19A2.A2020052.h18v03.single_Optical_Depth_055.5
```

Replaces #178 