### PR TITLE
i.sentinel.download: try/except tqdm import

### DIFF
--- a/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -168,7 +168,6 @@ import requests
 import xml.etree.ElementTree as ET
 import shutil
 import sys
-from tqdm import tqdm
 import logging
 import time
 from collections import OrderedDict
@@ -178,6 +177,11 @@ try:
     import pandas
 except ImportError as e:
     gs.fatal(_("Module requires pandas library: {}").format(e))
+
+try:
+    from tqdm import tqdm
+except ImportError as e:
+    gs.fatal(_("Module requires tqdm library: {}").format(e))
 
 
 def create_dir(dir):


### PR DESCRIPTION
Fixes broken manual page creation on GRASS GIS server:

```
Traceback (most recent call last):
  File "/home/neteler/.grass7/addons/scripts/i.sentinel.download", line 171, in <module>
    from tqdm import tqdm
ModuleNotFoundError: No module named 'tqdm'
make[1]: *** [/home/neteler/src/releasebranch_7_8/dist.x86_64-pc-linux-gnu//include/Make/Html.make:14: i.sentinel.download.tmp.html] Error 1
```