### PR TITLE
i.sentinel.import: write semantic label with r.support

### DIFF
--- a/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
+++ b/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
@@ -923,7 +923,7 @@ class SentinelImporter(object):
                     "source2": img_file,
                     "history": descr,
                 }
-                # Band refrence available after version 7.9
+                # Band references/semantic labels available from GRASS GIS 8.0.0 onwards
                 if float(gs.version()["version"][0:3]) >= 7.9:
                     support_args["bandref"] = self._extract_bandref(map_name)
                 for band in bands:

--- a/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
+++ b/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
@@ -965,7 +965,7 @@ class SentinelImporter(object):
                 fd.write(
                     "{img}{sep}{ts}".format(img=map_name, sep=sep, ts=timestamp_str)
                 )
-                # Band refrence available after version 7.9
+                # Band references/semantic labels available from GRASS GIS 8.0.0 onwards
                 if float(gs.version()["version"][0:3]) >= 7.9:
                     band_ref = self._extract_bandref(map_name)
                     if band_ref is None:


### PR DESCRIPTION
This adds the bandref directly to the raster map. I think if would also have been written upon registration in the temporal database but this way it is available without using temporal modules...

As discussed in #609