### PR TITLE
i.sentinel.coverage: fix footprints

### DIFF
--- a/grass7/imagery/i.sentinel/i.sentinel.coverage/i.sentinel.coverage.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.coverage/i.sentinel.coverage.py
@@ -235,7 +235,8 @@ def main():
     for name in name_list_tmp:
         real_producttype, start_day, end_day = scenename_split(name)
         if real_producttype != producttype:
-            grass.fatal("Producttype of ")
+            grass.fatal(_
+                ("Producttype of {} not supported".format(real_producttype)))
         fpi = 'tmp_fps_%s_%s' % (name, str(os.getpid()))
         try:
             grass.run_command(
@@ -245,6 +246,7 @@ def main():
                 start=start_day,
                 end=end_day,
                 footprints=fpi,
+                producttype = producttype,
                 query="identifier=%s" % name,
                 flags='lb',
                 quiet=True)

--- a/grass7/imagery/i.sentinel/i.sentinel.coverage/i.sentinel.coverage.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.coverage/i.sentinel.coverage.py
@@ -173,8 +173,7 @@ def scenename_split(scenename):
         start_day = start_day_dt.strftime('%Y-%m-%d')
         end_day = end_day_dt.strftime('%Y-%m-%d')
     except Exception as e:
-        grass.fatal(_(
-            "The name of the scene must have a format of e.g."
+        grass.fatal(_("The name of the scene must have a format of e.g."
             + " S2A_MSIL1C_YYYYMMDDT155901_N0206_R097_T17SPV_20180822T212023"))
     return producttype, start_day, end_day
 

--- a/grass7/imagery/i.sentinel/i.sentinel.coverage/i.sentinel.coverage.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.coverage/i.sentinel.coverage.py
@@ -94,6 +94,12 @@
 #% required: no
 #%end
 
+#%rules
+#% required: names, output
+#% collective: start,end
+#% excludes: names,start,end,clouds,producttype
+#%end
+
 import atexit
 import os
 from datetime import datetime, timedelta
@@ -147,7 +153,7 @@ def scenename_split(scenename):
 
     '''
     try:
-        ### get producttype
+        # get producttype
         name_split = scenename.split('_')
 
         if name_split[0].startswith('S2'):
@@ -165,8 +171,10 @@ def scenename_split(scenename):
         end_day_dt = dt_obj + timedelta(days=1)
         start_day = start_day_dt.strftime('%Y-%m-%d')
         end_day = end_day_dt.strftime('%Y-%m-%d')
-    except:
-        grass.fatal("The name of the scene must have a format of e.g. S2A_MSIL1C_YYYYMMDDT155901_N0206_R097_T17SPV_20180822T212023")
+    except Exception as e:
+        grass.fatal(_(
+            "The name of the scene must have a format of e.g."
+            + " S2A_MSIL1C_YYYYMMDDT155901_N0206_R097_T17SPV_20180822T212023"))
     return producttype, start_day, end_day
 
 
@@ -184,7 +192,8 @@ def get_size(vector):
         'v.to.db', map=tmpvector, columns='tmparea', option='area',
         units='meters', quiet=True, overwrite=True)
     sizeselected = grass.parse_command('v.db.select', map=tmpvector, flags="v")
-    sizesstr = [x.split('|')[1:] for x in sizeselected if x.startswith('tmparea|')][0]
+    sizesstr = [
+        x.split('|')[1:] for x in sizeselected if x.startswith('tmparea|')][0]
     sizes = [float(x) for x in sizesstr]
     return sum(sizes)
 
@@ -192,12 +201,6 @@ def get_size(vector):
 def main():
 
     global rm_regions, rm_rasters, rm_vectors
-
-    ### check if the i.sentinel.download addons is installed
-    if not grass.find_program('i.sentinel.download', '--help'):
-        grass.fatal(_("The 'i.sentinel.download' module was not found, install it first:") +
-                    "\n" +
-                    "g.extension i.sentinel")
 
     # parameters
     settings = options['settings']
@@ -219,38 +222,65 @@ def main():
             producttype=producttype,
             start=options['start'],
             end=options['end'],
-            footprints=fps,
             flags='lb',
             quiet=True)
         if len(s_list) == 0:
             grass.fatal('No products found')
-        name_list = [x.split(' ')[1] for x in s_list]
+        name_list_tmp = [x.split(' ')[1] for x in s_list]
     else:
-        name_list = []
-        fp_list = []
-        for name in options['names'].split(','):
-            real_producttype, start_day, end_day = scenename_split(name)
-            if real_producttype != producttype:
-                grass.fatal("Producttype of ")
-            fpi = 'tmp_fps_%s_%s' % (name, str(os.getpid()))
-            try:
-                grass.run_command(
-                    'i.sentinel.download',
-                    settings=settings,
-                    map=area,
-                    producttype=producttype,
-                    footprints=fpi,
-                    start=start_day,
-                    end=end_day,
-                    flags='bl',
-                    quiet=True)
-                name_list.append(name)
-                fp_list.append(fpi)
-                rm_vectors.append(fpi)
-            except:
-                grass.warning('%s was not found in %s' % (name, area))
-        grass.run_command(
-            'v.patch', input=','.join(fp_list), output=fps, quiet=True)
+        name_list_tmp = options['names'].split(',')
+    name_list = []
+    fp_list = []
+    for name in name_list_tmp:
+        real_producttype, start_day, end_day = scenename_split(name)
+        if real_producttype != producttype:
+            grass.fatal("Producttype of ")
+        fpi = 'tmp_fps_%s_%s' % (name, str(os.getpid()))
+        try:
+            grass.run_command(
+                'i.sentinel.download',
+                settings=settings,
+                map=area,
+                start=start_day,
+                end=end_day,
+                footprints=fpi,
+                query="identifier=%s" % name,
+                flags='lb',
+                quiet=True)
+            name_list.append(name)
+            fp_list.append(fpi)
+            rm_vectors.append(fpi)
+        except Exception as e:
+            grass.warning('%s was not found in %s' % (name, area))
+
+    if len(fp_list) > 1:
+        start_fp = fp_list[0]
+        for idx, fp in enumerate(fp_list[1:]):
+            temp_overlay = 'tmp_fp_overlay_%d' % idx
+            rm_vectors.append(temp_overlay)
+            grass.run_command('v.overlay', ainput=start_fp, binput=fp,
+                              operator='or', output=temp_overlay, quiet=True)
+            grass.run_command('v.db.update', map=temp_overlay,
+                              column='a_identifier',
+                              query_column='a_identifier || "+" '
+                              + '|| b_identifier',
+                              where='a_identifier NOT NULL AND '
+                              + 'b_identifier NOT NULL',
+                              quiet=True)
+            grass.run_command('v.db.update', map=temp_overlay,
+                              column='a_identifier',
+                              query_column='b_identifier',
+                              where='a_identifier IS NULL',
+                              quiet=True)
+            grass.run_command('v.db.dropcolumn', map=temp_overlay,
+                              columns='b_identifier', quiet=True)
+            grass.run_command('v.db.renamecolumn', map=temp_overlay,
+                              column='a_identifier,identifier', quiet=True)
+
+            start_fp = temp_overlay
+    else:
+        temp_overlay = fp_list[0]
+    grass.run_command('g.rename', vector='%s,%s' % (temp_overlay, fps))
 
     grass.message(_("Getting size of <%s> area ...") % area)
     areasize = get_size(area)
@@ -266,11 +296,14 @@ def main():
     grass.run_command(
         'v.db.update', map=fps_in_area, column='tmp', value=1, quiet=True)
     # list of scenes that actually intersect with bbox
-    name_list_updated = list(grass.parse_command('v.db.select',
-                                                 map=fps_in_area,
-                                                 column='a_identifier',
-                                                 flags='c').keys())
+    name_list_updated_tmp = list(grass.parse_command('v.db.select',
+                                                     map=fps_in_area,
+                                                     column='a_identifier',
+                                                     flags='c').keys())
 
+    # split along '+' and remove duplicates
+    name_list_updated = list(set([
+        item2 for item in name_list_updated_tmp for item2 in item.split('+')]))
     fps_in_area_dis = 'tmp_fps_in_area_dis_%s' % str(os.getpid())
     rm_vectors.append(fps_in_area_dis)
     grass.run_command(
@@ -281,11 +314,13 @@ def main():
     fpsize = get_size(fps_in_area_dis)
 
     percent = fpsize / areasize * 100.0
-    grass.message(_("%.2f percent of the area <%s> is covered") % (percent, area))
-
+    grass.message(_(
+        "%.2f percent of the area <%s> is covered") % (percent, area))
     if options['minpercent']:
         if percent < int(options['minpercent']):
-            grass.fatal("The percentage of coverage is too low (expected: %s)" % options['minpercent'])
+            grass.fatal(_(
+                "The percentage of coverage is too low (expected: %s)"
+                % options['minpercent']))
 
     # save list of Sentinel names
     if output:

--- a/grass7/imagery/i.sentinel/i.sentinel.coverage/i.sentinel.coverage.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.coverage/i.sentinel.coverage.py
@@ -165,7 +165,8 @@ def scenename_split(scenename):
             producttype = name_split[2][:3]
             date_string = name_split[4].split('T')[0]
         else:
-            grass.fatal(_("Sensor %s is not supported yet" % name_split[0]))
+            grass.fatal(_(
+                "Sensor {} is not supported yet".format(name_split[0])))
         dt_obj = datetime.strptime(date_string, "%Y%m%d")
         start_day_dt = dt_obj - timedelta(days=1)
         end_day_dt = dt_obj + timedelta(days=1)
@@ -207,7 +208,7 @@ def main():
     output = options['output']
     area = options['area']
     if not grass.find_file(area, element='vector')['file']:
-        grass.fatal(_("Vector map <%s> not found") % area)
+        grass.fatal(_("Vector map <{}> not found".format(area)))
     producttype = options['producttype']
 
     grass.message(_("Retrieving Sentinel footprints from ESA hub ..."))
@@ -251,7 +252,7 @@ def main():
             fp_list.append(fpi)
             rm_vectors.append(fpi)
         except Exception as e:
-            grass.warning('%s was not found in %s' % (name, area))
+            grass.warning(_('{} was not found in {}'.format(name, area)))
 
     if len(fp_list) > 1:
         start_fp = fp_list[0]
@@ -282,10 +283,11 @@ def main():
         temp_overlay = fp_list[0]
     grass.run_command('g.rename', vector='%s,%s' % (temp_overlay, fps))
 
-    grass.message(_("Getting size of <%s> area ...") % area)
+    grass.message(_("Getting size of <{}> area ...".format(area)))
     areasize = get_size(area)
 
-    grass.message(_("Getting size of footprints in area <%s> ...") % area)
+    grass.message(_(
+        "Getting size of footprints in area <{}> ...".format(area)))
     fps_in_area = 'tmp_fps_in_area_%s' % str(os.getpid())
     rm_vectors.append(fps_in_area)
     grass.run_command(
@@ -314,20 +316,22 @@ def main():
     fpsize = get_size(fps_in_area_dis)
 
     percent = fpsize / areasize * 100.0
+    percent_rounded = round(percent, 2)
     grass.message(_(
-        "%.2f percent of the area <%s> is covered") % (percent, area))
+        "{} percent of the area <{}> is covered".format(
+            str(percent_rounded), area)))
     if options['minpercent']:
         if percent < int(options['minpercent']):
             grass.fatal(_(
-                "The percentage of coverage is too low (expected: %s)"
-                % options['minpercent']))
-
+                "The percentage of coverage is too low (expected: {})".format(
+                    str(options['minpercent']))))
     # save list of Sentinel names
     if output:
         with open(output, 'w') as f:
             f.write(','.join(name_list_updated))
         grass.message(_(
-            "Name of Sentinel scenes are written to file <%s>") % (output))
+            "Name of Sentinel scenes are written to file <{}>".format(
+                output)))
 
     # TODO Sentinel-1 select only "one" scene (no overlap)
 

--- a/grass7/imagery/i.sentinel/i.sentinel.coverage/i.sentinel.coverage.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.coverage/i.sentinel.coverage.py
@@ -166,7 +166,7 @@ def scenename_split(scenename):
             date_string = name_split[4].split('T')[0]
         else:
             grass.fatal(_(
-                "Sensor {} is not supported yet".format(name_split[0])))
+                "Sensor {} is not supported yet").format(name_split[0]))
         dt_obj = datetime.strptime(date_string, "%Y%m%d")
         start_day_dt = dt_obj - timedelta(days=1)
         end_day_dt = dt_obj + timedelta(days=1)
@@ -208,7 +208,7 @@ def main():
     output = options['output']
     area = options['area']
     if not grass.find_file(area, element='vector')['file']:
-        grass.fatal(_("Vector map <{}> not found".format(area)))
+        grass.fatal(_("Vector map <{}> not found").format(area))
     producttype = options['producttype']
 
     grass.message(_("Retrieving Sentinel footprints from ESA hub ..."))
@@ -235,8 +235,8 @@ def main():
     for name in name_list_tmp:
         real_producttype, start_day, end_day = scenename_split(name)
         if real_producttype != producttype:
-            grass.fatal(_
-                ("Producttype of {} not supported".format(real_producttype)))
+            grass.fatal(_(
+                "Producttype of {} not supported").format(real_producttype))
         fpi = 'tmp_fps_%s_%s' % (name, str(os.getpid()))
         try:
             grass.run_command(
@@ -246,7 +246,7 @@ def main():
                 start=start_day,
                 end=end_day,
                 footprints=fpi,
-                producttype = producttype,
+                producttype=producttype,
                 query="identifier=%s" % name,
                 flags='lb',
                 quiet=True)
@@ -254,7 +254,7 @@ def main():
             fp_list.append(fpi)
             rm_vectors.append(fpi)
         except Exception as e:
-            grass.warning(_('{} was not found in {}'.format(name, area)))
+            grass.warning(_('{} was not found in {}').format(name, area))
 
     if len(fp_list) > 1:
         start_fp = fp_list[0]
@@ -285,11 +285,11 @@ def main():
         temp_overlay = fp_list[0]
     grass.run_command('g.rename', vector='%s,%s' % (temp_overlay, fps))
 
-    grass.message(_("Getting size of <{}> area ...".format(area)))
+    grass.message(_("Getting size of <{}> area ...").format(area))
     areasize = get_size(area)
 
     grass.message(_(
-        "Getting size of footprints in area <{}> ...".format(area)))
+        "Getting size of footprints in area <{}> ...").format(area))
     fps_in_area = 'tmp_fps_in_area_%s' % str(os.getpid())
     rm_vectors.append(fps_in_area)
     grass.run_command(
@@ -320,20 +320,20 @@ def main():
     percent = fpsize / areasize * 100.0
     percent_rounded = round(percent, 2)
     grass.message(_(
-        "{} percent of the area <{}> is covered".format(
-            str(percent_rounded), area)))
+        "{} percent of the area <{}> is covered").format(
+            str(percent_rounded), area))
     if options['minpercent']:
         if percent < int(options['minpercent']):
             grass.fatal(_(
-                "The percentage of coverage is too low (expected: {})".format(
-                    str(options['minpercent']))))
+                "The percentage of coverage is too low (expected: {})").format(
+                    str(options['minpercent'])))
     # save list of Sentinel names
     if output:
         with open(output, 'w') as f:
             f.write(','.join(name_list_updated))
         grass.message(_(
-            "Name of Sentinel scenes are written to file <{}>".format(
-                output)))
+            "Name of Sentinel scenes are written to file <{}>").format(
+                output))
 
     # TODO Sentinel-1 select only "one" scene (no overlap)
 


### PR DESCRIPTION
This PR fixes two issues with `i.sentinel.coverage`:

1. Downloading a lot of footprints together using `i.sentinel.download `may yield incorrect individual footprints. This is avoided by downloading all identified footprints individually (see attached screenshots)
2. Using `v.patch` to patch all footprints together yields a "XOR" result: overlapping areas are missing. This is avoided by using `v.overlay` sequentially

This PR further 

- Adds rules for input options
- Removes check for `i.sentinel` installation
- corrects some minor linting issues

Developed together with @anikaweinmann 

## Screenshots
##### Correct single footprint downloaded individually
![correct_footprint](https://user-images.githubusercontent.com/62383722/105972737-3a049980-608c-11eb-8dc3-917bb974b2b4.png)
##### Incorrect footprint as part of a large number of footprints downloaded in a single step using `i.sentinel.download`
![incorrect_footprints](https://user-images.githubusercontent.com/62383722/105972833-51438700-608c-11eb-82e6-79369db92d87.png)

