### PR TITLE
v.in.pygbif: lazy import of 'osgeo' module

### DIFF
--- a/grass7/vector/v.in.pygbif/v.in.pygbif.py
+++ b/grass7/vector/v.in.pygbif/v.in.pygbif.py
@@ -182,8 +182,6 @@ import sys
 
 # import os
 import math
-from osgeo import ogr, osr
-from osgeo import __version__ as gdal_version
 import grass.script as grass
 from grass.pygrass.vector import Vector
 from grass.pygrass.vector import VectorTopo
@@ -832,5 +830,13 @@ def main():
 
 # Run the module
 if __name__ == "__main__":
+    try:
+        from osgeo import ogr, osr
+        from osgeo import __version__ as gdal_version
+    except ImportError:
+        grass.fatal(_("Unable to load GDAL Python bindings (requires "
+                      "package 'python-gdal' or Python library GDAL "
+                      "to be installed)."))
+
     options, flags = grass.parser()
     sys.exit(main())


### PR DESCRIPTION
**Error message:**

```
Traceback (most recent call last):
  File "C:/Users/landa/grass_packager/grass784/x86_64/addons/v.in.pygbif/scripts/v.in.pygbif.py", line 185, in <module>
    from osgeo import ogr, osr
ModuleNotFoundError: No module named 'osgeo'
```

Log file:
https://wingrass.fsv.cvut.cz/grass78/x86_64/addons/latest/logs/v.in.pygbif.log

