### PR TITLE
wxGUI/wx.metadata: fix lazy import of GRASS GIS wxPy 'core.gcmd' module classes

### DIFF
--- a/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
+++ b/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
@@ -42,7 +42,6 @@ from grass.script.setup import set_gui_path
 
 set_gui_path()
 from core.debug import Debug
-from core.gcmd import GError, GMessage, RunCommand
 # from datacatalog.tree import LocationMapTree
 from core.utils import GetListOfLocations, ListOfMapsets
 
@@ -72,6 +71,17 @@ class LocationMapTree(wx.TreeCtrl):
                  wx.TR_HAS_BUTTONS | wx.TR_FULL_ROW_HIGHLIGHT | wx.TR_SINGLE):
         """Location Map Tree constructor."""
         super(LocationMapTree, self).__init__(parent, id=wx.ID_ANY, style=style)
+
+        try:
+            global RunCommand
+
+            from core.gcmd import RunCommand
+        except ModuleNotFoundError as e:
+            msg = e.msg
+            sys.exit(globalvar.MODULE_NOT_FOUND.format(
+                lib=msg.split("'")[-2],
+                url=globalvar.MODULE_URL))
+
         self.showNotification = Signal('Tree.showNotification')
         self.parent = parent
         self.root = self.AddRoot('Catalog') # will not be displayed when we use TR_HIDE_ROOT flag
@@ -288,6 +298,17 @@ class MdMainFrame(wx.Frame):
         @var batch: if true multiple editing metadata of maps is ON
         '''
         wx.Frame.__init__(self, None, title="Metadata Editor", size=(650, 500))
+
+        try:
+            global GError, GMessage
+
+            from core.gcmd import GError, GMessage
+        except ModuleNotFoundError as e:
+            msg = e.msg
+            sys.exit(globalvar.MODULE_NOT_FOUND.format(
+                lib=msg.split("'")[-2],
+                url=globalvar.MODULE_URL))
+
         self.initDefaultPathStorageMetadata()
 
         self.config = wx.Config("g.gui.metadata")
@@ -1076,6 +1097,17 @@ class MdDataCatalog(LocationMapTree):
         super(MdDataCatalog, self).__init__(parent=parent,
                                             style=wx.TR_MULTIPLE | wx.TR_HIDE_ROOT | wx.TR_HAS_BUTTONS |
                                                   wx.TR_FULL_ROW_HIGHLIGHT)
+
+        try:
+            global GError
+
+            from core.gcmd import GError
+        except ModuleNotFoundError as e:
+            msg = e.msg
+            sys.exit(globalvar.MODULE_NOT_FOUND.format(
+                lib=msg.split("'")[-2],
+                url=globalvar.MODULE_URL))
+
         try:
             tgis.init(True)
         except tgis.FatalError as e:

--- a/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/cswlib.py
@@ -27,7 +27,6 @@ from grass.script.setup import set_gui_path
 
 set_gui_path()
 
-from core.gcmd import GError, GMessage, GWarning
 from gui_core.forms import GUI
 
 import wx
@@ -97,8 +96,8 @@ class CSWBrowserPanel(wx.Panel):
 
         try:
             global BBox, CatalogueServiceWeb, Environment, ExceptionReport, \
-                FileSystemLoader, HtmlFormatter, PropertyIsLike, XmlLexer, \
-                highlight
+                FileSystemLoader, GError, GMessage, GWarning, HtmlFormatter, \
+                PropertyIsLike, XmlLexer, highlight
 
             from jinja2 import Environment, FileSystemLoader
 
@@ -109,6 +108,8 @@ class CSWBrowserPanel(wx.Panel):
             from pygments import highlight
             from pygments.formatters import HtmlFormatter
             from pygments.lexers import XmlLexer
+
+            from core.gcmd import GError, GMessage, GWarning
         except ModuleNotFoundError as e:
             msg = e.msg
             sys.exit(globalvar.MODULE_NOT_FOUND.format(
@@ -993,8 +994,8 @@ class CSWConnectionPanel(wx.Panel):
         wx.Panel.__init__(self, parent)
         try:
             global BBox, CatalogueServiceWeb, Environment, ExceptionReport, \
-                FileSystemLoader, HtmlFormatter, PropertyIsLike, XmlLexer, \
-                highlight
+                FileSystemLoader, GError, GMessage, GWarning, HtmlFormatter, \
+                PropertyIsLike, XmlLexer, highlight
 
             from jinja2 import Environment, FileSystemLoader
 
@@ -1005,6 +1006,8 @@ class CSWConnectionPanel(wx.Panel):
             from pygments import highlight
             from pygments.formatters import HtmlFormatter
             from pygments.lexers import XmlLexer
+
+            from core.gcmd import GError, GMessage, GWarning
         except ModuleNotFoundError as e:
             msg = e.msg
             sys.exit(globalvar.MODULE_NOT_FOUND.format(

--- a/grass7/gui/wxpython/wx.metadata/mdlib/mdeditorfactory.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/mdeditorfactory.py
@@ -27,8 +27,6 @@ import sys
 import tempfile
 from subprocess import PIPE
 
-from core.gcmd import GError, GMessage, RunCommand
-
 from grass.pygrass.modules import Module
 
 from gui_core.widgets import (
@@ -55,11 +53,14 @@ class MdFileWork():
     '''
 
     def __init__(self, pathToXml=None):
+
         try:
-            global Environment, FileSystemLoader, etree
+            global Environment, FileSystemLoader, etree, GError, GMessage
 
             from jinja2 import Environment, FileSystemLoader
             from lxml import etree
+
+            from core.gcmd import GError, GMessage
         except ModuleNotFoundError as e:
             msg = e.msg
             sys.exit(globalvar.MODULE_NOT_FOUND.format(
@@ -802,6 +803,17 @@ class MdNotebookPage(scrolled.ScrolledPanel):
 class MdKeywords(wx.BoxSizer):
     def __init__(self,parent,mdObject,mdOWS):
         wx.BoxSizer.__init__(self, wx.VERTICAL)
+
+        try:
+            global GMessage
+
+            from core.gcmd import GMessage
+        except ModuleNotFoundError as e:
+            msg = e.msg
+            sys.exit(globalvar.MODULE_NOT_FOUND.format(
+                lib=msg.split("'")[-2],
+                url=globalvar.MODULE_URL))
+
         self.itemHolder = set()
         self.parent = parent
         self.keywordsOWSObject = mdOWS
@@ -969,16 +981,19 @@ class MdMainEditor(wx.Panel):
         @param templateEditor: mode-creator of template
         '''
         wx.Panel.__init__(self, parent=parent, id=wx.ID_ANY)
+
         try:
             global CI_Date, CI_OnlineResource, CI_ResponsibleParty, \
                 DQ_DataQuality, EX_Extent, EX_GeographicBoundingBox, \
-                MD_Distribution, MD_ReferenceSystem
+                GError, MD_Distribution, MD_ReferenceSystem
 
             from owslib.iso import (
                 CI_Date, CI_OnlineResource, CI_ResponsibleParty,
                 DQ_DataQuality, EX_Extent, EX_GeographicBoundingBox,
                 MD_Distribution, MD_ReferenceSystem
             )
+
+            from core.gcmd import GError
         except ModuleNotFoundError as e:
             msg = e.msg
             sys.exit(globalvar.MODULE_NOT_FOUND.format(

--- a/grass7/gui/wxpython/wx.metadata/mdlib/mdjinjaparser.py
+++ b/grass7/gui/wxpython/wx.metadata/mdlib/mdjinjaparser.py
@@ -15,7 +15,10 @@ This program is free software under the GNU General Public License
 
 @author Matej Krejci <matejkrejci gmail.com> (GSoC 2014)
 """
-from core.gcmd import GError
+
+import sys
+
+from . import globalvar
 from .mdutil import findBetween
 
 
@@ -117,6 +120,17 @@ class JinjaTemplateParser():
         @var mdOWSTagStr: string representing OWSLib tags from template (per line)
         @var mdOWSTagStrList: on each index of list is one line with parsed OWSLib tag
         '''
+
+        try:
+            global GError
+
+            from core.gcmd import GError
+        except ModuleNotFoundError as e:
+            msg = e.msg
+            sys.exit(globalvar.MODULE_NOT_FOUND.format(
+                lib=msg.split("'")[-2],
+                url=globalvar.MODULE_URL))
+
         self.mdDescription = []
         self.mdOWSTag = []
         self.template = template


### PR DESCRIPTION
Fix lazy import of GRASS GIS wxPy `core.gcmd` module classes during compilation on Windows platform (server where builds Add-Ons)

**Error message**

```
Traceback (most recent call last):
  File "C:/Users/landa/grass_packager/grass785/x86_64/addons/wx.metadata/scripts/g.gui.cswbrowser.py", line 26, in <module>
    from mdlib.cswlib import CSWBrowserPanel, CSWConnectionPanel
  File "C:\msys64\usr\src\grass-addons\grass7\gui\wxpython\wx.metadata\mdlib\cswlib.py", line 30, in <module>
    from core.gcmd import GError, GMessage, GWarning
  File "C:/msys64/usr/src/grass785/dist.x86_64-w64-mingw32\gui\wxpython\core\gcmd.py", line 43, in <module>
    from win32file import ReadFile, WriteFile
ModuleNotFoundError: No module named 'win32file'
```

Full [compilation log file](https://wingrass.fsv.cvut.cz/grass78/x86_64/addons/latest/logs/wx.metadata.log).