### PR TITLE
g.citation: get year from file attributes

### DIFF
--- a/grass7/general/g.citation/g.citation.py
+++ b/grass7/general/g.citation/g.citation.py
@@ -185,6 +185,17 @@ def clean_line_item(text):
     return text
 
 
+def get_access_date_from_documentation_file_attributes(path):
+    """Extract year from file attributes of the documentation
+
+    >>> path = documentation_filename(name)
+    >>> get_year_from_documentation_file_attributes(path)
+    2011-10-14
+    """
+    date_installed = datetime.fromtimestamp(Path(path).stat().st_ctime).strftime("%Y-%m-%d")
+    return date_installed
+
+
 def get_year_from_documentation_file_attributes(path):
     """Extract year from file attributes of the documentation
 
@@ -611,8 +622,9 @@ def print_bibtex(citation):
 
     author_names = [author['name'] for author in citation['authors']]
     print("  author = {", " and ".join(author_names), "},", sep="")
+    print("  howpublished = {", citation['code-url'], "},", sep="")
     print("  year = {", citation['year'], "}", sep="")
-
+    print("  note = {Accessed: ", citation['access'], "},", sep="")
     print("}")
 
 
@@ -765,6 +777,7 @@ def citation_for_module(name, add_grass=False):
     citation['grass-build-date'] = g_version['build_date']
     citation['authors'] = get_authors_from_documentation(text)
     citation['year'] = get_year_from_documentation_file_attributes(path)
+    citation['access'] = get_access_date_from_documentation_file_attributes(path)
     code_url, code_history_url = get_code_urls_from_documentation(text)
     citation['code-url'] = code_url
     citation['url-code-history'] = code_history_url

--- a/grass7/general/g.citation/g.citation.py
+++ b/grass7/general/g.citation/g.citation.py
@@ -101,6 +101,8 @@ import os
 import re
 from collections import defaultdict
 import json
+from pathlib import Path
+from datetime import datetime
 from pprint import pprint
 
 import grass.script as gs
@@ -183,23 +185,15 @@ def clean_line_item(text):
     return text
 
 
-def get_year_from_documentation(text):
-    """Extract year from text containing SVN date entry
+def get_year_from_documentation_file_attributes(path):
+    """Extract year from file attributes of the documentation
 
-    >>> text = "<p><i>Last changed: $Date: 2011-09-29 15:18:47 $</i>"
-    >>> get_year_from_documentation(text)
+    >>> path = documentation_filename(name)
+    >>> get_year_from_documentation_file_attributes(path)
     2011
     """
-    # we try to capture even when not properly worded (same below)
-    # offending modules: grep -IrnE '\$Date: ' | grep -v "Last changed:"
-    year_capture = r"<p>\s*<(i|em)>(Last changed: )?\$Date: ([\d]+)-\d\d-\d\d .*\$</(i|em)>"
-    match = re.search(year_capture, text,
-                      re.MULTILINE | re.DOTALL | re.IGNORECASE)
-    if match:
-        return int(match.group(3))
-    else:
-        # TODO: raise or fatal? should be in library or module?
-        raise RuntimeError("The text does not contain date entry")
+    year_installed = datetime.fromtimestamp(Path(path).stat().st_ctime).year
+    return int(year_installed)
 
 
 def get_email(text):
@@ -770,7 +764,7 @@ def citation_for_module(name, add_grass=False):
     citation['grass-version'] = g_version['version']
     citation['grass-build-date'] = g_version['build_date']
     citation['authors'] = get_authors_from_documentation(text)
-    citation['year'] = get_year_from_documentation(text)
+    citation['year'] = get_year_from_documentation_file_attributes(path)
     code_url, code_history_url = get_code_urls_from_documentation(text)
     citation['code-url'] = code_url
     citation['url-code-history'] = code_history_url


### PR DESCRIPTION
Fix #489

The new solution is to take the year from the installation / creation of the module file. But since the URL i parsed properly, Modification time could (should) probably be fetched from git (with different routines for core modules and addons).

Some author names are not picked up properly. Maybe that schould be unified at some point in the manuals?

Also the citation does not look very comprehensive for e.g. bibtex. Maybe this should be used as a template: https://www.bibtex.com/e/entry-types/#misc ?

The module has doctests, sould I add a simple unittest never the less?
