### PR TITLE
v.in.redlist: fix lazy import of 'osgeo' module

### DIFF
--- a/grass7/vector/v.in.redlist/v.in.redlist.py
+++ b/grass7/vector/v.in.redlist/v.in.redlist.py
@@ -66,6 +66,12 @@ import grass.script as grass
 
 
 def main():
+    try:
+        from osgeo import ogr
+    except ImportError:
+        grass.fatal(_("Unable to load GDAL Python bindings (requires "
+                      "package 'python-gdal' or Python library GDAL "
+                      "to be installed)."))
 
     redlist_shapefile_long = options['input']
     imported_species = options['species_name']
@@ -124,12 +130,5 @@ def main():
                                                         quiet = True)
 
 if __name__ == "__main__":
-    try:
-        from osgeo import ogr
-    except ImportError:
-        grass.fatal(_("Unable to load GDAL Python bindings (requires "
-                      "package 'python-gdal' or Python library GDAL "
-                      "to be installed)."))
-
     options, flags = grass.parser()
     sys.exit(main())


### PR DESCRIPTION
**Error message** (during compilation on the server)**:**

```
ERROR: Unable to load GDAL Python bindings (requires package 'python-gdal'
       or Python library GDAL to be installed).
```

[Compilation log file](https://wingrass.fsv.cvut.cz/grass78/x86_64/addons/latest/logs/v.in.redlist.log).

We need to move 'osgeo' module import into main() function body. Same as with the [g.proj.identify](https://github.com/OSGeo/grass-addons/blob/master/grass7/general/g.proj.identify/g.proj.identify.py#L145) add-on, which was compiled successfully.