### PR TITLE
i.sentinel.download: fix footprints

### DIFF
--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -181,6 +181,8 @@ from datetime import datetime
 
 import grass.script as gs
 
+cloudcover_products = ["S2MSI1C", "S2MSI2A", "S2MSI2Ap"]
+
 
 def create_dir(dir):
     if not os.path.isdir(dir):
@@ -1109,6 +1111,8 @@ class SentinelDownloader(object):
 
 
 def main():
+    global cloudcover_products
+
     cred_req = True
     api_url = "https://apihub.copernicus.eu/apihub"
     if options["datasource"] == "GCS":
@@ -1159,8 +1163,6 @@ def main():
                 gs.fatal(_("Unable to open settings file: {}").format(e))
             if user is None or password is None:
                 gs.fatal(_("No user or password given"))
-
-    cloudcover_products = ["S2MSI1C", "S2MSI2A", "S2MSI2Ap"]
 
     if flags["b"]:
         map_box = get_aoi(options["map"])


### PR DESCRIPTION
By trying to download the footprints, I got the follow error:
```
Generating WKT from AOI map (5 vertices)...
Sending WKT from AOI map to ESA...
36 Sentinel product(s) found
Writing footprints into <fp>...
	- 'VirtualXPath'	[XML Path Language - XPath]
Traceback (most recent call last):
  File "/home/mundialis/.grass8/addons/scripts/i.sentinel.download", line 1262, in <module>
    sys.exit(main())
  File "/home/mundialis/.grass8/addons/scripts/i.sentinel.download", line 1217, in main
    downloader.save_footprints(options["footprints"])
  File "/home/mundialis/.grass8/addons/scripts/i.sentinel.download", line 889, in save_footprints
    if not any(type in prod_types for type in cloudcover_products):
NameError: name 'cloudcover_products' is not defined
```
This change is fixing this error.