### PR TITLE
wxGUI/wx.mwprecip: fix lazy import of 'psycopg2', 'numpy' module 

### DIFF
--- a/grass7/gui/wxpython/wx.mwprecip/mw3.py
+++ b/grass7/gui/wxpython/wx.mwprecip/mw3.py
@@ -16,7 +16,6 @@ from pgwrapper      import pgwrapper as pg
 from core.gcmd      import RunCommand
 from grass.pygrass.modules import Module
 import grass.script as grass
-import numpy as np
 from mw_util import *
 
 timeMes = MeasureTime()
@@ -30,7 +29,6 @@ class PointInterpolation():
         msg = e.msg
         grass.fatal(_("Unable to load python <{0}> lib (requires lib "
                       "<{0}> being installed).".format(msg.split("'")[-2])))
-
     def __init__(self, database, step, methodDist=False):
         timeMes.timeMsg("Interpolating points along lines...")
         self.step = float(step)
@@ -530,6 +528,13 @@ class TimeWindows():
         grass.warning(msg)
 
 class Computor():
+    try:
+        np = importlib.import_module('numpy')
+    except ModuleNotFoundError as e:
+        msg = e.msg
+        grass.fatal(_("Unable to load python <{0}> lib (requires lib "
+                      "<{0}> being installed).".format(msg.split("'")[-2])))
+
     def __init__(self, baseline, timeWin, database, exportData):
         self.awConst = baseline.aw
         self.database = database
@@ -858,9 +863,9 @@ class Computor():
             Returns the q'th percentile of the distribution given in the argument
             'data'. Uses the 'precision' parameter to control the noise level.
             """
-            #data = np.random.normal(size=2000000)
+            #data = self.np.random.normal(size=2000000)
             q = float(q)/100
-            N, bins = np.histogram(data, bins=precision*np.sqrt(len(data)))
+            N, bins = self.np.histogram(data, bins=precision*self.np.sqrt(len(data)))
             norm_cumul = 1.0*N.cumsum() / len(data)
             ret = bins[norm_cumul > q][0]
            # print "error in  %s quantile"%q, ((1.0*(data < ret).sum() / len(data)) -q)
@@ -876,12 +881,12 @@ class Computor():
                 linkid = linkid[0]
                 sql = "SELECT a from %s where linkid=%s" % (recordTable, linkid)
                 resu = database.connection.executeSql(sql, True, True)
-                data = np.array(resu)
+                data = self.np.array(resu)
                 #data=[item for sublist in data for item in sublist]#merge lists
                 #print data
                 #quantileRes=Quantile(data, baseline.quantile)
 
-                quantileRes = np.percentile(data, (100-float(baseline.quantile))/100)
+                quantileRes = self.np.percentile(data, (100-float(baseline.quantile))/100)
                 tmp.append(str(linkid) + ',' + str(quantileRes) + '\n')
             io0 = open(os.path.join(database.pathworkSchemaDir, "baseline"), 'w+')
             io0.writelines(tmp)

--- a/grass7/gui/wxpython/wx.mwprecip/mw3.py
+++ b/grass7/gui/wxpython/wx.mwprecip/mw3.py
@@ -5,7 +5,7 @@ from math import sin, cos, atan2, degrees, tan, sqrt
 from datetime import datetime
 from datetime import timedelta
 import shutil
-import psycopg2
+import importlib
 import time
 import math
 import sys
@@ -24,6 +24,13 @@ import logging
 logger = logging.getLogger('mwprecip.Computing')
 
 class PointInterpolation():
+    try:
+        psycopg2 = importlib.import_module('psycopg2')
+    except ModuleNotFoundError as e:
+        msg = e.msg
+        grass.fatal(_("Unable to load python <{0}> lib (requires lib "
+                      "<{0}> being installed).".format(msg.split("'")[-2])))
+
     def __init__(self, database, step, methodDist=False):
         timeMes.timeMsg("Interpolating points along lines...")
         self.step = float(step)
@@ -1495,7 +1502,7 @@ class Database():
                 conninfo['port'] = self.port
             self.connection = pg(**conninfo)
 
-        except psycopg2.OperationalError as e:
+        except self.psycopg2.OperationalError as e:
             grass.warning("Unable to connect to the database <%s>. %s" % (self.dbName, e))
 
     def firstPreparation(self):

--- a/grass7/gui/wxpython/wx.mwprecip/pgwrapper.py
+++ b/grass7/gui/wxpython/wx.mwprecip/pgwrapper.py
@@ -2,11 +2,17 @@
 # -*- coding: utf-8
 
 import sys
-import psycopg2 as ppg
-# import psycopg2.extensions
+import importlib
 import logging
 
 class pgwrapper:
+    try:
+        psycopg2 = importlib.import_module('psycopg2')
+    except ModuleNotFoundError as e:
+        msg = e.msg
+        gs.fatal(_("Unable to load python <{0}> lib (requires lib "
+                   "<{0}> being installed).".format(msg.split("'")[-2])))
+
     def __init__(self, dbname, host='', user='', passwd='', port=''):
         self.dbname = dbname  # Database name which connect to.
         self.host = host  # Host name (default is "localhost")
@@ -28,7 +34,7 @@ class pgwrapper:
         if self.port:
             conn_string += " port='%s'" % self.port
         try:
-            conn = ppg.connect(conn_string)
+            conn = self.psycopg2.connect(conn_string)
         except:
             self.logger.error('Cannot connect to database')
             self.print_message('Cannot connect to database')


### PR DESCRIPTION
**Error message:**

```
Traceback (most recent call last):
  File "/home/neteler/.grass7/addons/scripts/g.gui.mwprecip", line 27, in <module>
    from mw3            import *
  File "/home/neteler/.grass7/addons/etc/g.gui.mwprecip/mw3.py", line 8, in <module>
    import psycopg2
ModuleNotFoundError: No module named 'psycopg2'
```