### PR TITLE
r.learn.train: fix for scikit-learn==0.24.0

### DIFF
--- a/grass7/raster/r.learn.ml2/r.learn.train/r.learn.train.py
+++ b/grass7/raster/r.learn.ml2/r.learn.train/r.learn.train.py
@@ -638,7 +638,7 @@ def main():
     # outer resampling method (cv=cv)
     if cv > 1:
         if group_id is None and mode == "classification":
-            outer = StratifiedKFold(n_splits=cv, random_state=random_state)
+            outer = StratifiedKFold(n_splits=cv, random_state=random_state, shuffle=True)
         elif group_id is None and mode == "regression":
             outer = KFold(n_splits=cv, random_state=random_state)
         else:

--- a/grass7/raster/r.learn.ml2/r.learn.train/r.learn.train.py
+++ b/grass7/raster/r.learn.ml2/r.learn.train/r.learn.train.py
@@ -627,7 +627,7 @@ def main():
 
     if any(param_grid) is True:
         if group_id is None and mode == "classification":
-            inner = StratifiedKFold(n_splits=2, random_state=random_state)
+            inner = StratifiedKFold(n_splits=2, random_state=random_state, shuffle=True)
         elif group_id is None and mode == "regression":
             inner = KFold(n_splits=2, random_state=random_state)
         else:


### PR DESCRIPTION
By using `scikit-learn==0.24.0` `r.learn.train -f group=in_group model_name=RandomForestClassifier n_jobs=3 cv=5 training_points=training_set field=class_num save_model=model.gz` leads to an error:
```
Removing samples with NaN values in the raster feature variables...
Traceback (most recent call last):
 File "/usr/local/grass78/scripts/r.learn.train", line 872, in <module>
 main()
 File "/usr/local/grass78/scripts/r.learn.train", line 641, in main
 outer = StratifiedKFold(n_splits=cv, random_state=random_state)
 File "/usr/lib/python3.8/site-packages/sklearn/utils/validation.py", line 63, in inner_f
 return f(*args, **kwargs) 
 File "/usr/lib/python3.8/site-packages/sklearn/model_selection/_split.py", line 636, in __init__
 super().__init__(n_splits=n_splits, shuffle=shuffle,
 File "/usr/lib/python3.8/site-packages/sklearn/utils/validation.py", line 63, in inner_f
 return f(*args, **kwargs) 
 File "/usr/lib/python3.8/site-packages/sklearn/model_selection/_split.py", line 290, in __init__
 raise ValueError(
ValueError: Setting a random_state has no effect since shuffle is False. You should leave random_state to its default (None), or set shuffle=True.
Traceback (most recent call last):
 File "/usr/local/grass78/scripts/r.classify.train.classifier", line 174, in <module>
 sys.exit(main())
 File "/usr/local/grass78/scripts/r.classify.train.classifier", line 163, in main
 grass.run_command('r.learn.train', **param)
 File "/usr/local/grass78/etc/python/grass/script/core.py", line 441, in run_command
 return handle_errors(returncode, returncode, args, kwargs)
 File "/usr/local/grass78/etc/python/grass/script/core.py", line 342, in handle_errors
 raise CalledModuleError(module=None, code=code,
```
Adding `shuffle=True` to StratifiedKFold fixes the error.

This does not seem to be necessary for  `KFold`:
- https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.StratifiedKFold.html
- https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.KFold.html