### PR TITLE
i.sentinel.download: checksumming and lazy import

### DIFF
--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.html
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.html
@@ -413,6 +413,7 @@ i.sentinel.download datasource=USGS_EE start=2017-10-01 end=2017-11-01 productty
   <li><a href="https://pypi.python.org/pypi/sentinelsat">Sentinelsat library</a></li>
   <li><a href="https://pypi.python.org/pypi/pandas">Pandas library</a></li>
   <li><a href="https://pypi.python.org/pypi/landsatxplore">landsatxplore library</a></li> for downloading from USGS Earth Explorer
+  <li><a href="https://pypi.python.org/pypi/requests">requests library</a></li> for downloading from USGS Earth Explorer and Google Cloud Storage
 </ul>
 
 <h2>SEE ALSO</h2>

--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -872,6 +872,11 @@ class SentinelDownloader(object):
         )
 
     def get_products_from_uuid_usgs(self, uuid_list):
+        if ("pandas" not in sys.modules) or ("pandas" not in dir()):
+            try:
+                import pandas
+            except ImportError as e:
+                gs.fatal(_("Module requires pandas library: {}").format(e))
         scenes = []
         for uuid in uuid_list:
             metadata = self._api.metadata(uuid, "SENTINEL_2A")

--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -421,6 +421,10 @@ def download_gcs(scene, output):
         from tqdm import tqdm
     except ImportError as e:
         gs.fatal(_("Module requires tqdm library: {}").format(e))
+    try:
+        import requests
+    except ImportError as e:
+        gs.fatal(_("Module requires requests library: {}").format(e))
 
     final_scene_dir = os.path.join(output, "{}.SAFE".format(scene))
     create_dir(final_scene_dir)
@@ -911,6 +915,13 @@ class SentinelDownloader(object):
         asc=True,
         relativeorbitnumber=None,
     ):
+
+        try:
+            import pandas
+        except ImportError as e:
+            gs.fatal(_("Module requires pandas library: {}").format(e))
+
+
         if area_relation != "Intersects":
             gs.fatal(
                 _("USGS Earth Explorer only supports area_relation" " 'Intersects'")
@@ -1024,17 +1035,6 @@ class SentinelDownloader(object):
 
 
 def main():
-
-    # Lazy import nonstandard modules
-    try:
-        import pandas
-    except ImportError as e:
-        gs.fatal(_("Module requires pandas library: {}").format(e))
-
-    try:
-        import requests
-    except ImportError as e:
-        gs.fatal(_("Module requires requests library: {}").format(e))
 
     user = password = None
     if options["datasource"] == "ESA_COAH" or options["datasource"] == "GCS":

--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -557,8 +557,12 @@ def download_gcs(scene, output):
         return 1
     else:
         if len(failed_checksums) > 0:
-            gs.warning(_("Scene {} was downloaded but checksumming was not "
-                         "successful for one or more files.").format(scene))
+            gs.warning(
+                _(
+                    "Scene {} was downloaded but checksumming was not "
+                    "successful for one or more files."
+                ).format(scene)
+            )
             gs.verbose(
                 _("Checksumming was not successful for urls \n{}").format(
                     "\n".join(failed_checksums)

--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -380,6 +380,8 @@ def get_checksum(filename, hash_function="md5"):
             readable_hash = hashlib.md5(bytes).hexdigest()
         elif hash_function == "sha256":
             readable_hash = hashlib.sha256(bytes).hexdigest()
+        elif hash_function == "sha3-256":
+            readable_hash = hashlib.sha3_256(bytes).hexdigest()
         else:
             raise Exception(
                 (
@@ -401,7 +403,7 @@ def download_gcs_file(url, destination, checksum_function, checksum):
         r_file = requests.get(url, allow_redirects=True)
         open(destination, "wb").write(r_file.content)
         sum_dl = get_checksum(destination, checksum_function)
-        if sum_dl != checksum:
+        if sum_dl.lower() != checksum.lower():
             gs.verbose(_("Checksumming not successful for {}").format(destination))
             return 1
         else:


### PR DESCRIPTION
This PR adapts `i.sentinel.download` as follows:

- Checksumming from GCS is adapted. Some newer files use `sha3-256` method for checksumming. Also sometimes the checksum indicated in the `manifest.safe` is not the same as for the actually downloaded file, although the file content is identical. For this case, only a warning is now given to the user (instead of assuming the entire downloaded scene is invalid and is removed)

- lazy import is moved to individual functions and methods for `requests` and `pandas`. This seems to be necessary as importing in the main function is not sufficient for the import to be in the environment also for each method/function. Here I am not sure whether this is the best solution, please advise.