### PR TITLE
Reapply black without any options

### DIFF
--- a/grass7/general/g.projpicker/g.projpicker.py
+++ b/grass7/general/g.projpicker/g.projpicker.py
@@ -105,7 +105,9 @@ def main():
     try:
         import projpicker as ppik
     except ImportError:
-        grass.fatal(_("ProjPicker not installed. Use 'pip install projpicker'"))
+        grass.fatal(
+            _("ProjPicker not installed. Use 'pip install projpicker'")
+        )
 
     coords = options["coordinates"]
     operator = options["operator"]
@@ -123,7 +125,10 @@ def main():
     single = flags["1"]
     start_gui = flags["g"]
 
-    if bbox_map and grass.parse_command("g.proj", flags="g")["unit"] != "degree":
+    if (
+        bbox_map
+        and grass.parse_command("g.proj", flags="g")["unit"] != "degree"
+    ):
         grass.fatal(_("Cannot create vector in degree in a non-degree mapset"))
 
     # ppik.projpicker() appends input file contents to geometries from
@@ -202,7 +207,7 @@ def main():
             e = b.east_lon
             x = (w + e) / 2
             y = (s + n) / 2
-            line = f"L 5 1\n{w} {s}\n{w} {n}\n{e} {n}\n{e} {s}\n{w} {s}\n" f"1 {cat}\n"
+            line = f"L 5 1\n{w} {s}\n{w} {n}\n{e} {n}\n{e} {s}\n{w} {s}\n1 {cat}\n"
             # XXX: these two lines don't work probably because areas overlap?
             # line = (
             #    f"B 5 1\n{w} {s}\n{w} {n}\n{e} {n}\n{e} {s}\n{w} {s}\n"
@@ -220,9 +225,13 @@ def main():
         if p.returncode != 0:
             grass.fatal(_("Error creating output vector map %s") % bbox_map)
 
-        grass.run_command("v.db.addtable", map=bbox_map, columns="srid text, name text")
+        grass.run_command(
+            "v.db.addtable", map=bbox_map, columns="srid text, name text"
+        )
         for i in range(0, nbbox):
-            message("\b" * 80 + _("Populating table...") + f" {i+1}/{nbbox}", "")
+            message(
+                "\b" * 80 + _("Populating table...") + f" {i+1}/{nbbox}", ""
+            )
             b = bbox[i]
             srid = f"{b.crs_auth_name}:{b.crs_code}"
             cat = i + 1


### PR DESCRIPTION
Personally, I think this `black` formatting breaks *my* semantic indentation and even violates [PEP 8](https://www.python.org/dev/peps/pep-0008/). Also, it's not compatible with vim's `gq` and `gw` with the default line width. https://lists.osgeo.org/pipermail/grass-dev/2021-June/095226.html