### PR TITLE
tools/cronjobs_osgeo_lxd: enable path setting for footer html pages (topics.html...) on add-on manual page

### DIFF
--- a/tools/cronjobs_osgeo_lxd/compile_addons_git.sh
+++ b/tools/cronjobs_osgeo_lxd/compile_addons_git.sh
@@ -126,7 +126,8 @@ for c in "db" "display" "general" "gui/wxpython" "imagery" "misc" "raster" "rast
         SCRIPTDIR="$path/scripts" \
         ETC="$path/etc" \
             SOURCE_URL="https://github.com/OSGeo/grass-addons/tree/master/grass${GRASS_VERSION}/" > \
-            "$ADDON_PATH/logs/$m.log" 2>&1
+            "$ADDON_PATH/logs/$m.log" 2>&1 \
+        HTML_PAGE_FOOTER_PAGES_PATH="../"
     if [ `echo $?` -eq 0 ] ; then
         printf "%-30s%s\n" "$c/$m" "SUCCESS" >> "$ADDON_PATH/logs/${INDEX_FILE}.log"
         echo " SUCCESS"


### PR DESCRIPTION
Fixes #337. Apply this GRASS GIS [PR](https://github.com/OSGeo/grass/pull/1122) first, please.