### PR TITLE
r.in.nasadem + r.in.srtm.region: fix PROJ parsing

### DIFF
--- a/grass7/raster/r.in.nasadem/r.in.nasadem.py
+++ b/grass7/raster/r.in.nasadem/r.in.nasadem.py
@@ -339,11 +339,11 @@ def createTMPlocation(epsg=4326):
 
     # switch to temp location
     os.environ['GISRC'] = str(SRCGISRC)
-        proj = grass.parse_command('g.proj', flags='g')
-        if 'epsg' in proj:
-            currepsg = proj['epsg']
-        else:
-            currepsg = proj['srid'].split('EPSG:')[1]
+    proj = grass.parse_command('g.proj', flags='g')
+    if 'epsg' in proj:
+        currepsg = proj['epsg']
+    else:
+        currepsg = proj['srid'].split('EPSG:')[1]
 
     currepsg = ":".join(srid.split(":")[-1:])
     if currepsg != str(epsg):

--- a/grass7/raster/r.in.nasadem/r.in.nasadem.py
+++ b/grass7/raster/r.in.nasadem/r.in.nasadem.py
@@ -339,7 +339,12 @@ def createTMPlocation(epsg=4326):
 
     # switch to temp location
     os.environ['GISRC'] = str(SRCGISRC)
-    srid = grass.parse_command('g.proj', flags='g')['srid']
+        proj = grass.parse_command('g.proj', flags='g')
+        if 'epsg' in proj:
+            currepsg = proj['epsg']
+        else:
+            currepsg = proj['srid'].split('EPSG:')[1]
+
     currepsg = ":".join(srid.split(":")[-1:])
     if currepsg != str(epsg):
         grass.fatal("Creation of temporary location failed!")

--- a/grass7/raster/r.in.nasadem/r.in.nasadem.py
+++ b/grass7/raster/r.in.nasadem/r.in.nasadem.py
@@ -9,7 +9,7 @@
 #
 # PURPOSE:      Create a DEM from 1 arcsec NASADEM tiles
 #
-# COPYRIGHT:    (C) 2020 GRASS development team
+# COPYRIGHT:    (C) 2020-2021 GRASS development team
 #
 #               This program is free software under the GNU General
 #               Public License (>=v2). Read the file COPYING that
@@ -339,7 +339,9 @@ def createTMPlocation(epsg=4326):
 
     # switch to temp location
     os.environ['GISRC'] = str(SRCGISRC)
-    if grass.parse_command('g.proj', flags='g')['epsg'] != str(epsg):
+    srid = grass.parse_command('g.proj', flags='g')['srid']
+    currepsg = ":".join(srid.split(":")[-1:])
+    if currepsg != str(epsg):
         grass.fatal("Creation of temporary location failed!")
 
     return SRCGISRC, TMPLOC

--- a/grass7/raster/r.in.srtm.region/r.in.srtm.region.py
+++ b/grass7/raster/r.in.srtm.region/r.in.srtm.region.py
@@ -9,7 +9,7 @@
 #
 # PURPOSE:      Create a DEM from 3 arcsec SRTM v2.1 or 1 arcsec SRTM v3 tiles
 #
-# COPYRIGHT:    (C) 2011-2019 GRASS development team
+# COPYRIGHT:    (C) 2011-2021 GRASS development team
 #
 #               This program is free software under the GNU General
 #               Public License (>=v2). Read the file COPYING that
@@ -263,7 +263,9 @@ def createTMPlocation(epsg=4326):
 
     # switch to temp location
     os.environ['GISRC'] = str(SRCGISRC)
-    if grass.parse_command('g.proj', flags='g')['epsg'] != str(epsg):
+    srid = grass.parse_command('g.proj', flags='g')['srid']
+    currepsg = ":".join(srid.split(":")[-1:])
+    if currepsg != str(epsg):
         grass.fatal("Creation of temporary location failed!")
 
     return SRCGISRC, TMPLOC
@@ -597,6 +599,7 @@ def main():
     grass.try_remove(tmphist)
 
     grass.message(_("Done: generated map <%s>") % output)
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/grass7/raster/r.in.srtm.region/r.in.srtm.region.py
+++ b/grass7/raster/r.in.srtm.region/r.in.srtm.region.py
@@ -263,7 +263,12 @@ def createTMPlocation(epsg=4326):
 
     # switch to temp location
     os.environ['GISRC'] = str(SRCGISRC)
-    srid = grass.parse_command('g.proj', flags='g')['srid']
+    proj = grass.parse_command('g.proj', flags='g')
+    if 'epsg' in proj:
+        currepsg = proj['epsg']
+    else:
+        currepsg = proj['srid'].split('EPSG:')[1]
+
     currepsg = ":".join(srid.split(":")[-1:])
     if currepsg != str(epsg):
         grass.fatal("Creation of temporary location failed!")


### PR DESCRIPTION
Due to https://github.com/OSGeo/grass/pull/1240 the output structure of `g.proj -g` has changed, leading to `KeyError: 'EPSG'`:

```
r.in.nasadem user='neteler' password='XXXXXXXXX' output=nasadem resolution=30
Traceback (most recent call last):
  File "/home/mundialis/.grass7/addons/scripts/r.in.nasadem", line 631, in <module>
    main()
  File "/home/mundialis/.grass7/addons/scripts/r.in.nasadem", line 475, in main
    SRCGISRC, TMPLOC = createTMPlocation()
  File "/home/mundialis/.grass7/addons/scripts/r.in.nasadem", line 342, in createTMPlocation
    if grass.parse_command('g.proj', flags='g')['EPSG'] != str(epsg):
KeyError: 'EPSG'
ERROR: Region <r_in_nasadem_region_409609> not found
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/home/mundialis/.grass7/addons/scripts/r.in.nasadem", line 312, in cleanup
    grass.run_command("g.region", region=tmpregionname)
  File "/home/mundialis/software/grass78_git/dist.x86_64-pc-linux-gnu/etc/python/grass/script/core.py", line 441, in run_command
    return handle_errors(returncode, returncode, args, kwargs)
  File "/home/mundialis/software/grass78_git/dist.x86_64-pc-linux-gnu/etc/python/grass/script/core.py", line 342, in handle_errors
    raise CalledModuleError(module=None, code=code,
grass.exceptions.CalledModuleError: Module run None g.region region=r_in_nasadem_region_409609 ended with error
Process ended with non-zero return code 1. See errors in the (error) output.
```

Reason: the recent PROJ updates introduced `srid` in the output of `g.proj -g`:

```
{'name': 'WGS 84', 'datum': 'wgs84', 'ellps': 'wgs84', 'proj': 'll', 'no_defs': 'defined', 'srid': 'EPSG:4326', 'unit': 'degree', 'units': 'degrees', 'meters': '1.0'}
```

This PR addresses the needed parsing change (feedback concerning the Python style is welcome).

Fixes
- r.in.nasadem
- r.in.srtm.region

(perhaps other addons are affected as well)