### PR TITLE
CI: Install g.download.location only if needed

### DIFF
--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -3,10 +3,13 @@
 # fail on non-zero return code from a subprocess
 set -e
 
+# Install module from addons if not available (in v7).
+if ! grass --tmp-location XY --exec g.download.location --help; then
+    grass --tmp-location XY --exec \
+        g.extension g.download.location
+fi
 grass --tmp-location XY --exec \
-    g.extension g.download.location
-grass --tmp-location XY --exec \
-    g.download.location url=https://grass.osgeo.org/sampledata/north_carolina/nc_spm_full_v2alpha2.tar.gz dbase=$HOME
+    g.download.location url=https://grass.osgeo.org/sampledata/north_carolina/nc_spm_full_v2alpha2.tar.gz path=$HOME
 
 grass --tmp-location XY --exec \
     python3 -m grass.gunittest.main \


### PR DESCRIPTION
- g.download.location is included in the core for v8, so install it only if missing (assuming v7).
- Use path instead of dbase as in the core version of g.download.location (addons version supports both).
