### PR TITLE
CI: Make test report available as artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,5 +108,5 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: testreport-grass-${{ matrix.grass-version }}-python-${{ matrix.python-version }}
-        path: testreport
+        path: grass-addons/grass7/testreport
         retention-days: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,3 +103,10 @@ jobs:
       run: |
         cd grass-addons/grass7
         ../.github/workflows/test.sh
+
+    - name: Make HTML test report available
+      uses: actions/upload-artifact@v2
+      with:
+        name: testreport-grass-${{ matrix.grass-version }}-python-${{ matrix.python-version }}
+        path: testreport
+        retention-days: 3


### PR DESCRIPTION
Make the HTML test report available as an GitHub Actions artifact.
One ZIP file for each run for download, available for 3 days.

Port of OSGeo/grass#1290.
