### PR TITLE
addons: fix winGRASS log files URL

### DIFF
--- a/utils/cronjobs_osgeo_lxd/grass-addons-index.sh
+++ b/utils/cronjobs_osgeo_lxd/grass-addons-index.sh
@@ -137,7 +137,7 @@ document as well as the <a href=\"https://trac.osgeo.org/grass/wiki/Submitting\"
 <p>
 See also log files of compilation:
 <a href=\"https://grass.osgeo.org/addons/grass${major}/logs\">Linux log files</a> |
-<a href=\"https://wingrass.fsv.cvut.cz/grass${major}${minor}/x86_64/addons/latest/logs/\">Windows log files</a>
+<a href=\"https://wingrass.fsv.cvut.cz/grass${major}${minor}/x86_64/addons/grass-${major}.${minor}.dev/logs/\">Windows log files</a>
 
 </tr></table>
 <hr>


### PR DESCRIPTION
This link does not exists on server:
https://wingrass.fsv.cvut.cz/grass80/x86_64/addons/latest/logs/

changed to
https://wingrass.fsv.cvut.cz/grass80/x86_64/addons/grass-8.0.dev/logs/