### PR TITLE
NC full sample dataset: new URL

### DIFF
--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -6,7 +6,7 @@ set -e
 grass --tmp-location XY --exec \
     g.extension g.download.location
 grass --tmp-location XY --exec \
-    g.download.location url=http://fatra.cnr.ncsu.edu/data/nc_spm_full_v2alpha2.tar.gz dbase=$HOME
+    g.download.location url=https://grass.osgeo.org/sampledata/north_carolina/nc_spm_full_v2alpha2.tar.gz dbase=$HOME
 
 grass --tmp-location XY --exec \
     python3 -m grass.gunittest.main \


### PR DESCRIPTION
Moved (due to server failure) from

- http://fatra.cnr.ncsu.edu/data/nc_spm_full_v2alpha2.tar.gz
to
- https://grass.osgeo.org/sampledata/north_carolina/nc_spm_full_v2alpha2.tar.gz

in order to get the CI running again.

See also https://github.com/OSGeo/grass/pull/1463