### PR TITLE
i.sentinel.download: print size and skip existing scenes

### DIFF
--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.html
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.html
@@ -28,6 +28,21 @@ for download from the <b>Copernicus Open Access Hub</b>:
     <li>S2MSI1C: Top-Of-Atmosphere reflectances in cartographic geometry (Level-1C)</li>
   </ul>
   </li>
+  <li>Sentinel-3 (OLCI and SLSTR instrument data products at level 2; available from April 2018 to present day)
+  (optical) <a href="https://sentinel.esa.int/web/sentinel/missions/sentinel-3/data-products">products</a>:
+  <ul>
+    <li>S3OL2LFR: Land and atmosphere geophysical parameters</li>
+    <li>S3OL2LRR: Land and atmosphere geophysical parameters at reduced resolution</li>
+    <li>S3SL2LST: Land Surface Temperature</li>
+    <li>S3SL2FRP: Fire Radiative Power</li>
+    <li>S3SR2LAN: Land Surface Height</li>
+    <li>S3SY2SYN: Surface Reflectance and Aerosol parameters over Land</li>
+    <li>S3SY2VGP: 1 km VEGETATION-Like product (~VGT-P) - TOA Reflectance</li>
+    <li>S3SY2VG1: 1 km VEGETATION-Like product (~VGT-S1) 1 day synthesis surface reflectance and NDVI</li>
+    <li>S3SY2V10: 1 km VEGETATION-Like product (~VGT-S10) 10 day synthesis surface reflectance and NDVI</li>
+    <li>S3SY2AOD: Global Aerosol parameter over land and sea on super pixel resolution (4.5 km x 4.5 km)</li>
+  </ul>
+  </li>
 </ul>
 
 <p>

--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -68,7 +68,7 @@
 #% description: Sentinel product type to filter
 #% label: USGS Earth Explorer only supports S2MSI1C
 #% required: no
-#% options: SLC,GRD,OCN,S2MSI1C,S2MSI2A,S2MSI2Ap,S3SL2LST
+#% options: SLC,GRD,OCN,S2MSI1C,S2MSI2A,S2MSI2Ap,S3OL2LFR,S3OL2LRR,S3SL2LST,S3SL2FRP,S3SY2SYN,S3SY2VGP,S3SY2VG1,S3SY2V10,S3SY2AOD,S3SR2LAN
 #% answer: S2MSI2A
 #% guisection: Filter
 #%end
@@ -796,7 +796,7 @@ class SentinelDownloader(object):
 
         # Sentinel-1 data does not have cloudcoverpercentage
         prod_types = [type for type in self._products_df_sorted["producttype"]]
-        if any(type in prod_types for type in no_cloudcoverpercentage):
+        if not any(type in prod_types for type in cloudcover_products):
             del attrs["cloudcoverpercentage"]
 
         for key in attrs.keys():
@@ -1076,7 +1076,7 @@ def main():
         except IOError as e:
             gs.fatal(_("Unable to open settings file: {}").format(e))
 
-    no_cloudcoverpercentage = ["SLC", "GRD", "OCN", "S3SL2LST"]
+    cloudcover_products = ["S2MSI1C", "S2MSI2A", "S2MSI2Ap"]
 
     if user is None or password is None:
         gs.fatal(_("No user or password given"))
@@ -1087,7 +1087,7 @@ def main():
         map_box = get_aoi_box(options["map"])
 
     sortby = options["sort"].split(",")
-    if options["producttype"] in (no_cloudcoverpercentage):
+    if not options["producttype"] in cloudcover_products:
         if options["clouds"]:
             gs.info(
                 _(

--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -574,8 +574,11 @@ class SentinelDownloader(object):
         asc=True,
         relativeorbitnumber=None,
     ):
+        # Dict to identify plaforms from requested product
         platforms = {
-            "S1": "Sentinel-1",
+            "SL": "Sentinel-1",
+            "GR": "Sentinel-1",
+            "OC": "Sentinel-1",
             "S2": "Sentinel-2",
             "S3": "Sentinel-3",
         }

--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -152,6 +152,11 @@
 #% guisection: Print
 #%end
 #%flag
+#% key: s
+#% description: Skip scenes that have already been downloaded after ingestiondate
+#% guisection: Filter
+#%end
+#%flag
 #% key: b
 #% description: Use the borders of the AOI polygon and not the region of the AOI
 #%end
@@ -170,6 +175,8 @@ import sys
 import logging
 import time
 from collections import OrderedDict
+from glob import glob
+from datetime import datetime
 
 import grass.script as gs
 
@@ -675,8 +682,42 @@ class SentinelDownloader(object):
             print_str += " {0} {1}".format(time_string, ccp)
             if kw_idx == 0:
                 print_str += " {0}".format(self._products_df_sorted["producttype"][idx])
+                print_str += " {0}".format(self._products_df_sorted["size"][idx])
 
             print(print_str)
+
+    def skip_existing(self, output, pattern_file):
+        prod_df_type = type(self._products_df_sorted)
+        # Check i skipping is possible/required
+        if prod_df_type != dict:
+            if self._products_df_sorted.empty:
+                return
+        elif not self._products_df_sorted or os.path.exists(output) == False:
+            return
+        # Check if ingestion date is returned by API
+        if "ingestiondate" not in self._products_df_sorted:
+            gs.warning(_("Ingestiondate not returned. Cannot filter previously downloaded scenes"))
+            return
+        # Check for previously downloaded scenes
+        existing_files = glob(os.path.join(output, pattern_file))
+        if len(existing_files) <= 1:
+            return
+        # Filter by ingestion date
+        skiprows = []
+        for idx, display_id in enumerate(self._products_df_sorted["identifier"]):
+            existing_file = [sfile for sfile in existing_files if display_id in sfile]
+            if existing_file:
+                creation_time = datetime.fromtimestamp(os.path.getctime(existing_file[0]))
+                if self._products_df_sorted["ingestiondate"][idx] <= creation_time:
+                    gs.verbose(_("Skipping scene: {} which is already downloaded.".format(self._products_df_sorted["identifier"][idx])))
+                    skiprows.append(display_id)
+        if prod_df_type == dict:
+            for scene in skiprows:
+                idx = self._products_df_sorted["identifier"].index(scene)
+                for key in self._products_df_sorted:
+                    self._products_df_sorted[key].pop(idx)
+        else:
+            self._products_df_sorted = self._products_df_sorted[~self._products_df_sorted["identifier"].isin(skiprows)]
 
     def download(self, output, sleep=False, maxretry=False, datasource="ESA_COAH"):
         if self._products_df_sorted is None:
@@ -1136,6 +1177,9 @@ def main():
 
     if options["footprints"]:
         downloader.save_footprints(options["footprints"])
+
+    if flags["s"]:
+        downloader.skip_existing(options["output"], "*.zip")
 
     if flags["l"]:
         downloader.list()

--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -542,7 +542,7 @@ class SentinelDownloader(object):
         # init logger
         root = logging.getLogger()
         root.addHandler(logging.StreamHandler(sys.stderr))
-        if self._apiname not in ["USGS_EE", "GCS"]:  # == "https://apihub.copernicus.eu/apihub":
+        if self._apiname not in ["USGS_EE", "GCS"]:
             try:
                 from sentinelsat import SentinelAPI
             except ImportError as e:

--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -696,7 +696,11 @@ class SentinelDownloader(object):
             return
         # Check if ingestion date is returned by API
         if "ingestiondate" not in self._products_df_sorted:
-            gs.warning(_("Ingestiondate not returned. Cannot filter previously downloaded scenes"))
+            gs.warning(
+                _(
+                    "Ingestiondate not returned. Cannot filter previously downloaded scenes"
+                )
+            )
             return
         # Check for previously downloaded scenes
         existing_files = glob(os.path.join(output, pattern_file))
@@ -707,9 +711,17 @@ class SentinelDownloader(object):
         for idx, display_id in enumerate(self._products_df_sorted["identifier"]):
             existing_file = [sfile for sfile in existing_files if display_id in sfile]
             if existing_file:
-                creation_time = datetime.fromtimestamp(os.path.getctime(existing_file[0]))
+                creation_time = datetime.fromtimestamp(
+                    os.path.getctime(existing_file[0])
+                )
                 if self._products_df_sorted["ingestiondate"][idx] <= creation_time:
-                    gs.verbose(_("Skipping scene: {} which is already downloaded.".format(self._products_df_sorted["identifier"][idx])))
+                    gs.verbose(
+                        _(
+                            "Skipping scene: {} which is already downloaded.".format(
+                                self._products_df_sorted["identifier"][idx]
+                            )
+                        )
+                    )
                     skiprows.append(display_id)
         if prod_df_type == dict:
             for scene in skiprows:
@@ -717,7 +729,9 @@ class SentinelDownloader(object):
                 for key in self._products_df_sorted:
                     self._products_df_sorted[key].pop(idx)
         else:
-            self._products_df_sorted = self._products_df_sorted[~self._products_df_sorted["identifier"].isin(skiprows)]
+            self._products_df_sorted = self._products_df_sorted[
+                ~self._products_df_sorted["identifier"].isin(skiprows)
+            ]
 
     def download(self, output, sleep=False, maxretry=False, datasource="ESA_COAH"):
         if self._products_df_sorted is None:

--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -542,7 +542,7 @@ class SentinelDownloader(object):
         # init logger
         root = logging.getLogger()
         root.addHandler(logging.StreamHandler(sys.stderr))
-        if self._apiname == "https://apihub.copernicus.eu/apihub":
+        if self._apiname not in ["USGS_EE", "GCS"]:  # == "https://apihub.copernicus.eu/apihub":
             try:
                 from sentinelsat import SentinelAPI
             except ImportError as e:


### PR DESCRIPTION
Currently, scenes present in the `input` directory are downloaded again if they are part of a query. This PR adds a flag to skip downloading those again if the ingestion date of the scscene is not newer than the creation time of the local file.

Additionally, `-l` now also writes size of the scenes, wich can be useful information if one lists scenes before downloading...

The base branch of this PR is that of #609 (not sure how the situation ideally would be handled in git when one wants to add other functionality on top of a not yet merged PR). Will change the PR according to recommendations then.
