### PR TITLE
r.in.usgs: Split memory amount, keep extracted files

### DIFF
--- a/src/raster/r.in.usgs/r.in.usgs.py
+++ b/src/raster/r.in.usgs/r.in.usgs.py
@@ -880,7 +880,7 @@ def main():
                             resolution_value=product_resolution,
                             extent="region",
                             resample=product_interpolation,
-                            memory=float(memory) / int(nprocs),
+                            memory=int(float(memory) // int(nprocs)),
                         ),
                     )
                 else:

--- a/src/raster/r.in.usgs/r.in.usgs.py
+++ b/src/raster/r.in.usgs/r.in.usgs.py
@@ -126,7 +126,7 @@
 
 #%flag
 #% key: k
-#% description: Keep extracted files after GRASS import and patch
+#% description: Keep imported tiles in the mapset after patch
 #% guisection: Speed
 #%end
 
@@ -378,7 +378,7 @@ def main():
     memory = options["memory"]
     nprocs = options["nprocs"]
 
-    preserve_extracted_files = gui_k_flag
+    preserve_extracted_files = True
     use_existing_extracted_files = True
     preserve_imported_tiles = gui_k_flag
     use_existing_imported_tiles = True
@@ -880,7 +880,7 @@ def main():
                             resolution_value=product_resolution,
                             extent="region",
                             resample=product_interpolation,
-                            memory=memory,
+                            memory=float(memory) / int(nprocs),
                         ),
                     )
                 else:
@@ -1043,11 +1043,6 @@ def main():
         gscript.fatal(
             _("Error in getting or importing the data (see above). Please retry.")
         )
-
-    # Keep source files if 'k' flag active
-    if gui_k_flag:
-        src_msg = ("<k> flag selected: Source tiles remain in '{0}'").format(work_dir)
-        gscript.info(src_msg)
 
     # set appropriate color table
     if gui_product == "ned":


### PR DESCRIPTION
* Split assigneded memory between parallel subprocesses based on nprocs instead of passing the memory value as is.
* Keep extracted file in cache by default. -k now only adds keeping of tiles in the target mapset. Message about -k enable was removed.
