### PR TITLE
g.extension/Windows: fix special characters

### DIFF
--- a/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.html
+++ b/grass7/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.html
@@ -92,7 +92,7 @@ possible to use predifined templates with this editing mode.
 
 On the right side of editor there is a validator of metadata. Currently, 
 validator is able to validate two build-in profiles. 
-<!--For selection of profile “Load custom” is set by default the inspire profile.-->
+<!--For selection of profile "Load custom" is set by default the inspire profile.-->
 
 <h3>Updating GRASS native metadata </h3>
 

--- a/grass7/gui/wxpython/wx.mwprecip/mw3.py
+++ b/grass7/gui/wxpython/wx.mwprecip/mw3.py
@@ -1100,9 +1100,9 @@ class Computor():
     def computeAlphaK(self, freq, polarization):
         """@RECOMMENDATION ITU-R P.838-3
         Specific attenuation model for rain for use in prediction methods
-        γR = kR^α
-        return kv and αv (vertical polarization)
-        return kh and αh (horizontal polarization)
+        gamma_R = kR^alpha
+        return kv and alpha_v (vertical polarization)
+        return kh and alpha_h (horizontal polarization)
         """
         freq /= 1000000
 

--- a/grass7/imagery/i.edge/i.edge.html
+++ b/grass7/imagery/i.edge/i.edge.html
@@ -107,7 +107,7 @@ Edge strengths (gradient values) are not provided as an output but might be adde
 <ul>
 
 <li>J. Canny. <i>A Computational Approach to Edge Detection</i>. In: IEEE Trans.
-Pattern Anal. Mach. Intell. 8.6 (June 1986), pp. 679–698. issn: 0162-8828.</li>
+Pattern Anal. Mach. Intell. 8.6 (June 1986), pp. 679-698. issn: 0162-8828.</li>
 
 <li>J.C. Russ. <i>The image processing handbook</i>. CRC, 2011.</li>
 
@@ -121,7 +121,7 @@ vision</i>. PWS Pub. Pacific Grove (1999).
 
 <li>P. Zimmermann. <i>A new framework for automatic building detection analysing
 multiple cue data</i>. In: International Archives of Photogrammetry and Remote
-Sensing 33.B3/2; PART 3 (2000), pp. 1063–1070.</li>
+Sensing 33.B3/2; PART 3 (2000), pp. 1063-1070.</li>
 
 </ul>
 

--- a/grass7/imagery/i.feotio2/feo.c
+++ b/grass7/imagery/i.feotio2/feo.c
@@ -1,7 +1,7 @@
 #include<math.h>
 /* 
  * Wilcox, B.B., Lucey, P.G., Gillis, J.J., 2005. Mapping iron in the lunar mare: An improved approach. J. Geophys. Res. 110(E11):2156-2202.
- * with theta = 1.3885 rad, the ‘average slope of the trends in the mare’ from Wilcox et al (2005).
+ * with theta = 1.3885 rad, the 'average slope of the trends in the mare' from Wilcox et al (2005).
  */
 double feo(double r750, double r950, double theta)
 {

--- a/grass7/imagery/i.fusion.hpf/README.md
+++ b/grass7/imagery/i.fusion.hpf/README.md
@@ -129,9 +129,9 @@ References
 
 - Gangkofner, U. G., Pradhan, P. S., and Holcomb, D. W. (2008). Optimizing
 the high-pass filter addition technique for image fusion.
-PHOTOGRAMMETRIC ENGINEERING & REMOTE SENSING, 74(9):1107–1118.
+PHOTOGRAMMETRIC ENGINEERING & REMOTE SENSING, 74(9):1107-1118.
 
-- “ERDAS IMAGINE.” Accessed March 19, 2015. http://doc.hexagongeospatial.com/ERDAS%20IMAGINE/ERDAS_IMAGINE_Help/#ii_hpfmerge_mergedialog.htm.
+- "ERDAS IMAGINE." Accessed March 19, 2015. http://doc.hexagongeospatial.com/ERDAS%20IMAGINE/ERDAS_IMAGINE_Help/#ii_hpfmerge_mergedialog.htm.
 
 
 - Aniruddha Ghosh & P.K. Joshi (2013) Assessment of pan-sharpened very high-resolution WorldView-2 images, International Journal of Remote Sensing, 34:23, 8336-8359

--- a/grass7/imagery/i.fusion.hpf/constants.py
+++ b/grass7/imagery/i.fusion.hpf/constants.py
@@ -14,7 +14,7 @@ Sources:
 - "Optimizing the High-Pass Filter Addition Technique for Image Fusion",
 Ute G. Gangkofner, Pushkar S. Pradhan, and Derrold W. Holcomb (2008).
 
-- “ERDAS IMAGINE.” Accessed March 19, 2015.
+- "ERDAS IMAGINE." Accessed March 19, 2015.
 http://doc.hexagongeospatial.com/ERDAS%20IMAGINE/ERDAS_IMAGINE_Help/#ii_hpfmerge_mergedialog.htm.
 
 """

--- a/grass7/imagery/i.gravity/gravity.c
+++ b/grass7/imagery/i.gravity/gravity.c
@@ -27,7 +27,7 @@ double free_air(h){
 /*# Bouguer Correction*/
 double delta_g_bouguer(double rho,double h){
  /* Bouguer Correction (mGal)
- G=gravity constant 6.67398 × 10^-11 [m3 kg-1 s-2]
+ G=gravity constant 6.67398 * 10^-11 [m3 kg-1 s-2]
  rho=density of slab (Mg/m3)
  h=height (m)*/
  return (2*M_PI*6.67398*pow(10,-11)*rho*h);

--- a/grass7/imagery/i.landsat8.swlst/column_water_vapor.py
+++ b/grass7/imagery/i.landsat8.swlst/column_water_vapor.py
@@ -48,10 +48,10 @@ class Column_Water_Vapor():
 
     - c0, c1 and c2 are coefficients obtained from simulated data;
 
-    - τ is the band effective atmospheric transmittance;
+    - tau is the band effective atmospheric transmittance;
 
     - N is the number of adjacent pixels (excluding water and cloud pixels)
-    in a spatial window of size n (i.e., N = n × n);
+    in a spatial window of size n (i.e., N = n * n);
 
     - Ti,k and Tj,k are Top of Atmosphere brightness temperatures (K) of
     bands i and j for the kth pixel;
@@ -102,7 +102,7 @@ class Column_Water_Vapor():
     Ren, H.; Du, C.; Qin, Q.; Liu, R.; Meng, J.; Li, J. Atmospheric water vapor
     retrieval from landsat 8 and its validation. In Proceedings of the IEEE
     International Geosciene and Remote Sensing Symposium (IGARSS), Quebec, QC,
-    Canada, July 2014; pp. 3045–3048.
+    Canada, July 2014; pp. 3045-3048.
     """
 
     def __init__(self, window_size, ti, tj):

--- a/grass7/imagery/i.landsat8.swlst/i.landsat8.swlst.html
+++ b/grass7/imagery/i.landsat8.swlst/i.landsat8.swlst.html
@@ -45,7 +45,7 @@
 <p><code>LST = b0 + [b1 + b2 * (1-e)/e + b3 * (De/e2)] * (Ti+T)/j2 + [b4 + b5 * (1-e)/e + b6 * (De/e2)] * (Ti-Tj)/2 + b7 * (Ti-Tj)^2</code></p>
 <p>where:</p>
 <ul>
-<li><code>Ti</code> and <code>Tj</code> are Top of Atmosphere brightness temperatures measured in channels <code>i</code> (~11.0 microns) and <code>j</code> (~12.0 µm), respectively</li>
+<li><code>Ti</code> and <code>Tj</code> are Top of Atmosphere brightness temperatures measured in channels <code>i</code> (~11.0 microns) and <code>j</code> (~12.0 microns), respectively</li>
 <li>from http://landsat.usgs.gov/band_designations_landsat_satellites.php:
 <ul>
 <li>Band 10, Thermal Infrared (TIRS) 1, 10.60-11.19, 100*(30)</li>

--- a/grass7/imagery/i.landsat8.swlst/i.landsat8.swlst.py
+++ b/grass7/imagery/i.landsat8.swlst/i.landsat8.swlst.py
@@ -69,7 +69,7 @@
                [1] [Look below for the publised paper!] Huazhong Ren, Chen Du,
                Qiming Qin, Rongyuan Liu, Jinjie Meng, and Jing Li. "Atmospheric
                Water Vapor Retrieval from Landsat 8 and Its Validation."
-               3045–3048. IEEE, 2014.
+               3045-3048. IEEE, 2014.
 
                [2] Ren, H., Du, C., Liu, R., Qin, Q., Yan, G., Li, Z. L., &
                Meng, J. (2015). Atmospheric water vapor retrieval from Landsat

--- a/grass7/imagery/i.landsat8.swlst/landsat8_mtl.py
+++ b/grass7/imagery/i.landsat8.swlst/landsat8_mtl.py
@@ -145,11 +145,11 @@ class Landsat8_MTL():
         can be converted to TOA spectral radiance using the radiance rescaling
         factors provided in the metadata file:
 
-        Lλ = ML * Qcal + AL
+        L_lambda = ML * Qcal + AL
 
         where:
 
-        - Lλ = TOA spectral radiance (Watts/( m2 * srad * μm))
+        - L_lambda = TOA spectral radiance (Watts/( m2 * srad * micrometer))
 
         - ML = Band-specific multiplicative rescaling factor from the metadata
         (RADIANCE_MULT_BAND_x, where x is the band number)
@@ -188,12 +188,12 @@ class Landsat8_MTL():
         equation is used to convert DN values to TOA reflectance for OLI data
         as follows:
 
-                ρλ' = MρQcal + Aρ
+                ρ_lambda' = MρQcal + Aρ
 
         where:
 
-        - ρλ' = TOA planetary reflectance, without correction for solar angle.
-          Note that ρλ' does not contain a correction for the sun angle.
+        - ρ_lambda' = TOA planetary reflectance, without correction for solar angle.
+          Note that ρ_lambda' does not contain a correction for the sun angle.
 
         - Mρ  = Band-specific multiplicative rescaling factor from the metadata
           (REFLECTANCE_MULT_BAND_x, where x is the band number)
@@ -205,12 +205,12 @@ class Landsat8_MTL():
 
         TOA reflectance with a correction for the sun angle is then:
 
-        ρλ = ρλ' = ρλ'  ### Fix This!
+        ρ_lambda = ρ_lambda' = ρ_lambda'  ### Fix This!
         cos(θSZ) sin(θSE) ### Fix This!
 
         where:
 
-        - ρλ = TOA planetary reflectance
+        - ρ_lambda = TOA planetary reflectance
         - θSE = Local sun elevation angle. The scene center sun elevation angle
           in degrees is provided in the metadata (SUN_ELEVATION).
         - θSZ = Local solar zenith angle;
@@ -232,13 +232,13 @@ class Landsat8_MTL():
         TIRS band data can be converted from spectral radiance to brightness
         temperature using the thermal constants provided in the metadata file:
 
-        T = K2 / ln( (K1/Lλ) + 1 )
+        T = K2 / ln( (K1/L_lambda) + 1 )
 
         where:
 
         - T = At-satellite brightness temperature (K)
 
-        - Lλ = TOA spectral radiance (Watts/( m2 * srad * μm)), below
+        - L_lambda = TOA spectral radiance (Watts/( m2 * srad * μm)), below
           'DUMMY_RADIANCE'
 
         - K1 = Band-specific thermal conversion constant from the metadata

--- a/grass7/imagery/i.landsat8.swlst/split_window_lst.py
+++ b/grass7/imagery/i.landsat8.swlst/split_window_lst.py
@@ -50,7 +50,7 @@ class SplitWindowLST():
 
     The algorithm removes the atmospheric effect through differential
     atmospheric absorption in the two adjacent thermal infrared channels
-    centered at about 11 and 12 μm.
+    centered at about 11 and 12 micrometer.
 
     The linear or non-linear combination of the brightness temperatures is
     finally applied for LST estimation based on the equation:
@@ -77,7 +77,7 @@ class SplitWindowLST():
 
     For example, the LST pixel with a CWV of 2.1 g/cm2 is estimated by using
     the coefficients of [0.0, 2.5] and [2.0, 3.5]. This process initially
-    reduces the δLSTinc and improves the spatial continuity of the LST product.
+    reduces the delta-LSTinc and improves the spatial continuity of the LST product.
     """
 
     def __init__(self, landcover):

--- a/grass7/imagery/i.lswt/i.lswt.py
+++ b/grass7/imagery/i.lswt/i.lswt.py
@@ -17,7 +17,7 @@
 # The satellite specific split-window coefficients are taken from:
 # Jimenez-Munoz, J.-C., Sobrino, J.A., 2008. Split-Window Coefficients for
 # Land Surface Temperature Retrieval From Low-Resolution Thermal Infrared Sensors.
-# IEEE Geoscience and Remote Sensing Letters 5, 806–809. doi:10.1109/LGRS.2008.2001636
+# IEEE Geoscience and Remote Sensing Letters 5, 806-809. doi:10.1109/LGRS.2008.2001636
 #
 # A new method to develop continuos time series of LSWT from historical AVHRR
 # is explained below, uses the same split window technique implemented here:

--- a/grass7/imagery/i.nightlights.intercalibration/i.nightlights.intercalibration.py
+++ b/grass7/imagery/i.nightlights.intercalibration/i.nightlights.intercalibration.py
@@ -33,7 +33,7 @@ PURPOSE:        Performing inter-satellite calibration on DMSP-OLS Nighttime
                 - Liu (2012)
 
                   Empirical second order polynomial regression model & optimal
-                  threshold method:  DNc = a × DN^2 + b × DN + c
+                  threshold method:  DNc = a * DN^2 + b * DN + c
 
                   where:
 
@@ -46,7 +46,7 @@ PURPOSE:        Performing inter-satellite calibration on DMSP-OLS Nighttime
 
                 - Wu (2013)
 
-                  Power calibration model:  DNc + 1 = a × (DN + 1)^b
+                  Power calibration model:  DNc + 1 = a * (DN + 1)^b
 
                   where:
 
@@ -71,11 +71,11 @@ PURPOSE:        Performing inter-satellite calibration on DMSP-OLS Nighttime
    |              |                                                       |
    | +--Regression+Models-----------------------------------------------+ |
    | |                                                                  | |
-   | |  Elvidge, 2009/2014:  DNc = C0 + C1×DN + C2×DNv2                 | |
+   | |  Elvidge, 2009/2014:  DNc = C0 + C1*DN + C2*DNv2                 | |
    | |                                                                  | |
    | |  Liu, 2012:  based on Elvidge's model + optimal threshold method | |
    | |                                                                  | |
-   | |  Wu, 2014:            DNc + 1 = a×(DN + 1)^b                     | |
+   | |  Wu, 2014:            DNc + 1 = a*(DN + 1)^b                     | |
    | |                                                                  | |
    | |  Others?                                                         | |
    | |                                                                  | |

--- a/grass7/imagery/i.nightlights.intercalibration/intercalibration_coefficients.py
+++ b/grass7/imagery/i.nightlights.intercalibration/intercalibration_coefficients.py
@@ -5,7 +5,7 @@
 Regression coefficients derived from models for
 Inter-Satellite Calibration  of  DMSP-OLS Night-Time Light Time Series
 
-Elvidge 2009, 2014:  dn_adjusted = C0 + C1 × dn + C2 × dn^2
+Elvidge 2009, 2014:  dn_adjusted = C0 + C1 * dn + C2 * dn^2
 Liu 2012:  dn_calibrated = a * dn^2 + b * dn + c
 Wu 2013:  dn_calibrated + 1 = a * (dn + 1)^b
 """
@@ -16,7 +16,7 @@ CITATIONS = {
          'Kimberly E. Baugh, Benjamin T. Tuttle, Tilottama Ghosh, Dee W. Pack, '
          'Edward H. Erwin, and Mikhail Zhizhin. "A Fifteen Year Record of '
          'Global Natural Gas Flaring Derived from Satellite Data." Energies 2, '
-         'no. 2 (August 7, 2009): 595–622.'),
+         'no. 2 (August 7, 2009): 595-622.'),
     'ELVIDGE2014':
         ('Elvidge, Christopher D., Feng-Chi Hsu, '
          'Kimberly E. Baugh, and Tilottama Ghosh. "National Trends in '

--- a/grass7/imagery/i.nightlights.intercalibration/intercalibration_models.py
+++ b/grass7/imagery/i.nightlights.intercalibration/intercalibration_models.py
@@ -133,7 +133,7 @@ class Elvidge(CalibrationModel):
     """
     Empirical second order, DMSP-OLS inter-satellite, calibration model
     proposed by Elvidge, 2009  or  Elvidge, 2014.
-    DN adj. = C0 + C1×DN + C2×DN^2
+    DN adj. = C0 + C1*DN + C2*DN^2
     """
 
     def __init__(self, satellite, year, version):
@@ -226,7 +226,7 @@ class Elvidge(CalibrationModel):
 class Liu2012(CalibrationModel):
     """
     Empirical second order calibration model (& optimal threshold method)
-    proposed by Liu, 2012.  DNc = a × DN^2 + b × DN + c, where:
+    proposed by Liu, 2012.  DNc = a * DN^2 + b * DN + c, where:
     - DNc:
     - DN:
     - a:
@@ -307,7 +307,7 @@ class Liu2012(CalibrationModel):
 class Wu2013(CalibrationModel):
     """
     Power calibration model proposed by Wu 2013.
-    DNc + 1 = a × (DN + 1)^b
+    DNc + 1 = a * (DN + 1)^b
     Subclass, inheriting from CalibrationModel
     """
 

--- a/grass7/imagery/i.variance/i.variance.html
+++ b/grass7/imagery/i.variance/i.variance.html
@@ -140,7 +140,7 @@ resolution,min_diff
 <h2>REFERENCES</h2>
 
 Woodcock, C.E., Strahler, A.H., 1987. The factor of scale in remote sensing. 
-	Remote Sensing of Environment 21, 311–332. 
+	Remote Sensing of Environment 21, 311-332. 
 	http://doi.org/10.1016/0034-4257(87)90015-0
 
 <h2>SEE ALSO</h2>

--- a/grass7/imagery/i.wi/awei.c
+++ b/grass7/imagery/i.wi/awei.c
@@ -5,8 +5,8 @@
     /* Automated Water Extraction Index
      * Feyisa, G.L., Meilby, H., Fensholt, R., & Proud, S.R. (2014). Automated Water Extraction
 Index: A new technique for surface water mapping using Landsat imagery. Remote
-Sensing of Environment, 140, 23–35. http://dx.doi.org/10.1016/j.rse.2013.08.029.
-     * Landsat TM/ETM+ : 4 × (b2 - b5 ) - (0.25 × b4 + 2.75 × b5 )
+Sensing of Environment, 140, 23-35. http://dx.doi.org/10.1016/j.rse.2013.08.029.
+     * Landsat TM/ETM+ : 4 * (b2 - b5 ) - (0.25 * b4 + 2.75 * b5 )
      */ 
 double awei_noshadow(double greenchan, double nirchan, double chan5chan) 
 {
@@ -17,8 +17,8 @@ double awei_noshadow(double greenchan, double nirchan, double chan5chan)
     /* Automated Water Extraction Index
      * Feyisa, G.L., Meilby, H., Fensholt, R., & Proud, S.R. (2014). Automated Water Extraction
 Index: A new technique for surface water mapping using Landsat imagery. Remote
-Sensing of Environment, 140, 23–35. http://dx.doi.org/10.1016/j.rse.2013.08.029.
-     * Landsat TM/ETM+ : b1 + 2.5 × b2 - 1.5 × (b4 + b5 ) - 0.25 × b7
+Sensing of Environment, 140, 23-35. http://dx.doi.org/10.1016/j.rse.2013.08.029.
+     * Landsat TM/ETM+ : b1 + 2.5 * b2 - 1.5 * (b4 + b5 ) - 0.25 * b7
      */ 
 double awei_shadow(double bluechan, double greenchan, double nirchan, double chan5chan, double chan7chan) 
 {

--- a/grass7/imagery/i.wi/ndwi.c
+++ b/grass7/imagery/i.wi/ndwi.c
@@ -5,7 +5,7 @@
     /* Normalized Difference Water Index (NDWI McFeeters)
      * McFeeters, S.K. (1996). The use of the Normalized Difference Water Index (NDWI) in the
 delineation of open water features. International Journal of Remote Sensing, 17,
-1425–1432. http://dx.doi.org/10.1080/01431169608948714.
+1425-1432. http://dx.doi.org/10.1080/01431169608948714.
      * Landsat TM/ETM+ : (b2-b4)/(b2+b4) (green-NIR)/(green+NIR)
      */ 
 double ndwi_mcfeeters(double greenchan, double nirchan) 
@@ -24,7 +24,7 @@ double ndwi_mcfeeters(double greenchan, double nirchan)
     /* Normalized Difference Water Index (NDWI Xu)
      * Xu, H. (2006). Modification of normalised difference water index (NDWI) to enhance
 open water features in remotely sensed imagery. International Journal of Remote
-Sensing, 27, 3025–3033. http://dx.doi.org/10.1080/01431160600589179.
+Sensing, 27, 3025-3033. http://dx.doi.org/10.1080/01431160600589179.
      * Landsat TM/ETM+ : (b2-b5)/(b2+b5) (green-MIR)/(green+MIR)
      */ 
 double ndwi_xu(double greenchan, double chan5chan) 

--- a/grass7/imagery/i.wi/tcw.c
+++ b/grass7/imagery/i.wi/tcw.c
@@ -4,7 +4,7 @@
 
     /* T C W 
      * Crist, E.P. (1985). A TM tasseled cap equivalent transformation for reflectance factor data.
-Remote Sensing of Environment, 17, 301–306.
+Remote Sensing of Environment, 17, 301-306.
      * Landsat TM/ETM+ : 0.0315*b1 + 0.2021*b2 + 0.3102*b3 + 0.1594*b4 - 0.6806*b5 - 0.6109*b7
      */ 
 double tcw(double bluechan, double greenchan, double redchan, double nirchan, double chan5chan, double chan7chan) 

--- a/grass7/raster/r.convergence/r.convergence.html
+++ b/grass7/raster/r.convergence/r.convergence.html
@@ -65,7 +65,7 @@ Journal of Hydrology, 187(1-2), 145-156 .</p>
 <p>
 Bauer J., Rohdenburg H., Bork H.-R., (1985), Ein Digitales Reliefmodell als Vorraussetzung fuer ein deterministisches Modell der Wasser- und Stoff-Fluesse, <i>IN: Bork, H.-R., Rohdenburg, H., Landschaftsgenese und Landschaftsoekologie, Parameteraufbereitung fuer deterministische Gebiets-Wassermodelle, Grundlagenarbeiten zu Analyse von Agrar-Oekosystemen</i>, 1-15.
 <p>
-Böhner J., Blaschke T., Montanarella, L. (eds.) (2008). SAGA Seconds Out. Hamburger Beiträge zur Physischen Geographie und Landschaftsökologie, 19: 113 s.</p>
+B&ouml;hner J., Blaschke T., Montanarella, L. (eds.) (2008). SAGA Seconds Out. Hamburger Beitr&auml;ge zur Physischen Geographie und Landschafts&ouml;kologie, 19: 113 s.</p>
 
 <h2>AUTHOR</h2>
 Jarek Jasiewicz

--- a/grass7/raster/r.edm.eval/r.edm.eval.html
+++ b/grass7/raster/r.edm.eval/r.edm.eval.html
@@ -25,10 +25,10 @@
 
 <h2>REFERENCES</h2>
 <p>Jiménez-Valverde, A. 2012. Insights into the area under the receiver operating characteristic curve (AUC) as a discrimination measure in species distribution modelling. Global Ecology and Biogeography 21: 498-507
-<p>Lobo, J. M., Jiménez-Valverde, A., & Real, R. 2008. AUC: a misleading measure of the performance of predictive distribution models. Global Ecology and Biogeography 17: 145-151.
+<p>Lobo, J. M., Jim&eacute;nez-Valverde, A., &amp; Real, R. 2008. AUC: a misleading measure of the performance of predictive distribution models. Global Ecology and Biogeography 17: 145-151.
 <p>Hijmans, R. J. 2012. Cross-validation of species distribution models: removing spatial sorting bias and calibration with a null model. Ecology 93: 679-688.
-<P>Allouche, O., Tsoar, A., & Kadmon, R. 2006. Assessing the accuracy of species distribution models: prevalence, kappa and the true skill statistic (TSS). Journal of Applied Ecology 43: 1223-1232.
-<p>McPHERSON, J. M., Jetz, W., & Rogers, D. J. 2004. The effects of species' range sizes on the accuracy of distribution models: ecological phenomenon or statistical artefact? Journal of Applied Ecology 41: 811-823.
+<P>Allouche, O., Tsoar, A., &amp; Kadmon, R. 2006. Assessing the accuracy of species distribution models: prevalence, kappa and the true skill statistic (TSS). Journal of Applied Ecology 43: 1223-1232.
+<p>McPHERSON, J. M., Jetz, W., &amp; Rogers, D. J. 2004. The effects of species' range sizes on the accuracy of distribution models: ecological phenomenon or statistical artefact? Journal of Applied Ecology 41: 811-823.
 
 
 <h2>AUTHOR</h2>

--- a/grass7/raster/r.estimap.recreation/LICENSE
+++ b/grass7/raster/r.estimap.recreation/LICENSE
@@ -10,7 +10,7 @@ extent such use is covered by a right of the copyright holder of the Work).
 
 The Work is provided under the terms of this Licence when the Licensor (as
 defined below) has placed the following notice immediately following the
-copyright notice for the Work: “Licensed under the EUPL”, or has expressed by
+copyright notice for the Work: "Licensed under the EUPL", or has expressed by
 any other means his willingness to license under the EUPL.
 
 1. Definitions

--- a/grass7/raster/r.estimap.recreation/README.md
+++ b/grass7/raster/r.estimap.recreation/README.md
@@ -1080,8 +1080,8 @@ Licence
 
 Copyright 2018 European Union
 
-Licensed under the EUPL, Version 1.2 or – as soon they will be
-approved by the European Commission – subsequent versions of the
+Licensed under the EUPL, Version 1.2 or - as soon they will be
+approved by the European Commission - subsequent versions of the
 EUPL (the "Licence");
 
 You may not use this work except in compliance with the Licence.

--- a/grass7/raster/r.estimap.recreation/r.estimap.recreation/r.estimap.recreation.py
+++ b/grass7/raster/r.estimap.recreation/r.estimap.recreation/r.estimap.recreation.py
@@ -18,8 +18,8 @@
 
  COPYRIGHT:    Copyright 2018 European Union
 
-               Licensed under the EUPL, Version 1.2 or – as soon they will be
-               approved by the European Commission – subsequent versions of the
+               Licensed under the EUPL, Version 1.2 or - as soon they will be
+               approved by the European Commission - subsequent versions of the
                EUPL (the "Licence");
 
                You may not use this work except in compliance with the Licence.

--- a/grass7/raster/r.fuzzy.logic/r.fuzzy.logic.html
+++ b/grass7/raster/r.fuzzy.logic/r.fuzzy.logic.html
@@ -66,12 +66,12 @@ partial membership</dd>
 
 <ul>
 <li>Jasiewicz, J. (2011). A new GRASS GIS fuzzy inference system for massive data analysis.
-Computers & Geosciences (37) 1525-1531. DOI <a href="https://doi.org/10.1016/j.cageo.2010.09.008">https://doi.org/10.1016/j.cageo.2010.09.008</a>
+Computers &amp; Geosciences (37) 1525-1531. DOI <a href="https://doi.org/10.1016/j.cageo.2010.09.008">https://doi.org/10.1016/j.cageo.2010.09.008</a>
 
 <li>Zadeh, L.A. (1965). "Fuzzy sets". Information and Control 8 (3): 338-353.
-<a href="https://doi.org/10.1016/S0019-9958(65)90241-X"><a href="https://doi.org/10.1016/S0019-9958(65)90241-X"</a>. ISSN 0019-9958.
+<a href="https://doi.org/10.1016/S0019-9958(65)90241-X">https://doi.org/10.1016/S0019-9958(65)90241-X</a>. ISSN 0019-9958.
 
-<li>Novák, Vilém (1989). Fuzzy Sets and Their Applications. Bristol: Adam Hilger.
+<li>Nov&aacute;k, Vil&eacute;m (1989). Fuzzy Sets and Their Applications. Bristol: Adam Hilger.
 ISBN 0-85274-583-4.
 
 <li>Klir, George J.; Yuan, Bo (1995). Fuzzy sets and fuzzy logic: theory and
@@ -82,9 +82,9 @@ foundations and applications. Englewood Cliffs, NJ: Prentice Hall. ISBN
 0133410587.
 
 <li>Meyer D, Hornik K (2009a). Generalized and Customizable Sets in R. Journal of
-Statistical Software, 31(2), 1-27. DOI <a href="https://doi.org/10.18637/jss.v031.i02">https://doi.org/10.18637/jss.v031.i02</a>
+Statistical Software, 31(2), 1-27. DOI <a href="http://dx.doi.org/10.18637/jss.v031.i02">DOI:10.18637/jss.v031.i02</a>
 
-<li>Meyer D, Hornik K (2009b). sets: Sets, Generalized Sets, and Customizable Sets.
+<li>Meyer D, Hornik K (2009b). Sets: Sets, Generalized Sets, and Customizable Sets.
 R~package version~1.0, URL <a href="http://CRAN.R-project.org/package=sets">http://CRAN.R-project.org/package=sets</a>.
 </ul>
 

--- a/grass7/raster/r.fuzzy.set/r.fuzzy.set.html
+++ b/grass7/raster/r.fuzzy.set/r.fuzzy.set.html
@@ -127,12 +127,12 @@ where m: shape parameter.
 
 <ul>
 <li>Jasiewicz, J. (2011). A new GRASS GIS fuzzy inference system for massive data analysis.
-Computers & Geosciences (37) 1525-1531. DOI <a href=https://doi.org/10.1016/j.cageo.2010.09.008">https://doi.org/10.1016/j.cageo.2010.09.008</a>
+Computers &amp; Geosciences (37) 1525-1531. DOI <a href="https://doi.org/10.1016/j.cageo.2010.09.008">https://doi.org/10.1016/j.cageo.2010.09.008</a>
 
-<li>Zadeh, L.A. (1965). "Fuzzy sets". Information and Control 8 (3): 338–353.
-<a href="https://doi.org/10.1016/S0019-9958(65)90241-X"><a href="https://doi.org/10.1016/S0019-9958(65)90241-X"</a>.
+<li>Zadeh, L.A. (1965). "Fuzzy sets". Information and Control 8 (3): 338-353.
+<a href="https://doi.org/10.1016/S0019-9958(65)90241-X">https://doi.org/10.1016/S0019-9958(65)90241-X</a>. ISSN 0019-9958.
 
-<li>Novák, Vilém (1989). Fuzzy Sets and Their Applications. Bristol: Adam Hilger.
+<li>Nov&aacute;k, Vil&eacute;m (1989). Fuzzy Sets and Their Applications. Bristol: Adam Hilger.
 ISBN 0-85274-583-4.
 
 <li>Klir, George J.; Yuan, Bo (1995). Fuzzy sets and fuzzy logic: theory and
@@ -143,9 +143,9 @@ foundations and applications. Englewood Cliffs, NJ: Prentice Hall. ISBN
 0133410587.
 
 <li>Meyer D, Hornik K (2009a). Generalized and Customizable Sets in R. Journal of
-Statistical Software, 31(2), 1-27. DOI <a href="https://doi.org/10.18637/jss.v031.i02">https://doi.org/10.18637/jss.v031.i02</a>
+Statistical Software, 31(2), 1-27. DOI <a href="http://dx.doi.org/10.18637/jss.v031.i02">DOI:10.18637/jss.v031.i02</a>
 
-<li>Meyer D, Hornik K (2009b). sets: Sets, Generalized Sets, and Customizable Sets.
+<li>Meyer D, Hornik K (2009b). Sets: Sets, Generalized Sets, and Customizable Sets.
 R~package version~1.0, URL <a href="http://CRAN.R-project.org/package=sets">http://CRAN.R-project.org/package=sets</a>.
 </ul>
 

--- a/grass7/raster/r.fuzzy.system/r.fuzzy.system.html
+++ b/grass7/raster/r.fuzzy.system/r.fuzzy.system.html
@@ -305,12 +305,12 @@ risk, green, blue end so on moderate risk.
 
 <ul>
 <li>Jasiewicz, J. (2011). A new GRASS GIS fuzzy inference system for massive data analysis.
-Computers & Geosciences (37) 1525-1531. DOI <a href="https://doi.org/10.1016/j.cageo.2010.09.008">https://doi.org/10.1016/j.cageo.2010.09.008</a>
+Computers &amp; Geosciences (37) 1525-1531. DOI <a href="https://doi.org/10.1016/j.cageo.2010.09.008">https://doi.org/10.1016/j.cageo.2010.09.008</a>
 
 <li>Zadeh, L.A. (1965). "Fuzzy sets". Information and Control 8 (3): 338-353.
-<a href="https://doi.org/10.1016/S0019-9958(65)90241-X">DOI:10.1016/S0019-9958(65)90241-X</a>. ISSN 0019-9958.
+<a href="https://doi.org/10.1016/S0019-9958(65)90241-X">https://doi.org/10.1016/S0019-9958(65)90241-X</a>. ISSN 0019-9958.
 
-<li>Nov&aacute;k, V. (1989). Fuzzy Sets and Their Applications. Bristol: Adam Hilger.
+<li>Nov&aacute;k, Vil&eacute;m (1989). Fuzzy Sets and Their Applications. Bristol: Adam Hilger.
 ISBN 0-85274-583-4.
 
 <li>Klir, George J.; Yuan, Bo (1995). Fuzzy sets and fuzzy logic: theory and
@@ -323,7 +323,7 @@ foundations and applications. Englewood Cliffs, NJ: Prentice Hall. ISBN
 <li>Meyer D, Hornik K (2009a). Generalized and Customizable Sets in R. Journal of
 Statistical Software, 31(2), 1-27. DOI <a href="http://dx.doi.org/10.18637/jss.v031.i02">DOI:10.18637/jss.v031.i02</a>
 
-<li>Meyer D, Hornik K (2009b). sets: Sets, Generalized Sets, and Customizable Sets.
+<li>Meyer D, Hornik K (2009b). Sets: Sets, Generalized Sets, and Customizable Sets.
 R~package version~1.0, URL <a href="http://CRAN.R-project.org/package=sets">http://CRAN.R-project.org/package=sets</a>.
 </ul>
 

--- a/grass7/raster/r.green/r.green.biomassfor/r.green.biomassfor.technical/biomasfor.technical.py
+++ b/grass7/raster/r.green/r.green.biomassfor/r.green.biomassfor.technical/biomasfor.technical.py
@@ -85,7 +85,7 @@
 #%option
 #% key: energy_tops_hf
 #% type: double
-#% description: Energy for tops and branches in high forest in MWh/m³
+#% description: Energy for tops and branches in high forest in MWh/m^3
 #% answer: 0.49
 #% required : no
 #% guisection: Energy
@@ -93,7 +93,7 @@
 #%option
 #% key: energy_cormometric_vol_hf
 #% type: double
-#% description: Energy for tops and branches for high forest in MWh/m³
+#% description: Energy for tops and branches for high forest in MWh/m^3
 #% answer: 1.97
 #% required : no
 #% guisection: Energy
@@ -101,7 +101,7 @@
 #%option
 #% key: energy_tops_cop
 #% type: double
-#% description: Energy for tops and branches for Coppices in MWh/m³
+#% description: Energy for tops and branches for Coppices in MWh/m^3
 #% answer: 0.55
 #% required : no
 #% guisection: Energy

--- a/grass7/raster/r.green/r.green.gshp/r.green.gshp.theoretical/r.green.gshp.theoretical.py
+++ b/grass7/raster/r.green/r.green.gshp/r.green.gshp.theoretical/r.green.gshp.theoretical.py
@@ -267,9 +267,9 @@ def main(opts, flgs):
     borehole_length: [m]
         Borehole length, default: 100m
     ground_temperature: [°C]
-        Initial ground temperature, default: 10 °C
+        Initial ground temperature, default: 10 deg C
     fluid_limit_temperature: [°C]
-        Minimum or maximum fluid temperature, default: -2 °C
+        Minimum or maximum fluid temperature, default: -2 deg C
     """
     pid = os.getpid()
     DEBUG = flags['d']

--- a/grass7/raster/r.green/r.green.hydro/r.green.hydro.technical/r.green.hydro.technical.py
+++ b/grass7/raster/r.green/r.green.hydro/r.green.hydro.technical/r.green.hydro.technical.py
@@ -299,7 +299,7 @@ def losses_Colebrooke(discharge, length, diameter, epsilon=0.015):
 
         Parameters
         -----------
-        discharge: float [m³/s]
+        discharge: float [m^3/s]
             Design discharge
         length: float [m]
             Design length of the pipe/derivation
@@ -321,7 +321,7 @@ def losses_Colebrooke(discharge, length, diameter, epsilon=0.015):
         Solve the Colebrook-White formula and return 1/radq(f)
         Parameters
         -----------
-        discharge: float [m³/s]
+        discharge: float [m^3/s]
             Design discharge
         diameter: float [m]
             Design diameter for the derivation pipe
@@ -351,7 +351,7 @@ def losses_Strickler(discharge, length, diameter, theta, velocity, ks=75):
     Parameters
     -----------
 
-    discharge: float [m³/s]
+    discharge: float [m^3/s]
         Design discharge
     length: float [m]
         Design length of the pipe/derivation

--- a/grass7/raster/r.gsflow.hydrodem/r.gsflow.hydrodem.html
+++ b/grass7/raster/r.gsflow.hydrodem/r.gsflow.hydrodem.html
@@ -6,7 +6,7 @@
 
 Ng, G.-H. C., A. D. Wickert, R. L. McLaughlin, J. La Frenierre, S. Liess, and L. Sabeeri (2016),
 Modeling the role of groundwater and vegetation in the hydrological response of tropical
-glaciated watersheds to climate change, in AGU Fall Meeting Abstracts, H13L–1590, San
+glaciated watersheds to climate change, in AGU Fall Meeting Abstracts, H13L-1590, San
 Francisco, CA.
 
 <h2>SEE ALSO</h2>

--- a/grass7/raster/r.landscape.evol/r.landscape.evol.html
+++ b/grass7/raster/r.landscape.evol/r.landscape.evol.html
@@ -579,7 +579,7 @@ Equation) Monthly Erosivity Index from Readily Available Rainfall
 Data in Mediterranean Area. The Environmentalist 26, 63-70. <a
 href="https://doi.org/10.1007/s10669-006-5359-x">https://doi.org/10.1007/s10669-006-5359-x</a></p>
 
-<p>Hammad, A.A., Lundekvam, H., Børresen, T., 2004. Adaptation of RUSLE in
+<p>Hammad, A.A., Lundekvam, H., B&oslash;rresen, T., 2004. Adaptation of RUSLE in
 the Eastern Part of the Mediterranean Region. Environmental Management 34,
 829-841.</p>
 
@@ -591,7 +591,7 @@ Soils Conference. University of Sydney, Australia.</p>
 <p>Kelley, A.D., Malin, M.C., Nielson, G.M., 1988. Terrain simulation using
 a model of stream erosion. ACM SIGGRAPH Computer Graphics 22, 263-268.</p>
 
-<p>Koko, Š., 2011. Simulation of gully erosion using the SIMWE model and
+<p>Koko, &Scaron;., 2011. Simulation of gully erosion using the SIMWE model and
 GIS. Landform Analysis 17, 81-86.</p>
 
 <p>Kwang, J.S., Parker, G., 2017. Landscape evolution models using the stream
@@ -599,12 +599,12 @@ power incision model show unrealistic behavior when m / n equals 0.5.
 Earth Surface Dynamics 5, 807-820. <a
 href="https://doi.org/10.5194/esurf-5-807-2017">https://doi.org/10.5194/esurf-5-807-2017</a></p>
 
-<p>Martínez-Casasnovas, J.A., Sánchez-Bosch, I., 2000. Impact assessment
+<p>Mart&iacute;nez-Casasnovas, J.A., S&aacute;nchez-Bosch, I., 2000. Impact assessment
 of changes in land use/conservation practices on soil erosion in the
 Penedès-Anoia vineyard region (NE Spain). Soil and Tillage Research 57,
 101-106.</p>
 
-<p>Mathier, L., Roy, A.G., Paré, J.P., 1989. The effect of
+<p>Mathier, L., Roy, A.G., Par&eacute;, J.P., 1989. The effect of
 slope gradient and length on the parameters of a sediment
 transport equation for sheetwash. CATENA 16, 545-558. <a
 href="https://doi.org/10.1016/0341-8162(89)90041-6">https://doi.org/10.1016/0341-8162(89)90041-6</a></p>
@@ -648,7 +648,7 @@ in a catchment of Sicily (southern Italy). Environmental Geology 50,
 <p>Panagos, P., Ballabio, C., Borrelli, P., Meusburger, K., Klik,
 A., Rousseva, S., Tadi&#263;, M.P., Michaelides, S., Hrabal&iacute;kov&aacute;,
 M., Olsen, P., Aalto, J., Lakatos, M., Rymszewicz, A., Dumitrescu,
-A., Beguería, S., Alewell, C., 2015a. Rainfall erosivity in
+A., Beguer&iacute;a, S., Alewell, C., 2015a. Rainfall erosivity in
 Europe. Science of The Total Environment 511, 801-814. <a
 href="https://doi.org/10.1016/j.scitotenv.2015.01.008">https://doi.org/10.1016/j.scitotenv.2015.01.008</a></p>
 

--- a/grass7/raster/r.landscape.evol/r.landscape.evol.md
+++ b/grass7/raster/r.landscape.evol/r.landscape.evol.md
@@ -245,83 +245,83 @@ Mitasova, H., C. M. Barton, I. I. Ullah, J. Hofierka, and R. S. Harmon 2013 GIS-
 
 ## REFERENCES
 
-Aiello, A., Adamo, M., Canora, F., 2015. Remote sensing and GIS to assess soil erosion with RUSLE3D and USPED at river basin scale in southern Italy. CATENA 131, 174–185. https://doi.org/10.1016/j.catena.2015.04.003
+Aiello, A., Adamo, M., Canora, F., 2015. Remote sensing and GIS to assess soil erosion with RUSLE3D and USPED at river basin scale in southern Italy. CATENA 131, 174-185. https://doi.org/10.1016/j.catena.2015.04.003
 
-Aksoy, H., Kavvas, M.L., 2005. A review of hillslope and watershed scale erosion and sediment transport models. CATENA 64, 247–271. https://doi.org/10.1016/j.catena.2005.08.008
+Aksoy, H., Kavvas, M.L., 2005. A review of hillslope and watershed scale erosion and sediment transport models. CATENA 64, 247-271. https://doi.org/10.1016/j.catena.2005.08.008
 
-Ayala, G., French, C., 2005. Erosion modeling of past land-use practices in the Fiume di Sotto di Troina river valley, north-central Sicily. Geoarchaeology 20, 149–167.
+Ayala, G., French, C., 2005. Erosion modeling of past land-use practices in the Fiume di Sotto di Troina river valley, north-central Sicily. Geoarchaeology 20, 149-167.
 
-Benavidez, R., Jackson, B., Maxwell, D., Norton, K., 2018. A review of the (Revised) Universal Soil Loss Equation (R/USLE): with a view to increasing its global applicability and improving soil loss estimates. Hydrology and Earth System Sciences Discussions 1–34. https://doi.org/10.5194/hess-2018-68
+Benavidez, R., Jackson, B., Maxwell, D., Norton, K., 2018. A review of the (Revised) Universal Soil Loss Equation (R/USLE): with a view to increasing its global applicability and improving soil loss estimates. Hydrology and Earth System Sciences Discussions 1-34. https://doi.org/10.5194/hess-2018-68
 
-Bosco, C., de Rigo, D., Dewitte, O., Poesen, J., Panagos, P., 2015. Modelling soil erosion at European scale: towards harmonization and reproducibility. Natural Hazards and Earth System Science 15, 225–245. https://doi.org/10.5194/nhess-15-225-2015
+Bosco, C., de Rigo, D., Dewitte, O., Poesen, J., Panagos, P., 2015. Modelling soil erosion at European scale: towards harmonization and reproducibility. Natural Hazards and Earth System Science 15, 225-245. https://doi.org/10.5194/nhess-15-225-2015
 
-Davy, P., Crave, A., 2000. Upscaling local-scale transport processes in large-scale relief dynamics. Physics and Chemistry of the Earth, Part A: Solid Earth and Geodesy 25, 533–541. https://doi.org/10.1016/S1464-1895(00)00082-X
+Davy, P., Crave, A., 2000. Upscaling local-scale transport processes in large-scale relief dynamics. Physics and Chemistry of the Earth, Part A: Solid Earth and Geodesy 25, 533-541. https://doi.org/10.1016/S1464-1895(00)00082-X
 
-Dietrich, W.E., Bellugi, D.G., Sklar, L.S., Stock, J.D., Heimsath, A.M., Roering, J.J., 2003. Geomorphic Transport Laws for Predicting Landscape form and Dynamics, in: Wilcock, P.R., Iverson, R.M. (Eds.), Prediction in Geomorphology, Geophysical Monograph. American Geophysical Union, pp. 103–132.
+Dietrich, W.E., Bellugi, D.G., Sklar, L.S., Stock, J.D., Heimsath, A.M., Roering, J.J., 2003. Geomorphic Transport Laws for Predicting Landscape form and Dynamics, in: Wilcock, P.R., Iverson, R.M. (Eds.), Prediction in Geomorphology, Geophysical Monograph. American Geophysical Union, pp. 103-132.
 
-Diodato, N., 2006. Predicting RUSLE (Revised Universal Soil Loss Equation) Monthly Erosivity Index from Readily Available Rainfall Data in Mediterranean Area. The Environmentalist 26, 63–70. https://doi.org/10.1007/s10669-006-5359-x
+Diodato, N., 2006. Predicting RUSLE (Revised Universal Soil Loss Equation) Monthly Erosivity Index from Readily Available Rainfall Data in Mediterranean Area. The Environmentalist 26, 63-70. https://doi.org/10.1007/s10669-006-5359-x
 
-Hammad, A.A., Lundekvam, H., Børresen, T., 2004. Adaptation of RUSLE in the Eastern Part of the Mediterranean Region. Environmental Management 34, 829–841.
+Hammad, A.A., Lundekvam, H., Børresen, T., 2004. Adaptation of RUSLE in the Eastern Part of the Mediterranean Region. Environmental Management 34, 829-841.
 
-Hancock, G.R., 2004. Modelling soil erosion on the catchment and landscape scale using landscape evolution models – a probabilistic approach using digital elevation model error, in: Super Soil 2004:3rd Australian New Zealand Soils Conference. University of Sydney, Australia.
+Hancock, G.R., 2004. Modelling soil erosion on the catchment and landscape scale using landscape evolution models - a probabilistic approach using digital elevation model error, in: Super Soil 2004:3rd Australian New Zealand Soils Conference. University of Sydney, Australia.
 
-Kelley, A.D., Malin, M.C., Nielson, G.M., 1988. Terrain simulation using a model of stream erosion. ACM SIGGRAPH Computer Graphics 22, 263–268.
+Kelley, A.D., Malin, M.C., Nielson, G.M., 1988. Terrain simulation using a model of stream erosion. ACM SIGGRAPH Computer Graphics 22, 263-268.
 
-Koko, Š., 2011. Simulation of gully erosion using the SIMWE model and GIS. Landform Analysis 17, 81–86.
+Koko, Š., 2011. Simulation of gully erosion using the SIMWE model and GIS. Landform Analysis 17, 81-86.
 
-Kwang, J.S., Parker, G., 2017. Landscape evolution models using the stream power incision model show unrealistic behavior when &lt;i&gt;m&lt;/i&gt; ∕ &lt;i&gt;n&lt;/i&gt; equals 0.5. Earth Surface Dynamics 5, 807–820. https://doi.org/10.5194/esurf-5-807-2017
+Kwang, J.S., Parker, G., 2017. Landscape evolution models using the stream power incision model show unrealistic behavior when &lt;i&gt;m&lt;/i&gt; ∕ &lt;i&gt;n&lt;/i&gt; equals 0.5. Earth Surface Dynamics 5, 807-820. https://doi.org/10.5194/esurf-5-807-2017
 
-Martínez-Casasnovas, J.A., Sánchez-Bosch, I., 2000. Impact assessment of changes in land use/conservation practices on soil erosion in the Penedès-Anoia vineyard region (NE Spain). Soil and Tillage Research 57, 101–106.
+Martínez-Casasnovas, J.A., Sánchez-Bosch, I., 2000. Impact assessment of changes in land use/conservation practices on soil erosion in the Penedès-Anoia vineyard region (NE Spain). Soil and Tillage Research 57, 101-106.
 
-Mathier, L., Roy, A.G., Paré, J.P., 1989. The effect of slope gradient and length on the parameters of a sediment transport equation for sheetwash. CATENA 16, 545–558. https://doi.org/10.1016/0341-8162(89)90041-6
+Mathier, L., Roy, A.G., Paré, J.P., 1989. The effect of slope gradient and length on the parameters of a sediment transport equation for sheetwash. CATENA 16, 545-558. https://doi.org/10.1016/0341-8162(89)90041-6
 
-Mitasova, H., Barton, C.M., Ullah, I.I., Hofierka, J., Harmon, R.S., 2013. GIS-based soil erosion modeling, in: Shroder, J., Bishop, M.P. (Eds.), Remote Sensing and GIScience in Geomorphology, Treatise in Geomorphology. Academic Press, San Diego, pp. 228–258.
+Mitasova, H., Barton, C.M., Ullah, I.I., Hofierka, J., Harmon, R.S., 2013. GIS-based soil erosion modeling, in: Shroder, J., Bishop, M.P. (Eds.), Remote Sensing and GIScience in Geomorphology, Treatise in Geomorphology. Academic Press, San Diego, pp. 228-258.
 
 Mitasova, H., Brown, W.M., Johnston, D., 2002. Terrain Modeling and Soil Erosion Simulation Final Report. Geographic Modeling Systems Lab, University of Illinois at Urbana-Champaign.
 
-Mitasova, H., Hofierka, J., Zlocha, M., Iverson, L.R., 1996a. Modelling topographic potential for erosion and deposition using GIS. International journal of geographical information systems 10, 629–641. https://doi.org/10.1080/02693799608902101
+Mitasova, H., Hofierka, J., Zlocha, M., Iverson, L.R., 1996a. Modelling topographic potential for erosion and deposition using GIS. International journal of geographical information systems 10, 629-641. https://doi.org/10.1080/02693799608902101
 
-Mitasova, H., Mitas, L., Brown, W.M., 2001. Multiscale Simulation of Land Use Impact on Soil Erosion and Deposition Patterns, in: Stott, D.E., Mohtar, R.H., Steinhardt, G.C. (Eds.), Sustaining the Global Farm: 10th International Soil Conservation Organization Meeting Held May 24-29, 1999. Purdue University and the USDA-ARS National Soil Erosion Research Laboratory, pp. 1163–1169.
+Mitasova, H., Mitas, L., Brown, W.M., 2001. Multiscale Simulation of Land Use Impact on Soil Erosion and Deposition Patterns, in: Stott, D.E., Mohtar, R.H., Steinhardt, G.C. (Eds.), Sustaining the Global Farm: 10th International Soil Conservation Organization Meeting Held May 24-29, 1999. Purdue University and the USDA-ARS National Soil Erosion Research Laboratory, pp. 1163-1169.
 
 Mitasova, H., Mitas, L., Brown, W.M., Johnston, D., 1996b. Multidimensional Soil Erosion/Deposition Modeling Part III: Process based erosion simulation. Geographic Modeling and Systems Laboratory, University of Illinois at Urban-Champaign.
 
 Mitasova, H., Mitas, L., Brown, W.M., Johnston, D.M., 1999. Terrain modeling and Soil Erosion Simulations for Fort Hood and Fort Polk test areas. Geographic Modeling and Systems Laboratory, University of Illinois at Urbana-Champaign.
 
-Onori, F., De Bonis, P., Grauso, S., 2006. Soil erosion prediction at the basin scale using the revised universal soil loss equation (RUSLE) in a catchment of Sicily (southern Italy). Environmental Geology 50, 1129–1140.
+Onori, F., De Bonis, P., Grauso, S., 2006. Soil erosion prediction at the basin scale using the revised universal soil loss equation (RUSLE) in a catchment of Sicily (southern Italy). Environmental Geology 50, 1129-1140.
 
-Panagos, P., Ballabio, C., Borrelli, P., Meusburger, K., Klik, A., Rousseva, S., Tadić, M.P., Michaelides, S., Hrabalíková, M., Olsen, P., Aalto, J., Lakatos, M., Rymszewicz, A., Dumitrescu, A., Beguería, S., Alewell, C., 2015a. Rainfall erosivity in Europe. Science of The Total Environment 511, 801–814. https://doi.org/10.1016/j.scitotenv.2015.01.008
+Panagos, P., Ballabio, C., Borrelli, P., Meusburger, K., Klik, A., Rousseva, S., Tadić, M.P., Michaelides, S., Hrabalíková, M., Olsen, P., Aalto, J., Lakatos, M., Rymszewicz, A., Dumitrescu, A., Beguería, S., Alewell, C., 2015a. Rainfall erosivity in Europe. Science of The Total Environment 511, 801-814. https://doi.org/10.1016/j.scitotenv.2015.01.008
 
-Panagos, P., Borrelli, P., Meusburger, K., Alewell, C., Lugato, E., Montanarella, L., 2015b. Estimating the soil erosion cover-management factor at the European scale. Land Use Policy 48, 38–50. https://doi.org/10.1016/j.landusepol.2015.05.021
+Panagos, P., Borrelli, P., Meusburger, K., Alewell, C., Lugato, E., Montanarella, L., 2015b. Estimating the soil erosion cover-management factor at the European scale. Land Use Policy 48, 38-50. https://doi.org/10.1016/j.landusepol.2015.05.021
 
-Panagos, P., Borrelli, P., Meusburger, K., van der Zanden, E.H., Poesen, J., Alewell, C., 2015c. Modelling the effect of support practices (P-factor) on the reduction of soil erosion by water at European scale. Environmental Science & Policy 51, 23–34. https://doi.org/10.1016/j.envsci.2015.03.012
+Panagos, P., Borrelli, P., Meusburger, K., van der Zanden, E.H., Poesen, J., Alewell, C., 2015c. Modelling the effect of support practices (P-factor) on the reduction of soil erosion by water at European scale. Environmental Science & Policy 51, 23-34. https://doi.org/10.1016/j.envsci.2015.03.012
 
-Panagos, P., Meusburger, K., Ballabio, C., Borrelli, P., Alewell, C., 2014. Soil erodibility in Europe: A high-resolution dataset based on LUCAS. Science of The Total Environment 479–480, 189–200. https://doi.org/10.1016/j.scitotenv.2014.02.010
+Panagos, P., Meusburger, K., Ballabio, C., Borrelli, P., Alewell, C., 2014. Soil erodibility in Europe: A high-resolution dataset based on LUCAS. Science of The Total Environment 479-480, 189-200. https://doi.org/10.1016/j.scitotenv.2014.02.010
 
-Peckham, S.D., 2003. Fluvial landscape models and catchment-scale sediment transport. Global and Planetary Change 39, 31–51. https://doi.org/10.1016/S0921-8181(03)00014-6
+Peckham, S.D., 2003. Fluvial landscape models and catchment-scale sediment transport. Global and Planetary Change 39, 31-51. https://doi.org/10.1016/S0921-8181(03)00014-6
 
-Peeters, I., Rommens, T., Verstraeten, G., Govers, G., Van Rompaey, A., Poesen, J., Van Oost, K., 2006. Reconstructing ancient topography through erosion modelling. Geomorphology 78, 250–264.
+Peeters, I., Rommens, T., Verstraeten, G., Govers, G., Van Rompaey, A., Poesen, J., Van Oost, K., 2006. Reconstructing ancient topography through erosion modelling. Geomorphology 78, 250-264.
 Pistocchi, A., Cassani, G., Zani, O., n.d. Use of the USPED model for mapping soil erosion and managing best land conservation practices 7.
 
-Renard, K.G., Foster, G.R., Weesies, G.A., McCool, D.K., Yoder, D.C., 1997. Predicting soil erosion by water: a guide to conservation planning with the Revised Universal Soil Loss Equation (RUSLE), in: Agriculture Handbook. US Department of Agriculture, Washington, DC, pp. 1–251.
+Renard, K.G., Foster, G.R., Weesies, G.A., McCool, D.K., Yoder, D.C., 1997. Predicting soil erosion by water: a guide to conservation planning with the Revised Universal Soil Loss Equation (RUSLE), in: Agriculture Handbook. US Department of Agriculture, Washington, DC, pp. 1-251.
 
-Renard, K.G., Foster, G.R., Weesies, G.A., Porter, J.P., 1991. RUSLE: Revised Universal Soil Loss Equation. Journal of Soil and Water Conservation 46, 30–33.
+Renard, K.G., Foster, G.R., Weesies, G.A., Porter, J.P., 1991. RUSLE: Revised Universal Soil Loss Equation. Journal of Soil and Water Conservation 46, 30-33.
 
-Renard, K.G., Freimund, J.R., 1994. Using monthly precipitation data to estimate the R-factor in the revised USLE. Journal of Hydrology 157, 287–306.
+Renard, K.G., Freimund, J.R., 1994. Using monthly precipitation data to estimate the R-factor in the revised USLE. Journal of Hydrology 157, 287-306.
 
 
-Sklar, L.S., Riebe, C.S., Marshall, J.A., Genetti, J., Leclere, S., Lukens, C.L., Merces, V., 2017. The problem of predicting the size distribution of sediment supplied by hillslopes to rivers. Geomorphology 277, 31–49. https://doi.org/10.1016/j.geomorph.2016.05.005
+Sklar, L.S., Riebe, C.S., Marshall, J.A., Genetti, J., Leclere, S., Lukens, C.L., Merces, V., 2017. The problem of predicting the size distribution of sediment supplied by hillslopes to rivers. Geomorphology 277, 31-49. https://doi.org/10.1016/j.geomorph.2016.05.005
 
-Terranova, O., Antronico, L., Coscarelli, R., Iaquinta, P., 2009. Soil erosion risk scenarios in the Mediterranean environment using RUSLE and GIS: An application model for Calabria (southern Italy). Geomorphology 112, 228–245. https://doi.org/10.1016/j.geomorph.2009.06.009
+Terranova, O., Antronico, L., Coscarelli, R., Iaquinta, P., 2009. Soil erosion risk scenarios in the Mediterranean environment using RUSLE and GIS: An application model for Calabria (southern Italy). Geomorphology 112, 228-245. https://doi.org/10.1016/j.geomorph.2009.06.009
 
-Tucker, G.E., Whipple, K.X., 2002. Topographic outcomes predicted by stream erosion models: Sensitivity analysis and intermodel comparison. J. Geophys. Res 107, 1–1.
+Tucker, G.E., Whipple, K.X., 2002. Topographic outcomes predicted by stream erosion models: Sensitivity analysis and intermodel comparison. J. Geophys. Res 107, 1-1.
 
-Warren, S.D., Mitasova, H., Hohmann, M.G., Landsberger, S., Skander, F.Y., Ruzycki, T.S., Senseman, G.M., 2005. Validation of a 3-D enhancement of the Universal Soil Loss Equation for preediction of soil erosion and sediment deposition. Catena 64, 281–296.
+Warren, S.D., Mitasova, H., Hohmann, M.G., Landsberger, S., Skander, F.Y., Ruzycki, T.S., Senseman, G.M., 2005. Validation of a 3-D enhancement of the Universal Soil Loss Equation for preediction of soil erosion and sediment deposition. Catena 64, 281-296.
 
 Whipple, K.X., Tucker, G.E., 2002. Implications of sediment-flux-dependent river incision models for landscape evolution. Journal of Geophysical Research 107.
 
 Whipple, K.X., Tucker, G.E., 1999. Dynamics of the stream-power river incision model; implications for height limits of mountain ranges, landscape response timescales, and research needs. Journal of Geophysical Research 104, 17,661-17,674.
 
-Willgoose, G., 2005. Mathematical Modeling of Whole Landscape Evolution. Annual Review of Earth and Planetary Sciences 33, 443–459.
+Willgoose, G., 2005. Mathematical Modeling of Whole Landscape Evolution. Annual Review of Earth and Planetary Sciences 33, 443-459.
 
 <h2>AUTHORS</h2>
 Isaac I. Ullah, C. Michael Barton, and Helena Mitasova

--- a/grass7/raster/r.maxent.lambdas/r.maxent.lambdas.html
+++ b/grass7/raster/r.maxent.lambdas/r.maxent.lambdas.html
@@ -46,7 +46,7 @@ precision from the 7th decimal place onwards may occur in the logistic output.
 r.out.maxent_swd, r.in.xyz<br>
 
 MaxEnt 3.3.3e <a href="http://biodiversityinformatics.amnh.org/open_source/maxent/">http://biodiversityinformatics.amnh.org/open_source/maxent/</a><br>
-Jane Elith, Steven J. Phillips, Trevor Hastie, Miroslav Dudík, Yung En Chee, Colin J. Yates. 2011: A statistical explanation of MaxEnt 
+Jane Elith, Steven J. Phillips, Trevor Hastie, Miroslav Dud&iacute;k, Yung En Chee, Colin J. Yates. 2011: A statistical explanation of MaxEnt 
 for ecologists. Diversity and Distributions, (17):43-57, 2011.<br>
 
 Wilson, Peter D. 2009: Guidelines for computing MaxEnt model output values from a lambdas file. (Available at <a href="https://groups.google.com/group/MaxEnt">
@@ -55,7 +55,7 @@ https://groups.google.com/group/MaxEnt</a>)
 Steven J. Phillips, Robert P. Anderson, Robert E. Schapire. 2006: Maximum entropy modeling of species geographic distributions. 
 Ecological Modelling, (190):231-259, 2006.<br>
 
-Steven J. Phillips, Miroslav Dudík, Robert E. Schapire. 2004: A maximum entropy approach to species distribution modeling. In: Proceedings 
+Steven J. Phillips, Miroslav Dud&iacute;k, Robert E. Schapire. 2004: A maximum entropy approach to species distribution modeling. In: Proceedings 
 of the Twenty-First International Conference on Machine Learning, p. 655-662, 2004.
 
 <h2>AUTHOR</h2>

--- a/grass7/raster/r.mess/r.mess.py
+++ b/grass7/raster/r.mess/r.mess.py
@@ -7,7 +7,7 @@
 # AUTHOR(S):    Paulo van Breugel <paulo ecodiv earth>
 # PURPOSE:      Calculate the multivariate environmental similarity
 #               surface (MESS) as proposed by Elith et al., 2010,
-#               Methods in Ecology & Evolution, 1(330–342).
+#               Methods in Ecology & Evolution, 1(330-342).
 #
 # COPYRIGHT: (C) 2014-2017 by Paulo van Breugel and the GRASS Development Team
 #

--- a/grass7/raster/r.pops.spread/README.md
+++ b/grass7/raster/r.pops.spread/README.md
@@ -22,7 +22,7 @@ If you use this software or code, please cite the following papers:
 * Ross K. Meentemeyer, Nik J. Cunniffe, Alex R. Cook, Joao A. N. Filipe,
   Richard D. Hunter, David M. Rizzo, and Christopher A. Gilligan, 2011.
   Epidemiological modeling of invasion in heterogeneous landscapes:
-  spread of sudden oak death in California (1990–2030).
+  spread of sudden oak death in California (1990-2030).
   *Ecosphere* 2:art17.
   [DOI: 10.1890/ES10-00192.1](https://doi.org/10.1890/ES10-00192.1)
 

--- a/grass7/raster/r.pops.spread/pops-core/README.md
+++ b/grass7/raster/r.pops.spread/pops-core/README.md
@@ -23,7 +23,7 @@ If you use this software or code, please cite the following papers:
 * Ross K. Meentemeyer, Nik J. Cunniffe, Alex R. Cook, Joao A. N. Filipe,
   Richard D. Hunter, David M. Rizzo, and Christopher A. Gilligan, 2011.
   Epidemiological modeling of invasion in heterogeneous landscapes:
-  spread of sudden oak death in California (1990–2030).
+  spread of sudden oak death in California (1990-2030).
   *Ecosphere* 2:art17.
   [DOI: 10.1890/ES10-00192.1](https://doi.org/10.1890/ES10-00192.1)
 

--- a/grass7/raster/r.series.diversity/r.series.diversity.html
+++ b/grass7/raster/r.series.diversity/r.series.diversity.html
@@ -78,7 +78,7 @@ for <i>alpha=2</i>. With this index, 0 represents infinite diversity
 and 1, no diversity. As this is counterintuitive behavior for a 
 diversity index, we use <i>1 - D</i> (Gini, 1912; Simpson, 1949). This 
 is also called the probability of interspecific encounter (PIE) or the 
-Gini–Simpson index. The index represents the probability that two 
+Gini-Simpson index. The index represents the probability that two 
 individuals randomly selected from a sample will belong to different 
 species. The value ranges between 0 and 1, with greater values 
 representing greater sample diversity. The name of the output layer 

--- a/grass7/raster/r.series.filter/r.series.filter.py
+++ b/grass7/raster/r.series.filter/r.series.filter.py
@@ -165,7 +165,7 @@ def close_rasters(raster_list):
 def _filter_up(method, arr, winsize, order):
     """Filter array using algorithm from the next article:
         Chen, Jin, et al. "A simple method for reconstructing a high-quality
-        NDVI time-series data set based on the Savitzky–Golay filter."
+        NDVI time-series data set based on the Savitzky-Golay filter."
         Remote sensing of Environment 91.3 (2004): 332-344.
     """
 

--- a/grass7/raster/r.sim.water.mp/r.sim.water.mp.html
+++ b/grass7/raster/r.sim.water.mp/r.sim.water.mp.html
@@ -227,7 +227,7 @@ GRASS users conference 2002 - Trento, Italy, 11-13 September 2002.
 
 <li> Hofierka, J., Knutova, M., 2015,
 Simulating aspects of a flash flood using the Monte Carlo method and
-GRASS GIS: a case study of the Malá Svinka Basin (Slovakia),
+GRASS GIS: a case study of the Mal&aacute; Svinka Basin (Slovakia),
 Open Geosciences. Volume 7, Issue 1, ISSN (Online) 2391-5447, DOI:
 <a href="http://dx.doi.org/10.1515/geo-2015-0013">10.1515/geo-2015-0013</a>,
 April 2015

--- a/grass7/vector/v.class.mlR/v.class.mlR.html
+++ b/grass7/vector/v.class.mlR/v.class.mlR.html
@@ -184,7 +184,7 @@ v.class.mlR segments_file=segstats.csv training_file=training.csv train_class_co
 
 <p>
 <ul>
-	<li>Moreno-Seco, F. et al. (2006), Comparison of Classifier Fusion Methods for Classification in Pattern Recognition Tasks. In D.-Y. Yeung et al., eds. Structural, Syntactic, and Statistical Pattern Recognition. Lecture Notes in Computer Science. Springer Berlin Heidelberg, pp. 705–713, <a href="http://dx.doi.org/10.1007/11815921_77">http://dx.doi.org/10.1007/11815921_77</a>.</li>
+	<li>Moreno-Seco, F. et al. (2006), Comparison of Classifier Fusion Methods for Classification in Pattern Recognition Tasks. In D.-Y. Yeung et al., eds. Structural, Syntactic, and Statistical Pattern Recognition. Lecture Notes in Computer Science. Springer Berlin Heidelberg, pp. 705-713, <a href="http://dx.doi.org/10.1007/11815921_77">http://dx.doi.org/10.1007/11815921_77</a>.</li>
 	<li> Georganos, S. et al (2018), Less is more: optimizing classification performance through feature selection in a very-high-resolution remote sensing object-based urban application, GIScience and Remote Sensing, 55:2, 221-242, DOI: 10.1080/15481603.2017.1408892</li>
 </ul>
 
@@ -198,7 +198,7 @@ v.class.mlR segments_file=segstats.csv training_file=training.csv train_class_co
 </em>
 
 <h2>AUTHOR</h2>
-Moritz Lennert, Université Libre de Bruxelles (ULB)
+Moritz Lennert, Universit&eacute; Libre de Bruxelles (ULB)
 based on an initial R-script by Ruben Van De Kerchove, also ULB at the time
 
 <!--

--- a/grass7/vector/v.gsflow.export/v.gsflow.export.html
+++ b/grass7/vector/v.gsflow.export/v.gsflow.export.html
@@ -8,7 +8,7 @@ These outputs comprise many ASCII files that are read in by GSFLOW.
 
 <h2>REFERENCES</h2>
 
-Ng, G.-H. C., A. D. Wickert, R. L. McLaughlin, J. La Frenierre, S. Liess, and L. Sabeeri (2016), Modeling the role of groundwater and vegetation in the hydrological response of tropical glaciated watersheds to climate change, in AGU Fall Meeting Abstracts, H13L–1590, San Francisco, CA.
+Ng, G.-H. C., A. D. Wickert, R. L. McLaughlin, J. La Frenierre, S. Liess, and L. Sabeeri (2016), Modeling the role of groundwater and vegetation in the hydrological response of tropical glaciated watersheds to climate change, in AGU Fall Meeting Abstracts, H13L-1590, San Francisco, CA.
 
 <h2>SEE ALSO</h2>
 

--- a/grass7/vector/v.gsflow.gravres/v.gsflow.gravres.html
+++ b/grass7/vector/v.gsflow.gravres/v.gsflow.gravres.html
@@ -6,7 +6,7 @@
 
 Ng, G.-H. C., A. D. Wickert, R. L. McLaughlin, J. La Frenierre, S. Liess, and L. Sabeeri (2016),
 Modeling the role of groundwater and vegetation in the hydrological response of tropical
-glaciated watersheds to climate change, in AGU Fall Meeting Abstracts, H13L–1590, San
+glaciated watersheds to climate change, in AGU Fall Meeting Abstracts, H13L-1590, San
 Francisco, CA.
 
 <h2>SEE ALSO</h2>

--- a/grass7/vector/v.gsflow.grid/v.gsflow.grid.html
+++ b/grass7/vector/v.gsflow.grid/v.gsflow.grid.html
@@ -6,7 +6,7 @@
 
 Ng, G.-H. C., A. D. Wickert, R. L. McLaughlin, J. La Frenierre, S. Liess, and L. Sabeeri (2016),
 Modeling the role of groundwater and vegetation in the hydrological response of tropical
-glaciated watersheds to climate change, in AGU Fall Meeting Abstracts, H13L–1590, San
+glaciated watersheds to climate change, in AGU Fall Meeting Abstracts, H13L-1590, San
 Francisco, CA.
 
 <h2>AUTHORS</h2>

--- a/grass7/vector/v.gsflow.hruparams/v.gsflow.hruparams.html
+++ b/grass7/vector/v.gsflow.hruparams/v.gsflow.hruparams.html
@@ -6,7 +6,7 @@
 
 Ng, G.-H. C., A. D. Wickert, R. L. McLaughlin, J. La Frenierre, S. Liess, and L. Sabeeri (2016),
 Modeling the role of groundwater and vegetation in the hydrological response of tropical
-glaciated watersheds to climate change, in AGU Fall Meeting Abstracts, H13L–1590, San
+glaciated watersheds to climate change, in AGU Fall Meeting Abstracts, H13L-1590, San
 Francisco, CA.
 
 <h2>SEE ALSO</h2>

--- a/grass7/vector/v.gsflow.reaches/v.gsflow.reaches.html
+++ b/grass7/vector/v.gsflow.reaches/v.gsflow.reaches.html
@@ -6,7 +6,7 @@
 
 Ng, G.-H. C., A. D. Wickert, R. L. McLaughlin, J. La Frenierre, S. Liess, and L. Sabeeri (2016),
 Modeling the role of groundwater and vegetation in the hydrological response of tropical
-glaciated watersheds to climate change, in AGU Fall Meeting Abstracts, H13L–1590, San
+glaciated watersheds to climate change, in AGU Fall Meeting Abstracts, H13L-1590, San
 Francisco, CA.
 
 <h2>SEE ALSO</h2>

--- a/grass7/vector/v.gsflow.segments/v.gsflow.segments.html
+++ b/grass7/vector/v.gsflow.segments/v.gsflow.segments.html
@@ -6,7 +6,7 @@
 
 Ng, G.-H. C., A. D. Wickert, R. L. McLaughlin, J. La Frenierre, S. Liess, and L. Sabeeri (2016),
 Modeling the role of groundwater and vegetation in the hydrological response of tropical
-glaciated watersheds to climate change, in AGU Fall Meeting Abstracts, H13L–1590, San
+glaciated watersheds to climate change, in AGU Fall Meeting Abstracts, H13L-1590, San
 Francisco, CA.
 
 <h2>SEE ALSO</h2>

--- a/grass7/vector/v.in.redwg/v.in.redwg.html
+++ b/grass7/vector/v.in.redwg/v.in.redwg.html
@@ -31,7 +31,7 @@ Not all entity types are supported (warning printed).
 
 <h2>AUTHOR</h2>
 
-Rodrigo Rodrigues da Silva (pitanga at members dot fsf dot org), São Paulo, Brazil
+Rodrigo Rodrigues da Silva (pitanga at members dot fsf dot org), S&atilde;o Paulo, Brazil
 <br>based on original code by Radim Blazek, ITC-Irst, Trento, Italy
 
 <!--

--- a/grass7/vector/v.in.wfs2/v.in.wfs2.html
+++ b/grass7/vector/v.in.wfs2/v.in.wfs2.html
@@ -22,7 +22,7 @@ v.in.wfs2 url=http://www2.dmsolutions.ca/cgi-bin/mswfs_gmap output=parks srs=423
 
 <h2>AUTHORS</h2>
 
-Štěpán Turek
+&Scaron;t&ecaron;p&aacute;n Turek
 
 <!--
 <p>

--- a/grass7/vector/v.mapcalc/v.mapcalc.py
+++ b/grass7/vector/v.mapcalc/v.mapcalc.py
@@ -2,7 +2,7 @@
 
 """
 MODULE:       v.mapcalc
-AUTHOR(S):    Thomas Leppelt, Soeren Gebbert, Thünen Institut Germany,
+AUTHOR(S):    Thomas Leppelt, Soeren Gebbert, Thuenen Institut Germany,
 
 PURPOSE:      Vector map algebra
 COPYRIGHT:    (C) 2013-2015 by the GRASS Development Team

--- a/grass7/vector/v.maxent.swd/v.maxent.swd.html
+++ b/grass7/vector/v.maxent.swd/v.maxent.swd.html
@@ -39,14 +39,14 @@ and subsequently used in other models / functions.
 <h2>REFERENCES</h2>
 
 <ul>
-    <li> Steven J. Phillips, Miroslav Dudík, Robert E. Schapire.A maximum
+    <li> Steven J. Phillips, Miroslav Dud&iacute;k, Robert E. Schapire.A maximum
     entropy approach to species distribution modeling. In Proceedings of the
     Twenty-First International Conference on Machine Learning, pages 655-662,
     2004.</li>
     <li>Steven J. Phillips, Robert P. Anderson, Robert E. Schapire. Maximum
     entropy modeling of species geographic distributions. Ecological Modelling,
     190:231-259, 2006.</li>
-    <li>Jane Elith, Steven J. Phillips, Trevor Hastie, Miroslav Dudík, Yung En
+    <li>Jane Elith, Steven J. Phillips, Trevor Hastie, Miroslav Dud&iacute;k, Yung En
     Chee, Colin J. Yates. A statistical explanation of MaxEnt for ecologists.
     Diversity and Distributions, 17:43-57, 2011. </li>
 </ul>

--- a/grass7/vector/v.stream.inbasin/v.stream.inbasin.html
+++ b/grass7/vector/v.stream.inbasin/v.stream.inbasin.html
@@ -6,7 +6,7 @@
 
 Ng, G.-H. C., A. D. Wickert, R. L. McLaughlin, J. La Frenierre, S. Liess, and L. Sabeeri (2016),
 Modeling the role of groundwater and vegetation in the hydrological response of tropical
-glaciated watersheds to climate change, in AGU Fall Meeting Abstracts, H13L–1590, San
+glaciated watersheds to climate change, in AGU Fall Meeting Abstracts, H13L-1590, San
 Francisco, CA.
 
 <h2>SEE ALSO</h2>


### PR DESCRIPTION
This PR replaces numerous special characters g.extension on Windows is unable to deal with, as reported in https://github.com/OSGeo/grass/issues/1499.

The main problem appears to be ASCII vs UTF-8 encoding confusion.