### PR TITLE
i.edge: add -n flag for empty input/output

### DIFF
--- a/grass7/imagery/i.edge/canny.c
+++ b/grass7/imagery/i.edge/canny.c
@@ -337,7 +337,7 @@ void performHysteresis(CELL * edges, CELL * magnitude, int low, int high,
 
 void thresholdEdges(CELL * edges, int rows, int cols)
 {
-    int i;
+    size_t i;
     size_t max = (size_t)rows * cols;
 
     for (i = 0; i < max; i++) {

--- a/grass7/imagery/i.edge/main.c
+++ b/grass7/imagery/i.edge/main.c
@@ -295,6 +295,8 @@ int main(int argc, char *argv[])
 	    }
 
 	    G_free(outrast);
+
+	    exit(EXIT_SUCCESS);
 	}
     }
 

--- a/grass7/imagery/i.edge/main.c
+++ b/grass7/imagery/i.edge/main.c
@@ -134,7 +134,7 @@ int main(int argc, char *argv[])
     static const int MAGNITUDE_LIMIT = 1000;
 
     int lowThreshold, highThreshold, low, high;
-    int nrows, ncols;
+    int nrows, ncols, i;
     size_t dim_2;
     DCELL *mat1;
 
@@ -270,7 +270,7 @@ int main(int argc, char *argv[])
 
 	    outrast = Rast_allocate_buf(CELL_TYPE);
 	    Rast_set_c_null_value(outrast, ncols);
-	    for (r = 0; r < nrows; r++) {
+	    for (i = 0; i < nrows; i++) {
 		Rast_put_row(outfd, outrast, CELL_TYPE);
 	    }
 
@@ -283,7 +283,7 @@ int main(int argc, char *argv[])
 	    if (anglesMapName) {
 		outfd = Rast_open_new(anglesMapName, CELL_TYPE);
 
-		for (r = 0; r < nrows; r++) {
+		for (i = 0; i < nrows; i++) {
 		    Rast_put_row(outfd, outrast, CELL_TYPE);
 		}
 


### PR DESCRIPTION
`i.edge` currently exits with fatal error if the input is empty. The new -n flag allows to create an empty output map without fatal error if the input map is empty.