### PR TITLE
v.mapcalc, v.stream.profiler: fix MODULE_TOPDIR

### DIFF
--- a/src/vector/v.mapcalc/Makefile
+++ b/src/vector/v.mapcalc/Makefile
@@ -1,4 +1,4 @@
-MODULE_TOPDIR = ../../grass7.0/grass_trunk
+MODULE_TOPDIR = ../..
 
 PGM = v.mapcalc
 

--- a/src/vector/v.stream.profiler/Makefile
+++ b/src/vector/v.stream.profiler/Makefile
@@ -1,8 +1,7 @@
-MODULE_TOPDIR = /usr/local/grass-7.3.svn
+MODULE_TOPDIR = ../..
 
 PGM = v.stream.profiler
 
 include $(MODULE_TOPDIR)/include/Make/Script.make
 
 default: script
-


### PR DESCRIPTION
fix `MODULE_TOPDIR = ...garbage` entries to `MODULE_TOPDIR = ../..`