### PR TITLE
r.colors.out_sld: fix typo in description

### DIFF
--- a/src/raster/r.colors.out_sld/r.colors.out_sld.html
+++ b/src/raster/r.colors.out_sld/r.colors.out_sld.html
@@ -16,7 +16,7 @@ generated SLD file which leads e.g. in GeoServer to an error when using such SLD
 
 <div class="code"><pre>
 # Exporting a color ramp
-r.out.colors_sld map=testmap style_name=Celsius</pre>
+r.colors.out_sld map=testmap style_name=Celsius</pre>
 </div>
 
 <h2>SEE ALSO</h2>


### PR DESCRIPTION
fix typo in example