### PR TITLE
CI: Add Python version to job name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,13 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.grass_version }}
+    name: ${{ matrix.grass-version }} (Python ${{ matrix.python-version }})
 
     runs-on: ubuntu-20.04
 
     strategy:
       matrix:
-        grass_version:
+        grass-version:
         - master
         - releasebranch_7_8
         python-version:
@@ -29,7 +29,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: OSGeo/grass
-        ref: ${{ matrix.grass_version }}
+        ref: ${{ matrix.grass-version }}
         path: grass
 
     - name: Checkout core


### PR DESCRIPTION
Avoid two same names in the list of jobs in the main build and test workflow.
