### PR TITLE
g.download.location: Add path option for compatibility with core module

### DIFF
--- a/src/general/g.download.location/g.download.location.py
+++ b/src/general/g.download.location/g.download.location.py
@@ -35,8 +35,20 @@
 #% key_desc: name
 #%end
 #%option G_OPT_M_DBASE
+#% key: path
 #% required: no
 #% multiple: no
+#%end
+#%option
+#% key: dbase
+#% multiple: no
+#% type: string
+#% label: Path to database, use path option instead
+#% description: This option is obsolete and replaced by path
+#% required: no
+#%end
+#%rules
+#% exclusive: path,dbase
 #%end
 
 import os
@@ -232,7 +244,9 @@ def location_name_from_url(url):
 def main(options, flags):
     url = options["url"]
     name = options["name"]
-    database = options["dbase"]
+    database = options["path"]
+    if not database:
+        database = options["dbase"]
 
     if not database:
         # use current


### PR DESCRIPTION
This adds path option for compatibility with the version of the module in v8.
It is an additional option, so the original dbase still works.
Same code can now be used for v7 and v8, but the original code for v7 still works
(v8 code should be updated to use the version in core, not the addon).
