### PR TITLE
i.sentinel.download: fixes for downloading using ESA-identifier

### DIFF
--- a/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -677,6 +677,12 @@ class SentinelDownloader(object):
             for scene in scenes:
                 if scene['display_id'].split('_')[1] != utm_tile:
                     scenes.remove(scene)
+            # remove redundant scene
+            if len(scenes) == 2:
+                start_dates = [scene['acquisition_start_date']
+                               for scene in scenes]
+                min_idx = start_dates.index(min(start_dates))
+                scenes.pop(min_idx)
         if len(scenes) < 1:
             gs.message(_('No product found'))
             return

--- a/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -645,7 +645,9 @@ class SentinelDownloader(object):
                     acq_date[:4], acq_date[4:6], acq_date[6:])
                 start_date = end_date = acq_date_string
                 # build the USGS style S2-identifier
-                bbox = get_bbox_from_S2_UTMtile(utm_tile.replace('T', ''))
+                if utm_tile.startswith('T'):
+                    utm_tile_base = utm_tile[1:]
+                bbox = get_bbox_from_S2_UTMtile(utm_tile_base)
         else:
             # get coordinate pairs from wkt string
             str_1 = 'POLYGON(('

--- a/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -270,7 +270,7 @@ def check_s2l1c_identifier(identifier, source='esa'):
     # checks beginning of identifier string for correct pattern
     import re
     if source == 'esa':
-        expression = '^(S2[A-B]_MSIL1C_20[0-9][0-9][0-9][1-9])'
+        expression = '^(S2[A-B]_MSIL1C_20[0-9][0-9][0-9][0-9])'
         test = re.match(expression, identifier)
         if bool(test) is False:
             gs.fatal(_('Query parameter "identifier"/"filename" has'

--- a/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -639,6 +639,7 @@ class SentinelDownloader(object):
                 else:
                     esa_id = query['identifier']
                 check_s2l1c_identifier(esa_id, source='esa')
+                esa_prod_id = esa_id.split('_')[-1]
                 utm_tile = esa_id.split('_')[-2]
                 acq_date = esa_id.split('_')[2].split('T')[0]
                 acq_date_string = '{0}-{1}-{2}'.format(
@@ -679,10 +680,10 @@ class SentinelDownloader(object):
                     scenes.remove(scene)
             # remove redundant scene
             if len(scenes) == 2:
-                start_dates = [scene['acquisition_start_date']
-                               for scene in scenes]
-                min_idx = start_dates.index(min(start_dates))
-                scenes.pop(min_idx)
+                for scene in scenes:
+                    prod_id = scene['display_id'].split('_')[-1]
+                    if prod_id != esa_prod_id:
+                        scenes.remove(scene)
         if len(scenes) < 1:
             gs.message(_('No product found'))
             return


### PR DESCRIPTION
This PR fixes three bugs when using `i.sentinel.download` to download from USGS using an **ESA-identifier**:
- Automatic tile association needs the tile in the format `32UMB`, i.e. without a `T` at the beginning. Simply replacing `T` with `''` leads an error when a `T` is also in the tile definition (e.g. `31UFT`)
- Automatic filenaming checking failed for some scenes because of a bug in the regular expression
- For some scene-identifiers from ESA-Hub there are **two** scenes in USGS (see screenshot below). This redundancy is solved by using ESA's `<Product_Discriminator>` (The last part of each S2-filename, see https://sentinel.esa.int/web/sentinel/user-guides/sentinel-2-msi/naming-convention/)
![usgs_utmtile_redundancy](https://user-images.githubusercontent.com/62383722/111122805-d4eb0180-856e-11eb-8eec-9d0e51eea3cf.png)

