### PR TITLE
r.extract: new addon for extracting categories 

### DIFF
--- a/grass7/raster/r.extract/Makefile
+++ b/grass7/raster/r.extract/Makefile
@@ -1,0 +1,7 @@
+MODULE_TOPDIR = ../..
+
+PGM = r.extract
+
+include $(MODULE_TOPDIR)/include/Make/Script.make
+
+default: script

--- a/grass7/raster/r.extract/r.extract.html
+++ b/grass7/raster/r.extract/r.extract.html
@@ -1,31 +1,77 @@
 <h2>DESCRIPTION</h2>
 
+This module extracts selected categories from integer raster map
+into a new raster, similarly to
+<em><a href="https://grass.osgeo.org/grass-stable/manuals/v.extract.html">v.extract</a></em>
+for vectors. The categories and color table are preserved.
+
+<p>
+The category values can be specified as:
+
+<ul>
+<li>cat1,cat2,...</li>
+<li>cat1-cat3</li>
+<li>cat1-</li>
+<li>-cat1</li>
+<li>and their combination: -cat1,cat2,cat3-cat6</li>
+</ul>
+
+<p>
+The extent of the new raster can be changed with flag <b>-c</b>
+to fit the extent of the extracted data. When using flag <b>-s</b>
+output raster is a reclassified input raster
+(see <em><a href="https://grass.osgeo.org/grass-stable/manuals/r.reclass.html">r.reclass</a></em>
+for details).
 
 
 <h2>NOTES</h2>
-
+This implementation supports only integer raster maps (type CELL).
 
 <h2>EXAMPLES</h2>
 
 The following examples are using the full North Carolina sample
-location.
+dataset. We will extract certain zipcodes.
 
+
+First print zipcodes raster info:
+<div class="code"><pre>
+g.region raster=zipcodes -p
+r.info zipcodes -rg
+</pre></div>
+<pre>
+...
+rows=1350
+cols=1500
+min=27511
+max=27610
+...
+</pre>
+
+Now we extract 2 categories and automatically adjust the raster extent
+to fit the extracted data.
 
 <div class="code"><pre>
-
+r.extract input=zipcodes output=selected_zipcodes cats=27605,27601 -c
+r.info selected_zipcodes -rg
 </pre></div>
+<pre>
+...
+rows=404
+cols=377
+min=27601
+max=27605
+...
+</pre>
+
+
 
 <h2>SEE ALSO</h2>
 
-<em>
-<a href="https://grass.osgeo.org/grass-stable/manuals/r.reclass.html">r.reclass</a>
-</em>
+<em><a href="https://grass.osgeo.org/grass-stable/manuals/r.reclass.html">r.reclass</a></em> (used in this implementation)<br>
+<em><a href="https://grass.osgeo.org/grass-stable/manuals/v.extract.html">v.extract</a></em> (for extracting vector data)
+
 
 <h2>AUTHOR</h2>
 
-Anna Petrasova, <a href="http://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll Lab</a>
+Anna Petrasova, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll Lab</a>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/grass7/raster/r.extract/r.extract.html
+++ b/grass7/raster/r.extract/r.extract.html
@@ -1,0 +1,31 @@
+<h2>DESCRIPTION</h2>
+
+
+
+<h2>NOTES</h2>
+
+
+<h2>EXAMPLES</h2>
+
+The following examples are using the full North Carolina sample
+location.
+
+
+<div class="code"><pre>
+
+</pre></div>
+
+<h2>SEE ALSO</h2>
+
+<em>
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.reclass.html">r.reclass</a>
+</em>
+
+<h2>AUTHOR</h2>
+
+Anna Petrasova, <a href="http://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll Lab</a>
+
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/grass7/raster/r.extract/r.extract.html
+++ b/grass7/raster/r.extract/r.extract.html
@@ -1,6 +1,6 @@
 <h2>DESCRIPTION</h2>
 
-This module extracts selected categories from integer raster map
+This module extracts selected categories from an integer raster map
 into a new raster, similarly to
 <em><a href="https://grass.osgeo.org/grass-stable/manuals/v.extract.html">v.extract</a></em>
 for vectors. The categories and color table are preserved.
@@ -74,4 +74,3 @@ max=27605
 <h2>AUTHOR</h2>
 
 Anna Petrasova, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll Lab</a>
-

--- a/grass7/raster/r.extract/r.extract.py
+++ b/grass7/raster/r.extract/r.extract.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 
 #%module
-#% label: Extracts specified categories of an integer input map
+#% description: Extracts specified categories of an integer input map.
 #% keyword: raster
 #% keyword: extract
 #% keyword: extent
+#% keyword: category
 #%end
 #%option G_OPT_R_INPUT
 #%end

--- a/grass7/raster/r.extract/r.extract.py
+++ b/grass7/raster/r.extract/r.extract.py
@@ -1,5 +1,18 @@
 #!/usr/bin/env python
 
+############################################################################
+#
+# MODULE:       r.extract
+# AUTHOR(S):    Anna Petrasova
+# PURPOSE:      Extracts specified categories of an integer input map.
+# COPYRIGHT:    (c) 2021 by Anna Petrasova and the GRASS Development Team
+#
+#               This program is free software under the GNU General Public
+#               License (>=v2). Read the file COPYING that comes with GRASS
+#               for details.
+#
+#############################################################################
+
 #%module
 #% description: Extracts specified categories of an integer input map.
 #% keyword: raster
@@ -79,7 +92,7 @@ def main():
     rules = parse(original, cats)
     if flags["c"] and flags["s"]:
         gs.warning(
-            _("The extent of the output reclassified" " raster cannot be changed")
+            _("The extent of the output reclassified raster cannot be changed")
         )
 
     if flags["s"]:

--- a/grass7/raster/r.extract/r.extract.py
+++ b/grass7/raster/r.extract/r.extract.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+
+#%module
+#% label: Extracts specified categories of the integer input map
+#% keyword: raster
+#% keyword: extract
+#% keyword: extent
+#%end
+#%option G_OPT_R_INPUT
+#%end
+#%option G_OPT_R_OUTPUT
+#%end
+#%option
+#% key: cats
+#% type: string
+#% required: yes
+#% multiple: no
+#% key_desc: range
+#% label: Category values
+#% description: Example: 1,3,7-9,13
+#% gisprompt: old,cats,cats
+#%end
+
+
+import sys
+import atexit
+
+import grass.script as gs
+
+
+TMP = []
+
+
+def cleanup():
+    if TMP:
+        gs.run_command('g.remove', type='raster', name=TMP, flags='f', quiet=True)
+
+
+def parse(raster, values):
+    info = gs.raster_info(raster)
+    if info['datatype'] != 'CELL':
+        gs.fatal(_("Input raster map must be of type CELL"))
+    rules = []
+    vals = values.split(',')
+    for val in vals:
+        if '-' in val:
+            a, b = val.split('-')
+            if not a:
+                a = info['min']
+            if not b:
+                b = info['max']
+            for i in range(int(a), int(b) + 1):
+                rules.append("{v} = {v}".format(v=i))
+        else:
+            rules.append("{v} = {v}".format(v=val))
+    return rules
+
+
+def main():
+    options, flags = gs.parser()
+
+    original = options['input']
+    output = options['output']
+    cats = options['cats']
+
+    output_tmp = gs.append_random('tmp', 8)
+    rules = parse(original, cats)
+    TMP.append(output_tmp)
+    gs.write_command('r.reclass', input=original, output=output_tmp,
+                     rules='-', stdin='\n'.join(rules))
+    gs.use_temp_region()
+    gs.run_command('g.region', zoom=output_tmp)
+    gs.mapcalc(output + " = " + output_tmp)
+    gs.run_command('r.colors', map=output, raster=original)
+    gs.del_temp_region()
+
+
+if __name__ == '__main__':
+    atexit.register(cleanup)
+    sys.exit(main())

--- a/grass7/raster/r.extract/testsuite/r_extract_test.py
+++ b/grass7/raster/r.extract/testsuite/r_extract_test.py
@@ -1,0 +1,65 @@
+from grass.gunittest.case import TestCase
+from grass.gunittest.main import test
+from grass.script.core import parse_command
+
+
+class TestRExtract(TestCase):
+    """Test case for r.extract module"""
+
+    inp = "zipcodes"
+    output = "selected_zipcodes"
+    mapcalc_output = "reference_output"
+
+    @classmethod
+    def setUpClass(cls):
+        """Ensures expected computational region and setup"""
+        cls.use_temp_region()
+        cls.runModule("g.region", raster=cls.inp)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Remove the temporary region"""
+        cls.del_temp_region()
+
+    def tearDown(self):
+        """Remove the outputs created by r.extract.
+
+        This is executed after each test run.
+        """
+        self.runModule(
+            "g.remove",
+            flags="f",
+            type="raster",
+            name=[self.output, self.mapcalc_output],
+        )
+
+    def test_extract_cats(self):
+        # run mapcalc for reference
+        expr = "{o} = if ({i} <= 27513 || {i} == 27529 || ({i} >= 27601 && {i} <= 27605) || {i} >= 27608, {i}, null())"
+        self.runModule(
+            "r.mapcalc", expression=expr.format(o=self.mapcalc_output, i=self.inp)
+        )
+        # run the module
+        self.assertModule(
+            "r.extract",
+            input=self.inp,
+            output=self.output,
+            cats="-27513,27529,27601-27605,27608-",
+        )
+        # check to see if output file exists
+        self.assertRasterExists(self.output, msg="Output raster does not exist")
+        # compare univars, because comparing rasters doesn't take nulls into account correctly
+        out_univar = parse_command("r.univar", map=self.output, flags="g")
+        mapcalc_univar = parse_command("r.univar", map=self.mapcalc_output, flags="g")
+        self.assertDictEqual(out_univar, mapcalc_univar)
+
+    def test_extract_clip(self):
+        self.assertModule(
+            "r.extract", input=self.inp, output=self.output, cats="27605", flags="c"
+        )
+        bbox = "rows=210\ncols=186"
+        self.assertRasterFitsInfo(raster=self.output, reference=bbox)
+
+
+if __name__ == "__main__":
+    test()


### PR DESCRIPTION
This is a wrapper around r.reclass to simplify extraction of categories in integer raster maps:
```
r.extract input=zipcodes output=selected_zipcodes cats=27605,27601 -c
```