### PR TITLE
Use open() for opening files, Python 3 update

### DIFF
--- a/grass7/display/d.vect.thematic2/d.vect.thematic2.py
+++ b/grass7/display/d.vect.thematic2/d.vect.thematic2.py
@@ -340,7 +340,7 @@ def main():
     if not group:
         group = "themes"
 
-    f_group = file(tmp_group, 'w')
+    f_group = open(tmp_group, "w")
     f_group.write("Group %s\n" % group)
 
     # Calculate statistics for thematic intervals
@@ -410,7 +410,7 @@ def main():
         xlower = 0
 
     # legend title
-    f_graph = file(tmp_graph, 'w')
+    f_graph = open(tmp_graph, "w")
     out(f_graph, locals(), """\
 color 0:0:0
 size 2 2
@@ -421,12 +421,12 @@ move 4 90
 text Value range: $min - $max
 """)
 
-    f_gisleg = file(tmp_gisleg, 'w')
+    f_gisleg = open(tmp_gisleg, "w")
     out(f_gisleg, locals(), """\
 title - - - {Thematic map legend for column $column of map $map}
 """)
 
-    f_psleg = file(tmp_psleg, 'w')
+    f_psleg = open(tmp_psleg, "w")
     out(f_psleg, locals(), """\
 text 1% 95% Thematic map legend for column $column of map $map
   ref bottom left
@@ -452,7 +452,7 @@ end
     }
 
     # open file for psmap instructions
-    f_psmap = file(tmp_psmap, 'w')
+    f_psmap = open(tmp_psmap, "w")
 
     # graduated color thematic mapping
     if themetype == "graduated_colors":

--- a/grass7/hadoop/hd/hdfsgrass/grass_map.py
+++ b/grass7/hadoop/hd/hdfsgrass/grass_map.py
@@ -24,7 +24,7 @@ class VectorDBInfo:
 
     def _CheckDBConnection(self):
         """Check DB connection"""
-        nuldev = file(os.devnull, 'w+')
+        nuldev = open(os.devnull, "w+")
         # if map is not defined (happens with vnet initialization) or it doesn't exist
         try:
             self.layers = grass.vector_db(map=self.map, stderr=nuldev)

--- a/grass7/raster/r.catchment/r.catchment.py
+++ b/grass7/raster/r.catchment/r.catchment.py
@@ -322,7 +322,7 @@ def main():
     ####################################################
         grass.verbose('Creating output map')
         t = grass.tempfile()
-        temp = file(t, 'w+')
+        temp = open(t, "w+")
         temp.write('0 thru %s = %s\n' % (int(cutoff), mapval))
         temp.flush()
         grass.run_command('r.reclass', overwrite=grass.overwrite(), input=cost,

--- a/grass7/raster/r.mcda.output/r.mcda.output.py
+++ b/grass7/raster/r.mcda.output/r.mcda.output.py
@@ -71,7 +71,7 @@ def main():
     nsres = int(gregion['nsres'])
     print(nrows, ncols, ewres,nsres)
 
-    outf = file(output,"w")
+    outf = open(output, "w")
     outf.write("**ATTRIBUTES\n")
     for i in range(len(attributes)):
         outf.write("+ %s: (continuous)\n" % attributes[i])

--- a/grass7/raster/r.mcda.roughset/r.mcda.roughset.py
+++ b/grass7/raster/r.mcda.roughset/r.mcda.roughset.py
@@ -78,7 +78,7 @@ from functools import reduce
 
 def BuildFileISF(attributes, preferences, decision, outputMap, outputTxt):
     outputTxt = outputTxt+".isf"
-    outf = file(outputTxt,"w")
+    outf = open(outputTxt, "w")
     outf.write("**ATTRIBUTES\n")
     for i in range(len(attributes)):
         outf.write("+ %s: (continuous)\n" % attributes[i])

--- a/grass7/vector/v.explode/v.explode.py
+++ b/grass7/vector/v.explode/v.explode.py
@@ -64,30 +64,46 @@ except:
 
 
 def cleanup():
-    nuldev = file(os.devnull, 'w')
-    grass.run_command('g.remove', type_ = 'vect', pattern = 'v_explode*', flags = 'f',
-                      quiet = True, stderr = nuldev)
+    with open(os.devnull, "w") as nuldev:
+        grass.run_command(
+            "g.remove",
+            type_="vect",
+            pattern="v_explode*",
+            flags="f",
+            quiet=True,
+            stderr=nuldev,
+        )
+
 
 def main():
-    inmap = options['input']
-    outmap = options['output']
-
-    global nuldev
-    nuldev = None
+    inmap = options["input"]
+    outmap = options["output"]
 
     # check if input file exists
-    if not grass.find_file(inmap, element = 'vector')['file']:
+    if not grass.find_file(inmap, element="vector")["file"]:
         grass.fatal(_("<%s> does not exist.") % inmap)
 
-
-    out_split = 'v_explode' + '_' + 'split'
-    grass.run_command('v.split', input_ = inmap, vertices = 2,
-                          out = out_split, quiet = True, stderr = nuldev)
-    out_catdel = 'v_explode' + '_' + 'catdel'
-    grass.run_command('v.category', input_ = out_split, opt = 'del',
-                      output = out_catdel, quiet = True, stderr = nuldev)
-    grass.run_command('v.category', input_ = out_catdel, opt = 'add',
-                      output = outmap, quiet = True, stderr = nuldev)
+    out_split = "v_explode" + "_" + "split"
+    grass.run_command(
+        "v.split", input_=inmap, vertices=2, out=out_split, quiet=True, stderr=None
+    )
+    out_catdel = "v_explode" + "_" + "catdel"
+    grass.run_command(
+        "v.category",
+        input_=out_split,
+        opt="del",
+        output=out_catdel,
+        quiet=True,
+        stderr=None,
+    )
+    grass.run_command(
+        "v.category",
+        input_=out_catdel,
+        opt="add",
+        output=outmap,
+        quiet=True,
+        stderr=None,
+    )
 
 
 if __name__ == "__main__":

--- a/grass7/vector/v.gsflow.export/v.gsflow.export.py
+++ b/grass7/vector/v.gsflow.export/v.gsflow.export.py
@@ -256,11 +256,11 @@ def main():
             outstr = 'discharge_pt: row_i '+_y+' col_i '+_x
             if (len(bc_cell) > 0):
                 outstr += '\n'
-            outfile = file(out_pour_point_boundary+'.txt', 'w')
+            outfile = open(out_pour_point_boundary + ".txt", "w")
             outfile.write(outstr)
         # Bounadry condition
         if (len(bc_cell) > 0):
-            outfile = file(out_pour_point_boundary+'.txt', 'a')
+            outfile = open(out_pour_point_boundary + ".txt", "a")
             _xys = np.squeeze(gscript.db_select(sql='SELECT row,col FROM ' +
                                 bc_cell))
             # if only one point (so was on N-S, W-E direct connection),

--- a/grass7/vector/v.in.gns/v.in.gns.py
+++ b/grass7/vector/v.in.gns/v.in.gns.py
@@ -98,8 +98,8 @@ def main():
 
     header = None
     num_places = 0
-    inf = file(fileorig)
-    outf = file(tmpfile, 'wb')
+    inf = open(fileorig)
+    outf = open(tmpfile, "wb")
     for line in inf:
         fields = line.rstrip('\r\n').split('\t')
         if not header:

--- a/grass7/vector/v.in.wfs2/wfs_base.py
+++ b/grass7/vector/v.in.wfs2/wfs_base.py
@@ -208,7 +208,7 @@ class WFSBase:
             temp_warpmap = self._temp()
 
             if int(os.getenv('GRASS_VERBOSE', '2')) <= 2:
-                nuldev = file(os.devnull, 'w+')
+                nuldev = open(os.devnull, "w+")
             else:
                 nuldev = None
 

--- a/grass7/vector/v.what.spoly/v.what.spoly.py
+++ b/grass7/vector/v.what.spoly/v.what.spoly.py
@@ -76,12 +76,19 @@ except:
 
 def cleanup():
     inmap = options['input']
-    nuldev = file(os.devnull, 'w')
     grass.try_remove(tmp)
     for f in glob.glob(tmp + '*'):
         grass.try_remove(f)
-    grass.run_command('g.remove', type_ = 'vect', pat = 'v_temp*', flags = 'f',
-                      quiet = True, stderr = nuldev)
+    with open(os.devnull, "w") as nuldev:
+        grass.run_command(
+            "g.remove",
+            type_="vect",
+            pat="v_temp*",
+            flags="f",
+            quiet=True,
+            stderr=nuldev,
+        )
+
 
 def main():
     inmap = options['input']
@@ -89,8 +96,7 @@ def main():
     coor = options['coor']
     coor = coor.replace(',',' ')
 
-    global tmp, nuldev, grass_version
-    nuldev = None
+    global tmp, grass_version
 
     # setup temporary files
     tmp = grass.tempfile()
@@ -106,16 +112,29 @@ def main():
 
     ## DO IT ##
     ## add categories to boundaries
-    grass.run_command('v.category', input_ = inmap, option = 'add',
-                      type_ = 'boundary', output = 'v_temp_bcats',
-                      quiet = True, stderr = nuldev)
+    grass.run_command(
+        "v.category",
+        input_=inmap,
+        option="add",
+        type_="boundary",
+        output="v_temp_bcats",
+        quiet=True,
+        stderr=None,
+    )
 
     ## export polygons to CSV + WKT
     tmp1 = tmp + '.csv'
     tmp2 = tmp + '2.csv'
-    grass.run_command('v.out.ogr', input_ = 'v_temp_bcats', output = tmp1,
-                      format_ = "CSV", type_ = ('boundary'),
-                      lco = "GEOMETRY=AS_WKT", quiet = True, stderr = nuldev)
+    grass.run_command(
+        "v.out.ogr",
+        input_="v_temp_bcats",
+        output=tmp1,
+        format_="CSV",
+        type_=("boundary"),
+        lco="GEOMETRY=AS_WKT",
+        quiet=True,
+        stderr=None,
+    )
 
     ## convert lines to polygons
     f1 = open(tmp1, 'r')
@@ -149,8 +168,15 @@ def main():
         cmd = 'ogrinfo -al -fields=YES -geom=SUMMARY' + ' ' + tmp3 + ' ' + lyr_name
         os.system(cmd)
     else:
-        grass.run_command('v.in.ogr', input_ = tmp3, layer = lyr_name,
-                          output = outmap, flags = 'c', quiet = True, stderr = nuldev)
+        grass.run_command(
+            "v.in.ogr",
+            input_=tmp3,
+            layer=lyr_name,
+            output=outmap,
+            flags="c",
+            quiet=True,
+            stderr=None,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Following #515 I located some more uses of `file()` to open files among grass7 addons. `file()` was removed with Python 3 and leads to fatal error. This replaces those remaining cases with `open()`.