### PR TITLE
i.sentinel.download: Enable downloading from Google Cloud

### DIFF
--- a/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.html
+++ b/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.html
@@ -181,7 +181,7 @@ the <b>retry</b> parameter) to retry a download after the <b>sleep</b> value in 
 
 <p>
 As an alternative to triggering re-upload Sentinel-2 data from the LTA, scenes can be downloaded
-from <b>USGS Earth Explorer</b> or <b>Goodle Cloud Storage</b> where all data remain online and directly accessible.
+from <b>USGS Earth Explorer</b> or <b>Google Cloud Storage</b> where all data remain online and directly accessible.
 However, this applies only to Sentinel-2 data in levels 1C (USGS and GCS) and 2A (only GCS).
 
 <h2>EXAMPLES</h2>
@@ -447,7 +447,7 @@ Martin Landa, <a href="http://geomatics.fsv.cvut.cz/research/geoforall/">GeoForA
 Lab</a>, CTU in Prague, Czech Republic with support
 of <a href="https://opengeolabs.cz/en/home/">OpenGeoLabs</a> company
 <br>
-Guido Riembauer, <a href="https://www.mundialis.de/">mundialis</a> (USGS provider support)
+Guido Riembauer, <a href="https://www.mundialis.de/">mundialis</a> (USGS and GCS provider support)
 <!--
 <p>
 <i>Last changed: $Date$</i>

--- a/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.html
+++ b/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.html
@@ -1,8 +1,9 @@
 <h2>DESCRIPTION</h2>
 
-The <em>i.sentinel.download</em> allows downloading Sentinel satellite products
-from the <a href="https://scihub.copernicus.eu/">Copernicus Open Access Hub</a>.
-Sentinel-2 Level-1C data can also be downloaded from the <a href="https://earthexplorer.usgs.gov/">USGS Earth Explorer</a>.
+The <em>i.sentinel.download</em> addon allows downloading Sentinel satellite products
+from the <a href="https://scihub.copernicus.eu/">Copernicus Open Access Hub</a>,
+<a href="https://earthexplorer.usgs.gov/">USGS Earth Explorer</a>, or
+<a href="https://cloud.google.com/storage/docs/public-datasets/sentinel-2?hl=en">Google Cloud Storage</a>.
 
 <h3>Copernicus Open Access Hub</h3>
 <p>
@@ -52,6 +53,30 @@ To connect to the USGS Earth Explorer both a <em>user</em> name
 and <em>password</em> are required;
 see <a href="https://ers.cr.usgs.gov/register">EROS Registration System</a>
 page for signing up.
+
+<h3>Google Cloud Storage</h3>
+<p>
+The following product types (parameter <b>producttype</b>) are currently supported
+for download from <b>Google Cloud Storage</b>:
+<ul>
+  <li>Sentinel-2 (optical and infrared):
+  <ul>
+    <li>S2MSI2A: operational Bottom-Of-Atmosphere reflectances in cartographic geometry Level-2A)</li>
+  </ul>
+  <ul>
+    <li>S2MSI1C: Top-Of-Atmosphere reflectances in cartographic geometry (Level-1C)</li>
+  </ul>
+  </li>
+</ul>
+Querying and filtering data on Google Cloud Storage requires the fee-based usage of
+<a href="https://cloud.google.com/bigquery/external-data-cloud-storage?hl=en">BigQuery</a>, which
+is currently not supported by <em>i.sentinel.download</em>. Instead, when using the <b>datasource=GCS</b>
+option, querying is performed using the <a href="https://scihub.copernicus.eu/">Copernicus Open Access Hub</a>
+interface, while only the download step makes use of Google Cloud Storage (download links are
+automatically generated from the respective Sentinel-2 identifier). As a consequence, a <b>settings</b> file
+with valid credentials for the Copernicus Open Access Hub is required for downloading
+from Google Cloud Storage in <em>i.sentinel.download</em>.
+
 
 <h3>Credentials file</h3>
 <p><em>i.sentinel.download</em> reads the user credentials
@@ -156,8 +181,8 @@ the <b>retry</b> parameter) to retry a download after the <b>sleep</b> value in 
 
 <p>
 As an alternative to triggering re-upload Sentinel-2 data from the LTA, scenes can be downloaded
-from the <b>USGS Earth Explorer</b> where all data remain online and directly accessible.
-However, this applies only to Sentinel-2 S2MSI1C (Level-1C) data.
+from <b>USGS Earth Explorer</b> or <b>Goodle Cloud Storage</b> where all data remain online and directly accessible.
+However, this applies only to Sentinel-2 data in levels 1C (USGS and GCS) and 2A (only GCS).
 
 <h2>EXAMPLES</h2>
 
@@ -286,6 +311,11 @@ g.region n=42 w=12 s=41 e=13 res=0:01 -p
 i.sentinel.download settings=credentials.txt producttype=S2MSI2A start=2018-05-01 end=2018-05-31 limit=1 output=s2_L2A_may2018/
 </pre></div>
 
+Download first (<b>limit=1</b>) S2MSI2A product found from <b>Google Cloud Storage</b>:
+<div class="code"><pre>
+i.sentinel.download settings=credentials.txt producttype=S2MSI2A start=2018-05-01 end=2018-05-31 limit=1 output=s2_L2A_may2018/ datasource=GCS
+</pre></div>
+
 The downloaded Sentinel data can subsequently be easily imported into GRASS GIS
 using <em><a href="i.sentinel.import.html">i.sentinel.import</a></em>
 module.
@@ -296,6 +326,12 @@ Example of downloading a single Sentinel product by UUID:
 
 <div class="code"><pre>
 i.sentinel.download settings=credentials.txt uuid=6a10da0f-7777-4818-bc2c-4680e82297ac output=s2_data/
+<pre></div>
+
+<p>
+Example of downloading a single Sentinel product by UUID from <b>Google Cloud Storage</b>
+<div class="code"><pre>
+i.sentinel.download datasource=GCS settings=credentials.txt uuid=6a10da0f-7777-4818-bc2c-4680e82297ac output=s2_data/
 <pre></div>
 
 <p>
@@ -344,8 +380,17 @@ i.sentinel.download settings=credentials.txt \
 <pre></div>
 
 <p>
+Example of downloading a single Sentinel product by scene name from
+<b>Google Cloud Storage</b>:
+<div class="code"><pre>
+i.sentinel.download datasource=GCS start=2021-01-01 end=2021-02-15 producttype=S2MSI2A \
+  query="filename=S2B_MSIL2A_20210120T155559_N0214_R054_T17SPV_20210120T201821.SAFE" settings=credentials.txt \
+  output=s2_data/
+<pre></div>
+
+<p>
 Example of downloading a single Sentinel product from <b>USGS Earth Explorer</b>
-by the USGS-identifier.
+by the USGS-identifier:
 <div class="code"><pre>
 i.sentinel.download datasource=USGS_EE start=2017-09-01 end=2017-12-01 producttype=S2MSI1C \
   query="usgs_identifier=L1C_T32ULA_A003180_20171015T104525" settings=credentials.txt \
@@ -367,7 +412,7 @@ i.sentinel.download datasource=USGS_EE start=2017-10-01 end=2017-11-01 productty
 <ul>
   <li><a href="https://pypi.python.org/pypi/sentinelsat">Sentinelsat library</a></li>
   <li><a href="https://pypi.python.org/pypi/pandas">Pandas library</a></li>
-  <li><a href="https://pypi.python.org/pypi/landsatxplore">landsatxplore library</a></li>
+  <li><a href="https://pypi.python.org/pypi/landsatxplore">landsatxplore library</a></li> for downloading from USGS Earth Explorer
 </ul>
 
 <h2>SEE ALSO</h2>

--- a/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -185,11 +185,12 @@ def create_dir(dir):
             os.makedirs(dir)
             return 0
         except Exception as e:
-            gs.warning(_('Could not create directory {}').format(dir))
+            gs.warning(_("Could not create directory {}").format(dir))
             return 1
     else:
-        gs.verbose(_('Directory {} already exists').format(dir))
+        gs.verbose(_("Directory {} already exists").format(dir))
         return 0
+
 
 def get_aoi_box(vector=None):
     args = {}
@@ -200,7 +201,7 @@ def get_aoi_box(vector=None):
     s = gs.read_command("g.proj", flags='j')
     kv = gs.parse_key_val(s)
     if '+proj' not in kv:
-        gs.fatal('Unable to get AOI bounding box: unprojected location not supported')
+        gs.fatal(_("Unable to get AOI bounding box: unprojected location not supported"))
     if kv['+proj'] != 'longlat':
         info = gs.parse_command('g.region', flags='uplg', **args)
         return 'POLYGON(({nw_lon} {nw_lat}, {ne_lon} {ne_lat}, {se_lon} {se_lat}, {sw_lon} {sw_lat}, {nw_lon} {nw_lat}))'.format(
@@ -230,7 +231,7 @@ def get_aoi(vector=None):
     s = gs.read_command("g.proj", flags='j')
     kv = gs.parse_key_val(s)
     if '+proj' not in kv:
-        gs.fatal('Unable to get AOI: unprojected location not supported')
+        gs.fatal(_("Unable to get AOI: unprojected location not supported"))
     geom_dict = gs.parse_command('v.out.ascii', format='wkt', **args)
     num_vertices = len(str(geom_dict.keys()).split(','))
     geom = [key for key in geom_dict][0]
@@ -288,10 +289,10 @@ def check_s2l1c_identifier(identifier, source='esa'):
         expression = '^(S2[A-B]_MSIL1C_20[0-9][0-9][0-9][0-9])'
         test = re.match(expression, identifier)
         if bool(test) is False:
-            gs.fatal(_('Query parameter "identifier"/"filename" has'
-                       ' to be in format S2X_MSIL1C_YYYYMMDDTHHMMSS'
-                       '_NXXXX_RYYY_TUUUUU_YYYYMMDDTHHMMSS for '
-                       'usage with USGS Earth Explorer'))
+            gs.fatal(_("Query parameter 'identifier'/'filename' has"
+                       " to be in format S2X_MSIL1C_YYYYMMDDTHHMMSS"
+                       "_NXXXX_RYYY_TUUUUU_YYYYMMDDTHHMMSS for "
+                       "usage with USGS Earth Explorer"))
     elif source == 'usgs':
         # usgs can have two formats, depending on age
         expression1 = '^(L1C_T[0-9][0-9][A-Z][A-Z][A-Z]_A[0-9])'
@@ -299,10 +300,10 @@ def check_s2l1c_identifier(identifier, source='esa'):
         test1 = re.match(expression1, identifier)
         test2 = re.match(expression2, identifier)
         if bool(test1) is False and bool(test2) is False:
-            gs.fatal(_('Query parameter "usgs_identifier" has to be either in'
-                       ' format L1C_TUUUUU_AXXXXXX_YYYYMMDDTHHMMSS or '
-                       'S2X_OPER_MSI_L1C_TL_EPA__YYYYMMDDTHHMMSS_'
-                       'YYYYMMDDTHHMMSS_AOOOOOO_TUUUUU_NXX_YY_ZZ'))
+            gs.fatal(_("Query parameter 'usgs_identifier' has to be either in"
+                       " format L1C_TUUUUU_AXXXXXX_YYYYMMDDTHHMMSS or "
+                       "S2X_OPER_MSI_L1C_TL_EPA__YYYYMMDDTHHMMSS_"
+                       "YYYYMMDDTHHMMSS_AOOOOOO_TUUUUU_NXX_YY_ZZ"))
     return
 
 
@@ -348,7 +349,9 @@ def get_checksum(filename, hash_function='md5'):
         elif hash_function == "sha256":
             readable_hash = hashlib.sha256(bytes).hexdigest()
         else:
-            raise Exception("{} is an invalid hash function. Please Enter MD5 or SHA256".format(hash_function))
+            raise Exception(("{} is an invalid hash function. "
+                             "Please Enter MD5 or SHA256").format(
+                            hash_function))
 
     return readable_hash
 
@@ -373,7 +376,7 @@ def download_gcs_file(url, destination, checksum_function, checksum):
             return 0
 
     except Exception as e:
-        gs.verbose(_('There was a problem downloading {}').format(url))
+        gs.verbose(_("There was a problem downloading {}").format(url))
         return 1
 
 
@@ -403,7 +406,7 @@ def download_gcs(scene, output):
     output_path_safe = os.path.join(final_scene_dir, safe_file)
     r_safe = requests.get(safe_url, allow_redirects=True)
     if r_safe.status_code != 200:
-        gs.warning(_('Scene <{}> was not found on Google Cloud').format(scene))
+        gs.warning(_("Scene <{}> was not found on Google Cloud").format(scene))
         return 1
     root_manifest = ET.fromstring(r_safe.content)
     open(output_path_safe, 'wb').write(r_safe.content)
@@ -453,9 +456,9 @@ def download_gcs(scene, output):
             failed_downloads.append(dl_url)
 
     if len(failed_downloads) > 0:
-        gs.verbose(_('Downloading was not successful for urls \n{}').format(
+        gs.verbose(_("Downloading was not successful for urls \n{}").format(
             '\n'.join(failed_downloads)))
-        gs.warning(_('Downloading was not successful for scene <{}>').format(
+        gs.warning(_("Downloading was not successful for scene <{}>").format(
             scene))
         return 1
     else:
@@ -510,7 +513,7 @@ class SentinelDownloader(object):
             if producttype.startswith('S2') and int(relativeorbitnumber) > 143:
                 gs.warning("This relative orbit number is out of range")
             elif int(relativeorbitnumber) > 175:
-                gs.warning("This relative orbit number is out of range")
+                gs.warning(_("This relative orbit number is out of range"))
         if producttype:
             args['producttype'] = producttype
             if producttype.startswith('S2'):
@@ -528,11 +531,11 @@ class SentinelDownloader(object):
         if query:
             redefined = [value for value in args.keys() if value in query.keys()]
             if redefined:
-                gs.warning("Query overrides already defined options ({})".format(
+                gs.warning(_("Query overrides already defined options ({})").format(
                     ','.join(redefined)
                 ))
             args.update(query)
-        gs.verbose("Query: area={} area_relation={} date=({}, {}) args={}".format(
+        gs.verbose(_("Query: area={} area_relation={} date=({}, {}) args={}").format(
             area, area_relation, start, end, args
         ))
         products = self._api.query(
@@ -542,7 +545,7 @@ class SentinelDownloader(object):
         )
         products_df = self._api.to_dataframe(products)
         if len(products_df) < 1:
-            gs.message(_('No product found'))
+            gs.message(_("No product found"))
             return
 
         # sort and limit to first sorted product
@@ -557,7 +560,7 @@ class SentinelDownloader(object):
         if limit:
             self._products_df_sorted = self._products_df_sorted.head(int(limit))
 
-        gs.message(_('{} Sentinel product(s) found').format(len(self._products_df_sorted)))
+        gs.message(_("{} Sentinel product(s) found").format(len(self._products_df_sorted)))
 
     def list(self):
         if self._products_df_sorted is None:
@@ -595,7 +598,7 @@ class SentinelDownloader(object):
             return
 
         create_dir(output)
-        gs.message(_('Downloading data into <{}>...').format(output))
+        gs.message(_("Downloading data into <{}>...").format(output))
         if datasource == 'USGS_EE':
             from landsatxplore.earthexplorer import EarthExplorer
             from landsatxplore.errors import EarthExplorerError
@@ -612,7 +615,7 @@ class SentinelDownloader(object):
                 scene = self._products_df_sorted['entity_id'][idx]
                 identifier = self._products_df_sorted['display_id'][idx]
                 zip_file = os.path.join(output, '{}.zip'.format(identifier))
-                gs.message('Downloading {}...'.format(identifier))
+                gs.message(_("Downloading {}...").format(identifier))
                 try:
                     ee.download(identifier=identifier, output_dir=output, timeout=600)
                 except EarthExplorerError as e:
@@ -623,11 +626,11 @@ class SentinelDownloader(object):
                     safe_name = zip.namelist()[0].split('/')[0]
                     outpath = os.path.join(output, safe_name)
                     zip.extractall(path=output)
-                gs.message(_('Downloaded to <{}>').format(outpath))
+                gs.message(_("Downloaded to <{}>").format(outpath))
                 try:
                     os.remove(zip_file)
                 except Exception as e:
-                    gs.warning(_('Unable to remove {0}:{1}').format(
+                    gs.warning(_("Unable to remove {0}:{1}").format(
                         zip_file, e))
 
         elif datasource == "ESA_COAH":
@@ -652,10 +655,10 @@ class SentinelDownloader(object):
                             online = True
         elif datasource == 'GCS':
             for scene_id in self._products_df_sorted['identifier']:
-                gs.message(_('Downloading {}...').format(scene_id))
+                gs.message(_("Downloading {}...").format(scene_id))
                 dl_code = download_gcs(scene_id, output)
                 if dl_code == 0:
-                    gs.message(_('Downloaded to {}').format(
+                    gs.message(_("Downloaded to {}").format(
                         os.path.join(output, '{}.SAFE'.format(scene_id))))
                 else:
                     # remove incomplete file
@@ -664,15 +667,15 @@ class SentinelDownloader(object):
                     try:
                         shutil.rmtree(del_folder)
                     except Exception as e:
-                        gs.warning(_('Unable to removed unfinished '
-                                     'download {}'.format(del_folder)))
+                        gs.warning(_("Unable to removed unfinished "
+                                     "download {}".format(del_folder)))
 
     def save_footprints(self, map_name):
         if self._products_df_sorted is None:
             return
         if self._apiname == 'USGS_EE':
             gs.fatal(_(
-                'USGS Earth Explorer does not support footprint download.'))
+                "USGS Earth Explorer does not support footprint download."))
         try:
             from osgeo import ogr, osr
         except ImportError as e:
@@ -745,7 +748,7 @@ class SentinelDownloader(object):
             scenes.append(metadata)
         scenes_df = pandas.DataFrame.from_dict(scenes)
         self._products_df_sorted = scenes_df
-        gs.message(_('{} Sentinel product(s) found').format(
+        gs.message(_("{} Sentinel product(s) found").format(
             len(self._products_df_sorted)))
 
     def set_uuid(self, uuid_list):
@@ -765,7 +768,7 @@ class SentinelDownloader(object):
                 try:
                     odata = self._api.get_product_odata(uuid, full=True)
                 except SentinelAPIError as e:
-                    gs.error('{0}. UUID {1} skipped'.format(e, uuid))
+                    gs.error(_("{0}. UUID {1} skipped".format(e, uuid)))
                     continue
 
                 for k, v in odata.items():
@@ -794,21 +797,21 @@ class SentinelDownloader(object):
                     asc=True, relativeorbitnumber=None):
         if area_relation != 'Intersects':
             gs.fatal(_(
-                'USGS Earth Explorer only supports area_relation'
-                ' "Intersects"'))
+                "USGS Earth Explorer only supports area_relation"
+                " 'Intersects'"))
         if relativeorbitnumber:
             gs.fatal(_(
-                'USGS Earth Explorer does not support "relativeorbitnumber"'
-                ' option.'))
+                "USGS Earth Explorer does not support 'relativeorbitnumber'"
+                " option."))
         if producttype and producttype != 'S2MSI1C':
             gs.fatal(_(
-                'USGS Earth Explorer only supports producttype S2MSI1C'))
+                "USGS Earth Explorer only supports producttype S2MSI1C"))
         if query:
             if not any(key in query for key in ['identifier', 'filename',
                                                 'usgs_identifier']):
                 gs.fatal(_(
-                    'USGS Earth Explorer only supports query options'
-                    ' "filename", "identifier" or "usgs_identifier".'))
+                    "USGS Earth Explorer only supports query options"
+                    " 'filename', 'identifier' or 'usgs_identifier'."))
             if 'usgs_identifier' in query:
                 # get entityId from usgs identifier and directly save results
                 usgs_id = query['usgs_identifier']
@@ -870,7 +873,7 @@ class SentinelDownloader(object):
                     if prod_id != esa_prod_id:
                         scenes.remove(scene)
         if len(scenes) < 1:
-            gs.message(_('No product found'))
+            gs.message(_("No product found"))
             return
         scenes_df = pandas.DataFrame.from_dict(scenes)
         if sortby:
@@ -892,7 +895,8 @@ class SentinelDownloader(object):
             )
         else:
             self._products_df_sorted = scenes_df
-        gs.message(_('{} Sentinel product(s) found').format(len(self._products_df_sorted)))
+        gs.message(_("{} Sentinel product(s) found").format(
+            len(self._products_df_sorted)))
 
 
 def main():
@@ -903,8 +907,8 @@ def main():
         api_url = 'USGS_EE'
     if options['datasource'] == 'GCS' and (options['producttype'] not in
        ['S2MSI2A','S2MSI1C']):
-        gs.fatal(_('Download from GCS only supports producttypes S2MSI2A '
-                   'or S2MSI1C'))
+        gs.fatal(_("Download from GCS only supports producttypes S2MSI2A "
+                   "or S2MSI1C"))
 
     if options['settings'] == '-':
         # stdin
@@ -938,10 +942,9 @@ def main():
     sortby = options['sort'].split(',')
     if options['producttype'] in ('SLC', 'GRD', 'OCN'):
         if options['clouds']:
-            gs.info("Option <{}> ignored: cloud cover percentage "
-                    "is not defined for product type {}".format(
-                        "clouds", options['producttype']
-                    ))
+            gs.info(_("Option <{}> ignored: cloud cover percentage "
+                    "is not defined for product type {}").format(
+                        "clouds", options['producttype']))
             options['clouds'] = None
         try:
             sortby.remove('cloudcoverpercentage')
@@ -976,7 +979,7 @@ def main():
             elif options['datasource'] == 'USGS_EE':
                 downloader.filter_USGS(**filter_args)
     except Exception as e:
-        gs.fatal(_('Unable to connect to {0}: {1}').format(
+        gs.fatal(_("Unable to connect to {0}: {1}").format(
             options['datasource'], e))
 
     if options['footprints']:

--- a/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -4,8 +4,8 @@
 #
 # MODULE:      i.sentinel.download
 # AUTHOR(S):   Martin Landa
-# PURPOSE:     Downloads Sentinel data from Copernicus Open Access Hub
-#              and USGS Earth Explorer using sentinelsat library.
+# PURPOSE:     Downloads Sentinel data from Copernicus Open Access Hub,
+#              USGS Earth Explorer or Google Cloud Storage.
 # COPYRIGHT:   (C) 2018-2021 by Martin Landa, and the GRASS development team
 #
 #              This program is free software under the GNU General Public
@@ -15,7 +15,7 @@
 #############################################################################
 
 #%module
-#% description: Downloads Sentinel satellite data from Copernicus Open Access Hub and USGS Earth Explorer.
+#% description: Downloads Sentinel satellite data from Copernicus Open Access Hub, USGS Earth Explorer, or Google Cloud Storage.
 #% keyword: imagery
 #% keyword: satellite
 #% keyword: Sentinel

--- a/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -379,6 +379,7 @@ def download_gcs(scene, output):
             except Exception as e:
                 gs.warning(_('Unable to create folder {}').format(folder))
     failed_downloads = []
+    failed_scenes = []
     for dl_file in files_list:
         # remove the '.' for relative path in the URLS
         if dl_file['href'].startswith('.'):
@@ -397,17 +398,22 @@ def download_gcs(scene, output):
             checksum_function = dl_file['checksumName'].lower()
             sum_dl = get_checksum(output_path_file, checksum_function)
             if sum_dl != dl_file['checksum']:
-                gs.warning(_("Checksumming not successful for {}").format(
+                gs.verbose(_("Checksumming not successful for {}").format(
                     output_path_file))
                 failed_downloads.append(dl_url)
+                failed_scenes.append(scene)
 
         except Exception as e:
-            gs.warning(_('There was a problem downloading {}').format(dl_url))
+            gs.verbose(_('There was a problem downloading {}').format(dl_url))
             failed_downloads.append(dl_url)
+            failed_scenes.append(scene)
 
+    failed_scenes_unique = list(set(failed_scenes))
     if len(failed_downloads) > 0:
-        gs.warning(_('Downloading was not successful for urls \n{}').format(
+        gs.verbose(_('Downloading was not successful for urls \n{}').format(
             '\n'.join(failed_downloads)))
+        gs.warning(_('Downloading was not successful for scene \n{}').format(
+            '\n'.join(failed_scenes_unique)))
 
 
 class SentinelDownloader(object):
@@ -836,7 +842,6 @@ class SentinelDownloader(object):
 
 
 def main():
-
     user = password = None
     if options['datasource'] == 'ESA_COAH' or options['datasource'] == 'GCS':
         api_url = 'https://scihub.copernicus.eu/apihub'


### PR DESCRIPTION
While Querying Sentinel-2 data from Google Cloud (https://cloud.google.com/storage/docs/public-datasets/sentinel-2) requires a google account and a GCP project (not free), the Sentinel-2 data themselves are freely available. They can be accessed by following the folder structure. Although it is not possible to download an entire .SAFE-folder, all individual files can be downloaded and put together to a complete S2-scene.

This PR enables `i.sentinel.download` to download from GCS. Searching and filtering scenes still requires an ESA-login. 