### PR TITLE
i.sentinel.download: change ESA api_url to https://scihub.copernicus.eu/apihub

### DIFF
--- a/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.html
+++ b/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.html
@@ -78,7 +78,7 @@ work in the graphical user interface.
 <div class="code"><pre>
 Insert username: myusername
 Insert password:
-Insert API URL (leave empty for https://scihub.copernicus.eu/dhus):
+Insert API URL (leave empty for https://scihub.copernicus.eu/apihub):
 </pre></div>
 
 <p>
@@ -321,23 +321,23 @@ variants, either with <b>identifier</b> or <b>filename</b>:
 <div class="code"><pre>
 # North Carolina sample dataset example
 
-# Sentinel-1, identifier= without ".SAFE" in the name 
+# Sentinel-1, identifier= without ".SAFE" in the name
 i.sentinel.download settings=credentials.txt \
   query='identifier=S1A_IW_GRDH_1SDV_20210130T231425_20210130T231450_036374_0444CC_0EA9' \
   producttype=GRD start=2021-01-01 end=2021-02-15 output=s1_data/
 
-# Sentinel-1, filename= requires ".SAFE" in the name 
+# Sentinel-1, filename= requires ".SAFE" in the name
 i.sentinel.download settings=credentials.txt \
   query='filename=S1A_IW_GRDH_1SDV_20210130T231425_20210130T231450_036374_0444CC_0EA9.SAFE' \
   producttype=GRD start=2021-01-01 end=2021-02-15 output=s1_data/
 
 
-# Sentinel-2, identifier= without ".SAFE" in the name 
+# Sentinel-2, identifier= without ".SAFE" in the name
 i.sentinel.download settings=credentials.txt \
   query='identifier=S2B_MSIL2A_20210120T155559_N0214_R054_T17SPV_20210120T201821' \
   producttype=S2MSI2A start=2021-01-01 end=2021-02-15 output=s2_data/
 
-# Sentinel-2, filename= requires ".SAFE" in the name 
+# Sentinel-2, filename= requires ".SAFE" in the name
 i.sentinel.download settings=credentials.txt \
   query='filename=S2B_MSIL2A_20210120T155559_N0214_R054_T17SPV_20210120T201821.SAFE' \
   producttype=S2MSI2A start=2021-01-01 end=2021-02-15 output=s2_data/

--- a/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -292,7 +292,7 @@ def check_s2l1c_identifier(identifier, source='esa'):
 
 
 class SentinelDownloader(object):
-    def __init__(self, user, password, api_url='https://scihub.copernicus.eu/dhus'):
+    def __init__(self, user, password, api_url='https://scihub.copernicus.eu/apihub'):
 
         self._apiname = api_url
         self._user = user
@@ -303,14 +303,14 @@ class SentinelDownloader(object):
         root.addHandler(logging.StreamHandler(
             sys.stderr
         ))
-        if self._apiname == 'https://scihub.copernicus.eu/dhus':
+        if self._apiname == 'https://scihub.copernicus.eu/apihub':
             try:
                 from sentinelsat import SentinelAPI
             except ImportError as e:
                 gs.fatal(_("Module requires sentinelsat library: {}").format(e))
             # connect SciHub via API
             self._api = SentinelAPI(self._user, self._password,
-                                    api_url=api_url
+                                    api_url=self._apiname
                                     )
         elif self._apiname == 'USGS_EE':
             try:
@@ -705,7 +705,7 @@ def main():
 
     user = password = None
     if options['datasource'] == 'ESA_COAH':
-        api_url = 'https://scihub.copernicus.eu/dhus'
+        api_url = 'https://scihub.copernicus.eu/apihub'
     else:
         api_url = 'USGS_EE'
 


### PR DESCRIPTION
`i.sentinel.download` uses the URL `https://scihub.copernicus.eu/dhus` as standard URL for the `sentinelsat` API to request from ESA-Copernicus Open Access Hub. `sentinelsat`'s default option seems to have changed at some point to `https://scihub.copernicus.eu/apihub` (https://sentinelsat.readthedocs.io/en/latest/api_reference.html) and also the main page of the Copernicus Open Access Hub (https://scihub.copernicus.eu/) encourages to use this URL: `Access to APIs (no GUI)
All users downloading data on a regular basis are encouraged to use this access point for a better performance`.
This PR thus changes the default `api_url` of `i.sentinel.download` to `https://scihub.copernicus.eu/apihub`. All downloading/query tests so far were successful also with the new url.

If there is a strong reason to use `https://scihub.copernicus.eu/dhus` instead, please do comment! I haven't found a hint for this in the history of `i.sentinel.download.py` though.