### PR TITLE
r.in.usgs: Use system user cache dir

### DIFF
--- a/src/raster/r.in.usgs/r.in.usgs.html
+++ b/src/raster/r.in.usgs/r.in.usgs.html
@@ -3,8 +3,8 @@
 the current GRASS computational region and coordinate reference system. 
 Associated parameters are automatically passed to 
 <a href="https://viewer.nationalmap.gov/tnmaccess/api/index">
-The National Map Access API</a>, downloaded to a user-specified
-local directory, then imported and patched.
+The National Map Access API</a>, downloaded to a local cache directory,
+then imported, and patched together.
 
 <em>r.in.usgs</em> supports the following datasets:
 <ul>
@@ -38,11 +38,23 @@ If the <b>i</b> flag is set, only information about data meeting the input param
 is displayed without downloading the data.
 
 <p>
-By default, downloaded files are kept in the specified <b>output_direcory</b>,
-so that they can be reused in case different computational region is required.
+By default, downloaded files are kept in a user cache directory according to
+the operating system standards.
+These files can be reused in case a different, but overlapping, computational
+region is required.
 However, unzipped files and imported rasters before patching are removed.
 If the <b>k</b> flag is set, extracted files from compressed archives are also kept within the
-download directory after the import.
+cache directory after the import.
+The location of the cache directory depends on the operating system.
+You can clear the cache by deleting the directory.
+Where this directory is depends on operating system,
+for example on Linux, it is under <code>~/.cache</code>,
+on macOS under <code>~/Library/Caches</code>,
+and on Microsoft Windows under the Application Data directory.
+If you have limited space or other special needs, you can set
+<b>output_directory</b> to a custom directory,
+e.g., <code>/tmp</code> on Linux.
+The custom directory needs to exist before calling this module.
 
 <p>
 By default, resampling method is chosen based on the nature of the dataset,
@@ -51,11 +63,10 @@ bilinear for NED and nearest for NAIP. This can be changed with option
 
 <h2>EXAMPLE</h2>
 We will download NED 1/9 arc-second digital elevation model in the extent of raster 'elevation'.
-First, we just list the files to be downloaded
- (change output directory depending on the operating system):
+First, we just list the files to be downloaded:
 <div class="code"><pre>
 g.region raster=elevation
-r.in.usgs product=ned ned_dataset=ned19sec output_directory=/tmp output_name=ned -i
+r.in.usgs product=ned ned_dataset=ned19sec output_name=ned -i
 </pre></div>
 <pre>
 USGS file(s) to download:
@@ -74,7 +85,7 @@ To download USGS data, remove i flag, and rerun r.in.usgs.
 
 We proceed with the download:
 <div class="code"><pre>
-r.in.usgs product=ned ned_dataset=ned19sec output_directory=/tmp output_name=ned
+r.in.usgs product=ned ned_dataset=ned19sec output_name=ned
 r.colors map=ned_small color=grey
 </pre></div>
 
@@ -82,10 +93,12 @@ We change the computational region to a smaller extent and create a new DEM,
 downloaded files will be used.
 <div class="code"><pre>
 g.region n=224649 s=222000 w=633000 e=636000
-r.in.usgs product=ned ned_dataset=ned19sec output_directory=/tmp output_name=ned_small
+r.in.usgs product=ned ned_dataset=ned19sec output_name=ned_small
 </pre></div>
 
-For a different extent we download NAIP imagery:
+For a different extent we download NAIP imagery and we use a custom cache directory
+(replace <code>/tmp</code> by an existing path suitable
+for your operating system and needs):
 <div class="code"><pre>
 g.region n=224649 s=222000 w=636000 e=639000
 r.in.usgs product=naip output_directory=/tmp output_name=ortho

--- a/src/raster/r.in.usgs/r.in.usgs.py
+++ b/src/raster/r.in.usgs/r.in.usgs.py
@@ -168,7 +168,7 @@ def get_cache_dir(name):
         # App name, directory, and the assumption that the directory exists
         # (and thus that it should be used) are derived from the startup script.
         app_name = "GRASS8"
-        path = Path(os.getenv("APPDATA")) / "Cache" / app_name / name
+        path = Path(os.getenv("APPDATA")) / app_name / "Cache" / name
     elif sys.platform.startswith('darwin'):
         app_name = "grass"
         path = Path('~/Library/Caches').expanduser() / app_name / app_version / name

--- a/src/raster/r.in.usgs/r.in.usgs.py
+++ b/src/raster/r.in.usgs/r.in.usgs.py
@@ -11,7 +11,7 @@
 #
 # PURPOSE:   Download user-requested products through the USGS TNM API.
 #
-# COPYRIGHT: (C) 2017-2019 Zechariah Krautwurst and the GRASS Development Team
+# COPYRIGHT: (C) 2017-2021 Zechariah Krautwurst and the GRASS Development Team
 #
 #            This program is free software under the GNU General Public
 #            License (>=v2). Read the file COPYING that comes with GRASS
@@ -158,16 +158,17 @@ def get_cache_dir(name):
     """Get the default user cache directory
 
     The name parameter is used to distinguish cache data from different
-    componenets, e.g., from different modules.
+    components, e.g., from different modules.
 
     The function creates the directory (including all its parent directories)
     if it does not exist.
     """
     app_version = gs.version()["version"]
     if sys.platform.startswith("win"):
-        # App name, directory, and the assumption that the directory exists
-        # (and thus that it should be used) are derived from the startup script.
-        app_name = "GRASS8"
+        # App name, directory, and the assumption that the directory
+        # should be used are derived from the startup script.
+        # Major version is part of the directory name.
+        app_name = "GRASS{}".format(app_version.split(".", maxsplit=1)[0])
         path = Path(os.getenv("APPDATA")) / app_name / "Cache" / name
     elif sys.platform.startswith("darwin"):
         app_name = "grass"

--- a/src/raster/r.in.usgs/r.in.usgs.py
+++ b/src/raster/r.in.usgs/r.in.usgs.py
@@ -128,7 +128,7 @@
 
 #%flag
 #% key: k
-#% description: Keep imported tiles in the mapset after patch
+#% description: Keep extracted files after GRASS import and patch
 #% guisection: Speed
 #%end
 
@@ -415,7 +415,7 @@ def main():
     memory = options["memory"]
     nprocs = options["nprocs"]
 
-    preserve_extracted_files = True
+    preserve_extracted_files = gui_k_flag
     use_existing_extracted_files = True
     preserve_imported_tiles = gui_k_flag
     use_existing_imported_tiles = True
@@ -554,60 +554,76 @@ def main():
     # Some combinations produce >10 byte differences.
     size_diff_tolerance = 5
     exist_dwnld_size = 0
-
-    # Fatal error if API query returns no results for GUI input
-    if tile_API_count == 0:
-        gscript.fatal(
-            _("USGS TNM API error or no tiles available for given input parameters")
-        )
-
-    dwnld_size = []
-    dwnld_url = []
-    TNM_file_titles = []
-    exist_dwnld_url = []
-    exist_TNM_titles = []
-    exist_zip_list = []
-    exist_tile_list = []
-    extract_zip_list = []
-    # for each file returned, assign variables to needed parameters
-    for f in return_JSON["items"]:
-        TNM_file_title = f["title"]
-        TNM_file_URL = str(f["downloadURL"])
-        TNM_file_size = int(f["sizeInBytes"])
-        TNM_file_name = TNM_file_URL.split(product_url_split)[-1]
-        if gui_product == "ned":
-            local_file_path = os.path.join(work_dir, ned_data_abbrv + TNM_file_name)
-            local_zip_path = os.path.join(work_dir, ned_data_abbrv + TNM_file_name)
-            local_tile_path = os.path.join(work_dir, ned_data_abbrv + TNM_file_name)
-        else:
-            local_file_path = os.path.join(work_dir, TNM_file_name)
-            local_zip_path = os.path.join(work_dir, TNM_file_name)
-            local_tile_path = os.path.join(work_dir, TNM_file_name)
-        file_exists = os.path.exists(local_file_path)
-        file_complete = None
-        # If file exists, do not download,
-        # but if incomplete (e.g. interupted download), redownload.
-        if file_exists:
-            existing_local_file_size = os.path.getsize(local_file_path)
-            # if local file is incomplete
-            if abs(existing_local_file_size - TNM_file_size) > size_diff_tolerance:
-                gscript.verbose(
-                    _(
-                        "Size of local file {filename} ({local_size}) differs"
-                        " from a file size specified in the API ({api_size})"
-                        " by {difference} bytes"
-                        " which is more than tolerance ({tolerance})."
-                        " It will be downloaded again."
-                    ).format(
-                        filename=local_file_path,
-                        local_size=existing_local_file_size,
-                        api_size=TNM_file_size,
-                        difference=abs(existing_local_file_size - TNM_file_size),
-                        tolerance=size_diff_tolerance,
+    if tile_API_count > 0:
+        dwnld_size = []
+        dwnld_url = []
+        TNM_file_titles = []
+        exist_dwnld_url = []
+        exist_TNM_titles = []
+        exist_zip_list = []
+        exist_tile_list = []
+        extract_zip_list = []
+        # for each file returned, assign variables to needed parameters
+        for f in return_JSON["items"]:
+            TNM_file_title = f["title"]
+            TNM_file_URL = str(f["downloadURL"])
+            TNM_file_size = int(f["sizeInBytes"])
+            TNM_file_name = TNM_file_URL.split(product_url_split)[-1]
+            if gui_product == "ned":
+                local_file_path = os.path.join(work_dir, ned_data_abbrv + TNM_file_name)
+                local_zip_path = os.path.join(work_dir, ned_data_abbrv + TNM_file_name)
+                local_tile_path = os.path.join(work_dir, ned_data_abbrv + TNM_file_name)
+            else:
+                local_file_path = os.path.join(work_dir, TNM_file_name)
+                local_zip_path = os.path.join(work_dir, TNM_file_name)
+                local_tile_path = os.path.join(work_dir, TNM_file_name)
+            file_exists = os.path.exists(local_file_path)
+            file_complete = None
+            # If file exists, do not download,
+            # but if incomplete (e.g. interupted download), redownload.
+            if file_exists:
+                existing_local_file_size = os.path.getsize(local_file_path)
+                # if local file is incomplete
+                if abs(existing_local_file_size - TNM_file_size) > size_diff_tolerance:
+                    gscript.verbose(
+                        _(
+                            "Size of local file {filename} ({local_size}) differs"
+                            " from a file size specified in the API ({api_size})"
+                            " by {difference} bytes"
+                            " which is more than tolerance ({tolerance})."
+                            " It will be downloaded again."
+                        ).format(
+                            filename=local_file_path,
+                            local_size=existing_local_file_size,
+                            api_size=TNM_file_size,
+                            difference=abs(existing_local_file_size - TNM_file_size),
+                            tolerance=size_diff_tolerance,
+                        )
                     )
-                )
-                # NLCD API query returns subsets that cannot be filtered before
-                # results are returned. gui_subset is used to filter results.
+                    # NLCD API query returns subsets that cannot be filtered before
+                    # results are returned. gui_subset is used to filter results.
+                    if not gui_subset:
+                        tiles_needed_count += 1
+                        down_list()
+                    else:
+                        if gui_subset in TNM_file_title:
+                            tiles_needed_count += 1
+                            down_list()
+                        else:
+                            continue
+                else:
+                    if not gui_subset:
+                        tiles_needed_count += 1
+                        exist_list()
+                        exist_dwnld_size += TNM_file_size
+                    else:
+                        if gui_subset in TNM_file_title:
+                            tiles_needed_count += 1
+                            exist_list()
+                            exist_dwnld_size += TNM_file_size
+                        else:
+                            continue
+            else:
                 if not gui_subset:
                     tiles_needed_count += 1
                     down_list()
@@ -615,29 +631,13 @@ def main():
                     if gui_subset in TNM_file_title:
                         tiles_needed_count += 1
                         down_list()
-                    else:
                         continue
-            else:
-                if not gui_subset:
-                    tiles_needed_count += 1
-                    exist_list()
-                    exist_dwnld_size += TNM_file_size
-                else:
-                    if gui_subset in TNM_file_title:
-                        tiles_needed_count += 1
-                        exist_list()
-                        exist_dwnld_size += TNM_file_size
-                    else:
-                        continue
-        else:
-            if not gui_subset:
-                tiles_needed_count += 1
-                down_list()
-            else:
-                if gui_subset in TNM_file_title:
-                    tiles_needed_count += 1
-                    down_list()
-                    continue
+
+    # return fatal error if API query returns no results for GUI input
+    elif tile_API_count == 0:
+        gscript.fatal(
+            _("TNM API ERROR or Zero tiles available for given input parameters.")
+        )
 
     # number of files to be downloaded
     file_download_count = len(dwnld_url)
@@ -739,12 +739,6 @@ def main():
             file_name = url.split(product_url_split)[-1]
             local_file_path = os.path.join(work_dir, file_name)
         try:
-            download_count += 1
-            gscript.info(
-                _("Download {current} of {total}...").format(
-                    current=download_count, total=TNM_count
-                )
-            )
             # download files in chunks rather than write complete files to memory
             dwnld_req = urlopen(url, timeout=12)
             download_bytes = int(dwnld_req.info()["Content-Length"])
@@ -761,22 +755,27 @@ def main():
                     local_file.write(chunk)
                 gscript.percent(1, 1, 1)
             local_file.close()
+            download_count += 1
             # determine if file is a zip archive or another format
             if product_is_zip:
                 local_zip_path_list.append(local_file_path)
             else:
                 local_tile_path_list.append(local_file_path)
-        except URLError as error:
-            gscript.fatal(
-                _(
-                    "USGS download request for {url} has timed out. Network or formatting error: {err}"
-                ).format(url=url, err=error)
+            file_complete = "Download {0} of {1}: COMPLETE".format(
+                download_count, TNM_count
             )
-        except StandardError as error:
+            gscript.info(file_complete)
+        except URLError:
+            gscript.fatal(
+                _("USGS download request has timed out. Network or formatting error.")
+            )
+        except StandardError:
             cleanup_list.append(local_file_path)
-            gscript.fatal(
-                _("Download of {url} failed: {err}").format(url=url, err=error)
-            )
+            if download_count:
+                file_failed = "Download {0} of {1}: FAILED".format(
+                    download_count, TNM_count
+                )
+                gscript.fatal(file_failed)
 
     # sets already downloaded zip files or tiles to be extracted or imported
     # our pre-stats for extraction are broken, collecting stats during
@@ -920,7 +919,7 @@ def main():
                             resolution_value=product_resolution,
                             extent="region",
                             resample=product_interpolation,
-                            memory=float(memory) / int(nprocs),
+                            memory=memory,
                         ),
                     )
                 else:
@@ -1083,6 +1082,11 @@ def main():
         gscript.fatal(
             _("Error in getting or importing the data (see above). Please retry.")
         )
+
+    # Keep source files if 'k' flag active
+    if gui_k_flag:
+        src_msg = ("<k> flag selected: Source tiles remain in '{0}'").format(work_dir)
+        gscript.info(src_msg)
 
     # set appropriate color table
     if gui_product == "ned":


### PR DESCRIPTION
Instead of a required output/work/cache dir, use a subdirectory of the user cache dir according to the standards of each operating system.

Linux/Freedesktop uses .cache and we use grass as the application name, then version string (from g.version), and then name of the module.
MacOS is the same, but in Library/Caches. For Windows, we use APPDATA as in the startup script with Cache as an additional subdirectory.
