### PR TITLE
i.sentinel.import: Improved cloud masking

### DIFF
--- a/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.html
+++ b/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.html
@@ -120,8 +120,8 @@ This mask is based on the cloud probability layer which is part of each Level2A 
 By specifying the <b>cloud_*</b>-options the creation of the cloud mask can be controlled.
 The default cloud masking threshold applied to the probability layer is set to 65%, which corresponds to
 the classification of such areas as most likely cloudy according to the ESA classification scheme used for the creation of the SCL layer.
-The SCL Layer itself is used if shadow masks should be included in the _MSK_CLOUDS layer. This requires to set <em>cloud_shadows=yes</em>,
-which includes shadows as part of the output layer. The area threshold parameter allows to exclude
+The SCL Layer itself is used if shadow masks should be included in the _MSK_CLOUDS layer. This requires to call the <b>-s</b> flag,
+which adds shadows as part of the _MSK_CLOUDS output layer. The area threshold parameter allows to exclude
 small areas of cloud and shadow cover, which in case of vector outputs tend to increase the computational speed.
 Note that the resolution of the _MSK_CLOUDS layer (20m) is determined by the native resolution of the
 cloud probability layer and the SCL layer, respectively.

--- a/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.html
+++ b/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.html
@@ -6,9 +6,9 @@ module.
 
 <p>
 By default <em>i.sentinel.import</em> imports all Sentinel scene files found
-in the <b>input</b> directory. The number of scene files can be optionally 
-reduced by the <b>pattern_file</b> option. In this option, a regular expression 
-for filtering the file names should be given, e.g. "MSIL2A.*T32VNR_2019" for 
+in the <b>input</b> directory. The number of scene files can be optionally
+reduced by the <b>pattern_file</b> option. In this option, a regular expression
+for filtering the file names should be given, e.g. "MSIL2A.*T32VNR_2019" for
 importing only level 2A products for tile T32VNR from 2019.
 <p>
 By default <em>i.sentinel.import</em> imports the full scene. Optionally, the
@@ -17,13 +17,13 @@ import can be reduced to the computational region extent with
 
 <p>
 Note that in the case that spatial reference system of input data differs
-from GRASS GIS location, the input data need to be reprojected with 
+from GRASS GIS location, the input data need to be reprojected with
 <em><a href="https://grass.osgeo.org/grass-stable/manuals/r.import.html">r.import</a></em>. To speed up this
 process, a higher than default value can be specified for the <b>memory</b>
 option.
 
 <p>
-In order to ignore insignificant mismatch of the spatial reference 
+In order to ignore insignificant mismatch of the spatial reference
 systems, the projection check can be suppressed with the <b>-o</b> flag.
 
 <p>
@@ -109,12 +109,22 @@ AZIMUTH_ANGLE_5=295.354861828927<br>
 </tbody>
 </table>
 
+
 <h2>NOTES</h2>
 
 <p>
-If <b>-c</b> flag is given, than also cloud mask file is imported as
-vector map if available. The name of created vector map is determined from
-input Sentinel product.
+<b>Importing cloud and cloud shadow masks:</b>
+
+If <b>-c</b> flag is given, a cloud mask with suffix _MSK_CLOUDS is additionally created.
+This mask is based on the cloud probability layer which is part of each Level2A product.
+By specifying the <b>cloud_*</b>-options the creation of the cloud mask can be controlled.
+The default cloud masking threshold applied to the probability layer is set to 65%, which corresponds to
+the classification of such areas as most likely cloudy according to the ESA classification scheme used for the creation of the SCL layer.
+The SCL Layer itself is used if shadow masks should be included in the _MSK_CLOUDS layer. This requires to set <em>cloud_shadows=yes</em>,
+which includes shadows as part of the output layer. The area threshold parameter allows to exclude
+small areas of cloud and shadow cover, which in case of vector outputs tend to increase the computational speed.
+Note that the resolution of the _MSK_CLOUDS layer (20m) is determined by the native resolution of the
+cloud probability layer and the SCL layer, respectively.
 
 <p>
 By <b>register_file</b> option <em>i.sentinel.import</em> allows
@@ -125,7 +135,7 @@ currently a register file can be created only for Sentinel-2 data. See
 example below.
 
 <p>
-<b>Metadata import</b>
+<b>Metadata import:</b>
 
 By using the <b>-j</b> flag the band metadata are additionally stored
 in JSON format (in the current mapset under <tt>cell_misc</tt>). These

--- a/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
+++ b/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
@@ -95,15 +95,6 @@
 #% answer: vector
 #% label: Create cloud mask as raster or vector product
 #%end
-#%option
-#% key: cloud_shadows
-#% type: string
-#% required: no
-#% multiple: no
-#% options: yes, no
-#% answer: yes
-#% label: Include cloud shadows in cloud masking
-#%end
 #%flag
 #% key: r
 #% description: Reproject raster data using r.import if needed
@@ -121,7 +112,12 @@
 #%end
 #%flag
 #% key: c
-#% description: Import cloud (and cloud shadows) masks
+#% description: Import cloud masks
+#% guisection: Settings
+#%end
+#%flag
+#% key: s
+#% description: Import cloud shadow masks
 #% guisection: Settings
 #%end
 #%flag
@@ -144,6 +140,7 @@
 #% exclusive: -o,-r
 #% exclusive: extent,-l
 #% exclusive: metadata,-j
+#% requires: -s,-c
 #%end
 
 import os
@@ -423,7 +420,7 @@ class SentinelImporter(object):
                 gs.mapcalc(f'{clouds_selected} = if({clouds_imported} >= {prob_threshold}, 1, 0)')
 
                 # Add shadow mask
-                if shadows == 'yes':
+                if shadows:
                     try:
                         shadow_file = self._filter("_".join([items[5], items[2], "SCL_20m.jp2"]))
                         if reproject:
@@ -488,7 +485,7 @@ class SentinelImporter(object):
                     gs.raster_history(map_name)
 
                 gs.message(_(f'Areal proportion of masked clouds:{[key.split()[1] for key in info_stats][0]}'))
-                if shadows == 'yes':
+                if shadows:
                     if len(info_stats) > 2:
                         gs.message(_(f'Areal proportion of masked shadows:{[key.split()[1] for key in info_stats][1]}'))
                     else:
@@ -756,7 +753,7 @@ def main():
         importer.import_cloud_masks(options["cloud_area_threshold"],
                                     options["cloud_probability_threshold"],
                                     options["cloud_output"],
-                                    options["cloud_shadows"],
+                                    flags["s"],
                                     flags["r"])
 
     if options["register_output"]:

--- a/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
+++ b/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
@@ -3,7 +3,7 @@
 ############################################################################
 #
 # MODULE:      i.sentinel.import
-# AUTHOR(S):   Martin Landa
+# AUTHOR(S):   Martin Landa, Felix Kröber
 # PURPOSE:     Imports Sentinel data downloaded from Copernicus Open Access Hub
 #              using i.sentinel.download.
 # COPYRIGHT:   (C) 2018-2019 by Martin Landa, and the GRASS development team
@@ -71,6 +71,39 @@
 #% description: Name of directory into which Sentinel metadata json dumps are saved
 #% required: no
 #%end
+#%option
+#% key: cloud_area_threshold
+#% description: Threshold above which areas of clouds and/or cloud shadows will be masked (in hectares)
+#% type: double
+#% required: no
+#% answer: 1
+#%end
+#%option
+#% key: cloud_probability_threshold
+#% description: Minimum cloud probability for pixels to be masked
+#% type: integer
+#% required: no
+#% options: 0-100
+#% answer: 65
+#%end
+#%option
+#% key: cloud_output
+#% type: string
+#% required: no
+#% multiple: no
+#% options: vector,raster
+#% answer: vector
+#% label: Create cloud mask as raster or vector product
+#%end
+#%option
+#% key: cloud_shadows
+#% type: string
+#% required: no
+#% multiple: no
+#% options: yes, no
+#% answer: yes
+#% label: Include cloud shadows in cloud masking
+#%end
 #%flag
 #% key: r
 #% description: Reproject raster data using r.import if needed
@@ -88,7 +121,7 @@
 #%end
 #%flag
 #% key: c
-#% description: Import cloud masks as vector maps
+#% description: Import cloud (and cloud shadows) masks
 #% guisection: Settings
 #%end
 #%flag
@@ -112,6 +145,7 @@
 #% exclusive: extent,-l
 #% exclusive: metadata,-j
 #%end
+
 import os
 import sys
 import re
@@ -127,8 +161,9 @@ from grass.exceptions import CalledModuleError
 
 class SentinelImporter(object):
     def __init__(self, input_dir, unzip_dir):
-        # list of directories to cleanup
+        # list of directories & maps to cleanup
         self._dir_list = []
+        self._map_list = []
 
         # check if input dir exists
         self.input_dir = input_dir
@@ -144,6 +179,12 @@ class SentinelImporter(object):
             gs.fatal(_("Directory <{}> does not exist").format(unzip_dir))
 
     def __del__(self):
+        # remove temporary maps
+        for map in self._map_list:
+            if gs.find_file(map, element='cell')['file']:
+                gs.run_command("g.remove", flags="fb", type='raster', name=map,
+                               quiet=True)
+
         if flags["l"]:
             # unzipped files are required when linking
             return
@@ -235,25 +276,25 @@ class SentinelImporter(object):
         return files
 
     def import_products(self, reproject=False, link=False, override=False):
-        args = {}
+        self._args = {}
         if link:
             module = "r.external"
-            args["flags"] = "o" if override else None
+            self._args["flags"] = "o" if override else None
         else:
-            args["memory"] = options["memory"]
+            self._args["memory"] = options["memory"]
             if reproject:
                 module = "r.import"
-                args["resample"] = "bilinear"
-                args["resolution"] = "value"
-                args["extent"] = options["extent"]
+                self._args["resample"] = "bilinear"
+                self._args["resolution"] = "value"
+                self._args["extent"] = options["extent"]
             else:
                 module = "r.in.gdal"
-                args["flags"] = "o" if override else None
+                self._args["flags"] = "o" if override else None
                 if options["extent"] == "region":
-                    if args["flags"]:
-                        args["flags"] += "r"
+                    if self._args["flags"]:
+                        self._args["flags"] += "r"
                     else:
-                        args["flags"] = "r"
+                        self._args["flags"] = "r"
 
         for f in self.files:
             if not override and (link or (not link and not reproject)):
@@ -265,7 +306,7 @@ class SentinelImporter(object):
                         )
                     )
 
-            self._import_file(f, module, args)
+            self._import_file(f, module, self._args)
 
     def _check_projection(self, filename):
         try:
@@ -314,9 +355,9 @@ class SentinelImporter(object):
         mapname = self._map_name(filename)
         gs.message(_("Processing <{}>...").format(mapname))
         if module == "r.import":
-            args["resolution_value"] = self._raster_resolution(filename)
+            self._args["resolution_value"] = self._raster_resolution(filename)
         try:
-            gs.run_command(module, input=filename, output=mapname, **args)
+            gs.run_command(module, input=filename, output=mapname, **self._args)
             if gs.raster_info(mapname)["datatype"] in ("FCELL", "DCELL"):
                 gs.message("Rounding to integer after reprojection")
                 gs.use_temp_region()
@@ -337,33 +378,126 @@ class SentinelImporter(object):
         except CalledModuleError as e:
             pass  # error already printed
 
-    def import_cloud_masks(self, override):
-        from osgeo import ogr
-
-        files = self._filter("MSK_CLOUDS_B00.gml")
+    def import_cloud_masks(self, area_threshold, prob_threshold, output, shadows, reproject):
+        files = self._filter("MSK_CLDPRB_20m.jp2")
 
         for f in files:
             safe_dir = os.path.dirname(f).split(os.path.sep)[-4]
             items = safe_dir.split("_")
-            map_name = "_".join([items[5], items[2], "MSK", "CLOUDS"])
-            # check if any OGR layer
-            dsn = ogr.Open(f)
-            layer_count = dsn.GetLayerCount()
-            dsn.Destroy()
-            if layer_count < 1:
-                gs.info("No clouds layer found in <{}>. Import skipped".format(f))
+
+            if 'L2A' not in items[1]:
+                gs.warning(_(f'No Level2A product: Unable to import cloud mask for {"_".join([items[5], items[2]])}'))
                 continue
+
+            # Define names of final & temporary maps
+            map_name = "_".join([items[5], items[2], "MSK", "CLOUDS"])
+            clouds_imported = "_".join([items[5], items[2], "cloudprob"])
+            clouds_selected = "_".join([items[5], items[2], "clouds_selected"])
+            shadows_imported = "_".join([items[5], items[2], "shadows"])
+            shadows_selected = "_".join([items[5], items[2], "shadows_selected"])
+            mask_selected = "_".join([items[5], items[2], "mask_selected"])
+            mask_cleaned = "_".join([items[5], items[2], "mask_cleaned"])
+
+            self._map_list.extend([clouds_imported, clouds_selected,
+                                  shadows_imported, shadows_selected,
+                                  mask_selected, mask_cleaned])
+
             try:
-                gs.run_command(
-                    "v.import",
-                    input=f,
-                    flags="o" if override else None,  # same SRS as data
-                    output=map_name,
-                    quiet=True,
-                )
-                gs.vector_history(map_name)
-            except CalledModuleError as e:
-                pass  # error already printed
+                # Import & Threshold cloud probability layer
+                gs.message(_(f'Importing cloud mask for {"_".join([items[5], items[2]])}'))
+                if reproject:
+                    self._args["resolution_value"] = self._raster_resolution(f)
+                    self._args["resample"] = "bilinear"
+                    gs.run_command("r.import",
+                                   input=f,
+                                   output=clouds_imported,
+                                   **self._args)
+                else:
+                    gs.run_command("r.in.gdal",
+                                   input=f,
+                                   output=clouds_imported,
+                                   **self._args)
+
+                gs.use_temp_region()
+                gs.run_command("g.region", raster=clouds_imported)
+                gs.mapcalc(f'{clouds_selected} = if({clouds_imported} >= {prob_threshold}, 1, 0)')
+
+                # Add shadow mask
+                if shadows == 'yes':
+                    try:
+                        shadow_file = self._filter("_".join([items[5], items[2], "SCL_20m.jp2"]))
+                        if reproject:
+                            self._args["resolution_value"] = self._raster_resolution(shadow_file[0])
+                            self._args["resample"] = "nearest"
+                            gs.run_command("r.import",
+                                           input=shadow_file,
+                                           output=shadows_imported,
+                                           **self._args)
+                        else:
+                            gs.run_command("r.in.gdal",
+                                           input=shadow_file,
+                                           output=shadows_imported,
+                                           **self._args)
+
+                        gs.mapcalc(f'{shadows_selected} = if({shadows_imported} == 3, 2, 0)')
+                        gs.mapcalc(f'{mask_selected} = max({shadows_selected},{clouds_selected})')
+                    except Exception as e:
+                        gs.warning(_(f'Unable to import shadows for {"_".join([items[5], items[2]])}. Error: {e}'))
+
+                else:
+                    gs.run_command("g.rename", quiet=True, raster=(clouds_selected, mask_selected))
+
+
+                # Cleaning small patches
+                try:
+                    gs.run_command('r.reclass.area',
+                                   input=mask_selected,
+                                   output=mask_cleaned,
+                                   value=area_threshold,
+                                   mode='greater')
+                except Exception as e:
+                    pass # error already printed
+
+                # Extract & Label clouds (and shadows)
+                gs.run_command('r.null', map=mask_cleaned, setnull='0')
+
+                labels = ['1:clouds','2:shadows']
+                labelling = gs.feed_command('r.category', map=mask_cleaned, separator=':', rules="-")
+                labelling.stdin.write("\n".join(labels).encode())
+                labelling.stdin.close()
+                labelling.wait()
+
+                info_stats = gs.parse_command('r.stats', input=mask_cleaned, flags='p')
+
+                # Create final cloud (and shadow) mask & display areal statistics
+                if output == 'vector':
+                    gs.run_command('r.to.vect', input=mask_cleaned, output=map_name, type='area', flags='s')
+                    gs.run_command('v.db.addcolumn', map=map_name, columns='GRASSRGB varchar(20)', quiet=True)
+                    gs.run_command('v.db.update', map=map_name, column='GRASSRGB', where='label=="clouds"', value='230:230:230', quiet=True)
+                    gs.run_command('v.db.update', map=map_name, column='GRASSRGB', where='label=="shadows"', value='60:60:60', quiet=True)
+                    gs.run_command('v.colors', map=map_name, use='attr', column='value', rgb_column='GRASSRGB', flags='c', quiet=True)
+                    gs.vector_history(map_name)
+
+                else:
+                    gs.run_command('g.rename', quiet=True, raster=(mask_cleaned, map_name))
+                    colours = ['1 230:230:230','2 60:60:60']
+                    colourise = gs.feed_command('r.colors', map=map_name, rules="-", quiet=True)
+                    colourise.stdin.write("\n".join(colours).encode())
+                    colourise.stdin.close()
+                    colourise.wait()
+                    gs.raster_history(map_name)
+
+                gs.message(_(f'Areal proportion of masked clouds:{[key.split()[1] for key in info_stats][0]}'))
+                if shadows == 'yes':
+                    if len(info_stats) > 2:
+                        gs.message(_(f'Areal proportion of masked shadows:{[key.split()[1] for key in info_stats][1]}'))
+                    else:
+                        gs.message(_('Areal proportion of masked shadows:0%'))
+
+                gs.del_temp_region()
+
+            except Exception as e:
+                gs.warning(_(f'Unable to import cloud mask for {"_".join([items[5], items[2]])}. Error: {e}'))
 
     def print_products(self):
         for f in self.files:
@@ -619,7 +753,11 @@ def main():
 
     if flags["c"]:
         # import cloud mask if requested
-        importer.import_cloud_masks(flags["o"])
+        importer.import_cloud_masks(options["cloud_area_threshold"],
+                                    options["cloud_probability_threshold"],
+                                    options["cloud_output"],
+                                    options["cloud_shadows"],
+                                    flags["r"])
 
     if options["register_output"]:
         # create t.register file if requested


### PR DESCRIPTION
Suggestion for improved cloud masking during import based on the Level-2A inherent cloud probability layer (QI_DATA/*CLDPRB_20m) and scene classification layer (IMG_DATA/R20m/*SCL_20m) instead of the previously used MSK_CLOUDS layer (QI_DATA). The latter didn't include the possibility to mask cloud shadows and areas of clouds were masked less accurately. The comparison below presents the cloud masking output based on the proposed changes in i.sentinel.import (second image) and the result of the current version of i.sentinel.import (last image).

![grafik](https://user-images.githubusercontent.com/85885893/124601558-432e3980-de68-11eb-9679-046b42296476.png)
![grafik](https://user-images.githubusercontent.com/85885893/124601621-593bfa00-de68-11eb-912a-b9b30e2bda70.png)
![grafik](https://user-images.githubusercontent.com/85885893/124601680-69ec7000-de68-11eb-9618-3bf42097eacb.png)


