### PR TITLE
wxGUI/wx.metadata: add missing 'globalvar' py script file

### DIFF
--- a/grass7/gui/wxpython/wx.metadata/mdlib/globalvar.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/globalvar.py
@@ -1,0 +1,5 @@
+MODULE_URL = 'https://grasswiki.osgeo.org/wiki/ISO/INSPIRE_Metadata_Support'
+
+MODULE_NOT_FOUND = _("Unable to load python <{lib}> lib (requires lib "
+                     "<{lib}> being installed). Check requirements "
+                     " on the manual page <{url}>")


### PR DESCRIPTION
Add missing 'globalvar' py script file. 

**Error message:**

```
Traceback (most recent call last):
  File "/home/neteler/.grass7/addons/scripts/db.csw.harvest", line 57, in <module>
    from mdlib import globalvar
ImportError: cannot import name 'globalvar' from 'mdlib' (/home/neteler/src/grass-addons/grass7/gui/wxpython/wx.metadata/mdlib/__init__.py)
```

Compilation [log file](https://grass.osgeo.org/addons/grass7/logs/wx.metadata.log).