### PR TITLE
CI: Test with v8.0 in grass8 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,12 @@ jobs:
       matrix:
         grass-version:
         - main
-        - releasebranch_7_8
+        - releasebranch_8_0
         python-version:
-        - 3.6
-        - 3.8
+        # Test with supported Python versions.
+        # Test only with every second version to reduce number of jobs.
+        - "3.8"
+        - "3.10"
       fail-fast: false
 
     steps:


### PR DESCRIPTION
* Instead of v7.8, test with v8.0 release branch in the grass8 branch.
* Add test with Python 3.10.
* Remove test with Python 3.6.
* Keep testing only every second version to reduce jobs - add a comment about that.
* Use (explicit) strings to specify versions (not floats).
