### PR TITLE
i.landsat manuals: add timeout option in i.landsat.download and add i.landsat.qa + author

### DIFF
--- a/grass7/imagery/i.landsat/i.landsat.download/i.landsat.download.html
+++ b/grass7/imagery/i.landsat/i.landsat.download/i.landsat.download.html
@@ -56,7 +56,7 @@ and
 </table>
 
 <p>
-To connect to EarthExplorer both a <em>user</em> name and <em>password</em>
+To connect to EarthExplorer both a <em>user</em> name and a <em>password</em>
 are required. See the <a href="https://ers.cr.usgs.gov/register">register</a>
 page for signing up.
 
@@ -97,7 +97,9 @@ remove the <b>l</b> flag and provide an <b>output</b> directory. Otherwise,
 files will be downloaded into <em>/tmp</em> directory.
 To download only selected scenes, one or more IDs must be provided
 through the <b>id</b> option, along with the <b>settings</b> file and an
-<b>output</b> directory.
+<b>output</b> directory. In addition, a <em>timeout</em> (in seconds)
+can be set to define how long a request should wait for a response before
+aborting (default is 300 seconds).
 
 <h2>EXAMPLES</h2>
 
@@ -105,7 +107,7 @@ Search available scenes:
 
 <div class="code"><pre>
 i.landsat.download -l settings=credentials.txt \
-    dataset=LANDSAT_8_C1 clouds=15 \
+    dataset=landsat_8_c1 clouds=15 \
     start='2018-08-24' end='2018-12-21'
 <pre></div>
 
@@ -113,8 +115,9 @@ Download all available scenes:
 
 <div class="code"><pre>
 i.landsat.download settings=credentials.txt \
-    dataset=LANDSAT_8_C1 clouds=15 \
-    start='2018-08-24' end='2018-12-21'
+    dataset=landsat_8_c1 clouds=15 \
+    start='2018-08-24' end='2018-12-21' \
+    timeout=600
 <pre></div>
 
 Download selected scenes by ID:
@@ -139,6 +142,7 @@ i.landsat.download settings=credentials.txt \
 <p>
 <em>
 <a href="i.landsat.import.html">i.landsat.import</a>,
+<a href="i.landsat.qa.html">i.landsat.qa</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/i.landsat.toar.html">i.landsat.toar</a>
 </em>
 <p>

--- a/grass7/imagery/i.landsat/i.landsat.download/i.landsat.download.html
+++ b/grass7/imagery/i.landsat/i.landsat.download/i.landsat.download.html
@@ -8,7 +8,7 @@ Python library. Datasets currently supported include
 and 
 <a href="https://www.usgs.gov/core-science-systems/nli/landsat/landsat-collection-2?qt-science_support_page_related_con=2#qt-science_support_page_related_con">Collection 2</a>.
 
-<table>
+<table border="1">
 <thead>
 <tr>
 <th>Dataset Name</th>
@@ -97,7 +97,7 @@ remove the <b>l</b> flag and provide an <b>output</b> directory. Otherwise,
 files will be downloaded into <em>/tmp</em> directory.
 To download only selected scenes, one or more IDs must be provided
 through the <b>id</b> option, along with the <b>settings</b> file and an
-<b>output</b> directory. In addition, a <em>timeout</em> (in seconds)
+<b>output</b> directory. In addition, a <b>timeout</b> (in seconds)
 can be set to define how long a request should wait for a response before
 aborting (default is 300 seconds).
 

--- a/grass7/imagery/i.landsat/i.landsat.html
+++ b/grass7/imagery/i.landsat/i.landsat.html
@@ -13,7 +13,7 @@
 
 <h2>NAME</h2>
 
-<em><b>i.landsat</b></em> - Toolset to download and import Landsat TM, ETM and OLI products.
+<em><b>i.landsat</b></em> - Toolset to download and process Landsat TM, ETM and OLI products.
 
 <h2>KEYWORDS</h2>
 <a href="https://grass.osgeo.org/grass-stable/manuals/imagery.html">imagery</a>,
@@ -24,16 +24,18 @@
 <!-- meta page description: Toolset to download and import Landsat products -->
 <h2>DESCRIPTION</h2>
 
-The <em>i.landsat</em> toolset consists of two modules:
+The <em>i.landsat</em> toolset consists of three modules:
 
 <dl>
   <dt><a href="i.landsat.download.html">i.landsat.download</a></dt>
-  <dd>downloads Landsat TM, ETM and OLI data from
+    <dd>downloads Landsat TM, ETM and OLI data from
       <a href="https://earthexplorer.usgs.gov/">EarthExplorer</a> using
       <a href="https://github.com/yannforget/landsatxplore">landsatxplore</a>
       Python library</dd>
   <dt><a href="i.landsat.import.html">i.landsat.import</a></dt>
-  <dd>imports Landsat data downloaded from EarthExplorer into GRASS GIS mapsets</dd>
+    <dd>imports Landsat data downloaded from EarthExplorer into GRASS GIS mapsets</dd>
+  <dt><a href="i.landsat.qa.html">i.landsat.qa</a></dt>
+    <dd>reclassifies Landsat QA band according to acceptable pixel quality as defined by the user</dd>
 </dl>
 
 <h2>REQUIREMENTS</h2>
@@ -43,11 +45,14 @@ The <em>i.landsat</em> toolset consists of two modules:
   <li><a href="https://github.com/yannforget/landsatxplore">landsatxplore library</a> (install with <code>pip install landsatxplore</code>)</li>
 </ul>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 <a href="https://veroandreo.gitlab.io/" target="_blank">Veronica Andreo</a>, CONICET, Argentina.
 
+Stefan Blumentrath, Norwegian Institute for Nature Research, Oslo (Norway)
+
 <h2>SOURCE CODE</h2>
+
 <p>Available at: <a href="https://github.com/OSGeo/grass-addons/tree/master/grass7/imagery/i.landsat">i.landsat source code</a> (<a href="https://github.com/OSGeo/grass-addons/commits/master/grass7/imagery/i.landsat">history</a>)</p>
 
 <!--

--- a/grass7/imagery/i.landsat/i.landsat.import/i.landsat.import.html
+++ b/grass7/imagery/i.landsat/i.landsat.import/i.landsat.import.html
@@ -179,8 +179,8 @@ t.register input=landsat_ts file=t_register.txt
 <p>
 <em>
 <a href="i.landsat.download.html">i.landsat.download</a>,
+<a href="i.landsat.qa.html">i.landsat.qa</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/i.landsat.toar.html">i.landsat.toar</a>,
-<a href="https://grass.osgeo.org/grass-stable/manuals/addons/i.landsat8.qc.html">i.landsat8.qc</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/addons/i.landsat8.swlst.html">i.landsat8.swlst</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/r.import.html">r.import</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/r.external.html">r.external</a>


### PR DESCRIPTION
This PR fixes i.landsat.download examples, adds a short explanation about new `timeout` option and includes the new `i.landsat.qa` + author to the main i.landsat manual. Shall we add further examples?