### PR TITLE
wxGUI/wx.metadata: fix lazy import of GRASS GIS wxPy 'core.gcmd', 'gui_core.forms' module classes

### DIFF
--- a/src/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
+++ b/src/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
@@ -44,7 +44,6 @@ set_gui_path()
 from core.debug import Debug
 
 # from datacatalog.tree import LocationMapTree
-from core.utils import GetListOfLocations, ListOfMapsets
 
 grass.utils.set_path(modulename="wx.metadata", dirname="mdlib", path="..")
 
@@ -82,9 +81,10 @@ class LocationMapTree(wx.TreeCtrl):
         super(LocationMapTree, self).__init__(parent, id=wx.ID_ANY, style=style)
 
         try:
-            global RunCommand
+            global GetListOfLocations, ListOfMapsets, RunCommand
 
             from core.gcmd import RunCommand
+            from core.utils import GetListOfLocations, ListOfMapsets
         except ModuleNotFoundError as e:
             msg = e.msg
             sys.exit(

--- a/src/gui/wxpython/wx.metadata/mdlib/cswlib.py
+++ b/src/gui/wxpython/wx.metadata/mdlib/cswlib.py
@@ -27,8 +27,6 @@ from grass.script.setup import set_gui_path
 
 set_gui_path()
 
-from gui_core.forms import GUI
-
 import wx
 import wx.html as html
 from wx import SplitterWindow
@@ -105,7 +103,7 @@ class CSWBrowserPanel(wx.Panel):
         wx.Panel.__init__(self, parent)
 
         try:
-            global BBox, CatalogueServiceWeb, Environment, ExceptionReport, FileSystemLoader, GError, GMessage, GWarning, HtmlFormatter, PropertyIsLike, XmlLexer, highlight
+            global BBox, CatalogueServiceWeb, Environment, ExceptionReport, FileSystemLoader, GError, GMessage, GUI, GWarning, HtmlFormatter, PropertyIsLike, XmlLexer, highlight
 
             from jinja2 import Environment, FileSystemLoader
 
@@ -118,6 +116,7 @@ class CSWBrowserPanel(wx.Panel):
             from pygments.lexers import XmlLexer
 
             from core.gcmd import GError, GMessage, GWarning
+            from gui_core.forms import GUI
         except ModuleNotFoundError as e:
             msg = e.msg
             sys.exit(


### PR DESCRIPTION
Fix lazy import of GRASS GIS wxPy 'core.gcmd', 'gui_core.forms' module classes .Fix compilation errors on the OS MS Windows.

**Error messages**

```
Traceback (most recent call last):
  File "C:/Users/landa/grass_packager/grass786RC2/x86_64/addons/wx.metadata/scripts/g.gui.cswbrowser.py", line 26, in <module>
    from mdlib.cswlib import CSWBrowserPanel, CSWConnectionPanel
  File "C:\msys64\usr\src\grass-addons\src\gui\wxpython\wx.metadata\mdlib\cswlib.py", line 30, in <module>
    from gui_core.forms import GUI
  File "C:/msys64/usr/src/grass786RC2/dist.x86_64-w64-mingw32\gui\wxpython\gui_core\forms.py", line 98, in <module>
    from gui_core.widgets import StaticWrapText, ScrolledPanel, ColorTablesComboBox, \
  File "C:/msys64/usr/src/grass786RC2/dist.x86_64-w64-mingw32\gui\wxpython\gui_core\widgets.py", line 90, in <module>
    from core.gcmd import GMessage, GError
  File "C:/msys64/usr/src/grass786RC2/dist.x86_64-w64-mingw32\gui\wxpython\core\gcmd.py", line 43, in <module>
    from win32file import ReadFile, WriteFile
ModuleNotFoundError: No module named 'win32file'
```

```
Traceback (most recent call last):
  File "C:/Users/landa/grass_packager/grass786RC2/x86_64/addons/wx.metadata/scripts/g.gui.metadata.py", line 47, in <module>
    from core.utils import GetListOfLocations, ListOfMapsets
  File "C:/msys64/usr/src/grass786RC2/dist.x86_64-w64-mingw32\gui\wxpython\core\utils.py", line 29, in <module>
    from core.gcmd import RunCommand
  File "C:/msys64/usr/src/grass786RC2/dist.x86_64-w64-mingw32\gui\wxpython\core\gcmd.py", line 43, in <module>
    from win32file import ReadFile, WriteFile
ModuleNotFoundError: No module named 'win32file'
```

Full addon [compilation log](https://wingrass.fsv.cvut.cz/grass78/x86_64/addons/latest/logs/wx.metadata.log) on the MS Windows.