### PR TITLE
v.in.redlist: lazy import of 'osgeo' module

### DIFF
--- a/grass7/vector/v.in.redlist/v.in.redlist.py
+++ b/grass7/vector/v.in.redlist/v.in.redlist.py
@@ -63,7 +63,6 @@ COPYRIGHT: (C) 2015 by the GRASS Development Team
 import sys
 import os
 import grass.script as grass
-from osgeo import ogr
 
 
 def main():
@@ -125,5 +124,12 @@ def main():
                                                         quiet = True)
 
 if __name__ == "__main__":
+    try:
+        from osgeo import ogr
+    except ImportError:
+        grass.fatal(_("Unable to load GDAL Python bindings (requires "
+                      "package 'python-gdal' or Python library GDAL "
+                      "to be installed)."))
+
     options, flags = grass.parser()
     sys.exit(main())


### PR DESCRIPTION
**Error message:**

```
Traceback (most recent call last):
  File "C:/Users/landa/grass_packager/grass784/x86_64/addons/v.in.redlist/scripts/v.in.redlist.py", line 66, in <module>
    from osgeo import ogr
ModuleNotFoundError: No module named 'osgeo'
```

Log file:
https://wingrass.fsv.cvut.cz/grass78/x86_64/addons/latest/logs/v.in.redlist.log