### PR TITLE
r.slope.direction: replace method with slope_measure in the manual

### DIFF
--- a/grass7/raster/r.slope.direction/r.slope.direction.html
+++ b/grass7/raster/r.slope.direction/r.slope.direction.html
@@ -19,7 +19,7 @@ Possible values are
 difference devided by the total distance over the user given number of steps 
 along the direction map</li>
 <li><b>degree_int</b> - same as degree but multiplied with 100 and rounded 
-to the closest integer to limit data volumn</li>
+to the closest integer to limit data volume</li>
 <li><b>difference</b> - the total elevation difference independent from the 
 x-y distance along the direction map</li>
 <li><b>percent</b> - the ratio between the total elevation difference and 

--- a/grass7/raster/r.slope.direction/r.slope.direction.html
+++ b/grass7/raster/r.slope.direction/r.slope.direction.html
@@ -25,7 +25,7 @@ x-y distance along the direction map</li>
 <li><b>percent</b> - the ratio between the total elevation difference and 
 the total distance over the user given number of steps along the direction map</li>
 <li><b>percent_int</b> - same as percent but multiplied with 10000 and rounded 
-to the closest integer to limit data volumn</li>
+to the closest integer to limit data volume</li>
 </ul>
 
 <p>The <b>a</b>-flag allows to compute slope as absolute elevation differences.</p>

--- a/grass7/raster/r.slope.direction/r.slope.direction.html
+++ b/grass7/raster/r.slope.direction/r.slope.direction.html
@@ -12,15 +12,20 @@ addition to the computational region - mainly determined by the maximum
 <b>steps</b> value. Multiple neighboorhoods can be given in order to
 produce slope measures at different spatial scales.</p>
 
-The <b>method</b> defines the algorithm to be used for measuring slope
+The <b>slope_measure</b> option defines the format in which slope is reported. 
+Possible values are
 <ul>
-<li><b>mean</b> measures slope as the average elevation difference over the user
-given number of steps along the direction map</li>
-<li><b>absolute_mean</b> measure like in the mean option but builds the average
-only over the absolute values of elevation difference in each step</li>
-<li><b>total_gradient</b> measures slope as the total elevation difference
-devided by the total distance over the user given number of steps along the
-direction map</li>
+<li><b>degree</b> (the default) - the angle described by the total elevation 
+difference devided by the total distance over the user given number of steps 
+along the direction map</li>
+<li><b>degree_int</b> - same as degree but multiplied with 100 and rounded 
+to the closest integer to limit data volumn</li>
+<li><b>difference</b> - the total elevation difference independent from the 
+x-y distance along the direction map</li>
+<li><b>percent</b> - the ratio between the total elevation difference and 
+the total distance over the user given number of steps along the direction map</li>
+<li><b>percent_int</b> - same as percent but multiplied with 10000 and rounded 
+to the closest integer to limit data volumn</li>
 </ul>
 
 <p>The <b>a</b>-flag allows to compute slope as absolute elevation differences.</p>


### PR DESCRIPTION
Thanks for catching the flaw in the manual. I simply forgot to update the manual after major module change.

This PR should fix #433

Any checking of clarity, spelling and grammar would be very much appreciated...