### PR TITLE
Reduce build matrix, remove Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
         # only.
         include:
           - grass-version: main
-            python-version: "3.9"
-          - grass-version: releasebranch_8_0
             python-version: "3.8"
+          - grass-version: releasebranch_8_0
+            python-version: "3.7"
       fail-fast: false
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,15 @@ jobs:
 
     strategy:
       matrix:
-        grass-version:
-        - main
-        - releasebranch_8_0
-        python-version:
-        # Test with supported Python versions.
-        # Test only with every second version to reduce number of jobs.
-        - "3.8"
-        - "3.10"
+        # Test with relevant active branches or tags and supported Python
+        # versions, but also limit the number of jobs by, e.g., testing only
+        # every second version or testing older GRASS versions with older Python
+        # only.
+        include:
+          - grass-version: main
+            python-version: "3.9"
+          - grass-version: releasebranch_8_0
+            python-version: "3.8"
       fail-fast: false
 
     steps:


### PR DESCRIPTION
* Replace full matrix with all combinations of Python version and GRASS version by hand-picked combinations.
* Replace Python 3.10 by 3.9 because of failing GDAL package install.

In the future, tags or other branches can be added more freely without introducing multiple new jobs.
New Python versions can be tested with recent GRASS versions without interfering with old GRASS versions.
Multiple Python versions can still be tested (with a reduced number of jobs), although not in combination
with all GRASS versions.
