### PR TITLE
i.sentinel.coverage: adapt scenename handling for SLC data

### DIFF
--- a/grass7/imagery/i.sentinel/i.sentinel.coverage/i.sentinel.coverage.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.coverage/i.sentinel.coverage.py
@@ -165,7 +165,11 @@ def scenename_split(scenename):
             date_string = name_split[2].split('T')[0]
         elif name_split[0].startswith('S1'):
             producttype = name_split[2][:3]
-            date_string = name_split[4].split('T')[0]
+            if producttype == 'SLC':
+                date_string = name_split[5].split('T')[0]
+            else:
+                date_string = name_split[4].split('T')[0]
+
         else:
             grass.fatal(_(
                 "Sensor {} is not supported yet").format(name_split[0]))


### PR DESCRIPTION
This PR adapts the handling of scene names to be able to correctly identify Sentinel-1 SLC data. See also #447. SLC file names have one more `_` (underscore) which messed with the identification of scene specifications by `' '.split('_')`