### PR TITLE
Update name of core branch from master to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         grass-version:
-        - master
+        - main
         - releasebranch_7_8
         python-version:
         - 3.6

--- a/tools/cronjobs_osgeo_lxd/README.md
+++ b/tools/cronjobs_osgeo_lxd/README.md
@@ -10,7 +10,7 @@ This directory contains the relevant files to generate and deploy the GRASS GIS 
     - `hugo_clean_and_update_job.sh`
 - GRASS GIS source code weekly snapshots:
     - release_branch_7_8: `cron_grass78_src_relbr78_snapshot.sh`
-    - master: `cron_grass8_HEAD_src_snapshot.sh`
+    - main: `cron_grass8_HEAD_src_snapshot.sh`
 - GRASS GIS Linux binary weekly snapshots:
     - `cron_grass78_releasebranch_78_build_bins.sh`
 - GRASS GIS addons manual pages:

--- a/tools/cronjobs_osgeo_lxd/cron_grass74_releasebranch_74_build_bins.sh
+++ b/tools/cronjobs_osgeo_lxd/cron_grass74_releasebranch_74_build_bins.sh
@@ -54,12 +54,12 @@ LDFLAGSSTRING='-s'
 MAINDIR=/home/neteler
 # where to find the GRASS sources (git clone):
 SOURCE=$MAINDIR/src/
-BRANCH=releasebranch_7_$GMINOR # master
+BRANCH=releasebranch_7_$GMINOR
 GRASSBUILDDIR=$SOURCE/$BRANCH
 TARGETMAIN=/var/www/code_and_data/
 TARGETDIR=$TARGETMAIN/grass${VERSION}/binary/linux/snapshot
 TARGETHTMLDIR=$TARGETMAIN/grass${VERSION}/manuals/
-# programmer's manual only from master
+# programmer's manual is build only from the main branch
 
 MYBIN=$MAINDIR/binaries
 

--- a/tools/cronjobs_osgeo_lxd/cron_grass74_src_relbr74_snapshot.sh
+++ b/tools/cronjobs_osgeo_lxd/cron_grass74_src_relbr74_snapshot.sh
@@ -24,7 +24,7 @@ GSHORTGVERSION=$GMAJOR$GMINOR
 ###################
 # where to find the GRASS sources (git clone):
 SOURCE=$MAINDIR/src/
-BRANCH=releasebranch_${GMAJOR}_${GMINOR}  # or, master
+BRANCH=releasebranch_${GMAJOR}_${GMINOR}
 # where to put the resulting .tar.gz file:
 TARGETMAIN=/var/www/code_and_data/
 TARGETDIR=$TARGETMAIN/grass${GSHORTGVERSION}/source/snapshot

--- a/tools/cronjobs_osgeo_lxd/cron_grass76_releasebranch_76_build_bins.sh
+++ b/tools/cronjobs_osgeo_lxd/cron_grass76_releasebranch_76_build_bins.sh
@@ -55,12 +55,12 @@ LDFLAGSSTRING='-s'
 MAINDIR=/home/neteler
 # where to find the GRASS sources (git clone):
 SOURCE=$MAINDIR/src/
-BRANCH=releasebranch_7_$GMINOR # master
+BRANCH=releasebranch_7_$GMINOR
 GRASSBUILDDIR=$SOURCE/$BRANCH
 TARGETMAIN=/var/www/code_and_data/
 TARGETDIR=$TARGETMAIN/grass${VERSION}/binary/linux/snapshot
 TARGETHTMLDIR=$TARGETMAIN/grass${VERSION}/manuals/
-# programmer's manual only from master
+# programmer's manual is build only from the main branch
 
 MYBIN=$MAINDIR/binaries
 

--- a/tools/cronjobs_osgeo_lxd/cron_grass76_src_relbr76_snapshot.sh
+++ b/tools/cronjobs_osgeo_lxd/cron_grass76_src_relbr76_snapshot.sh
@@ -24,7 +24,7 @@ GSHORTGVERSION=$GMAJOR$GMINOR
 ###################
 # where to find the GRASS sources (git clone):
 SOURCE=$MAINDIR/src/
-BRANCH=releasebranch_${GMAJOR}_${GMINOR}  # or, master
+BRANCH=releasebranch_${GMAJOR}_${GMINOR}
 # where to put the resulting .tar.gz file:
 TARGETMAIN=/var/www/code_and_data/
 TARGETDIR=$TARGETMAIN/grass${GSHORTGVERSION}/source/snapshot

--- a/tools/cronjobs_osgeo_lxd/cron_grass78_releasebranch_78_build_bins.sh
+++ b/tools/cronjobs_osgeo_lxd/cron_grass78_releasebranch_78_build_bins.sh
@@ -60,12 +60,12 @@ LDFLAGSSTRING='-s'
 MAINDIR=/home/neteler
 # where to find the GRASS sources (git clone):
 SOURCE=$MAINDIR/src/
-BRANCH=releasebranch_7_$GMINOR # master
+BRANCH=releasebranch_7_$GMINOR
 GRASSBUILDDIR=$SOURCE/$BRANCH
 TARGETMAIN=/var/www/code_and_data/
 TARGETDIR=$TARGETMAIN/grass${VERSION}/binary/linux/snapshot
 TARGETHTMLDIR=$TARGETMAIN/grass${VERSION}/manuals/
-# programmer's manual only from master
+# programmer's manual is build only from the main branch
 
 MYBIN=$MAINDIR/binaries
 

--- a/tools/cronjobs_osgeo_lxd/cron_grass78_src_relbr78_snapshot.sh
+++ b/tools/cronjobs_osgeo_lxd/cron_grass78_src_relbr78_snapshot.sh
@@ -24,7 +24,7 @@ GSHORTGVERSION=$GMAJOR$GMINOR
 ###################
 # where to find the GRASS sources (git clone):
 SOURCE=$MAINDIR/src/
-BRANCH=releasebranch_${GMAJOR}_${GMINOR}  # or, master
+BRANCH=releasebranch_${GMAJOR}_${GMINOR}
 # where to put the resulting .tar.gz file:
 TARGETMAIN=/var/www/code_and_data/
 TARGETDIR=$TARGETMAIN/grass${GSHORTGVERSION}/source/snapshot

--- a/tools/cronjobs_osgeo_lxd/cron_grass8_HEAD_build_bins.sh
+++ b/tools/cronjobs_osgeo_lxd/cron_grass8_HEAD_build_bins.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# script to build GRASS 8.x master binaries (shared libs)
+# script to build GRASS 8.x binaries from the main branch (shared libs)
 # (c) GPL 2+ Markus Neteler <neteler@osgeo.org>
 # Nov 2008, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021
 #
@@ -117,7 +117,7 @@ rm -rf lib/python/docs/_build/ lib/python/docs/_templates/layout.html
 rm -f config_${DOTVERSION}.git_log.txt ChangeLog
 
 ## hard reset local git repo (just in case)
-#git checkout master && git reset --hard HEAD~1 && git reset --hard origin
+#git checkout main && git reset --hard HEAD~1 && git reset --hard origin
 
 echo "git update..."
 git fetch --all --prune && git checkout $BRANCH && git pull --rebase || halt_on_error "git update error!"

--- a/tools/cronjobs_osgeo_lxd/cron_grass8_HEAD_src_snapshot.sh
+++ b/tools/cronjobs_osgeo_lxd/cron_grass8_HEAD_src_snapshot.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# script to build GRASS sources package from git master of 8
+# script to build GRASS 8.x sources package from the main branch
 # (c) GPL 2+ Markus Neteler <neteler@osgeo.org>
 # Markus Neteler 2002, 2003, 2005, 2006, 2007, 2008, 2012, 2015, 2018, 2019, 2020, 2021
 #
@@ -57,7 +57,7 @@ rm -rf lib/python/docs/_build/ lib/python/docs/_templates/layout.html
 rm -f config_${DOTVERSION}.git_log.txt ChangeLog
 
 ## hard reset local git repo (just in case)
-#git checkout master && git reset --hard HEAD~1 && git reset --hard origin
+#git checkout main && git reset --hard HEAD~1 && git reset --hard origin
 
 echo "git update..."
 git fetch --all --prune       || halt_on_error "git fetch error!"


### PR DESCRIPTION
The development/default branch in the core repo will be renamed from master to main.
This includes updates of the CI, comments and documentation.
It removes the mention of the master/main branch when not necessary.

Notably, this does not update the code for OSGeo cron jobs because name of branch is used there additionally as a directory name and it is part of some non-scripted part of the setup.
This needs to be changed together with the setup on the OSGeo server.
