### PR TITLE
tools/cronjobs_osgeo_lxd: fix compile addons from Git addons repository branch 'grass7' on the server

### DIFF
--- a/tools/cronjobs_osgeo_lxd/compile_addons_git.sh
+++ b/tools/cronjobs_osgeo_lxd/compile_addons_git.sh
@@ -8,7 +8,7 @@
 
 if [ -z "$3" ]; then
     echo "Usage: $0 git_path topdir addons_path grass_startup_program [separate]"
-    echo "eg. $0 ~/src/grass_addons/grass7/ \
+    echo "eg. $0 ~/src/grass_addons/src/ \
 ~/src/releasebranch_7_8/dist.x86_64-pc-linux-gnu \
 ~/.grass7/addons \
 ~/src/releasebranch_7_8/bin.x86_64-pc-linux-gnu/grass78"
@@ -125,7 +125,7 @@ for c in "db" "display" "general" "gui/wxpython" "imagery" "misc" "raster" "rast
         MANBASEDIR="$path/docs/man" \
         SCRIPTDIR="$path/scripts" \
         ETC="$path/etc" \
-            SOURCE_URL="https://github.com/OSGeo/grass-addons/tree/master/grass${GRASS_VERSION}/" > \
+            SOURCE_URL="https://github.com/OSGeo/grass-addons/tree/grass${GRASS_VERSION}/src/" > \
             "$ADDON_PATH/logs/$m.log" 2>&1 \
         HTML_PAGE_FOOTER_PAGES_PATH="../"
     if [ `echo $?` -eq 0 ] ; then

--- a/tools/cronjobs_osgeo_lxd/cron_grass78_releasebranch_78_build_bins.sh
+++ b/tools/cronjobs_osgeo_lxd/cron_grass78_releasebranch_78_build_bins.sh
@@ -251,10 +251,10 @@ echo "Written to: $TARGETDIR"
 # compile addons
 
 # update addon repo
-(cd ~/src/grass-addons/grass7/ ; git pull origin master)
+(cd ~/src/grass-addons/; git fetch origin; git checkout grass${GMAJOR}; git pull origin grass${GMAJOR})
 # compile addons
 cd $GRASSBUILDDIR
-sh ~/cronjobs/compile_addons_git.sh ~/src/grass-addons/grass7/ \
+sh ~/cronjobs/compile_addons_git.sh ~/src/grass-addons/src/ \
    ~/src/releasebranch_7_8/dist.x86_64-pc-linux-gnu/ \
    ~/.grass7/addons \
    ~/src/releasebranch_7_8/bin.x86_64-pc-linux-gnu/grass$VERSION


### PR DESCRIPTION
**Describe the bug**
Compilation addons on the server use master branch (40 commits behind grass7 branch) instead of the current grass7 branch. This means that the [manual pages](https://grass.osgeo.org/grass78/manuals/addons/) are out of date and also the precompiled addons for MS Windows.

https://github.com/OSGeo/grass-addons/blob/0e26601ed7aeafaa2f562071e442ed95e59a38d2/tools/cronjobs_osgeo_lxd/cron_grass78_releasebranch_78_build_bins.sh#L254-L260




