### PR TITLE
i.modis.download: more reasonable error handling

### DIFF
--- a/grass7/imagery/i.modis/i.modis.download/i.modis.download.html
+++ b/grass7/imagery/i.modis/i.modis.download/i.modis.download.html
@@ -65,7 +65,19 @@ to 270 MB and the LST product ranges from 2 MB to 21 MB.
 
 <h2>EXAMPLES</h2>
 
+<h3>MODIS NDVI Global</h3>
+
+Download of the global MODIS product <em>MOD13C1 - MODIS/Terra Vegetation Indices
+16-Day L3 Global 0.05Deg CMG V006</em> by selecting a specific month, using the
+credentials conveniently stored in <pre>$HOME/.netrc</pre> file:
+
+<div class="code"><pre>
+# note: provided in Geographic Lat/Long Grid
+i.modis.download product=ndvi_terra_sixteen_5600 startday=2020-05-01 endday=2020-05-31 folder=/path/to/modisdata/
+</pre></div>
+
 <h3>MODIS Land Surface Temperature</h3>
+
 Download of the daily MODIS LST product "lst_terra_daily_1000" from the
 Terra satellite using the default options (all available tiles from newest
 available date) and passing the user and password through standard input.
@@ -73,7 +85,7 @@ Note that when settings is read from standard input, the option folder
 must be specified:
 
 <div class="code"><pre>
-i.modis.download settings=- folder=/tmp
+i.modis.download settings=- folder=/path/to/modisdata/
 </pre></div>
 
 <p>
@@ -90,7 +102,7 @@ Download of the LST Terra product using the default options and change of
 the starting and ending dates to custom values:
 
 <div class="code"><pre>
-i.modis.download settings=$HOME/.grass7/i.modis/SETTING startday=2011-05-01 endday=2011-05-31
+i.modis.download settings=$HOME/.grass7/i.modis/SETTING startday=2011-05-01 endday=2011-05-31 folder=/path/to/modisdata/
 </pre></div>
 
 <h3>MODIS Snow</h3>
@@ -99,7 +111,7 @@ Download of a different product (here: <em>Snow eight days 500 m</em>),
 default options (for settings, see example above):
 
 <div class="code"><pre>
-i.modis.download settings=$HOME/.grass7/i.modis/SETTING product=snow_terra_eight_500
+i.modis.download settings=$HOME/.grass7/i.modis/SETTING product=snow_terra_eight_500 folder=/path/to/modisdata/
 </pre></div>
 
 <h3>MODIS NDVI Global</h3>
@@ -108,7 +120,7 @@ Download of a global MODIS product (here: <em>MOD13C1 - MODIS/Terra Vegetation I
 16-Day L3 Global 0.05Deg CMG V006</em>), of a specific month (for settings, see example above):
 <div class="code"><pre>
 # note: provided in Geographic Lat/Long Grid
-i.modis.download settings=$HOME/.grass7/i.modis/SETTING product=ndvi_terra_sixteen_5600 startday=2011-05-01 endday=2011-05-31
+i.modis.download settings=$HOME/.grass7/i.modis/SETTING product=ndvi_terra_sixteen_5600 startday=2011-05-01 endday=2011-05-31 folder=/path/to/modisdata/
 </pre></div>
 
 <h3>Download of MODIS data in scripts</h3>
@@ -118,7 +130,7 @@ the user needs to set the <em>-g</em> flag to return the name of the file that
 contains the list of downloaded HDF files:
 
 <div class="code"><pre>
-i.modis.download -g settings=$HOME/.grass7/i.modis/SETTING startday=2011-05-01 endday=2011-05-31
+i.modis.download -g settings=$HOME/.grass7/i.modis/SETTING startday=2011-05-01 endday=2011-05-31 folder=/path/to/modisdata/
 </pre></div>
 
 <h2>SEE ALSO</h2>

--- a/grass7/imagery/i.modis/i.modis.download/i.modis.download.py
+++ b/grass7/imagery/i.modis/i.modis.download/i.modis.download.py
@@ -225,12 +225,6 @@ def main():
                                 "close this GRASS GIS session"))
             if check_folder(path):
                 fold = path
-    # check the version
-    version = grass.core.version()
-    # this is would be set automatically
-    if version['version'].find('7.') == -1:
-        grass.fatal(_('GRASS GIS version 7 required'))
-        return 0
     # the product
     products = options['product'].split(',')
     # first date and delta

--- a/grass7/imagery/i.modis/i.modis.download/i.modis.download.py
+++ b/grass7/imagery/i.modis/i.modis.download/i.modis.download.py
@@ -261,7 +261,7 @@ def main():
         modisOgg.connect()
         if modisOgg.nconnection <= 20:
             # download tha tiles
-            grass.message(_("Downloading MODIS product <%s>..." % produ))
+            grass.message(_("Downloading MODIS product <%s> (%s)..." % (produ, prod['prod'])))
             modisOgg.downloadsAllDay()
             filesize = int(os.path.getsize(modisOgg.filelist.name))
             if flags['g'] and filesize != 0:

--- a/grass7/imagery/i.modis/i.modis.download/i.modis.download.py
+++ b/grass7/imagery/i.modis/i.modis.download/i.modis.download.py
@@ -199,7 +199,7 @@ def main():
                           "the username and password"))
     # set username, password and folder by file
     else:
-        if os.path.isdir(options['settings']):
+        if not os.path.isfile(options['settings']):
             grass.fatal(_("The settings parameter <{}> is not a file").format(options['settings']))
         # open the file and read the the user and password:
         # first line is username

--- a/grass7/imagery/i.modis/i.modis.download/i.modis.download.py
+++ b/grass7/imagery/i.modis/i.modis.download/i.modis.download.py
@@ -8,7 +8,8 @@
 # PURPOSE:       i.modis.download is an interface to pyModis for download
 #                several tiles of MODIS produts from NASA ftp
 #
-# COPYRIGHT:        (C) 2011-2017 by Luca Delucchi
+# COPYRIGHT:     (C) 2011-2021 by Luca Delucchi
+#                Fixes by Anika Weinmann, Markus Neteler
 #
 #                This program is free software under the GNU General Public
 #                License (>=v2). Read the file COPYING that comes with GRASS

--- a/grass7/imagery/i.modis/i.modis.download/i.modis.download.py
+++ b/grass7/imagery/i.modis/i.modis.download/i.modis.download.py
@@ -103,10 +103,10 @@ def check_folder(folder):
     """ Check if a folder it is writable by the user that launch the process
     """
     if not os.path.exists(folder) or not os.path.isdir(folder):
-        grass.fatal(_("Folder {} does not exist").format(folder))
+        grass.fatal(_("Folder <{}> does not exist").format(folder))
 
     if not os.access(folder, os.W_OK):
-        grass.fatal(_("Folder {} is not writeable").format(folder))
+        grass.fatal(_("Folder <{}> is not writeable").format(folder))
 
     return True
 
@@ -174,6 +174,10 @@ def main():
         prod = product()
         prod.print_prods()
         return 0
+    # empty settings and folder would collide
+    if not options['settings'] and not options['folder']:
+        grass.fatal(_("With empty settings parameter (to use the .netrc file) "
+                      "the folder parameter needs to be specified"))
     # set username, password and folder if settings are insert by stdin
     if not options['settings']:
         user = None
@@ -195,6 +199,8 @@ def main():
                           "the username and password"))
     # set username, password and folder by file
     else:
+        if os.path.isdir(options['settings']):
+            grass.fatal(_("The settings parameter <{}> is not a file").format(options['settings']))
         # open the file and read the the user and password:
         # first line is username
         # second line is password
@@ -231,7 +237,7 @@ def main():
     # set tiles
     if options['tiles'] == '':
         tiles = None
-        grass.warning(_("Option 'tiles' not set. Downloading all available tiles"))
+        grass.warning(_("Option 'tiles' not set. Downloading all available tiles to <{}>").format(fold))
     else:
         tiles = options['tiles']
     # set the debug

--- a/grass7/imagery/i.modis/i.modis.download/i.modis.download.py
+++ b/grass7/imagery/i.modis/i.modis.download/i.modis.download.py
@@ -261,7 +261,7 @@ def main():
         modisOgg.connect()
         if modisOgg.nconnection <= 20:
             # download tha tiles
-            grass.message(_("Downloading MODIS product <%s> (%s)..." % (produ, prod['prod'])))
+            grass.message(_("Downloading MODIS product <{}> ({})...".format(produ, prod['prod'])))
             modisOgg.downloadsAllDay()
             filesize = int(os.path.getsize(modisOgg.filelist.name))
             if flags['g'] and filesize != 0:

--- a/grass7/imagery/i.modis/i.modis.html
+++ b/grass7/imagery/i.modis/i.modis.html
@@ -322,7 +322,8 @@ library. Please install it beforehand.
 
 <em>
 <a href="i.modis.download.html">i.modis.download</a>,
-<a href="i.modis.import.html">i.modis.import</a>
+<a href="i.modis.import.html">i.modis.import</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/i.modis.qc.html">i.modis.qc</a>
 <!-- <a href="i.modis.process.html">i.modis.process</a>,-->
 </em>
 <p>

--- a/grass7/imagery/i.modis/i.modis.import/i.modis.import.html
+++ b/grass7/imagery/i.modis/i.modis.import/i.modis.import.html
@@ -153,7 +153,7 @@ i.modis.import -m files=$HOME/listfileMOD11A1.006.txt \
 </pre></div>
 
 Extract and apply the mandatory QA band (for more details see 
-<a href="i.modis.qc.html">i.modis.qc</a>):
+<a href="https://grass.osgeo.org/grass-stable/manuals/i.modis.qc.html">i.modis.qc</a>):
 
 <div class="code"><pre>
 for map in `g.list type=raster pattern="*_QC_Day"` ; do
@@ -210,7 +210,7 @@ t.register input=LST_Day_daily file=$HOME/list_for_tregister.csv
 <em>
 <a href="i.modis.html">i.modis</a>,
 <a href="i.modis.download.html">i.modis.download</a>,
-<a href="i.modis.qc.html">i.modis.qc</a>
+<a href="https://grass.osgeo.org/grass-stable/manuals/i.modis.qc.html">i.modis.qc</a>
 </em>
 <p>
 <a href="https://grasswiki.osgeo.org/wiki/Temporal_data_processing">GRASS GIS Wiki: temporal data processing</a>


### PR DESCRIPTION
- catch more (user) errors
- more messages improved
- user example added with .netrc file
- fix broken URL to i.modis.qc
- remove obsolete GRASS GIS version test (hence, it also works with GRASS GIS 8)