### PR TITLE
i.sentinel.download: Download from GCS without settings file

### DIFF
--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.html
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.html
@@ -28,6 +28,21 @@ for download from the <b>Copernicus Open Access Hub</b>:
     <li>S2MSI1C: Top-Of-Atmosphere reflectances in cartographic geometry (Level-1C)</li>
   </ul>
   </li>
+  <li>Sentinel-3 (OLCI and SLSTR instrument data products at level 2; available from April 2018 to present day)
+  (optical) <a href="https://sentinel.esa.int/web/sentinel/missions/sentinel-3/data-products">products</a>:
+  <ul>
+    <li>S3OL2LFR: Land and atmosphere geophysical parameters</li>
+    <li>S3OL2LRR: Land and atmosphere geophysical parameters at reduced resolution</li>
+    <li>S3SL2LST: Land Surface Temperature</li>
+    <li>S3SL2FRP: Fire Radiative Power</li>
+    <li>S3SR2LAN: Land Surface Height</li>
+    <li>S3SY2SYN: Surface Reflectance and Aerosol parameters over Land</li>
+    <li>S3SY2VGP: 1 km VEGETATION-Like product (~VGT-P) - TOA Reflectance</li>
+    <li>S3SY2VG1: 1 km VEGETATION-Like product (~VGT-S1) 1 day synthesis surface reflectance and NDVI</li>
+    <li>S3SY2V10: 1 km VEGETATION-Like product (~VGT-S10) 10 day synthesis surface reflectance and NDVI</li>
+    <li>S3SY2AOD: Global Aerosol parameter over land and sea on super pixel resolution (4.5 km x 4.5 km)</li>
+  </ul>
+  </li>
 </ul>
 
 <p>

--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -68,7 +68,7 @@
 #% description: Sentinel product type to filter
 #% label: USGS Earth Explorer only supports S2MSI1C
 #% required: no
-#% options: SLC,GRD,OCN,S2MSI1C,S2MSI2A,S2MSI2Ap,S3SL2LST
+#% options: SLC,GRD,OCN,S2MSI1C,S2MSI2A,S2MSI2Ap,S3OL2LFR,S3OL2LRR,S3SL2LST,S3SL2FRP,S3SY2SYN,S3SY2VGP,S3SY2VG1,S3SY2V10,S3SY2AOD,S3SR2LAN
 #% answer: S2MSI2A
 #% guisection: Filter
 #%end
@@ -796,7 +796,7 @@ class SentinelDownloader(object):
 
         # Sentinel-1 data does not have cloudcoverpercentage
         prod_types = [type for type in self._products_df_sorted["producttype"]]
-        if any(type in prod_types for type in no_cloudcoverpercentage):
+        if not any(type in prod_types for type in cloudcover_products):
             del attrs["cloudcoverpercentage"]
 
         for key in attrs.keys():
@@ -1076,7 +1076,7 @@ def main():
         except IOError as e:
             gs.fatal(_("Unable to open settings file: {}").format(e))
 
-    no_cloudcoverpercentage = ["SLC", "GRD", "OCN", "S3SL2LST"]
+    cloudcover_products = ["S2MSI1C", "S2MSI2A", "S2MSI2Ap"]
 
     if user is None or password is None:
         gs.fatal(_("No user or password given"))
@@ -1087,7 +1087,7 @@ def main():
         map_box = get_aoi_box(options["map"])
 
     sortby = options["sort"].split(",")
-    if options["producttype"] in (no_cloudcoverpercentage):
+    if not options["producttype"] in cloudcover_products:
         if options["clouds"]:
             gs.info(
                 _(

--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -574,8 +574,11 @@ class SentinelDownloader(object):
         asc=True,
         relativeorbitnumber=None,
     ):
+        # Dict to identify plaforms from requested product
         platforms = {
-            "S1": "Sentinel-1",
+            "SL": "Sentinel-1",
+            "GR": "Sentinel-1",
+            "OC": "Sentinel-1",
             "S2": "Sentinel-2",
             "S3": "Sentinel-3",
         }

--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -24,6 +24,7 @@
 #%option G_OPT_F_INPUT
 #% key: settings
 #% label: Full path to settings file (user, password)
+#% required: no
 #% description: '-' for standard input
 #%end
 #%option G_OPT_M_DIR
@@ -534,10 +535,12 @@ def download_gcs(scene, output):
 
 
 class SentinelDownloader(object):
-    def __init__(self, user, password, api_url="https://apihub.copernicus.eu/apihub"):
+    def __init__(self, user, password, api_url="https://apihub.copernicus.eu/apihub",
+                 cred_req=True):
         self._apiname = api_url
         self._user = user
         self._password = password
+        self._cred_req = cred_req
 
         # init logger
         root = logging.getLogger()
@@ -623,6 +626,11 @@ class SentinelDownloader(object):
                 area, area_relation, start, end, args
             )
         )
+        if self._cred_req is False:
+            # in the main function it is ensured that there is an "identifier" query
+            self._products_df_sorted = pandas.DataFrame({"identifier": [query["identifier"]]})
+            return
+
         products = self._api.query(
             area=area, area_relation=area_relation, date=(start, end), **args
         )
@@ -1022,46 +1030,55 @@ class SentinelDownloader(object):
 
 
 def main():
-
+    cred_req = True
     api_url = "https://apihub.copernicus.eu/apihub"
     if options["datasource"] == "GCS":
         if options["producttype"] not in ["S2MSI2A", "S2MSI1C"]:
             gs.fatal(
                 _("Download from GCS only supports producttypes S2MSI2A " "or S2MSI1C")
             )
+        if options["query"]:
+            queries = options["query"].split(",")
+            query_names = [query.split("=")[0] for query in queries]
+            if "identifier" in query_names and not flags["l"]:
+                cred_req = False
     elif options["datasource"] == "USGS_EE":
         api_url = "USGS_EE"
 
+    if not options["settings"] and cred_req is True:
+        gs.fatal(
+            _("Credentials are required via the settings parameter.")
+        )
     user = password = None
+    if cred_req is True:
+        if options["settings"] == "-":
+            # stdin
+            import getpass
 
-    if options["settings"] == "-":
-        # stdin
-        import getpass
-
-        user = raw_input(_("Insert username: "))
-        password = getpass.getpass(_("Insert password: "))
-        url = raw_input(_("Insert API URL (leave empty for {}): ").format(api_url))
-        if url:
-            api_url = url
-    else:
-        try:
-            with open(options["settings"], "r") as fd:
-                lines = list(
-                    filter(None, (line.rstrip() for line in fd))
-                )  # non-blank lines only
-                if len(lines) < 2:
-                    gs.fatal(_("Invalid settings file"))
-                user = lines[0].strip()
-                password = lines[1].strip()
-                if len(lines) > 2:
-                    api_url = lines[2].strip()
-        except IOError as e:
-            gs.fatal(_("Unable to open settings file: {}").format(e))
+            user = raw_input(_("Insert username: "))
+            password = getpass.getpass(_("Insert password: "))
+            url = raw_input(_("Insert API URL (leave empty for {}): ").format(api_url))
+            if url:
+                api_url = url
+        else:
+            try:
+                with open(options["settings"], "r") as fd:
+                    lines = list(
+                        filter(None, (line.rstrip() for line in fd))
+                    )  # non-blank lines only
+                    if len(lines) < 2:
+                        gs.fatal(_("Invalid settings file"))
+                    user = lines[0].strip()
+                    password = lines[1].strip()
+                    if len(lines) > 2:
+                        api_url = lines[2].strip()
+            except IOError as e:
+                gs.fatal(_("Unable to open settings file: {}").format(e))
+            if user is None or password is None:
+                gs.fatal(_("No user or password given"))
 
     cloudcover_products = ["S2MSI1C", "S2MSI2A", "S2MSI2Ap"]
 
-    if user is None or password is None:
-        gs.fatal(_("No user or password given"))
 
     if flags["b"]:
         map_box = get_aoi(options["map"])
@@ -1083,7 +1100,7 @@ def main():
         except ValueError:
             pass
     try:
-        downloader = SentinelDownloader(user, password, api_url)
+        downloader = SentinelDownloader(user, password, api_url, cred_req)
 
         if options["uuid"]:
             downloader.set_uuid(options["uuid"].split(","))
@@ -1106,6 +1123,7 @@ def main():
                 "asc": True if options["order"] == "asc" else False,
                 "relativeorbitnumber": options["relativeorbitnumber"],
             }
+
             if options["datasource"] == "ESA_COAH" or options["datasource"] == "GCS":
                 downloader.filter(**filter_args)
             elif options["datasource"] == "USGS_EE":

--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -1023,35 +1023,14 @@ class SentinelDownloader(object):
 
 def main():
 
-    # Lazy import nonstandard modules
-    try:
-        import pandas
-    except ImportError as e:
-        gs.fatal(_("Module requires pandas library: {}").format(e))
-
-    try:
-        import requests
-    except ImportError as e:
-        gs.fatal(_("Module requires requests library: {}").format(e))
-
     api_url = "https://apihub.copernicus.eu/apihub"
     if options["datasource"] == "GCS":
-        # Lazy import tqdm
         if options["producttype"] not in ["S2MSI2A", "S2MSI1C"]:
             gs.fatal(
                 _("Download from GCS only supports producttypes S2MSI2A " "or S2MSI1C")
             )
-        try:
-            from tqdm import tqdm
-        except ImportError as e:
-            gs.fatal(_("Module requires tqdm library: {}").format(e))
     elif options["datasource"] == "USGS_EE":
         api_url = "USGS_EE"
-        try:
-            import landsatxplore.api
-            from landsatxplore.errors import EarthExplorerError
-        except ImportError as e:
-            gs.fatal(_("Module requires landsatxplore library: {}").format(e))
 
     user = password = None
 
@@ -1153,4 +1132,28 @@ def main():
 
 if __name__ == "__main__":
     options, flags = gs.parser()
+
+    if options["datasource"] == "GCS":
+        # Lazy import nonstandard modules
+        try:
+            import pandas
+        except ImportError as e:
+            gs.fatal(_("Module requires pandas library: {}").format(e))
+
+        try:
+            import requests
+        except ImportError as e:
+            gs.fatal(_("Module requires requests library: {}").format(e))
+
+        try:
+            from tqdm import tqdm
+        except ImportError as e:
+            gs.fatal(_("Module requires tqdm library: {}").format(e))
+    elif options["datasource"] == "USGS_EE":
+        try:
+            import landsatxplore.api
+            from landsatxplore.errors import EarthExplorerError
+        except ImportError as e:
+            gs.fatal(_("Module requires landsatxplore library: {}").format(e))
+
     sys.exit(main())

--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -542,7 +542,7 @@ class SentinelDownloader(object):
         # init logger
         root = logging.getLogger()
         root.addHandler(logging.StreamHandler(sys.stderr))
-        if self._apiname not in ["USGS_EE", "GCS"]:  # == "https://apihub.copernicus.eu/apihub":
+        if self._apiname not in ["USGS_EE", "GCS"]:
             try:
                 from sentinelsat import SentinelAPI
             except ImportError as e:

--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -542,7 +542,7 @@ class SentinelDownloader(object):
         # init logger
         root = logging.getLogger()
         root.addHandler(logging.StreamHandler(sys.stderr))
-        if self._apiname == "https://apihub.copernicus.eu/apihub":
+        if self._apiname not in ["USGS_EE", "GCS"]:  # == "https://apihub.copernicus.eu/apihub":
             try:
                 from sentinelsat import SentinelAPI
             except ImportError as e:


### PR DESCRIPTION
When the `query=` parameter holds a unique S-2 identifier, there is no need to query via ESA-Copernicus Hub and the scene can be downloaded directly.

(remaining changes in this PR based on #609 ; will be harmonized)