### PR TITLE
cronjobs: manual search form added

### DIFF
--- a/tools/cronjobs_osgeo_lxd/cron_grass78_releasebranch_78_build_bins.sh
+++ b/tools/cronjobs_osgeo_lxd/cron_grass78_releasebranch_78_build_bins.sh
@@ -14,6 +14,7 @@
 # Thu 16 Jan 2020 08:17:43 AM UTC
 # Fri 19 Jun 2020 07:56:20 PM UTC
 # Fri 20 Nov 2020 12:55:19 AM CET
+# Fri Jan  1 05:47:36 PM CET 2021
 #
 # GRASS GIS github, https://github.com/OSGeo/grass
 #
@@ -25,12 +26,13 @@
 #
 ###################################################################
 # how it works:
-# - it updates the GRASS source code from github server
+# - it updates locally the GRASS source code from github server
 # - configures, compiles
 # - packages the binaries
 # - generated the install scripts
 # - generates the pyGRASS HTML manual
 # - generates the user HTML manuals
+# - injects DuckDuckGo search field
 
 # Preparations:
 #  - Install PROJ: http://trac.osgeo.org/proj/ incl Datum shift grids
@@ -174,6 +176,9 @@ rm -f $TARGETHTMLDIR/*.*
 
 cp -rp dist.$ARCH/docs/html/* $TARGETHTMLDIR/
 echo "Copied pygrass progman to http://grass.osgeo.org/grass${VERSION}/manuals/libpython/"
+
+echo "Injecting DuckDuckGo search field into manual main page..."
+(cd $TARGETHTMLDIR/ ; sed -i -e "s+</table>+</table><\!\-\- injected in cron_grass78_releasebranch_78_build_bins.sh \-\-> <center><iframe src=\"https://duckduckgo.com/search.html?site=grass.osgeo.org\&prefill=Search manual pages at DuckDuckGo\" style=\"overflow:hidden;margin:0;padding:0;width:410px;height:40px;\" frameborder=\"0\"></iframe></center>+g" index.html)
 
 cp -p AUTHORS CHANGES CITING COPYING GPL.TXT INSTALL REQUIREMENTS.html $TARGETDIR/
 

--- a/tools/cronjobs_osgeo_lxd/cron_grass7_HEAD_build_bins.sh
+++ b/tools/cronjobs_osgeo_lxd/cron_grass7_HEAD_build_bins.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-# script to build GRASS 7.x trunk binaries (shared libs)
+# script to build GRASS 7.x master binaries (shared libs)
 # (c) GPL 2+ Markus Neteler <neteler@osgeo.org>
-# Nov 2008, 2014, 2015, 2016, 2017, 2018, 2019, 2020
+# Nov 2008, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021
 #
 # GRASS GIS github, https://github.com/OSGeo/grass
 #
@@ -11,13 +11,14 @@
 #
 ###################################################################
 # how it works:
-# - it downloads GRASS source code from github server
+# - it updates locally the GRASS source code from github server
 # - configures, compiles
 # - packages the binaries
 # - generated the install scripts
-# - generates the programmer HTML manual
+# - generates the programmer's HTML manual
 # - generates the pyGRASS HTML manual
 # - generates the user HTML manuals
+# - injects DuckDuckGo search field
 
 # Preparations:
 #  - Install PROJ: http://trac.osgeo.org/proj/ incl Datum shift grids
@@ -35,7 +36,7 @@ DOTVERSION=$GMAJOR.$GMINOR
 VERSION=$GMAJOR$GMINOR
 GVERSION=$GMAJOR
 
-####################
+###################
 CFLAGSSTRING='-O2'
 CFLAGSSTRING='-Werror-implicit-function-declaration -fno-common'
 LDFLAGSSTRING='-s'
@@ -162,6 +163,9 @@ rm -f $TARGETHTMLDIR/*.*
 cp -rp dist.$ARCH/docs/html/* $TARGETHTMLDIR/
 echo "Copied pygrass progman to http://grass.osgeo.org/grass${VERSION}/manuals/libpython/"
 
+echo "Injecting DuckDuckGo search field into manual main page..."
+(cd $TARGETHTMLDIR/ ; sed -i -e "s+</table>+</table><\!\-\- injected in cron_grass7_HEAD_build_bins.sh \-\-> <center><iframe src=\"https://duckduckgo.com/search.html?site=grass.osgeo.org\&prefill=Search manual pages at DuckDuckGo\" style=\"overflow:hidden;margin:0;padding:0;width:410px;height:40px;\" frameborder=\"0\"></iframe></center>+g" index.html)
+
 cp -p AUTHORS CHANGES CITING COPYING GPL.TXT INSTALL REQUIREMENTS.html $TARGETDIR/
 
 # note: addons are in grass7x compilation scripts
@@ -259,7 +263,7 @@ echo "Written to: $TARGETDIR"
 cd $GRASSBUILDDIR
 
 ############################################
-## compile addons <--- only for latest stable!
+## compile addons <--- only done for latest stable! See: cron_grass78_releasebranch_78_build_bins.sh
 #cd $GRASSBUILDDIR
 #sh ~/cronjobs/compile_addons_git.sh ~/src/grass-addons/grass7/ ~/src/master/dist.x86_64-pc-linux-gnu/ ~/.grass7/addons
 #mkdir $TARGETHTMLDIR/addons/


### PR DESCRIPTION
A DuckDuckGo based manual site search field is injected during compilation.

See "at work" at bottom of
https://grass.osgeo.org/grass78/manuals/index.html

Rationale: unless we don't change the manual pages to e.g. Sphinx, or install an own search engine, through this way we have at least a search form.