### PR TITLE
r.learn.ml: renamed jaccard_similarity_score to jaccard_score

### DIFF
--- a/src/raster/r.learn.ml/r.learn.ml.py
+++ b/src/raster/r.learn.ml/r.learn.ml.py
@@ -1315,7 +1315,7 @@ def cross_val_scores(
         "f1": metrics.f1_score,
         "fbeta": metrics.fbeta_score,
         "hamming_loss": metrics.hamming_loss,
-        "jaccard_similarity": metrics.jaccard_similarity_score,
+        "jaccard_similarity": metrics.jaccard_score,
         "log_loss": metrics.log_loss,
         "matthews_corrcoef": metrics.matthews_corrcoef,
         "precision": metrics.precision_score,


### PR DESCRIPTION
Sci-kit learn updated Jaccard score output metric to be named "jaccard_score." 