### PR TITLE
i.sentinel.coverage: fix potentially wrong output scene list

### DIFF
--- a/grass7/imagery/i.sentinel/i.sentinel.coverage/i.sentinel.coverage.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.coverage/i.sentinel.coverage.py
@@ -274,6 +274,12 @@ def main():
         'v.db.addcolumn', map=fps_in_area, columns="tmp INTEGER", quiet=True)
     grass.run_command(
         'v.db.update', map=fps_in_area, column='tmp', value=1, quiet=True)
+    # list of scenes that actually intersect with bbox
+    name_list_updated = list(grass.parse_command('v.db.select',
+                                                 map=fps_in_area,
+                                                 column='a_identifier',
+                                                 flags='c').keys())
+
     fps_in_area_dis = 'tmp_fps_in_area_dis_%s' % str(os.getpid())
     rm_vectors.append(fps_in_area_dis)
     grass.run_command(
@@ -293,7 +299,7 @@ def main():
     # save list of Sentinel names
     if output:
         with open(output, 'w') as f:
-            f.write(','.join(name_list))
+            f.write(','.join(name_list_updated))
         grass.message(_(
             "Name of Sentinel scenes are written to file <%s>") % (output))
 


### PR DESCRIPTION
This PR fixes the following Bug in `i.sentinel.coverage`:
The `output` list of scenes may contain scenes that actually do not intersect with the input `bbox`, e.g. because a Sentinel-2 scene only covers the southeast bit of its UTM-tile. This bug only occurs if the remaining scene/s do cover the entire `bbox`. 