### PR TITLE
r.green: Python, Makefile and manual fixes 

### DIFF
--- a/grass7/raster/r.green/r.green.biomassfor/Makefile
+++ b/grass7/raster/r.green/r.green.biomassfor/Makefile
@@ -16,3 +16,4 @@ include $(MODULE_TOPDIR)/include/Make/Dir.make
 default: parsubdirs htmldir
 
 install: installsubdirs
+	$(INSTALL_DATA) $(PGM).html $(INST_DIR)/docs/html/

--- a/grass7/raster/r.green/r.green.biomassfor/r.green.biomassfor.html
+++ b/grass7/raster/r.green/r.green.biomassfor/r.green.biomassfor.html
@@ -1,3 +1,26 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html>
+<head>
+<title>GRASS GIS manual: r.green.biomassfor</title>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<link rel="stylesheet" href="grassdocs.css" type="text/css">
+</head>
+<body bgcolor="white">
+<div id="container">
+
+<a href="https://grass.osgeo.org/grass-stable/manuals/index.html"><img src="grass_logo.png" alt="GRASS logo"></a>
+<hr class="header">
+
+<h2>NAME</h2>
+
+<em><b>r.green.biomassfor</b></em> - Toolset for computing the energy potential of biomass from
+the forestry residues, considering different limits and constraints.
+
+<h2>KEYWORDS</h2>
+<a href="https://grass.osgeo.org/grass-stable/manuals/raster.html">raster</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/topic_biomass.html">biomass topic</a>
+
+<!-- meta page description: Computes the residual energy potential of different renewable energies like biomass or hydropower -->
 <h2>DESCRIPTION</h2>
 
 The <em>r.green.biomassfor</em> suite computes the energy potential of biomass from 
@@ -17,11 +40,12 @@ The <em>r.green.biomassfor</em> suite consists of the following different parts:
 <li><a href="r.green.biomassfor.impact.html">r.green.biomassfor.impact</a> - Calculates impact and multifunctionality values </li>
 </ul>
 
-<h2>NOTES</h2>
+<h2>REFERENCES</h2>
 
-<h2>EXAMPLE</h2>
-
-<h2>REFERENCE</h2>
+<ul>
+<li> Garegnani, G., Geri, F., Zambelli, P., Grilli, G., Sacchelli, S., Paletto, A., Curetti, G., Ciolli, M., Vettorato, D. (2015). A new open source DSS for assessment and planning of renewable energy: r. green. Proceedings of FOSS4G Europe, Como, 14-17. (<a href="http://www.academia.edu/download/42063487/A_new_open_source_DSS_for_assessment_and20160204-20913-vxe2wt.pdf">PDF</a>)</li>
+<li> Garegnani, G., Zambelli, P., Geri, F., Gros, J., D'Alonzo, V., Grilli, G., Sacchelli, S., Balest, J. Curetti, G., Paletto, A., Ciolli, M., Vettorato, D. (2015): Evaluation of renewable energy potential in Pilot Areas: a Decision Support System. (<a href="http://www.recharge-green.eu/wp-content/uploads/2015/02/Poster_r-green_v4.pdf">PDF</a>)</li>
+</ul>
 
 <h2>SEE ALSO</h2>
 

--- a/grass7/raster/r.green/r.green.gshp/Makefile
+++ b/grass7/raster/r.green/r.green.gshp/Makefile
@@ -11,3 +11,4 @@ include $(MODULE_TOPDIR)/include/Make/Dir.make
 default: parsubdirs htmldir
 
 install: installsubdirs
+	$(INSTALL_DATA) $(PGM).html $(INST_DIR)/docs/html/

--- a/grass7/raster/r.green/r.green.gshp/r.green.gshp.html
+++ b/grass7/raster/r.green/r.green.gshp/r.green.gshp.html
@@ -1,3 +1,25 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html>
+<head>
+<title>GRASS GIS manual: r.green.gshp</title>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<link rel="stylesheet" href="grassdocs.css" type="text/css">
+</head>
+<body bgcolor="white">
+<div id="container">
+
+<a href="https://grass.osgeo.org/grass-stable/manuals/index.html"><img src="grass_logo.png" alt="GRASS logo"></a>
+<hr class="header">
+
+<h2>NAME</h2>
+
+The <em>r.green.gshp</em> - Toolset for computing the Ground Source Heat Pump potential.
+
+<h2>KEYWORDS</h2>
+<a href="https://grass.osgeo.org/grass-stable/manuals/raster.html">raster</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/topic_biomass.html">biomass topic</a>
+
+<!-- meta page description: Computes the residual energy potential of different renewable energies like biomass or hydropower -->
 <h2>DESCRIPTION</h2>
 
 The <em>r.green.gshp</em> suite computes the Ground Source Heat Pump potential.<br>
@@ -10,7 +32,7 @@ The development of this tool was funded by the Alpine Space
 
 <br>
 
-<a href="http://www.alpine-space.eu/projects/greta/en/home" target="_blank"><img src="http://greta.eurac.edu/static/geonode/img/greta_logo.png" class="logo" width="200px"></a>
+<a href="https://www.alpine-space.eu/projects/greta/en/home" target="_blank"><img src="https://greta.eurac.edu/static/geonode/img/greta_logo.png" class="logo" width="200px"></a>
 
 <br>
 

--- a/grass7/raster/r.green/r.green.html
+++ b/grass7/raster/r.green/r.green.html
@@ -13,6 +13,7 @@
 
 <h2>NAME</h2>
 <em><b>r.green</b></em> - Computes the residual energy potential of different renewable energies like biomass or hydropower.
+
 <h2>KEYWORDS</h2>
 <a href="https://grass.osgeo.org/grass-stable/manuals/raster.html">raster</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/topic_biomass.html">biomass topic</a>

--- a/grass7/raster/r.green/r.green.hydro/Makefile
+++ b/grass7/raster/r.green/r.green.hydro/Makefile
@@ -2,19 +2,28 @@ MODULE_TOPDIR = ../../..
 
 PGM = r.green.hydro
 
+# note: to deactivate a module, just place a file "DEPRECATED" into the subdir
+ALL_SUBDIRS := ${sort ${dir ${wildcard */.}}}
+DEPRECATED_SUBDIRS := ${sort ${dir ${wildcard */DEPRECATED}}}
+RM_SUBDIRS := bin/ docs/ etc/ scripts/
+SUBDIRS_1 := $(filter-out $(DEPRECATED_SUBDIRS), $(ALL_SUBDIRS))
+SUBDIRS := $(filter-out $(RM_SUBDIRS), $(SUBDIRS_1))
+
 SUBDIRS = libhydro \
-	r.green.hydro.theoretical  \
-	r.green.hydro.planning  \
-	r.green.hydro.technical    \
-	r.green.hydro.financial    \
-	r.green.hydro.closest      \
-	r.green.hydro.optimal      \
-	r.green.hydro.structure    \
-	r.green.hydro.delplants    \
-	r.green.hydro.discharge
+	r.green.hydro.closest \
+	r.green.hydro.delplants \
+	r.green.hydro.discharge \
+	r.green.hydro.financial \
+	r.green.hydro.optimal \
+	r.green.hydro.planning \
+	r.green.hydro.recommended \
+	r.green.hydro.structure \
+	r.green.hydro.technical \
+	r.green.hydro.theoretical
 
 include $(MODULE_TOPDIR)/include/Make/Dir.make
 
 default: parsubdirs htmldir
 
 install: installsubdirs
+	$(INSTALL_DATA) $(PGM).html $(INST_DIR)/docs/html/

--- a/grass7/raster/r.green/r.green.hydro/libhydro/plant.py
+++ b/grass7/raster/r.green/r.green.hydro/libhydro/plant.py
@@ -133,6 +133,7 @@ def read_plants(hydro, elev=None, restitution='restitution', intake='intake',
         if pnt is None:
             #import ipdb
             #ipdb.set_trace()
+            print('Number of pnts: None')
         if elev is None:
             select = ','.join([cid_plant, cid_point, ckind_label, celevation, cdischarge])
             id_plant, id_point, kind_label, el, disch = pnt.attrs[select]

--- a/grass7/raster/r.green/r.green.hydro/r.green.hydro.html
+++ b/grass7/raster/r.green/r.green.hydro/r.green.hydro.html
@@ -1,3 +1,25 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html>
+<head>
+<title>GRASS GIS manual: r.green.hydro</title>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<link rel="stylesheet" href="grassdocs.css" type="text/css">
+</head>
+<body bgcolor="white">
+<div id="container">
+
+<a href="https://grass.osgeo.org/grass-stable/manuals/index.html"><img src="grass_logo.png" alt="GRASS logo"></a>
+<hr class="header">
+
+<h2>NAME</h2>
+
+The <em>r.green.hydro</em>  - Toolset for computing the hydropower potential.
+
+<h2>KEYWORDS</h2>
+<a href="https://grass.osgeo.org/grass-stable/manuals/raster.html">raster</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/topic_biomass.html">biomass topic</a>
+
+<!-- meta page description: Computes the residual energy potential of different renewable energies like biomass or hydropower -->
 <h2>DESCRIPTION</h2>
 
 The <em>r.green.hydro</em> suite computes the hydropower potential. <br>
@@ -48,7 +70,7 @@ The <em>r.green.hydro</em> suite consists of the following six different parts:<
 
 <h2>AUTHORS</h2>
 
-For authors and references, please refer to the respective module of <em>r.green</em>.
+For authors and references, please refer to the respective modules of <em>r.green</em>.
 
 <!--
 <p>

--- a/grass7/raster/r.green/r.green.hydro/r.green.hydro.technical/r.green.hydro.technical.py
+++ b/grass7/raster/r.green/r.green.hydro/r.green.hydro.technical/r.green.hydro.technical.py
@@ -381,11 +381,12 @@ def losses_Strickler(discharge, length, diameter, theta, velocity, ks=75):
     Rh = A / pw
 
     #if round(discharge / A, 5) == round(velocity, 5):
-        #import ipdb
-        #ipdb.set_trace()
+    #   import ipdb
+    #   ipdb.set_trace()
+    #
+    #   i = v**2 / (ks**2 * Rh ** (4/3))
+    #   hs = i * l
 
-        # i = v**2 / (ks**2 * Rh ** (4/3))
-        # hs = i * l
     return velocity**2 / (ks**2 * Rh**(4./3.)) * length
 
 

--- a/grass7/raster/r.green/r.green.hydro/r.green.hydro.technical/r.green.hydro.technical.py
+++ b/grass7/raster/r.green/r.green.hydro/r.green.hydro.technical/r.green.hydro.technical.py
@@ -380,7 +380,7 @@ def losses_Strickler(discharge, length, diameter, theta, velocity, ks=75):
     pw = r * (2 * pi - theta)
     Rh = A / pw
 
-    if round(discharge / A, 5) == round(velocity, 5):
+    #if round(discharge / A, 5) == round(velocity, 5):
         #import ipdb
         #ipdb.set_trace()
 

--- a/grass7/raster/r.green/r.green.install/r.green.install.html
+++ b/grass7/raster/r.green/r.green.install/r.green.install.html
@@ -1,20 +1,53 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html>
+<head>
+<title>GRASS GIS manual: r.green.install</title>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<link rel="stylesheet" href="grassdocs.css" type="text/css">
+</head>
+<body bgcolor="white">
+<div id="container">
+
+<a href="https://grass.osgeo.org/grass-stable/manuals/index.html"><img src="grass_logo.png" alt="GRASS logo"></a>
+<hr class="header">
+
+<h2>NAME</h2>
+
+<em>r.green.install</em> - Toolset to check that all the necessary Python libraries like scipy
+and numexpr are present in the python path. The module also check post-installation troubles
+that sometimes may occur.
+
+<h2>KEYWORDS</h2>
+<a href="https://grass.osgeo.org/grass-stable/manuals/raster.html">raster</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/topic_biomass.html">biomass topic</a>
+
+<!-- meta page description: Computes the residual energy potential of different renewable energies like biomass or hydropower -->
 <h2>DESCRIPTION</h2>
 
-<em>r.green.install</em> checks that all the necessary python libraries like scipy and numexpr are present in the python path. The module also check post-installation troubles that sometimes may occur.
+The module installs the missing Python libraries for different operating systems and
+provide a general menu in the GRASS GUI.
 
 <h2>NOTES</h2>
 
+<em>r.green.install</em> checks that all the necessary Python libraries like scipy and numexpr
+are present in the python path. The module also check post-installation troubles that sometimes
+may occur.
 
-The module installs the missing python librariers for different operating systems and provide a general menu in the grass GUI.
-
-<h3>Microsoft Windows</h3><br><br> 
-You should install <a href="https://grass.osgeo.org/download/software/ms-windows/">GRASS</a> with admin rights, stand-alone installer or OSGeo4W package, in directory with full controll permissions, to be able to intall the r.green modules.
+<h3>Installation on Microsoft Windows</h3>
+You should install <a href="https://grass.osgeo.org/download/windows/">GRASS GIS</a> with administrator
+rights; either the stand-alone installer or via OSGeo4W package, in a directory with full control of
+permissions, to be able to intall the <em>r.green</em> modules.
 
 <center>
 <img src="r_green_install_permissions.png" alt="Microsoft Windows Permissions"><br>
 Microsoft Windows Permissions
 </center><br><br>
-The r.green modules are based on python libraries. The module r.green.install -i is able to download and install them. However some troubles can raise due to new links or versions. In this case, you can manually download the following libraries in your GRASS installation directory from  <a href="http://www.lfd.uci.edu/~gohlke/pythonlibs/">http://www.lfd.uci.edu/~gohlke/pythonlibs/</a> according with your GRASS download (32bit or 64bit):
+The <em>r.green</em> modules are based on Python libraries. The module <em>r.green.install -i</em> is
+able to download and install them. However, some troubles can raise due to new links or versions.
+In this case, you can manually download the following libraries in your GRASS installation directory
+from  <a href="http://www.lfd.uci.edu/~gohlke/pythonlibs/">http://www.lfd.uci.edu/~gohlke/pythonlibs/</a>
+according with your GRASS download (32bit or 64bit):
+
 <table border="1">
   <tr>
     <th>32bit</th>
@@ -45,9 +78,11 @@ The r.green modules are based on python libraries. The module r.green.install -i
     </td>	
   </tr>
 </table>
-After the downloading, in the grass Command Console use the following code to install libraries and the r.green menu:
+After the downloading, in the grass Command Console use the following code to install libraries and
+the <em>r.green</em> menu:
+
 <div class="code"><pre>
-r.green.istall -i
+r.green.install -i
 </pre></div><br>
 
 Check the list of suggested libraries with the previous table. If they agree, you can proceed with the installation.
@@ -57,7 +92,7 @@ If you install the Energy menu, use the following command:
 r.green.install -x
 </pre></div><br>
 
-Close GRASS and restart the programm to have in the the menu the session energy with all the r.green modules.
+Close GRASS and restart the programm to have in the the menu the session energy with all the <em>r.green</em> modules.
 
 <h2>SEE ALSO</h2>
 
@@ -65,7 +100,7 @@ Close GRASS and restart the programm to have in the the menu the session energy 
 <a href="r.green.html">r.green</a> - overview page
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Pietro Zambelli (Eurac Research, Bolzano, Italy)
 


### PR DESCRIPTION
- Makefile: added missing rule to install meta manual pages
- manual: fix headers of meta manual pages
- manual: minor HTML fixes
- manual: fix headers of meta manual pages
- Python: Attempt to fix `IndentationError: expected an indented block`

Addresses https://github.com/OSGeo/grass/issues/1499

TODO (help wanted):

`r.green.install:35: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses`
