### PR TITLE
i.sentinel.download: add support for Sentinel-3

### DIFF
--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.html
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.html
@@ -28,6 +28,21 @@ for download from the <b>Copernicus Open Access Hub</b>:
     <li>S2MSI1C: Top-Of-Atmosphere reflectances in cartographic geometry (Level-1C)</li>
   </ul>
   </li>
+  <li>Sentinel-3 (OLCI and SLSTR instrument data products at level 2; available from April 2018 to present day)
+  (optical) <a href="https://sentinel.esa.int/web/sentinel/missions/sentinel-3/data-products">products</a>:
+  <ul>
+    <li>S3OL2LFR: Land and atmosphere geophysical parameters</li>
+    <li>S3OL2LRR: Land and atmosphere geophysical parameters at reduced resolution</li>
+    <li>S3SL2LST: Land Surface Temperature</li>
+    <li>S3SL2FRP: Fire Radiative Power</li>
+    <li>S3SR2LAN: Land Surface Height</li>
+    <li>S3SY2SYN: Surface Reflectance and Aerosol parameters over Land</li>
+    <li>S3SY2VGP: 1 km VEGETATION-Like product (~VGT-P) - TOA Reflectance</li>
+    <li>S3SY2VG1: 1 km VEGETATION-Like product (~VGT-S1) 1 day synthesis surface reflectance and NDVI</li>
+    <li>S3SY2V10: 1 km VEGETATION-Like product (~VGT-S10) 10 day synthesis surface reflectance and NDVI</li>
+    <li>S3SY2AOD: Global Aerosol parameter over land and sea on super pixel resolution (4.5 km x 4.5 km)</li>
+  </ul>
+  </li>
 </ul>
 
 <p>

--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -68,7 +68,7 @@
 #% description: Sentinel product type to filter
 #% label: USGS Earth Explorer only supports S2MSI1C
 #% required: no
-#% options: SLC,GRD,OCN,S2MSI1C,S2MSI2A,S2MSI2Ap,S3SL2LST
+#% options: SLC,GRD,OCN,S2MSI1C,S2MSI2A,S2MSI2Ap,S3OL2LFR,S3OL2LRR,S3SL2LST,S3SL2FRP,S3SY2SYN,S3SY2VGP,S3SY2VG1,S3SY2V10,S3SY2AOD,S3SR2LAN
 #% answer: S2MSI2A
 #% guisection: Filter
 #%end
@@ -796,7 +796,7 @@ class SentinelDownloader(object):
 
         # Sentinel-1 data does not have cloudcoverpercentage
         prod_types = [type for type in self._products_df_sorted["producttype"]]
-        if any(type in prod_types for type in no_cloudcoverpercentage):
+        if not any(type in prod_types for type in cloudcover_products):
             del attrs["cloudcoverpercentage"]
 
         for key in attrs.keys():
@@ -1076,7 +1076,7 @@ def main():
         except IOError as e:
             gs.fatal(_("Unable to open settings file: {}").format(e))
 
-    no_cloudcoverpercentage = ["SLC", "GRD", "OCN", "S3SL2LST"]
+    cloudcover_products = ["S2MSI1C", "S2MSI2A", "S2MSI2Ap"]
 
     if user is None or password is None:
         gs.fatal(_("No user or password given"))
@@ -1087,7 +1087,7 @@ def main():
         map_box = get_aoi_box(options["map"])
 
     sortby = options["sort"].split(",")
-    if options["producttype"] in (no_cloudcoverpercentage):
+    if not options["producttype"] in cloudcover_products:
         if options["clouds"]:
             gs.info(
                 _(

--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -574,8 +574,11 @@ class SentinelDownloader(object):
         asc=True,
         relativeorbitnumber=None,
     ):
+        # Dict to identify plaforms from requested product
         platforms = {
-            "S1": "Sentinel-1",
+            "SL": "Sentinel-1",
+            "GR": "Sentinel-1",
+            "OC": "Sentinel-1",
             "S2": "Sentinel-2",
             "S3": "Sentinel-3",
         }


### PR DESCRIPTION
Thiss PR adds support for downloading Sentinel-3 data. It also addresses import issuses for optional libraries...

I am also working on import functions for Sentinel-3 level 2 products (LST in particular). But the format is not so well documented and differs between products. Further more, it is not supported by GDAL out of the box, so I am not sure if it would be appropriateto add it to `i.sentinel.import` or if a separate module would be needed. 