### PR TITLE
i.ann.maskrcnn: update installation command in docs

### DIFF
--- a/grass7/imagery/i.ann.maskrcnn/i.ann.maskrcnn.html
+++ b/grass7/imagery/i.ann.maskrcnn/i.ann.maskrcnn.html
@@ -43,7 +43,7 @@ use Python3, so please install Python3 versions.
 After dependencies are fulfilled, modules can be installed in
 GRASS GIS >= 7.8 using the <em>g.extension</em> module:
 <div class="code"><pre>
-g.extension extension=maskrcnn url=path/to/the/maskrcnn/folder
+g.extension extension=maskrcnn
 </pre></div>
 
 <h2>MODULES</h2>


### PR DESCRIPTION
The installation command in docs expected the installation from local path. As the modules are part of the official AddOns repository, the path specification in the installation command is not needed anymore.