### PR TITLE
r.pi.enn + r.pi.fnn: fix error message

### DIFF
--- a/grass7/raster/r.pi/r.pi.enn/matrix.c
+++ b/grass7/raster/r.pi/r.pi.enn/matrix.c
@@ -35,11 +35,8 @@ int writeDistMatrixAndID(char *name, Coords ** frags, int count)
 	/* open the new cellfile */
 	out_fd = Rast_open_new(name, DCELL_TYPE);
 	if (out_fd < 0) {
-	    char msg[200];
-
-	    sprintf(msg, "can't create new cell file <%s> in mapset %s\n",
-		    name, mapset);
-	    G_fatal_error(msg);
+	    G_fatal_error(_("can't create new cell file <%s> in mapset %s\n"),
+                      name, G_mapset());
 	    res = 1;
 	}
 	else {

--- a/grass7/raster/r.pi/r.pi.enn/matrix.c
+++ b/grass7/raster/r.pi/r.pi.enn/matrix.c
@@ -4,7 +4,6 @@ int writeDistMatrixAndID(char *name, Coords ** frags, int count)
 {
     FILE *out_fp;
     int res = 0;
-    const char *mapset;
     int out_fd;
     int row, col, i;
     DCELL *result;
@@ -30,7 +29,6 @@ int writeDistMatrixAndID(char *name, Coords ** frags, int count)
 	/* check if the new file name is correct */
     if (G_legal_filename(name) < 0)
 	    G_fatal_error(_("<%s> is an illegal file name"), name);
-	mapset = G_mapset();
 
 	/* open the new cellfile */
 	out_fd = Rast_open_new(name, DCELL_TYPE);

--- a/grass7/raster/r.pi/r.pi.fnn/heap.c
+++ b/grass7/raster/r.pi/r.pi.fnn/heap.c
@@ -3,7 +3,7 @@
 #include <grass/stats.h>
 #include "local_proto.h"
 
-inline void exchange(int p1, int p2)
+static void exchange(int p1, int p2)
 {
     Path_Coords tmp = heap[p1];
 

--- a/grass7/raster/r.pi/r.pi.fnn/matrix.c
+++ b/grass7/raster/r.pi/r.pi.fnn/matrix.c
@@ -37,11 +37,8 @@ int writeDistMatrixAndID(char *name, Coords ** frags, int count)
 	/* open the new cellfile */
 	out_fd = Rast_open_new(name, DCELL_TYPE);
 	if (out_fd < 0) {
-	    char msg[200];
-
-	    sprintf(msg, "can't create new cell file <%s> in mapset %s\n",
-		    name, mapset);
-	    G_fatal_error(msg);
+	    G_fatal_error(_("can't create new cell file <%s> in mapset %s\n"),
+                      name, G_mapset());
 	    res = 1;
 	}
 	else {

--- a/grass7/raster/r.pi/r.pi.fnn/matrix.c
+++ b/grass7/raster/r.pi/r.pi.fnn/matrix.c
@@ -4,7 +4,6 @@ int writeDistMatrixAndID(char *name, Coords ** frags, int count)
 {
     FILE *out_fp;
     int res = 0;
-    const char *mapset;
     int out_fd;
     int row, col, i;
     DCELL *result;
@@ -32,7 +31,6 @@ int writeDistMatrixAndID(char *name, Coords ** frags, int count)
 	    G_warning(_("<%s> is an illegal file name"), name);
 	    res = 1;
 	}
-	mapset = G_mapset();
 
 	/* open the new cellfile */
 	out_fd = Rast_open_new(name, DCELL_TYPE);


### PR DESCRIPTION
fixes #438

Remarks
- all related error messages in `r.pi.*` should be standardized in a separate PR
- or, better: remove entirely since `Rast_open_new()` in GRASS-core doesn't have any following `G_fatal_error()` error messages as not needed? Maybe an old artifact of G6 times...