### PR TITLE
i.landsat.import: add register_output option

### DIFF
--- a/grass7/imagery/i.landsat/i.landsat.download/i.landsat.download.html
+++ b/grass7/imagery/i.landsat/i.landsat.download/i.landsat.download.html
@@ -100,7 +100,7 @@ i.landsat.download settings=credentials.txt \
 
 <h2>AUTHOR</h2>
 
-Veronica Andreo
+<a href="https://veroandreo.gitlab.io/" target="_blank">Veronica Andreo</a>, CONICET, Argentina.
 
 <!--
 <p>

--- a/grass7/imagery/i.landsat/i.landsat.download/i.landsat.download.html
+++ b/grass7/imagery/i.landsat/i.landsat.download/i.landsat.download.html
@@ -85,10 +85,18 @@ i.landsat.download settings=credentials.txt \
 
 <h2>SEE ALSO</h2>
 
-<a href="i.landsat.html">Overview of i.landsat tools</a>,
+<em>
+<a href="i.landsat.html">Overview of i.landsat tools</a>
+</em>
+<p>
+<em>
 <a href="i.landsat.import.html">i.landsat.import</a>,
-<a href="https://grass.osgeo.org/grass-stable/manuals/i.landsat.toar">i.landsat.toar</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/i.landsat.toar">i.landsat.toar</a>
+</em>
+<p>
+<em>
 <a href="https://www.usgs.gov/core-science-systems/nli/landsat/landsat-collection-1?qt-science_support_page_related_con=1#qt-science_support_page_related_con">Landsat Collection 1 info</a>
+</em>
 
 <h2>AUTHOR</h2>
 

--- a/grass7/imagery/i.landsat/i.landsat.download/i.landsat.download.html
+++ b/grass7/imagery/i.landsat/i.landsat.download/i.landsat.download.html
@@ -80,7 +80,7 @@ i.landsat.download settings=credentials.txt \
 <h2>REQUIREMENTS</h2>
 
 <ul>
-    <li><a href="https://github.com/yannforget/landsatxplore">landsatxplore library</a> (install with <code>pip install landsatxplore</code></li>
+    <li><a href="https://github.com/yannforget/landsatxplore">landsatxplore library</a> (install with <code>pip install landsatxplore</code>)</li>
 </ul>
 
 <h2>SEE ALSO</h2>

--- a/grass7/imagery/i.landsat/i.landsat.html
+++ b/grass7/imagery/i.landsat/i.landsat.html
@@ -40,7 +40,7 @@ The <em>i.landsat</em> toolset consists of two modules:
 
 <ul>
   <li>An <a href="https://ers.cr.usgs.gov/register">EarthExplorer</a> account</li>
-  <li><a href="https://github.com/yannforget/landsatxplore">landsatxplore library</a> (install with <code>pip install landsatxplore</code></li>
+  <li><a href="https://github.com/yannforget/landsatxplore">landsatxplore library</a> (install with <code>pip install landsatxplore</code>)</li>
 </ul>
 
 <h2>AUTHOR</h2>

--- a/grass7/imagery/i.landsat/i.landsat.html
+++ b/grass7/imagery/i.landsat/i.landsat.html
@@ -45,7 +45,7 @@ The <em>i.landsat</em> toolset consists of two modules:
 
 <h2>AUTHOR</h2>
 
-Veronica Andreo
+<a href="https://veroandreo.gitlab.io/" target="_blank">Veronica Andreo</a>, CONICET, Argentina.
 
 <h2>SOURCE CODE</h2>
 <p>Available at: <a href="https://github.com/OSGeo/grass-addons/tree/master/grass7/imagery/i.landsat">i.landsat source code</a> (<a href="https://github.com/OSGeo/grass-addons/commits/master/grass7/imagery/i.landsat">history</a>)</p>

--- a/grass7/imagery/i.landsat/i.landsat.import/i.landsat.import.html
+++ b/grass7/imagery/i.landsat/i.landsat.import/i.landsat.import.html
@@ -143,13 +143,18 @@ i.landsat.import input=data pattern_file='229083_2019' pattern='B(4|5)'
 
 <h2>SEE ALSO</h2>
 
-<a href="i.landsat.html">Overview of i.landsat tools</a>,
+<em>
+<a href="i.landsat.html">Overview of i.landsat tools</a>
+</em>
+<p>
+<em>
 <a href="i.landsat.download.html">i.landsat.download</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/i.landsat.toar">i.landsat.toar</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/addons/i.landsat8.qc.html">i.landsat8.qc</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/addons/i.landsat8.swlst.html">i.landsat8.swlst</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/r.import.html">r.import</a>,
-<a href="https://grass.osgeo.org/grass-stable/manuals/r.external.html">r.external</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.external.html">r.external</a>
+</em>
 
 <h2>AUTHOR</h2>
 

--- a/grass7/imagery/i.landsat/i.landsat.import/i.landsat.import.html
+++ b/grass7/imagery/i.landsat/i.landsat.import/i.landsat.import.html
@@ -103,7 +103,6 @@ including detected input data EPSG code:
 
 <div class="code"><pre>
 i.landsat.import -p input=data
-
 </pre></div>
 
 <h3>Import Landsat data</h3>

--- a/grass7/imagery/i.landsat/i.landsat.import/i.landsat.import.html
+++ b/grass7/imagery/i.landsat/i.landsat.import/i.landsat.import.html
@@ -93,6 +93,22 @@ For further details about bands wavelength and scene size, visit the
 <a href="https://www.usgs.gov/faqs/what-are-band-designations-landsat-satellites?qt-news_science_products=0#qt-news_science_products" target="_blank">band designations</a>
 page at USGS website.
 
+<p>
+With the <b>register_output</b> option <em>i.landsat.import</em> allows
+to create a text file that can be used to register imported imagery data
+into a space-time raster dateset (STRDS) by means of
+<em><a href="https://grass.osgeo.org/grass-stable/manuals/t.register.html">t.register</a></em>.
+A register file typically contains 2 or 3 columns with the map name and
+start time or the map name plus start and end time in the case of interval
+time type. Landsat data is considered to be of <em>instance</em> time type,
+i.e., we only have one point in time. Hence, the output register file will
+contain the map name and start time separated by <tt>|</tt> when using GRASS
+GIS stable version.
+In the case of GRASS GIS development version which supports the band reference
+concept (see <em><a href="https://grass.osgeo.org/grass-devel/manuals/g.bands.html">g.bands</a></em> module for details),
+the output register file is extended by a third column containing the band
+reference information, see the examples below.
+
 <h2>EXAMPLES</h2>
 
 <h3>List Landsat bands to import</h3>
@@ -141,6 +157,20 @@ Limit import to bands 4 and 5 for path 229 and row 083 in 2019
 i.landsat.import input=data pattern_file='229083_2019' pattern='B(4|5)'
 </pre></div>
 
+<p>
+Limit import to bands 4 and 5 for path 229 and row 083 in 2019 and get a
+txt file to use in <em>t.register</em>
+
+<div class="code"><pre>
+i.landsat.import input=data pattern_file='229083_2019' pattern='B(4|5)' \
+    register_output=t_register.txt
+
+# create a STRDS and register imported data
+t.create output=landsat_ts title="Landsat 8 time series" \
+    description="Landsat 8 data, path-row 229-83, year 2020"
+t.register input=landsat_ts file=t_register.txt
+</pre></div>
+
 <h2>SEE ALSO</h2>
 
 <em>
@@ -158,7 +188,7 @@ i.landsat.import input=data pattern_file='229083_2019' pattern='B(4|5)'
 
 <h2>AUTHOR</h2>
 
-Veronica Andreo
+<a href="https://veroandreo.gitlab.io/" target="_blank">Veronica Andreo</a>, CONICET, Argentina.
 
 <!--
 <p>


### PR DESCRIPTION
This PR  addresses issue https://github.com/veroandreo/i.landsat/issues/15. The implemented option is a much simpler version of the function available in `i.sentinel.import`, i.e., it just parses the filenames of files to be imported and gets date, satellite number (5, 7 or 8) and band info to create the register file.