### PR TITLE
WIP: add collection 2 support in i.landsat.download

### DIFF
--- a/grass7/imagery/i.landsat/i.landsat.download/i.landsat.download.py
+++ b/grass7/imagery/i.landsat/i.landsat.download/i.landsat.download.py
@@ -210,7 +210,7 @@ def main():
 
             try:
 
-                ee.download(scene_id=i, output_dir=outdir, timeout=options["timeout"])
+                ee.download(scene_id=i, output_dir=outdir, timeout=int(options["timeout"]))
 
             except OSError:
 

--- a/grass7/imagery/i.landsat/i.landsat.download/i.landsat.download.py
+++ b/grass7/imagery/i.landsat/i.landsat.download/i.landsat.download.py
@@ -21,23 +21,27 @@
 #% keyword: Landsat
 #% keyword: download
 #%end
+
 #%option G_OPT_F_INPUT
 #% key: settings
 #% label: Full path to settings file (user, password)
 #% description: '-' for standard input
 #%end
+
 #%option G_OPT_M_DIR
 #% key: output
 #% description: Name for output directory where to store downloaded Landsat data
 #% required: no
 #% guisection: Output
 #%end
+
 #%option G_OPT_V_MAP
 #% label: Name of input vector map to define Area of Interest (AOI)
 #% description: If not given then current computational extent is used
 #% required: no
 #% guisection: Region
 #%end
+
 #%option
 #% key: clouds
 #% type: integer
@@ -45,27 +49,31 @@
 #% required: no
 #% guisection: Filter
 #%end
+
 #%option
 #% key: dataset
 #% type: string
 #% description: Landsat dataset to search for
 #% required: no
-#% options: LANDSAT_TM_C1, LANDSAT_ETM_C1, LANDSAT_8_C1
-#% answer: LANDSAT_8_C1
+#% options: landsat_tm_c1, landsat_etm_c1, landsat_8_c1, landsat_tm_c2_l1, landsat_tm_c2_l2, landsat_etm_c2_l1, landsat_etm_c2_l2, landsat_ot_c2_l1, landsat_ot_c2_l2
+#% answer: landsat_8_c1
 #% guisection: Filter
 #%end
+
 #%option
 #% key: start
 #% type: string
 #% description: Start date ('YYYY-MM-DD')
 #% guisection: Filter
 #%end
+
 #%option
 #% key: end
 #% type: string
 #% description: End date ('YYYY-MM-DD')
 #% guisection: Filter
 #%end
+
 #%option
 #% key: id
 #% type: string
@@ -73,6 +81,7 @@
 #% description: List of scenes IDs to download
 #% guisection: Filter
 #%end
+
 #%option
 #% key: tier
 #% type: string
@@ -81,14 +90,16 @@
 #% options: RT, T1, T2
 #% guisection: Filter
 #%end
+
 #%option
 #% key: sort
 #% description: Sort by values in given order
 #% multiple: yes
-#% options: acquisitionDate,cloudCover
-#% answer: cloudCover,acquisitionDate
+#% options: publishDate,cloudCover
+#% answer: cloudCover,publishDate
 #% guisection: Sort
 #%end
+
 #%option
 #% key: order
 #% description: Sort order (see sort parameter)
@@ -96,11 +107,13 @@
 #% answer: asc
 #% guisection: Sort
 #%end
+
 #%flag
 #% key: l
 #% description: List filtered products and exit
 #% guisection: Print
 #%end
+
 #%rules
 #% exclusive: -l, id
 #% exclusive: -l, output
@@ -238,7 +251,7 @@ def main():
                 print(
                     scene["entityId"],
                     scene["displayId"],
-                    scene["acquisitionDate"],
+                    scene["publishDate"],
                     scene["cloudCover"],
                 )
 

--- a/grass7/imagery/i.landsat/i.landsat.import/i.landsat.import.py
+++ b/grass7/imagery/i.landsat/i.landsat.import/i.landsat.import.py
@@ -21,21 +21,25 @@
 #% keyword: Landsat
 #% keyword: import
 #%end
+
 #%option G_OPT_M_DIR
 #% key: input
 #% description: Name of input directory with downloaded Landsat data
 #% required: yes
 #%end
+
 #%option
 #% key: pattern
 #% description: Band name pattern to import
 #% guisection: Filter
 #%end
+
 #%option
 #% key: pattern_file
 #% description: File name pattern to import
 #% guisection: Filter
 #%end
+
 #%option
 #% key: extent
 #% type: string
@@ -47,6 +51,7 @@
 #% descriptions: region;extent of current region;input;extent of input map
 #% guisection: Filter
 #%end
+
 #%option
 #% key: memory
 #% type: integer
@@ -56,31 +61,37 @@
 #% description: Cache size for raster rows
 #% answer: 300
 #%end
+
 #%option G_OPT_F_OUTPUT
 #% key: register_output
 #% description: Name for output file to use with t.register
 #% required: no
 #%end
+
 #%flag
 #% key: r
 #% description: Reproject raster data using r.import if needed
 #% guisection: Settings
 #%end
+
 #%flag
 #% key: l
 #% description: Link raster data instead of importing
 #% guisection: Settings
 #%end
+
 #%flag
 #% key: o
 #% description: Override projection check (use current location's projection)
 #% guisection: Settings
 #%end
+
 #%flag
 #% key: p
 #% description: Print raster data to be imported and exit
 #% guisection: Print
 #%end
+
 #%rules
 #% exclusive: -l,-r,-p
 #% exclusive: -o,-r


### PR DESCRIPTION
Here's a first working version of `i.landsat.download` with support for collection 2 data conforming with the new landsatxplore.

There have been some changes in terms of metadata in Landsat collections. Hence, instead of `acquisitionDate`, I have (for now) used `publishDate`. This has a problem though. While it has info for collection 1, it appears as `Unknown` for L8 in collection 2 only. Hence preventing the sort these data by date.

The option would be to use `scene['temporalCoverage']['startDate']` that is populated properly in both collection 1 and 2, but my limited python knowledge *prevents* me from modifying current lines 233-242 where date and clouds are used to sort the listed scenes. Can someone help here, please?? :pray: 

Here's my hardcoded testing script:

```
#!/usr/bin/env python

import landsatxplore.api

# Initialize a new API instance and get an access key
api = landsatxplore.api.API('your_usgs_username, 'your_usgs_password')

# Request
scenes = api.search(
    dataset='landsat_ot_c2_l2',
    longitude=-78.77428134,
    latitude=35.68792712,
    start_date='2015-01-01',
    end_date='2015-07-01',
    max_cloud_cover=80)

print('{} scenes found.'.format(len(scenes)))

sorted_scenes = sorted(scenes, key=lambda i: (i['temporalCoverage']['startDate'],i['cloudCover']))

# Output list of scenes found
print('ID', 'DisplayID', 'Date', 'Clouds')
for scene in sorted_scenes:
    print(scene['entityId'], scene['displayId'], scene['temporalCoverage']['startDate'], scene['cloudCover'])

api.logout()
```