### PR TITLE
r.catchment: read stdout as text, Python 3 update

### DIFF
--- a/src/raster/r.catchment/r.catchment.py
+++ b/src/raster/r.catchment/r.catchment.py
@@ -142,7 +142,12 @@ import grass.script as grass
 def out2dictnum(m, n, o):
     """Execute a grass command, and parse it to a dictionary
     This works differently than standard grass.parse_command syntax"""
-    p1 = subprocess.Popen("%s" % m, stdout=subprocess.PIPE, shell="bash")
+    p1 = subprocess.Popen(
+        "%s" % m,
+        stdout=subprocess.PIPE,
+        shell=True,
+        universal_newlines=True,
+    )
     p2 = p1.stdout.readlines()
     for y in p2:
         y0, y1 = y.split("%s" % n)


### PR DESCRIPTION
Fixes failure of r.catchment, likely introduced by changes in Python 3.

```
r.catchment --overwrite elevation=elev_srtm_30m@PERMANENT start_points=startinsite@user1 buffer=catchmentbuff area=5000000 map_val=1
WARNING: Bug in UI description. Description for option <b> missing
WARNING: Bug in UI description. Description for option <c> missing
WARNING: Bug in UI description. Description for option <d> missing
Wanted buffer area=5000000
Traceback (most recent call last):
  File "/Users/nila/Library/GRASS/7.9/Modules/scripts/r.c
atchment", line 379, in <module>
    main()
  File "/Users/nila/Library/GRASS/7.9/Modules/scripts/r.c
atchment", line 294, in main
    out2dictnum('r.stats -Aani input=' + cost +
  File "/Users/nila/Library/GRASS/7.9/Modules/scripts/r.c
atchment", line 147, in out2dictnum
    y0, y1 = y.split('%s' % n)
TypeError: a bytes-like object is required, not 'str'
```

Tested on Mac with Python 3.8.8 and Windows with Python 3.7.0.