### PR TITLE
g.projpicker: More information about XOR

### DIFF
--- a/src/general/g.projpicker/g.projpicker.html
+++ b/src/general/g.projpicker/g.projpicker.html
@@ -199,16 +199,15 @@ C
 D
 </pre></div>
 
-<p>This query string performs the XOR of all geometries and returns projections
-that completely contain only one of them:
+<p>This query string performs the XOR of two geometries and returns projections that completely contain only one of them:
 <div class="code"><pre>
 xor
-# A, B, C, or D can be point, poly, or bbox individually
+# A or B can be point, poly, or bbox individually
 A
 B
-C
-D
 </pre></div>
+
+<p>Since the XOR operator is performed on two geometries at a time, feeding more than two geometries does not return mutually exclusive projections.
 
 <h3>Postfix logical operations</h3>
 
@@ -247,6 +246,23 @@ B       # find B
 and     # A and B
 C       # find C
 xor     # (A and B) xor C
+</pre></div>
+
+<p>This query string returns all projections that contain only one of A, B, or C exclusively:
+<div class="code"><pre>
+postfix
+A       # find A
+B       # find B
+xor     # A xor B
+C       # find C
+xor     # A xor B xor C
+A	# find A again
+B	# find B again
+and	# A and B
+C	# find C again
+and	# A and B and C
+not	# not (A and B and C)
+and	# (A xor B xor C) and not (A and B and C)
 </pre></div>
 
 <h3>Special geometries for logical operations</h3>


### PR DESCRIPTION
XOR on two geometries at a time means feeding more than two geometries does not return mutually exclusive projections.