### PR TITLE
v.in.pygbif: fix lazy import of 'osgeo' module

### DIFF
--- a/grass7/vector/v.in.pygbif/v.in.pygbif.py
+++ b/grass7/vector/v.in.pygbif/v.in.pygbif.py
@@ -209,6 +209,13 @@ def main():
     from dateutil.parser import parse
 
     try:
+        from osgeo import ogr, osr
+        from osgeo import __version__ as gdal_version
+    except ImportError:
+        grass.fatal(_("Unable to load GDAL Python bindings (requires "
+                      "package 'python-gdal' or Python library GDAL "
+                      "to be installed)."))
+    try:
         from pygbif import occurrences
         from pygbif import species
     except ImportError:
@@ -830,13 +837,5 @@ def main():
 
 # Run the module
 if __name__ == "__main__":
-    try:
-        from osgeo import ogr, osr
-        from osgeo import __version__ as gdal_version
-    except ImportError:
-        grass.fatal(_("Unable to load GDAL Python bindings (requires "
-                      "package 'python-gdal' or Python library GDAL "
-                      "to be installed)."))
-
     options, flags = grass.parser()
     sys.exit(main())


### PR DESCRIPTION
**Error message** (during compilation on the server)**:**

```
ERROR: Unable to load GDAL Python bindings (requires package 'python-gdal'
       or Python library GDAL to be installed).
```

[Compilation log file](https://wingrass.fsv.cvut.cz/grass78/x86_64/addons/latest/logs/v.in.pygbif.log).

We need to move 'osgeo' module import into main() function body. Same as with the [g.proj.identify](https://github.com/OSGeo/grass-addons/blob/master/grass7/general/g.proj.identify/g.proj.identify.py#L145) add-on, which was compiled successfully.