### PR TITLE
i.sentinel.download: adapt API URL

### DIFF
--- a/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -480,7 +480,7 @@ def download_gcs(scene, output):
 
 
 class SentinelDownloader(object):
-    def __init__(self, user, password, api_url='https://scihub.copernicus.eu/apihub'):
+    def __init__(self, user, password, api_url='https://apihub.copernicus.eu/apihub'):
         self._apiname = api_url
         self._user = user
         self._password = password
@@ -490,7 +490,7 @@ class SentinelDownloader(object):
         root.addHandler(logging.StreamHandler(
             sys.stderr
         ))
-        if self._apiname == 'https://scihub.copernicus.eu/apihub':
+        if self._apiname == 'https://apihub.copernicus.eu/apihub':
             try:
                 from sentinelsat import SentinelAPI
             except ImportError as e:
@@ -916,7 +916,7 @@ class SentinelDownloader(object):
 def main():
     user = password = None
     if options['datasource'] == 'ESA_COAH' or options['datasource'] == 'GCS':
-        api_url = 'https://scihub.copernicus.eu/apihub'
+        api_url = 'https://apihub.copernicus.eu/apihub'
     else:
         api_url = 'USGS_EE'
     if options['datasource'] == 'GCS' and (options['producttype'] not in


### PR DESCRIPTION
The API Hub URL to download Sentinel-data from the Copernicus Open Access Hub has changed from https://scihub.copernicus.eu/apihub/ to https://apihub.copernicus.eu/apihub/ as of 28 April 2021. See also [announcement 1](https://scihub.copernicus.eu/news/News00865) and [announcement 2](https://scihub.copernicus.eu/news/News00865). Even though "the old URL will not be dismissed" ([announcement 1](https://scihub.copernicus.eu/news/News00865)) trying to list and download Sentinel data using the old URL yields an authentication error. Hence, this PR adapts the default URL. 

### known issues
With the adapted URL searching for data with the `-l` flag and downloading footprints works again. However, data download was so far **not successful** as all requested datasets supposedly lie in the long-term archive (even though they are only a few weeks old).  In [announcement 2](https://scihub.copernicus.eu/news/News00865) a 2-week migration period is mentioned, so hopefully this is the cause of the problem and it will be solved soon.
A quick fix for the meantime would be to return to the old URL https://scihub.copernicus.eu/dhus (which was initially adapted to the API-HUB url in https://github.com/OSGeo/grass-addons/pull/475), as it seems that querying and downloading from this URL works without any issues.
What do you recommend? 

(see also PR for sentinelsat: https://github.com/sentinelsat/sentinelsat/pull/445)
