### PR TITLE
r.object.activelearning: fix lazy import of 'scipy', 'numpy' module

### DIFF
--- a/grass7/raster/r.object.activelearning/r.object.activelearning.py
+++ b/grass7/raster/r.object.activelearning/r.object.activelearning.py
@@ -530,6 +530,15 @@ def main():
     except ImportError:
         gcore.fatal("This module requires the scikit-learn python package. Please install it.")
 
+    global scipy, np
+    try:
+        import scipy
+        import numpy as np
+    except ModuleNotFoundError as e:
+        msg = e.msg
+        gcore.fatal(_("Unable to load python <{0}> lib (requires lib "
+                      "<{0}> being installed).".format(msg.split("'")[-2])))
+
     learning_steps = int(options['learning_steps']) if options['learning_steps'] != '0' else 5
     search_iter = int(options['search_iter']) if options['search_iter'] != '0' else 10					# Number of samples to label at each iteration
     diversity_lambda = float(options['diversity_lambda']) if options['diversity_lambda'] != '' else 0.25		# Lambda parameter used in the diversity heuristic
@@ -569,13 +578,5 @@ def main():
 
 
 if __name__ == '__main__':
-    try:
-        import scipy
-        import numpy as np
-    except ModuleNotFoundError as e:
-        msg = e.msg
-        gcore.fatal(_("Unable to load python <{0}> lib (requires lib "
-                      "<{0}> being installed).".format(msg.split("'")[-2])))
-
     options, flags = grass.script.parser()
     main()


### PR DESCRIPTION
**Error message** (during compilation on the server)**:**

```
ERROR: Unable to load python <scipy> lib (requires lib <scipy> being
       installed).
```

[Compilation log file](https://wingrass.fsv.cvut.cz/grass78/x86_64/addons/latest/logs/r.object.activelearning.log).

We need to move 'scipy', 'numpy' module import into main() function body. Same as with the [g.proj.identify](https://github.com/OSGeo/grass-addons/blob/master/grass7/general/g.proj.identify/g.proj.identify.py#L145) add-on, which was compiled successfully.