### PR TITLE
Cleanup of older GRASS GIS 7 addons cronjobs on grass.osgeo.org

### DIFF
--- a/utils/cronjobs_osgeo_lxd/README.md
+++ b/utils/cronjobs_osgeo_lxd/README.md
@@ -9,19 +9,18 @@ This directory contains the relevant files to generate and deploy the GRASS GIS 
 - generate and deploy the GRASS GIS Web pages at https://grass.osgeo.org/:
     - `hugo_clean_and_update_job.sh`
 - GRASS GIS source code weekly snapshots:
-    - release_branch_7_8: `cron_grass78_src_relbr78_snapshot.sh`
-    - main: `cron_grass8_HEAD_src_snapshot.sh`
+    - grass7: `cron_grass7_main_src_snapshot.sh`
 - GRASS GIS Linux binary weekly snapshots:
-    - `cron_grass78_releasebranch_78_build_bins.sh`
+    - grass7: `cron_grass7_relbranch_build_binaries.sh`
 - GRASS GIS addons manual pages:
-    - within `cron_grass78_releasebranch_78_build_bins.sh`
+    - grass7: within `cron_grass7_relbranch_build_binaries.sh`
 - GRASS GIS addons overview page at https://grass.osgeo.org/grass7/manuals/addons/:
-    - `compile_addons_git.sh` - called from `cron_grass78_releasebranch_78_build_bins.sh`
-    - `grass-addons-fetch-xml.sh` - called from `cron_grass78_releasebranch_78_build_bins.sh`
-    - `grass-addons-index.sh` - called from `cron_grass78_releasebranch_78_build_bins.sh`
+    - `compile_addons_git.sh` - called from `cron_grass7_relbranch_build_binaries.sh`
+    - `grass-addons-fetch-xml.sh` - called from `cron_grass7_relbranch_build_binaries.sh`
+    - `grass-addons-index.sh` - called from `cron_grass7_relbranch_build_binaries.sh`
     - `get_page_description.py` - called from `grass-addons-index.sh`
 - GRASS GIS programmer's manual:
-    - within `cron_grass8_HEAD_build_bins.sh`
+    - within `cron_grass7_relbranch_build_binaries.sh`
 
 ## Web site organisation
 
@@ -34,7 +33,7 @@ Important: there are two web related directories on the server:
 
 The server is hosted as LXD container on `osgeo7`, see: https://wiki.osgeo.org/wiki/SAC_Service_Status#GRASS_GIS_server
 
-The container is only accessible via the related OSGeo ssh jumphost.
+The container is only accessible via the related OSGeo ssh jumphost and registered ssh pubkey.
 
 ## Cronjob execution
 
@@ -46,4 +45,4 @@ grasslxd:/home/neteler/cronjobs/
 
 ## History
 
-The cronjobs here have been initially written in 2002 and subsequently updated.
+The cronjobs here have been initially written in 2002 and subsequently been updated.

--- a/utils/cronjobs_osgeo_lxd/compile_addons_git.sh
+++ b/utils/cronjobs_osgeo_lxd/compile_addons_git.sh
@@ -3,15 +3,27 @@
 # Martin Landa, 2013
 # updated for GRASS GIS 7 (only) Addons by Markus Neteler, 2020
 # fixes for addon creation by Tomas Zigo, 2020
+# changes to variables by Markus Neteler, 2021
 
-# This script compiles GRASS Addons, it's called by cron_grass78_releasebranch_78_build_bins.sh | cron_grass7_HEAD_build_bins.sh
+# This script compiles GRASS Addons, it's called by cron_grass${GMAJOR}_main_build_binaries.sh | cron_grass${GMAJOR}_main_src_snapshot.sh
+
+GMAJOR=7
+GMINOR=8
+
+#################
+
+if [ `uname -m` = "x86_64" ] ; then
+    PLATFORM=x86_64
+else
+    PLATFORM=x86
+fi
 
 if [ -z "$3" ]; then
     echo "Usage: $0 git_path topdir addons_path grass_startup_program [separate]"
-    echo "eg. $0 ~/src/grass_addons/grass7/ \
-~/src/releasebranch_7_8/dist.x86_64-pc-linux-gnu \
-~/.grass7/addons \
-~/src/releasebranch_7_8/bin.x86_64-pc-linux-gnu/grass78"
+    echo "eg. $0 ~/src/grass_addons/grass${GMAJOR}/ \
+~/src/releasebranch_${GMAJOR}_${GMINOR}/dist.${PLATFORM}-pc-linux-gnu \
+~/.grass${GMAJOR}/addons \
+~/src/releasebranch_${GMAJOR}_${GMINOR}/bin.${PLATFORM}-pc-linux-gnu/grass${GMAJOR}"
     exit 1
 fi
 
@@ -19,8 +31,6 @@ GIT_PATH="$1"
 TOPDIR="$2"
 ADDON_PATH="$3"
 GRASS_STARTUP_PROGRAM="$4"
-#GRASS_VERSION=`echo -n ${GIT_PATH} | tail -c 1`
-GRASS_VERSION=7
 INDEX_FILE="index"
 INDEX_MANUAL_PAGES_FILE="index_manual_pages"
 ADDONS_PATHS_JSON_FILE="addons_paths.json"
@@ -30,7 +40,7 @@ if [ ! -d "$3" ] ; then
 fi
 
 if [ -z "$4" ] ; then
-    echo "ERROR: Set GRASS GIS startup program with full path (e.g., ~/src/releasebranch_7_8/bin.x86_64-pc-linux-gnu/grass78)"
+    echo "ERROR: Set GRASS GIS startup program with full path (e.g., ~/src/releasebranch_${GMAJOR}_${GMINOR}/bin.${PLATFORM}-pc-linux-gnu/grass${GMAJOR}${GMINOR})"
     exit 1
 fi
 
@@ -38,12 +48,6 @@ if [ -n "$5" ] ; then
     SEP=1 # useful for collecting files (see build-xml.py)
 else
     SEP=0
-fi
-
-if [ `uname -m` = "x86_64" ] ; then
-    PLATFORM=x86_64
-else
-    PLATFORM=x86
 fi
 
 rm -rf "$ADDON_PATH"
@@ -78,7 +82,7 @@ border: 1px solid black;
 </style>
 </head>
 <body>
-<h1>GRASS $GRASS_VERSION Addons ($PLATFORM) / $uname (logs generated $date)</h1>
+<h1>GRASS $GMAJOR Addons ($PLATFORM) / $uname (logs generated $date)</h1>
 <hr />
 <table cellpadding=\"5\">
 <tr><th style=\"background-color: grey\">AddOns</th>
@@ -96,7 +100,7 @@ echo "-----------------------------------------------------"
 
 pwd=`pwd`
 # .. "hadoop"
-# from ../../grass7/
+# from ../../grass${GMAJOR}/
 for c in "db" "display" "general" "gui/wxpython" "imagery" "misc" "raster" "raster3d" "temporal" "vector" ; do
     if [ ! -d $c ]; then
         continue
@@ -125,7 +129,7 @@ for c in "db" "display" "general" "gui/wxpython" "imagery" "misc" "raster" "rast
         MANBASEDIR="$path/docs/man" \
         SCRIPTDIR="$path/scripts" \
         ETC="$path/etc" \
-            SOURCE_URL="https://github.com/OSGeo/grass-addons/tree/master/grass${GRASS_VERSION}/" > \
+            SOURCE_URL="https://github.com/OSGeo/grass-addons/tree/grass${GMAJOR}/src/" > \
             "$ADDON_PATH/logs/$m.log" 2>&1 \
         HTML_PAGE_FOOTER_PAGES_PATH="../"
     if [ `echo $?` -eq 0 ] ; then

--- a/utils/cronjobs_osgeo_lxd/cron_job_list_grass
+++ b/utils/cronjobs_osgeo_lxd/cron_job_list_grass
@@ -1,5 +1,12 @@
+### UNUSED, see grass8 branch
+### UNUSED
+### UNUSED
+
+##################################################
 # crontab entries
-# see: https://github.com/OSGeo/grass-addons/tree/master/utils/cronjobs_osgeo_lxd/
+# see: https://github.com/OSGeo/grass-addons/tree/grass7/utils/cronjobs_osgeo_lxd/
+
+# IMPORTANT: only a single crontab file may exist. The GRASS GIS 7 + 8 addons are generated in the grass8 branch.
 
 # add GRASS GIS build jobs here and then run on `grasslxd`server:
 # crontab $HOME/cronjobs/cron_job_list_grass && crontab -l
@@ -22,16 +29,16 @@
 30 */12 * * * nice sh /home/neteler/cronjobs/hugo_clean_and_update_job.sh
 
 # weekly source snapshots (target dir: /var/www/code_and_data/)
-30 02 * * 6 nice sh /home/neteler/cronjobs/cron_grass8_HEAD_src_snapshot.sh
-46 02 * * 6 nice sh /home/neteler/cronjobs/cron_grass78_src_relbr78_snapshot.sh
+30 02 * * 6 nice sh /home/neteler/cronjobs/cron_grass8_main_src_snapshot.sh
+46 02 * * 6 nice sh /home/neteler/cronjobs/cron_grass7_main_src_snapshot.sh
 #59 02 * * 6 nice sh /home/neteler/cronjobs/cron_grass76_src_relbr76_snapshot.sh
 #12 03 * * 6 nice sh /home/neteler/cronjobs/cron_grass74_src_relbr74_snapshot.sh
 
 # daily Linux binary snapshots, also creates main manuals, addon manuals, and prog-manual (target dir: /var/www/code_and_data/)
-05 05 * * * nice sh /home/neteler/cronjobs/cron_grass8_HEAD_build_bins.sh               > /var/www/code_and_data/grass80/binary/linux/snapshot/build.log.txt 2>&1
-05 06 * * * nice sh /home/neteler/cronjobs/cron_grass78_releasebranch_78_build_bins.sh  > /var/www/code_and_data/grass78/binary/linux/snapshot/build.log.txt 2>&1
+05 05 * * * nice sh /home/neteler/cronjobs/cron_grass8_relbranch_build_binaries.sh > /var/www/code_and_data/grass80/binary/linux/snapshot/build.log.txt 2>&1
+05 06 * * * nice sh /home/neteler/cronjobs/cron_grass7_relbranch_build_binaries.sh > /var/www/code_and_data/grass78/binary/linux/snapshot/build.log.txt 2>&1
 #05 07 * * * nice sh /home/neteler/cronjobs/cron_grass76_releasebranch_76_build_bins.sh  > /var/www/code_and_data/grass76/binary/linux/snapshot/build.log.txt 2>&1
 #05 08 * * * nice sh /home/neteler/cronjobs/cron_grass74_releasebranch_74_build_bins.sh  > /var/www/code_and_data/grass74/binary/linux/snapshot/build.log.txt 2>&1
 
 # generate osgeo_mailman_stats/ + email
-# ... runs as root cronjob on osgeo6 machine
+# ...note: runs as a root cronjob on osgeo6 machine (lists.osgeo.org server)

--- a/utils/cronjobs_osgeo_lxd/get_page_description.py
+++ b/utils/cronjobs_osgeo_lxd/get_page_description.py
@@ -2,8 +2,6 @@
 
 # PURPOSE: Extracts page one line descriptions for index.html of GRASS GIS Addons
 #
-# cloned from https://github.com/OSGeo/grass-addons/blob/master/utils/addons/get_page_description.py
-#
 # AUTHORS: Martin Landa (Bash version)
 #          Vaclav Petras (Python version)
 

--- a/utils/cronjobs_osgeo_lxd/grass-addons-fetch-xml.sh
+++ b/utils/cronjobs_osgeo_lxd/grass-addons-fetch-xml.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-# cloned from https://github.com/OSGeo/grass-addons/blob/master/utils/addons/grass-addons-publish.sh
 #
 # This script copies built addons manual pages from the winGRASS build server
 # To be run on publishing server (grasslxd server)


### PR DESCRIPTION
**UNUSED SCRIPTS**

Nonetheless,
- partial update to scripts in `grass7` branch
- renaming of build scripts to more standardized names (see https://github.com/OSGeo/grass-addons/pull/613#issuecomment-991960892)
- update cron_job_list_grass accordingly. Note that this crontab is **NOT USED**. Instead, the version in the `grass8` branch is active.

(relates to #651 - grass8)