### PR TITLE
r.out.kde: lazy import of PIL library

### DIFF
--- a/grass7/raster/r.out.kde/r.out.kde.py
+++ b/grass7/raster/r.out.kde/r.out.kde.py
@@ -128,7 +128,7 @@ if __name__ == "__main__":
     try:
         from PIL import Image
     except ImportError:
-        grass.fatal("Cannot import PIL."
+        gscript.fatal("Cannot import PIL."
                     " Please install the Python pillow package.")
     options, flags = gscript.parser()
     rinput = options['input']

--- a/grass7/raster/r.out.kde/r.out.kde.py
+++ b/grass7/raster/r.out.kde/r.out.kde.py
@@ -48,7 +48,11 @@ import os
 import tempfile
 import atexit
 import shutil
-from PIL import Image
+try:
+    from PIL import Image
+except ImportError:
+    grass.fatal("Cannot import PIL."
+                " Please install the Python pillow package.")
 from math import exp
 import grass.script as gscript
 

--- a/grass7/raster/r.out.kde/r.out.kde.py
+++ b/grass7/raster/r.out.kde/r.out.kde.py
@@ -129,7 +129,7 @@ if __name__ == "__main__":
         from PIL import Image
     except ImportError:
         gscript.fatal("Cannot import PIL."
-                    " Please install the Python pillow package.")
+                      " Please install the Python pillow package.")
     options, flags = gscript.parser()
     rinput = options['input']
     bg = options['background']

--- a/grass7/raster/r.out.kde/r.out.kde.py
+++ b/grass7/raster/r.out.kde/r.out.kde.py
@@ -48,11 +48,6 @@ import os
 import tempfile
 import atexit
 import shutil
-try:
-    from PIL import Image
-except ImportError:
-    grass.fatal("Cannot import PIL."
-                " Please install the Python pillow package.")
 from math import exp
 import grass.script as gscript
 
@@ -130,6 +125,11 @@ def scale(cmin, cmax, intens, method):
 
 
 if __name__ == "__main__":
+    try:
+        from PIL import Image
+    except ImportError:
+        grass.fatal("Cannot import PIL."
+                    " Please install the Python pillow package.")
     options, flags = gscript.parser()
     rinput = options['input']
     bg = options['background']


### PR DESCRIPTION
Fixes error (see: https://wingrass.fsv.cvut.cz/grass78/x86_64/addons/latest/logs/r.out.kde.log)

```
Traceback (most recent call last):
  File "C:/Users/landa/grass_packager/grass784/x86_64/addons/r.out.kde/scripts/r.out.kde.py", line 51, in <module>
    from PIL import Image
ModuleNotFoundError: No module named 'PIL'
make: *** [/c/msys64/usr/src/grass784/include/Make/Html.make:14: r.out.kde.tmp.html] Error 1
```
