### PR TITLE
i.sentinel.download: changes to pandas module import

### DIFF
--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -169,6 +169,7 @@ import shutil
 import sys
 import logging
 import time
+import pandas
 from collections import OrderedDict
 
 import grass.script as gs
@@ -1023,11 +1024,12 @@ class SentinelDownloader(object):
 
 def main():
 
+    # --- Not needed anymore ---
     # Lazy import nonstandard modules
-    try:
-        import pandas
-    except ImportError as e:
-        gs.fatal(_("Module requires pandas library: {}").format(e))
+    #try:
+    #    import pandas
+    #except ImportError as e:
+    #    gs.fatal(_("Module requires pandas library: {}").format(e))
 
     try:
         import requests


### PR DESCRIPTION
Even though pandas is currently imported in the main function (l. 1027 ff.), the module doesn't seem to be available for further use in the called methods, i.e. filter_USGS (l. 1120), which in turn leads to an error when calling i.sentinel.download with producttype=USGS_EE ("Error: Unable to connect to USGS_EE: name 'pandas' is not defined"). Even though I do not understand why importing pandas at the beginning of main() doesn't work, importing pandas at the very beginning of the script (as suggested below) avoids the error. Feel free to change or discard this pull request in case there are better ways to handle the import of pandas!