### PR TITLE
r.learn.ml2: fix lazy import of 'sklearn' module

### DIFF
--- a/grass7/raster/r.learn.ml2/r.learn.predict/r.learn.predict.py
+++ b/grass7/raster/r.learn.ml2/r.learn.predict/r.learn.predict.py
@@ -77,12 +77,10 @@ from grass.script.utils import get_lib_path
 from grass.pygrass.gis.region import Region
 from grass.pygrass.modules.shortcuts import raster as r
 
-path = get_lib_path(modname="r.learn.ml2")
-if path is None:
-    gs.fatal("Not able to find the r.learn.ml2 library directory")
-sys.path.append(path)
+gs.utils.set_path(modulename='r.learn.ml2', dirname='rlearnlib',
+                  path='..')
 
-from raster import RasterStack
+from rlearnlib.raster import RasterStack
 
 
 def string_to_rules(string):

--- a/grass7/raster/r.learn.ml2/r.learn.train/r.learn.train.py
+++ b/grass7/raster/r.learn.ml2/r.learn.train/r.learn.train.py
@@ -346,12 +346,10 @@ from grass.pygrass.raster import RasterRow
 import numpy as np
 from grass.script.utils import get_lib_path
 
-path = get_lib_path(modname="r.learn.ml2")
-if path is None:
-    gs.fatal("Not able to find the r.learn.ml2 library directory")
-sys.path.append(path)
+gs.utils.set_path(modulename='r.learn.ml2', dirname='rlearnlib',
+                  path='..')
 
-from utils import (
+from rlearnlib.utils import (
     predefined_estimators,
     load_training_data,
     save_training_data,
@@ -359,7 +357,7 @@ from utils import (
     scoring_metrics,
     check_class_weights,
 )
-from raster import RasterStack
+from rlearnlib.raster import RasterStack
 
 
 tmp_rast = []
@@ -453,7 +451,7 @@ def main():
 
     try:
         import pandas as pd
-        
+
     except ImportError:
         gs.fatal("Package python3-pandas 0.25 or newer is not installed")
 
@@ -576,7 +574,7 @@ def main():
             y = y.flatten()
 
             with RasterRow(training_map) as src:
-                
+
                 if mode == "classification":
                     src_cats = {v: k for (k, v, m) in src.cats}
                     class_labels = {k:k for k in np.unique(y)}
@@ -587,7 +585,7 @@ def main():
         elif training_points != "":
             X, y, cat = stack.extract_points(training_points, field)
             y = y.flatten()
-            
+
             if y.dtype in (np.object_, np.object):
                 from sklearn.preprocessing import LabelEncoder
                 le = LabelEncoder()

--- a/grass7/raster/r.learn.ml2/rlearnlib/Makefile
+++ b/grass7/raster/r.learn.ml2/rlearnlib/Makefile
@@ -5,7 +5,7 @@ include $(MODULE_TOPDIR)/include/Make/Python.make
 
 MODULES = stats utils indexing raster transformers
 
-ETCDIR = $(ETC)/r.learn.ml2
+ETCDIR = $(ETC)/r.learn.ml2/rlearnlib
 
 PYFILES := $(patsubst %,$(ETCDIR)/%.py,$(MODULES))
 PYCFILES := $(patsubst %,$(ETCDIR)/%.pyc,$(MODULES))
@@ -13,10 +13,10 @@ PYCFILES := $(patsubst %,$(ETCDIR)/%.pyc,$(MODULES))
 default: $(PYFILES) $(PYCFILES)
 
 $(ETCDIR):
-	$(MKDIR) $@
+	$(MKDIR) -p $@
 
 $(ETCDIR)/%: % | $(ETCDIR)
 	$(INSTALL_DATA) $< $@
 
 install:
-	cp -r $(ETCDIR) $(INST_DIR)/etc
+	cp -r $(ETCDIR) $(INST_DIR)/etc/r.learn.ml2

--- a/grass7/raster/r.learn.ml2/rlearnlib/raster.py
+++ b/grass7/raster/r.learn.ml2/rlearnlib/raster.py
@@ -16,39 +16,39 @@ from grass.pygrass.raster import RasterRow, numpy2raster
 from grass.pygrass.raster.buffer import Buffer
 from grass.pygrass.utils import get_mapset_raster
 from grass.pygrass.vector import VectorTopo
-from indexing import _LocIndexer, _ILocIndexer
-from stats import StatisticsMixin
-from transformers import CategoryEncoder
+from .indexing import _LocIndexer, _ILocIndexer
+from .stats import StatisticsMixin
+from .transformers import CategoryEncoder
 
 
 class RasterStack(StatisticsMixin):
     def __init__(self, rasters=None, group=None):
         """A RasterStack enables a collection of raster layers to be bundled
         into a single RasterStack object
-        
+
         Parameters
         ----------
         rasters : list, str
             List of names of GRASS GIS raster maps. Note that although the
             maps can reside in different mapsets, they cannot have the same
             names.
-        
+
         group : str (opt)
             Create a RasterStack from rasters contained in a GRASS GIS imagery
             group. This parameter is mutually exclusive with the `rasters`
             parameter.
-        
+
         Attributes
         ----------
         loc : dict
             Name-based indexing of RasterRow objects within the RasterStack.
-        
+
         iloc : int
             Index-based indexing of RasterRow objects within the RasterStack.
-                        
+
         mtypes : dict
             Dict of key, value pairs of full_names and GRASS data types.
-        
+
         count : int
             Number of RasterRow objects within the RasterStack.
         """
@@ -87,13 +87,13 @@ class RasterStack(StatisticsMixin):
 
     def __getitem__(self, label):
         """Subset the RasterStack object using a label or list of labels
-        
+
         Parameters
         -----------
         label : str, list
             Label or list of labels representing RasterRow objects within the
             stack.
-            
+
         Returns
         -------
         RasterStack
@@ -103,7 +103,7 @@ class RasterStack(StatisticsMixin):
             label = [label]
 
         selected = []
-        
+
         for i in label:
             if i in self.names is False:
                 raise KeyError("layername not present in Raster object")
@@ -113,16 +113,16 @@ class RasterStack(StatisticsMixin):
         return RasterStack(selected)
 
     def __setitem__(self, key, value):
-        """Replace a RasterLayer within the Raster object with a new 
+        """Replace a RasterLayer within the Raster object with a new
         RasterLayer
-        
+
         Note that this modifies the Raster object in place
-        
+
         Parameters
         ----------
         key : str
             Key-based index of layer to be replaced.
-        
+
         value : grass.pygrass.raster.RasterRow
             RasterRow to use for replacement.
         """
@@ -135,11 +135,11 @@ class RasterStack(StatisticsMixin):
 
     @property
     def names(self):
-        """Return the names of the grass.pygrass.raster.RasterRow objects in 
+        """Return the names of the grass.pygrass.raster.RasterRow objects in
         the RasterStack
         """
         names = []
-        
+
         for src in self.loc.values():
             names.append(src.fullname())
 
@@ -152,7 +152,7 @@ class RasterStack(StatisticsMixin):
     @layers.setter
     def layers(self, mapnames):
         """Setter method for the layers attribute in the RasterStack
-        
+
         Parameters
         ----------
         mapnames : str, list
@@ -238,18 +238,18 @@ class RasterStack(StatisticsMixin):
 
     def append(self, other, in_place=True):
         """Setter method to add new RasterRows to a RasterStack object
-        
+
         Note that this modifies the Raster object in-place
 
         Parameters
         ----------
         other : str, or list
             Name of GRASS GIS rasters, or a list of names.
-        
+
         in_place : bool (opt). Default is True
             Whether to change the Raster object in-place or leave original and
             return a new Raster object.
-        
+
         Returns
         -------
         RasterStack
@@ -268,15 +268,15 @@ class RasterStack(StatisticsMixin):
 
     def drop(self, labels, in_place=True):
         """Drop individual RasterRow objects from the RasterStack
-        
+
         Note that this modifies the RasterStack object in-place by default
-        
+
         Parameters
         ---------
         labels : single label or list-like
             Index (int) or layer name to drop. Can be a single integer or
             label, or a list of integers or labels.
-        
+
         in_place : bool (opt). Default is True
             Whether to change the RasterStack object in-place or leave original
             and return a new RasterStack object.
@@ -303,16 +303,16 @@ class RasterStack(StatisticsMixin):
             new_raster = RasterStack(rasters=[i for i in subset_names])
 
             return new_raster
-    
+
     def read(self, row=None, rows=None):
         """Read data from RasterStack as a masked 3D numpy array
-        
+
         Notes
         -----
         Read an entire RasterStack into a numpy array
-        
+
         If the row parameter is used then a single row is read into a 3d numpy array
-        
+
         If the rows parameter is used, then a range of rows from (start_row, end_row) is read
         into a 3d numpy array
 
@@ -330,7 +330,7 @@ class RasterStack(StatisticsMixin):
 
         Returns
         -------
-        
+
         data : ndarray
             3d masked numpy array containing data from RasterStack rasters.
         """
@@ -523,17 +523,17 @@ class RasterStack(StatisticsMixin):
         ----------
         estimator : estimator object implementing 'fit'
             The object to use to fit the data.
-            
+
         output : str
             Output name for prediction raster.
-            
+
         height : int (opt).
             Number of raster rows to pass to estimator at one time. If not
             specified then the entire raster is read into memory.
-            
+
         overwrite : bool (opt). Default is False
             Option to overwrite an existing raster.
-        
+
         Returns
         -------
         RasterStack
@@ -604,7 +604,7 @@ class RasterStack(StatisticsMixin):
                 numpy2raster(
                     result[0, :, :], mtype=mtype, rastname=output, overwrite=overwrite
                 )
-            
+
             result_stack = RasterStack(output)
 
         return result_stack
@@ -616,22 +616,22 @@ class RasterStack(StatisticsMixin):
         ----------
         estimator : estimator object implementing 'fit'
             The object to use to fit the data
-            
+
         output : str
             Output name for prediction raster
-            
+
         class_labels : ndarray (opt)
             1d array containing indices of class labels to subset the
             prediction by. Only probability outputs for these classes will be
             produced.
-            
+
         height : int (opt)
             Number of raster rows to pass to estimator at one time. If not
             specified then the entire raster is read into memory.
-            
+
         overwrite : bool (opt). Default is False
             Option to overwrite an existing raster(s)
-        
+
         Returns
         -------
         RasterStack
@@ -710,7 +710,7 @@ class RasterStack(StatisticsMixin):
             if height is not None:
                 for i in dst:
                     i.close()
-        
+
         return RasterStack([i.name for i in dst])
 
     def row_windows(self, region=None, height=25):
@@ -720,7 +720,7 @@ class RasterStack(StatisticsMixin):
         ----------
         region : grass.pygrass.gis.region.Region (opt)
             Whether to restrict windows to specified region.
-            
+
         height : int (opt). Default is 25
             Height of window in number of image rows.
         """
@@ -738,18 +738,18 @@ class RasterStack(StatisticsMixin):
     def extract_pixels(self, rast_name, use_cats=False, as_df=False):
         """Extract pixel values from a RasterStack using another RasterRow
         object of labelled pixels
-        
+
         Parameters
         ----------
         rast_name : str
             Name of GRASS GIS raster map containing labelled pixels.
-        
+
         use_cats : bool (default is False)
             Whether to return pixel values as category labels instead of
             numeric values if the rast_name map has categories assigned to
             it. Note that if some categories are missing in the rast_name
             map then this option is ignored.
-        
+
         as_df : bool (opt). Default is False
             Whether to return the extracted RasterStack pixels as a Pandas
             DataFrame.
@@ -787,7 +787,7 @@ class RasterStack(StatisticsMixin):
         if labels and use_cats is True:
             enc = CategoryEncoder()
             enc.fit(labels)
-            y = enc.transform(y)            
+            y = enc.transform(y)
 
         if as_df is True:
             df = pd.DataFrame(
@@ -806,13 +806,13 @@ class RasterStack(StatisticsMixin):
         ----------
         vect_name : str
             Name of GRASS GIS vector containing point features.
-            
+
         fields : list, str
             Name of attribute(s) containing the vect_name variable(s).
-            
+
         na_rm : bool (opt). Default is True
             Whether to remove samples containing NaNs.
-        
+
         as_df : bool (opt). Default is False.
             Whether to return the extracted RasterStack values as a Pandas
             DataFrame.
@@ -822,11 +822,11 @@ class RasterStack(StatisticsMixin):
         X : ndarray
             2d array containing the extracted raster values with the dimensions
             ordered by (n_samples, n_features).
-            
+
         y : ndarray
-            1d or 2d array of labels with the dimensions ordered by 
+            1d or 2d array of labels with the dimensions ordered by
             (n_samples, n_fields).
-                
+
         df : pandas.DataFrame
             Extracted raster values as Pandas DataFrame if as_df = True.
         """
@@ -921,7 +921,7 @@ class RasterStack(StatisticsMixin):
 
     def to_pandas(self):
         """RasterStack to pandas DataFrame
-        
+
         Returns
         -------
         pandas.DataFrame
@@ -952,7 +952,7 @@ class RasterStack(StatisticsMixin):
         return df
 
     def head(self):
-        """Show the head (first rows, first columns) or tail (last rows, last 
+        """Show the head (first rows, first columns) or tail (last rows, last
         columns) of the cells of a Raster object.
 
         Returns

--- a/grass7/raster/r.learn.ml2/rlearnlib/transformers.py
+++ b/grass7/raster/r.learn.ml2/rlearnlib/transformers.py
@@ -1,22 +1,29 @@
-from sklearn.base import BaseEstimator, TransformerMixin
+import importlib
+
 import numpy as np
 
-class CategoryEncoder(BaseEstimator, TransformerMixin):
+
+class ImportSklearnModule():
+    """Lazy import of 'sklearn' module"""
+    sklearn_base = importlib.import_module('sklearn.base')
+
+
+class CategoryEncoder(ImportSklearnModule.sklearn_base.BaseEstimator,
+                      ImportSklearnModule.sklearn_base.TransformerMixin):
     """Transformer to encode GRASS GIS category labels into integer labels"""
     def __init__(self):
         self._encoding = None
         self._inverse = None
-    
+
     def fit(self, X, y = None):
         self._encoding = {value: label for (label, value, mtype) in X}
         self._inverse = {label: value for (label, value, mtype) in X}
-        return self 
-    
+        return self
+
     def transform(self, X, y = None):
         """Takes integer values and returns the category label"""
         return np.asarray([self._encoding[x] for x in X]).astype(np.object)
-    
+
     def inverse_transform(self, X, y = None):
         """Takes a category label and returns the category index"""
         return np.asarray([self._inverse[x] for x in X]).astype(np.object)
-


### PR DESCRIPTION
**Error message:**

```
Traceback (most recent call last):
  File "/tmp/.grass7//scripts/r.learn.train", line 362, in <module>
    from raster import RasterStack
  File "/tmp/.grass7/etc/r.learn.ml2/raster.py", line 21, in <module>
    from transformers import CategoryEncoder
  File "/tmp/.grass7/etc/r.learn.ml2/transformers.py", line 1, in <module>
    from sklearn.base import BaseEstimator, TransformerMixin
ModuleNotFoundError: No module named 'sklearn'
```

Plus fix import modules from 'rlearnlib' lib and install this lib dir content in the 'addons/etc/r.learn.ml2/rlearnlib' dir.