### PR TITLE
r.out.kde: fix lazy import of 'PIL' module

### DIFF
--- a/grass7/raster/r.out.kde/r.out.kde.py
+++ b/grass7/raster/r.out.kde/r.out.kde.py
@@ -62,6 +62,12 @@ def cleanup():
 
 
 def main(rinput, background, output, method):
+    try:
+        from PIL import Image
+    except ImportError:
+        gscript.fatal("Cannot import PIL."
+                      " Please install the Python pillow package.")
+
     if '@' in rinput:
         rinput = rinput.split('@')[0]
     suffix = '_' + os.path.basename(gscript.tempfile(False))
@@ -125,11 +131,6 @@ def scale(cmin, cmax, intens, method):
 
 
 if __name__ == "__main__":
-    try:
-        from PIL import Image
-    except ImportError:
-        gscript.fatal("Cannot import PIL."
-                      " Please install the Python pillow package.")
     options, flags = gscript.parser()
     rinput = options['input']
     bg = options['background']


### PR DESCRIPTION
**Error message** (during compilation on the server)**:**

```
ERROR: Cannot import PIL. Please install the Python pillow package.
```

[Compilation log file](https://wingrass.fsv.cvut.cz/grass78/x86_64/addons/latest/logs/r.out.kde.log).

We need to move 'PIL' module import into main() function body. Same as with the [g.proj.identify](https://github.com/OSGeo/grass-addons/blob/master/grass7/general/g.proj.identify/g.proj.identify.py#L145) add-on, which was compiled successfully.