### PR TITLE
i.landsat.download: add limit option

### DIFF
--- a/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
+++ b/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
@@ -116,6 +116,14 @@
 #% guisection: Optional
 #%end
 
+#%option
+#% key: limit
+#% type: integer
+#% description: maximum number of Landsat scenes
+#% answer: 50
+#% guisection: Optional
+#%end
+
 #%flag
 #% key: l
 #% description: List filtered products and exit
@@ -231,7 +239,7 @@ def main():
             start_date=start_date,
             end_date=end_date,
             max_cloud_cover=options["clouds"],
-            max_results=50,
+            max_results=options["limit"]
         )
 
         if options["tier"]:

--- a/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
+++ b/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
@@ -239,7 +239,7 @@ def main():
             start_date=start_date,
             end_date=end_date,
             max_cloud_cover=options["clouds"],
-            max_results=options["limit"]
+            max_results=options["limit"],
         )
 
         if options["tier"]:


### PR DESCRIPTION
This PR adds an optional `limit` options to `i.landsat.download` (similar to `i.sentinel.download`, https://github.com/OSGeo/grass-addons/blob/grass7/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py#L88) to limit the maximum number of scenes to be listed/downloaded.