### PR TITLE
i.sentinel.coverage: Exit with correct message if no products are found

### DIFF
--- a/grass7/imagery/i.sentinel/i.sentinel.coverage/i.sentinel.coverage.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.coverage/i.sentinel.coverage.py
@@ -249,7 +249,7 @@ def main():
             s_list = resp[0].decode('utf-8').strip().splitlines()
         else:
             if set(resp) == {b''}:
-                grass.fatal('No products found')
+                grass.fatal(_("No products found"))
             else:
                 error_msg = ""
                 for i in range(0, len(resp)):

--- a/grass7/imagery/i.sentinel/i.sentinel.coverage/i.sentinel.coverage.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.coverage/i.sentinel.coverage.py
@@ -248,14 +248,14 @@ def main():
         if resp[0] != b'':
             s_list = resp[0].decode('utf-8').strip().splitlines()
         else:
-            error_msg = ""
-            for i in range(0, len(resp)):
-                error_msg += resp[i].decode('utf-8')
-            grass.fatal(
-                _("Error using i.sentinel.download: {}").format(error_msg))
-
-        if len(s_list) == 0:
-            grass.fatal('No products found')
+            if set(resp) == {b''}:
+                grass.fatal('No products found')
+            else:
+                error_msg = ""
+                for i in range(0, len(resp)):
+                    error_msg += resp[i].decode('utf-8')
+                grass.fatal(
+                    _("Error using i.sentinel.download: {}").format(error_msg))
         name_list_tmp = [x.split(' ')[1] for x in s_list]
     else:
         name_list_tmp = options['names'].split(',')


### PR DESCRIPTION
This PR fixes #482: When using `i.sentinel.coverage` and no products are found, `i.sentinel.coverage` now exits with `No products found`.
