### PR TITLE
g.projpicker: Add error message if projpicker not found on system.

### DIFF
--- a/grass7/general/g.projpicker/g.projpicker.py
+++ b/grass7/general/g.projpicker/g.projpicker.py
@@ -105,8 +105,7 @@ def main():
     try:
         import projpicker as ppik
     except ImportError:
-        grass.fatal(_("ProjPicker not installed.\n"
-                      "Use 'pip install projpicker'"))
+        grass.fatal(_("ProjPicker not installed. Use 'pip install projpicker'"))
 
     coords = options["coordinates"]
     operator = options["operator"]

--- a/grass7/general/g.projpicker/g.projpicker.py
+++ b/grass7/general/g.projpicker/g.projpicker.py
@@ -102,7 +102,11 @@ def message(msg="", end=None):
 
 
 def main():
-    import projpicker as ppik
+    try:
+        import projpicker as ppik
+    except ImportError:
+        grass.fatal(_("ProjPicker not installed.\n"
+                      "Use 'pip install projpicker'"))
 
     coords = options["coordinates"]
     operator = options["operator"]


### PR DESCRIPTION
Really minor, but potentially very helpful as long as projpicker is not a part of core repository.