### PR TITLE
wx.metadata: check dependencies with Python3

### DIFF
--- a/grass7/gui/wxpython/wx.metadata/Makefile
+++ b/grass7/gui/wxpython/wx.metadata/Makefile
@@ -1,6 +1,6 @@
 MODULE_TOPDIR = ..
 
-SHELL_OUTPUT := $(shell python mdlib/dependency.py 2>&1)
+SHELL_OUTPUT := $(shell python3 mdlib/dependency.py 2>&1)
 ifeq ($(filter File mdlib/dependency.py,$(SHELL_OUTPUT)),)
     $(info $(SHELL_OUTPUT))
 else


### PR DESCRIPTION
Adress #397

The Makefile for mdlib might have to be checked as well...

When I tried to install with the make command given by
```g.extension -d extension=wx.metadata operation=add```

I get plenty of errors (but also the make command g.extension spits out might be incorrect...