### PR TITLE
tools/check_addons_urls: add parameter for optional color text output

### DIFF
--- a/tools/cronjobs_osgeo_lxd/check_addons_urls.sh
+++ b/tools/cronjobs_osgeo_lxd/check_addons_urls.sh
@@ -14,6 +14,28 @@ log_html_file_path"
     exit 1
 fi
 
+# Colour output text
+if [ $# -eq 3 ]; then
+    COLOR_OUTPUT=1
+else
+    case $4 in
+        ''|*[!0-9]*)
+            if [ "$4" == "true" ] || [ "$4" == "True" ]; then
+                COLOR_OUTPUT=0
+            else
+                COLOR_OUTPUT=1
+            fi
+            ;;
+        *)
+            if [ "$4" -eq 0 ]; then
+                COLOR_OUTPUT=0
+            else
+                COLOR_OUTPUT=1
+            fi
+           ;;
+    esac
+fi
+
 ADDONS_DOCS_HTML_DIR_PATH=$1
 LOG_FILE_PATH=$2
 LOG_HTML_FILE_PATH=$3
@@ -35,21 +57,31 @@ check_addon_html_manual_page() {
         echo "<tr><td><tt>$pgm</tt></td>" \
              >> "$LOG_HTML_FILE_PATH"
         if [ "$found_urls" -eq 2 ]; then
-            # Stdout, log file
-            echo "${NORMAL_COLOR}Checking $pgm... \
+            if [ "$COLOR_OUTPUT" -eq 0 ]; then
+                # Stdout, log file
+                echo "${NORMAL_COLOR}Checking $pgm... \
 source and commits URL: CORRECT" | tee -a "$LOG_FILE_PATH"
+            else
+                echo "Checking $pgm... \
+source and commits URL: CORRECT" | tee -a "$LOG_FILE_PATH"
+            fi
             # Html file
             echo "<td style=\"background-color: green\">\
 source and commits URL: CORRECT</td>" >> "$LOG_HTML_FILE_PATH"
         else
-            # Stdout, log file
-            echo "${RED_COLOR}Checking $pgm... source or \
+            if [ "$COLOR_OUTPUT" -eq 0 ]; then
+                # Stdout, log file
+                echo "${RED_COLOR}Checking $pgm... source or \
 commits URL: INCORRECT" | tee -a "$LOG_FILE_PATH"
+            else
+                echo "Checking $pgm... source or \
+commits URL: INCORRECT" | tee -a "$LOG_FILE_PATH"
+            fi
             # Html file
             echo "<td style=\"background-color: red\">\
 source or commits URL: INCORRECT</td>" >> "$LOG_HTML_FILE_PATH"
         fi;
-        tput sgr0
+        if [ "$COLOR_OUTPUT" -eq 0 ]; then tput sgr0; fi
    done;
 }
 

--- a/tools/cronjobs_osgeo_lxd/check_addons_urls.sh
+++ b/tools/cronjobs_osgeo_lxd/check_addons_urls.sh
@@ -20,7 +20,7 @@ if [ $# -eq 3 ]; then
 else
     case $4 in
         ''|*[!0-9]*)
-            if [ "$4" == "true" ] || [ "$4" == "True" ]; then
+            if [[ "$4" == [tT][rR][uU][eE] ]] || [[ "$4" == [yY][eE][sS] ]]; then
                 COLOR_OUTPUT=0
             else
                 COLOR_OUTPUT=1

--- a/tools/cronjobs_osgeo_lxd/cron_job_list_grass
+++ b/tools/cronjobs_osgeo_lxd/cron_job_list_grass
@@ -6,8 +6,6 @@
 
 #MAILTO=neteler@osgeo.org
 #STDOUT=/dev/null
-# needed to silence tput in cronjob:
-TERM=xterm
 
 # +---------------- minute (0 - 59)
 # |  +------------- hour (0 - 23)


### PR DESCRIPTION
Fixes #359. Color output is off by default (script run as cron job). It can be turned on via a script parameter (if you run script locally).