### PR TITLE
i.sentinel.mask: adapt for non-SQlite vector databases

### DIFF
--- a/grass7/imagery/i.sentinel/i.sentinel.mask/i.sentinel.mask.py
+++ b/grass7/imagery/i.sentinel/i.sentinel.mask/i.sentinel.mask.py
@@ -498,12 +498,14 @@ def main ():
                 gscript.run_command('v.centroids',
                     input=tmp["shadow_temp_mask"],
                     output=tmp["centroid"], quiet=True)
-                gscript.run_command('v.db.droptable',
-                    map=tmp["centroid"],
-                    flags='f', quiet=True)
+                # drop table only if it exists
+                if len(gscript.parse_command("v.db.connect", flags="p", map=tmp["centroid"])) > 0:
+                    gscript.run_command('v.db.droptable',
+                        map=tmp["centroid"],
+                        flags='f', quiet=True)
                 gscript.run_command('v.db.addtable',
                     map=tmp["centroid"],
-                    columns='value', quiet=True)
+                    columns='value integer', quiet=True)
                 gscript.run_command('v.db.update',
                     map=tmp["centroid"],
                     layer=1,
@@ -527,22 +529,25 @@ def main ():
                     output=tmp["addcat"],
                     option='add',
                     quiet=True)
-                gscript.run_command('v.db.droptable',
-                    map=tmp["addcat"],
-                    flags='f', quiet=True)
+                # drop table only if it exists
+                if len(gscript.parse_command("v.db.connect", flags="p", map=tmp["addcat"])) > 0:
+                    gscript.run_command('v.db.droptable',
+                        map=tmp["addcat"],
+                        flags='f', quiet=True)
                 gscript.run_command('v.db.addtable',
                     map=tmp["addcat"],
-                    columns='value', quiet=True)
+                    columns='value integer', quiet=True)
 
                 # End shadow mask preparation
                 # Start cloud mask preparation
-
-                gscript.run_command('v.db.droptable',
-                    map=cloud_mask,
-                    flags='f', quiet=True)
+                # drop table only if it exists
+                if len(gscript.parse_command("v.db.connect", flags="p", map=cloud_mask)) > 0:
+                    gscript.run_command('v.db.droptable',
+                        map=cloud_mask,
+                        flags='f', quiet=True)
                 gscript.run_command('v.db.addtable',
                     map=cloud_mask,
-                    columns='value', quiet=True)
+                    columns='value integer', quiet=True)
 
                 # End cloud mask preparation
                 # Shift cloud mask using dE e dN
@@ -617,10 +622,6 @@ def main ():
                         output=tmp["overlay"],
                         overwrite=True,
                         quiet=True, stderr=subprocess.DEVNULL)
-                    gscript.run_command('v.db.addcolumn',
-                        map=tmp["overlay"],
-                        columns='area double',
-                        quiet=True)
                     area = gscript.read_command('v.to.db',
                         map=tmp["overlay"],
                         option='area',


### PR DESCRIPTION
This PR adaps i.sentinel.mask such that it works in a mapset with a non-SQlite vector database connection. SQlite allows some simplifications of commands that are not possible in other systems (tested here with PostgreSQL):

- when running `v.db.addtable` to also add new columns, the datatype of the column must be indicated
- running `v.db.droptable` only works if the table exists in the database, it will otherwise throw an error. Because of this, a check is now implemented beforehand
- running `v.to.db` already creates an appropriate column so it is not necessary to create the column with `v.db.addcolumn` beforehand.