### PR TITLE
addons scripts: define versions as variables on top

### DIFF
--- a/utils/addons/build-xml.py
+++ b/utils/addons/build-xml.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+# TODO 2021: do not hardcode version numbers below but use GRASS_VERSION_OLD and GRASS_VERSION_STABLE
+
 # Support Python script used by compile-xml.sh
 
 import os

--- a/utils/addons/compile-addons.sh
+++ b/utils/addons/compile-addons.sh
@@ -3,6 +3,10 @@
 # updated for new CMS path MN 8/2015
 # updated to new utils/ path MN 12/2021
 
+# version numbers
+GRASS_VERSION_OLD="6 4"
+GRASS_VERSION_STABLE="7 8"
+
 DIR=$HOME/src
 # XMLDIR=/var/www/grass/grass-cms/addons/
 MANDIR=/var/www/grass/grass-cms/
@@ -24,8 +28,8 @@ build_addons() {
     	cd $XMLDIR/grass${version}/logs
     done
 
-    update_manual 7 8
-    update_manual 6 4
+    update_manual $GRASS_VERSION_STABLE
+    update_manual $GRASS_VERSION_OLD
 }
 
 update_manual() {

--- a/utils/addons/compile-grass.sh
+++ b/utils/addons/compile-grass.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# version numbers
+GRASS_VERSION_OLD="6 4"
+GRASS_VERSION_STABLE="7 8"
+
 DIR=$HOME/src
 
 recompile_grass() {
@@ -9,6 +13,7 @@ recompile_grass() {
     echo "Recompiling $gdir..." 1>&2
     git pull
     make distclean     >/dev/null 2>&1
+    # TODO 2021: verify flags
     OPTS="--enable-largefile --with-blas --with-bzlib --with-cairo --with-cxx \
           --with-freetype --with-freetype-includes=/usr/include/freetype2 --with-gdal --with-geos --with-lapack \
           --with-liblas=/usr/bin/liblas-config --with-motif -with-netcdf --with-nls --with-odbc --with-openmp \
@@ -27,5 +32,13 @@ recompile_grass() {
     fi
 }
 
-recompile_grass 64
-recompile_grass 78
+# parse version numbers
+G_OLD_MAJOR=`echo $GRASS_VERSION_OLD | cut -d' ' -f1`
+G_OLD_MINOR=`echo $GRASS_VERSION_OLD | cut -d' ' -f2`
+G_STABLE_MAJOR=`echo $GRASS_VERSION_STABLE | cut -d' ' -f1`
+G_STABLE_MINOR=`echo $GRASS_VERSION_STABLE | cut -d' ' -f2`
+
+recompile_grass ${G_OLD_MAJOR}${G_OLD_MINOR}
+recompile_grass ${G_STABLE_MAJOR}${G_STABLE_MINOR}
+
+exit 0

--- a/utils/addons/compile-xml.sh
+++ b/utils/addons/compile-xml.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+GRASS_VERSION_OLD="6 4"
+GRASS_VERSION_STABLE="7 8"
+
 if test -z "$1" ; then
     echo "DEST not defined"
     exit 1
@@ -16,15 +19,21 @@ build_xml() {
     cp -r $1/logs $DEST/grass$2/
 }
 
-# update GRASS Addons SVN
+# update GRASS Addons from git
 (cd ..; git pull)
 
-# compile AddOns for GRASS 7 and GRASS 6.5
-compile ../../grass7 ~/src/grass78/dist.x86_64-pc-linux-gnu /tmp/.grass7/addons
-compile ../../grass6 ~/src/grass64/dist.x86_64-pc-linux-gnu /tmp/.grass6/addons
+# parse version numbers
+G_OLD_MAJOR=`echo $GRASS_VERSION_OLD | cut -d' ' -f1`
+G_OLD_MINOR=`echo $GRASS_VERSION_OLD | cut -d' ' -f2`
+G_STABLE_MAJOR=`echo $GRASS_VERSION_STABLE | cut -d' ' -f1`
+G_STABLE_MINOR=`echo $GRASS_VERSION_STABLE | cut -d' ' -f2`
+
+# compile AddOns for old and stable
+compile ../../grass${G_STABLE_MAJOR} ~/src/grass${G_STABLE_MAJOR}${G_STABLE_MINOR}/dist.x86_64-pc-linux-gnu /tmp/.grass${G_STABLE_MAJOR}/addons
+compile ../../grass${G_OLD_MAJOR} ~/src/grass${G_OLD_MAJOR}${G_OLD_MINOR}/dist.x86_64-pc-linux-gnu /tmp/.grass${G_OLD_MAJOR}/addons
 
 # create XML file for AddOns
-build_xml /tmp/.grass7/addons 7
-build_xml /tmp/.grass6/addons 6
+build_xml /tmp/.grass${G_STABLE_MAJOR}/addons ${G_STABLE_MAJOR}
+build_xml /tmp/.grass${G_OLD_MAJOR}/addons ${G_OLD_MAJOR}
 
 exit 0

--- a/utils/addons/grass-addons-build.sh
+++ b/utils/addons/grass-addons-build.sh
@@ -8,6 +8,10 @@
 #
 # original author: Martin Landa
 
+# version numbers
+GRASS_VERSION_OLD="6 4"
+GRASS_VERSION_STABLE="7 8"
+
 DST=/var/www/grass
 DIST=dist.x86_64-pc-linux-gnu
 SRC=${HOME}/src/
@@ -53,7 +57,7 @@ promote() {
     cp html.tar.gz ${DST}/addons/grass${major}
 }
 
-promote 6 4
-promote 7 8
+promote $GRASS_VERSION_OLD
+promote $GRASS_VERSION_STABLE
 
 exit 0

--- a/utils/addons/grass-addons-index.sh
+++ b/utils/addons/grass-addons-index.sh
@@ -14,6 +14,10 @@
 # generated Addon HTML manual pages are expected to be in the directory
 # /var/www/grass/grass-cms/grass${major}${minor}/manuals/addons
 
+# version numbers
+GRASS_VERSION_OLD="6 4"
+GRASS_VERSION_STABLE="7 8"
+
 module_prefix () {
     case "$1" in
 	"db")
@@ -164,8 +168,8 @@ See also log files of compilation:
     echo "</body></html>" >> index.html
 }
 
-generate 7 8
-generate 6 4
+generate $GRASS_VERSION_STABLE
+generate $GRASS_VERSION_OLD
 
 exit 0
 

--- a/utils/addons/grass-addons-publish.sh
+++ b/utils/addons/grass-addons-publish.sh
@@ -9,6 +9,10 @@
 # updated for new CMS path MN 8/2015
 set -e
 
+# version numbers
+GRASS_VERSION_OLD="6 4"
+GRASS_VERSION_STABLE="7 8"
+
 URL=http://geo102.fsv.cvut.cz/grass/addons/
 ADDONS=${HOME}/src/grass-addons
 
@@ -41,8 +45,8 @@ process () {
 cd $ADDONS
 nup=`git pull | wc -l`
 if [ "$nup" -gt 1 ] || [ "$1" = "f" ] ; then
-    process 7 8
-    process 6 4 
+    process $GRASS_VERSION_STABLE
+    process $GRASS_VERSION_OLD
 
     ${ADDONS}/utils/addons/grass-addons-index.sh
 fi


### PR DESCRIPTION
Avoid hardcoded version numbers throughout the script and use variables defined on top.

TODO: update `utils/addons/build-xml.py`