### PR TITLE
utils/cronjobs_osgeo_lxd: generate addons modules.xml file on osgeo lxd container server

### DIFF
--- a/utils/cronjobs_osgeo_lxd/README.md
+++ b/utils/cronjobs_osgeo_lxd/README.md
@@ -38,7 +38,7 @@ subdir are shared across all installed addons (this dir structure is used
 to install the addon using the `g.extension` module). Addon installed directory
 is setted via global variable [`GRASS_ADDON_BASE`](https://github.com/OSGeo/grass-addons/pull/656/commits/8c08184415ec32fe409bf09b2599b0506d7650ab#diff-f0fc8363c0e166fdbe9eecb74a9e261498ec0bbf15500e56b1bb1b5ba7afb900L119),
 e.g. for db.join addon is`GRASS_ADDON_BASE=$HOME/.grass8/addons/db.join/`.
-Before compilation and installation is downloaded **[addons_paths.json](https://github.com/OSGeo/grass-addons/pull/656/commits/8c08184415ec32fe409bf09b2599b0506d7650ab#diff-f0fc8363c0e166fdbe9eecb74a9e261498ec0bbf15500e56b1bb1b5ba7afb900R128)**
+Before compilation and installation is downloaded [addons_paths.json](https://github.com/OSGeo/grass-addons/pull/656/commits/8c08184415ec32fe409bf09b2599b0506d7650ab#diff-f0fc8363c0e166fdbe9eecb74a9e261498ec0bbf15500e56b1bb1b5ba7afb900R128)
 but only once, for first compiled addon, and then this file is moved to
 [one level directory up](https://github.com/OSGeo/grass-addons/pull/656/commits/8c08184415ec32fe409bf09b2599b0506d7650ab#diff-f0fc8363c0e166fdbe9eecb74a9e261498ec0bbf15500e56b1bb1b5ba7afb900R133)
 to sharing for all next compiled add-ons, to prevent download this file

--- a/utils/cronjobs_osgeo_lxd/README.md
+++ b/utils/cronjobs_osgeo_lxd/README.md
@@ -19,12 +19,14 @@ This directory contains the relevant files to generate and deploy the GRASS GIS 
     - grass8: within `cron_grass8_relbranch_build_binaries.sh`
 - GRASS GIS addons overview page at https://grass.osgeo.org/grass7/manuals/addons/:
     - `compile_addons_git.sh` - called from `cron_grass7_relbranch_build_binaries.sh`
-    - `grass-addons-fetch-xml.sh` - called from `cron_grass7_relbranch_build_binaries.sh`
+    - `build-xml.py` - called from `cron_grass7_relbranch_build_binaries.sh`,
+    generates the modules.xml file required for the g.extension module
     - `grass-addons-index.sh` - called from `cron_grass7_relbranch_build_binaries.sh`
     - `get_page_description.py` - called from `grass-addons-index.sh`
 - GRASS GIS addons overview page at https://grass.osgeo.org/grass8/manuals/addons/:
     - `compile_addons_git.sh` - called from `cron_grass8_relbranch_build_binaries.sh`
-    - `grass-addons-fetch-xml.sh` - called from `cron_grass8_relbranch_build_binaries.sh`
+    - `build-xml.py` - called from `cron_grass8_relbranch_build_binaries.sh`
+    generates the modules.xml file required for the g.extension module
     - `grass-addons-index.sh` - called from `cron_grass8_relbranch_build_binaries.sh`
     - `get_page_description.py` - called from `grass-addons-index.sh`
 - GRASS GIS programmer's manual:

--- a/utils/cronjobs_osgeo_lxd/README.md
+++ b/utils/cronjobs_osgeo_lxd/README.md
@@ -29,6 +29,30 @@ This directory contains the relevant files to generate and deploy the GRASS GIS 
     - `get_page_description.py` - called from `grass-addons-index.sh`
 - GRASS GIS programmer's manual:
     - within `cron_grass8_relbranch_build_binaries.sh`
+- compilation addons:
+  - `compile_addons_git.sh` it's called with `$5` arg, addon is
+installed into own individual directory, with **bin/ docs/ etc/ scripts/**
+subdir e.g. db.join addon dir `$HOME/.grass8/addons/db.join/`, instead of
+directory structure`$HOME/.grass8/addons/` where **bin/ docs/ etc/ scripts/**
+subdir are shared across all installed addons (this dir structure is used
+to install the addon using the `g.extension` module). Addon installed directory
+is setted via global variable [`GRASS_ADDON_BASE`](https://github.com/OSGeo/grass-addons/pull/656/commits/8c08184415ec32fe409bf09b2599b0506d7650ab#diff-f0fc8363c0e166fdbe9eecb74a9e261498ec0bbf15500e56b1bb1b5ba7afb900L119),
+e.g. for db.join addon is`GRASS_ADDON_BASE=$HOME/.grass8/addons/db.join/`.
+Before compilation and installation is downloaded **[addons_paths.json](https://github.com/OSGeo/grass-addons/pull/656/commits/8c08184415ec32fe409bf09b2599b0506d7650ab#diff-f0fc8363c0e166fdbe9eecb74a9e261498ec0bbf15500e56b1bb1b5ba7afb900R128)**
+but only once, for first compiled addon, and then this file is moved to
+[one level directory up](https://github.com/OSGeo/grass-addons/pull/656/commits/8c08184415ec32fe409bf09b2599b0506d7650ab#diff-f0fc8363c0e166fdbe9eecb74a9e261498ec0bbf15500e56b1bb1b5ba7afb900R133)
+to sharing for all next compiled add-ons, to prevent download this file
+again in next addon compilation loop e.g. move
+`$HOME/.grass8/addons/db.join/addons_paths.json` -> `$HOME/.grass8/addons/addons_paths.json`.
+Next during addon compilation addon is called
+[mkhtml.py](https://github.com/OSGeo/grass/blob/main/utils/mkhtml.py)
+script (generate html manual page), `get_addon_path()` function, where is
+the parsed global variable `GRASS_ADDON_BASE` (base directory of installed
+addon), where is trying to find the **addons_paths.json** file and in
+[directory one level up](https://github.com/OSGeo/grass/pull/2054/commits/5a374101a825c451675d18b0d59e6ac99ee6cb02#diff-3e1684c5c5d40b273b6488a9b5a5558f556d2bcf2973ba5106b6125e01aa6959R314).
+When the add-on was found among the official add-ons, the source code
+and add-on history URL are set on the html man page, the entire man
+page is generated.
 
 ## Web site organisation
 

--- a/utils/cronjobs_osgeo_lxd/build-xml.py
+++ b/utils/cronjobs_osgeo_lxd/build-xml.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+
+"""Creates the addons file module.xml required by the module g.extension
+@Author: Martin Landa
+"""
+
+import os
+import sys
+import glob
+import tempfile
+import argparse
+from datetime import datetime
+
+import grass.script.task as gtask
+
+
+def get_list(addons):
+    mlist = [
+        d
+        for d in os.listdir(os.path.join(addons))
+        if os.path.isdir(os.path.join(addons, d))
+    ]
+    if "logs" in mlist:
+        mlist.remove("logs")
+    mlist.sort()
+    return mlist
+
+
+class BuildXML:
+    def __init__(self, build_path):
+        self.build_path = build_path
+
+    def run(self):
+        with open(os.path.join(self.build_path, "modules.xml"), "w") as fd:
+            self._header(fd)
+            self._parse_modules(fd, get_list(self.build_path))
+            self._footer(fd)
+
+    def _parse_modules(self, fd, mlist):
+        indent = 4
+        blacklist = ["v.feature.algebra", "m.eigensystem"]
+        for m in mlist:
+            if m in blacklist:
+                continue  # skip blacklisted modules
+            print(f"Parsing <{m}>...", end="")
+            desc, keyw = self._get_module_metadata(m)
+            fd.write(f"{' ' * indent}<task name=\"{m}\">\n")
+            indent += 4
+            fd.write(f"{' ' * indent}<description>{desc}</description>\n")
+            fd.write(f"{' ' * indent}<keywords>{','.join(keyw)}</keywords>\n")
+            fd.write(f"{' ' * indent}<binary>\n")
+            indent += 4
+            for f in self._get_module_files(m):
+                fd.write(f"{' ' * indent}<file>{f}</file>\n")
+            indent -= 4
+            fd.write(f"{' ' * indent}</binary>\n")
+            indent -= 4
+            fd.write(f"{' ' * indent}</task>\n")
+            if desc:
+                print(" SUCCESS")
+            else:
+                print(" FAILED")
+
+    @staticmethod
+    def parse_gui_modules(fd, mlist):
+        indent = 4
+        for m in mlist:
+            print("Parsing <{}>...".format(m))
+            fd.write('%s<task name="%s">\n' % (" " * indent, m))
+            fd.write("%s</task>\n" % (" " * indent))
+
+    def _scandirs(self, path):
+        flist = list()
+        for f in glob.glob(os.path.join(path, "*")):
+            if os.path.isdir(f):
+                flist += self._scandirs(f)
+            else:
+                flist.append(f)
+        return flist
+
+    def _get_module_files(self, name):
+        cur_dir = os.getcwd()
+        os.chdir(os.path.join(self.build_path, name))
+        files = self._scandirs("*")
+        os.chdir(cur_dir)  # prevent gtask.parse_interface() return None
+        return files
+
+    def _get_module_metadata(self, name):
+        path = os.environ["PATH"]
+        os.environ["PATH"] += (
+            os.pathsep
+            + os.path.join(self.build_path, name, "bin")
+            + os.pathsep
+            + os.path.join(self.build_path, name, "scripts")
+        )
+        try:
+            task = gtask.parse_interface(name)
+        except:
+            task = None
+        os.environ["PATH"] = path
+        if not task:
+            return "", ""
+
+        return task.get_description(full=True), task.get_keywords()
+
+    @staticmethod
+    def _header(fd):
+        import grass.script.core as grass
+
+        fd.write('<?xml version="1.0" encoding="UTF-8"?>\n')
+        fd.write('<!DOCTYPE task SYSTEM "grass-addons.dtd">\n')  # TODO
+        vInfo = grass.parse_command("g.version", flags="g")
+        fd.write(
+            f"<addons version=\"{vInfo['version'].split('.')[0]}\""
+            f" revision=\"{vInfo['revision']}\""
+            f' date="{datetime.now()}">\n'
+        )
+
+    @staticmethod
+    def _footer(fd):
+        fd.write("</addons>\n")
+
+
+def main(build_path):
+    builder = BuildXML(build_path)
+    builder.run()
+
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--build", help="Path to GRASS Addons build", required=True)
+    args = parser.parse_args()
+
+    sys.exit(main(args.build))

--- a/utils/cronjobs_osgeo_lxd/compile_addons_git.sh
+++ b/utils/cronjobs_osgeo_lxd/compile_addons_git.sh
@@ -117,9 +117,21 @@ for c in "db" "display" "general" "gui/wxpython" "imagery" "misc" "raster" "rast
     fi
 
     export GRASS_ADDON_BASE=$path
+    if [ ! -f $GRASS_ADDON_BASE ]; then
+        # Create addon dir first for download addons_paths.json file if
+        # addon has own dir e.g. ~/.grass8/addons/db.join/ with bin/ docs/
+        # etc/ scripts/ subdir (check condition $SEP -eq 1)
+        mkdir $GRASS_ADDON_BASE
+    fi
     # Try download Add-Ons json file paths
-    if [ ! -f  "$GRASS_ADDON_BASE/$ADDONS_PATHS_JSON_FILE" ]; then
-        $GRASS_STARTUP_PROGRAM --tmp-location EPSG:4326 --exec g.extension -j > /dev/null 2>&1
+    if [ ! -f "$GRASS_ADDON_BASE/$ADDONS_PATHS_JSON_FILE" ] && [ ! -f "$(dirname $GRASS_ADDON_BASE)/$ADDONS_PATHS_JSON_FILE" ]; then
+        $GRASS_STARTUP_PROGRAM --tmp-location EPSG:4326 --exec g.extension -j
+        # Prevent download addons_paths.json file for every addon compilation if
+        # addon has own dir e.g. ~/.grass8/addons/db.join/ with bin/ docs/
+        # etc/ scripts/ subdir (check condition $SEP -eq 1)
+        if [ ! -f "$(dirname $GRASS_ADDON_BASE)/$ADDONS_PATHS_JSON_FILE" ]; then
+            mv "$GRASS_ADDON_BASE/$ADDONS_PATHS_JSON_FILE" "$(dirname $GRASS_ADDON_BASE)/$ADDONS_PATHS_JSON_FILE"
+        fi
     fi
     echo "<tr><td><tt>$c/$m</tt></td>" >> "$ADDON_PATH/logs/${INDEX_FILE}.html"
     make MODULE_TOPDIR="$TOPDIR" clean > /dev/null 2>&1

--- a/utils/cronjobs_osgeo_lxd/compile_addons_git.sh
+++ b/utils/cronjobs_osgeo_lxd/compile_addons_git.sh
@@ -165,7 +165,7 @@ echo "</table><hr />
 </body></html>" >> "$ADDON_PATH/logs/${INDEX_FILE}.html"
 
 echo ""
-bash ~/cronjobs/check_addons_urls.sh "$ADDON_PATH/docs/html" \
+bash ~/cronjobs/check_addons_urls.sh "$ADDON_PATH" \
    "$ADDON_PATH/logs/${INDEX_MANUAL_PAGES_FILE}.log" \
    "$ADDON_PATH/logs/${INDEX_MANUAL_PAGES_FILE}.html"
 echo ""

--- a/utils/cronjobs_osgeo_lxd/cron_grass7_relbranch_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass7_relbranch_build_binaries.sh
@@ -248,9 +248,11 @@ mkdir -p $TARGETHTMLDIR/addons/
 # subdir
 for dir in `find ~/.grass$GMAJOR/addons -maxdepth 1 -type d`; do
     if [ -d $dir/docs/html ] ; then
-        for f in $dir/docs/html/*; do
-            cp $f $TARGETHTMLDIR/addons/
-        done
+        if [ "$(ls -A $dir/docs/html/)" ]; then
+            for f in $dir/docs/html/*; do
+                cp $f $TARGETHTMLDIR/addons/
+            done
+        fi
     fi
 done
 sh ~/cronjobs/grass-addons-index.sh $GMAJOR $GMINOR $TARGETHTMLDIR/addons/

--- a/utils/cronjobs_osgeo_lxd/cron_grass7_relbranch_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass7_relbranch_build_binaries.sh
@@ -51,7 +51,7 @@ MAINDIR=/home/neteler
 SOURCE=$MAINDIR/src/
 BRANCH=releasebranch_${GMAJOR}_$GMINOR
 GRASSBUILDDIR=$SOURCE/$BRANCH
-TARGETMAIN=/var/www/code_and_data/
+TARGETMAIN=/var/www/code_and_data
 TARGETDIR=$TARGETMAIN/grass${VERSION}/binary/linux/snapshot
 TARGETHTMLDIR=$TARGETMAIN/grass${VERSION}/manuals/
 # programmer's manual is only built from the relbranch_8_0
@@ -264,7 +264,7 @@ cp -p ~/.grass$GMAJOR/addons/logs/* $TARGETMAIN/addons/grass$GMAJOR/logs/
 
 # generate addons module.xml file (required for g.extension module)
 ~/src/$BRANCH/bin.$ARCH/grass$VERSION --tmp-location EPSG:4326 --exec ~/cronjobs/build-xml.py --build ~/.grass$GMAJOR/addons
-cp ~/.grass$GMAJOR/addons/modules.xml $TARGETDIR/modules.xml
+cp ~/.grass$GMAJOR/addons/modules.xml $TARGETMAIN/addons/grass$GMAJOR/modules.xml
 
 ############################################
 # create sitemaps to expand the hugo sitemap

--- a/utils/cronjobs_osgeo_lxd/cron_grass7_relbranch_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass7_relbranch_build_binaries.sh
@@ -240,9 +240,19 @@ cd $GRASSBUILDDIR
 sh ~/cronjobs/compile_addons_git.sh ~/src/grass$GMAJOR-addons/src/ \
    ~/src/$BRANCH/dist.$ARCH/ \
    ~/.grass$GMAJOR/addons \
-   ~/src/$BRANCH/bin.$ARCH/grass$VERSION
+   ~/src/$BRANCH/bin.$ARCH/grass$VERSION \
+   1
 mkdir -p $TARGETHTMLDIR/addons/
-cp ~/.grass$GMAJOR/addons/docs/html/* $TARGETHTMLDIR/addons/
+# copy indvidual addon html files into one target dir if compiled addon
+# has own dir e.g. ~/.grass8/addons/db.join/ with bin/ docs/ etc/ scripts/
+# subdir
+for dir in `find ~/.grass$GMAJOR/addons -maxdepth 1 -type d`; do
+    if [ -d $dir/docs/html ] ; then
+        for f in $dir/docs/html/*; do
+            cp $f $TARGETHTMLDIR/addons/
+        done
+    fi
+done
 sh ~/cronjobs/grass-addons-index.sh $GMAJOR $GMINOR $TARGETHTMLDIR/addons/
 chmod -R a+r,g+w $TARGETHTMLDIR 2> /dev/null
 
@@ -250,8 +260,9 @@ chmod -R a+r,g+w $TARGETHTMLDIR 2> /dev/null
 mkdir -p $TARGETMAIN/addons/grass$GMAJOR/logs/
 cp -p ~/.grass$GMAJOR/addons/logs/* $TARGETMAIN/addons/grass$GMAJOR/logs/
 
-# cp XML from winGRASS server
-sh ~/cronjobs/grass-addons-fetch-xml.sh $TARGETMAIN/addons/
+# generate addons module.xml file (required for g.extension module)
+~/src/$BRANCH/bin.$ARCH/grass$VERSION --tmp-location EPSG:4326 --exec ~/cronjobs/build-xml.py --build ~/.grass$GMAJOR/addons
+cp ~/.grass$GMAJOR/addons/modules.xml $TARGETDIR/modules.xml
 
 ############################################
 # create sitemaps to expand the hugo sitemap

--- a/utils/cronjobs_osgeo_lxd/cron_grass7_relbranch_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass7_relbranch_build_binaries.sh
@@ -244,7 +244,7 @@ sh ~/cronjobs/compile_addons_git.sh ~/src/grass$GMAJOR-addons/src/ \
    1
 mkdir -p $TARGETHTMLDIR/addons/
 # copy indvidual addon html files into one target dir if compiled addon
-# has own dir e.g. ~/.grass8/addons/db.join/ with bin/ docs/ etc/ scripts/
+# has own dir e.g. ~/.grass7/addons/db.join/ with bin/ docs/ etc/ scripts/
 # subdir
 for dir in `find ~/.grass$GMAJOR/addons -maxdepth 1 -type d`; do
     if [ -d $dir/docs/html ] ; then

--- a/utils/cronjobs_osgeo_lxd/cron_grass8_relbranch_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass8_relbranch_build_binaries.sh
@@ -52,7 +52,7 @@ MAINDIR=/home/neteler
 SOURCE=$MAINDIR/src/
 BRANCH=releasebranch_${GMAJOR}_$GMINOR
 GRASSBUILDDIR=$SOURCE/$BRANCH
-TARGETMAIN=/var/www/code_and_data/
+TARGETMAIN=/var/www/code_and_data
 TARGETDIR=$TARGETMAIN/grass${VERSION}/binary/linux/snapshot
 TARGETHTMLDIR=$TARGETMAIN/grass${VERSION}/manuals/
 TARGETPROGMAN=$TARGETMAIN/programming${GVERSION}
@@ -295,7 +295,7 @@ cp -p ~/.grass$GMAJOR/addons/logs/* $TARGETMAIN/addons/grass$GMAJOR/logs/
 
 # generate addons modules.xml file (required for g.extension module)
 ~/src/$BRANCH/bin.$ARCH/grass --tmp-location EPSG:4326 --exec ~/cronjobs/build-xml.py --build ~/.grass$GMAJOR/addons
-cp ~/.grass$GMAJOR/addons/modules.xml $TARGETDIR/modules.xml
+cp ~/.grass$GMAJOR/addons/modules.xml $TARGETMAIN/addons/grass$GMAJOR/modules.xml
 
 ############################################
 # create sitemaps to expand the hugo sitemap

--- a/utils/cronjobs_osgeo_lxd/cron_grass8_relbranch_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass8_relbranch_build_binaries.sh
@@ -278,9 +278,11 @@ mkdir -p $TARGETHTMLDIR/addons/
 # subdir
 for dir in `find ~/.grass$GMAJOR/addons -maxdepth 1 -type d`; do
     if [ -d $dir/docs/html ] ; then
-        for f in $dir/docs/html/*; do
-            cp $f $TARGETHTMLDIR/addons/
-        done
+        if [ "$(ls -A $dir/docs/html/)" ]; then
+            for f in $dir/docs/html/*; do
+                cp $f $TARGETHTMLDIR/addons/
+            done
+        fi
     fi
 done
 sh ~/cronjobs/grass-addons-index.sh $GMAJOR $GMINOR $TARGETHTMLDIR/addons/

--- a/utils/cronjobs_osgeo_lxd/cron_grass8_relbranch_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass8_relbranch_build_binaries.sh
@@ -270,9 +270,19 @@ cd $GRASSBUILDDIR
 sh ~/cronjobs/compile_addons_git.sh ~/src/grass$GMAJOR-addons/src/ \
    ~/src/$BRANCH/dist.$ARCH/ \
    ~/.grass$GMAJOR/addons \
-   ~/src/$BRANCH/bin.$ARCH/grass$VERSION
+   ~/src/$BRANCH/bin.$ARCH/grass \
+   1
 mkdir -p $TARGETHTMLDIR/addons/
-cp ~/.grass$GMAJOR/addons/docs/html/* $TARGETHTMLDIR/addons/
+# copy indvidual addon html files into one target dir if compiled addon
+# has own dir e.g. ~/.grass8/addons/db.join/ with bin/ docs/ etc/ scripts/
+# subdir
+for dir in `find ~/.grass$GMAJOR/addons -maxdepth 1 -type d`; do
+    if [ -d $dir/docs/html ] ; then
+        for f in $dir/docs/html/*; do
+            cp $f $TARGETHTMLDIR/addons/
+        done
+    fi
+done
 sh ~/cronjobs/grass-addons-index.sh $GMAJOR $GMINOR $TARGETHTMLDIR/addons/
 cp $TARGETHTMLDIR/grass_logo.png $TARGETHTMLDIR/grassdocs.css $TARGETHTMLDIR/addons/
 chmod -R a+r,g+w $TARGETHTMLDIR 2> /dev/null
@@ -281,8 +291,9 @@ chmod -R a+r,g+w $TARGETHTMLDIR 2> /dev/null
 mkdir -p $TARGETMAIN/addons/grass$GMAJOR/logs/
 cp -p ~/.grass$GMAJOR/addons/logs/* $TARGETMAIN/addons/grass$GMAJOR/logs/
 
-# cp XML from winGRASS server
-sh ~/cronjobs/grass-addons-fetch-xml.sh $TARGETMAIN/addons/
+# generate addons modules.xml file (required for g.extension module)
+~/src/$BRANCH/bin.$ARCH/grass --tmp-location EPSG:4326 --exec ~/cronjobs/build-xml.py --build ~/.grass$GMAJOR/addons
+cp ~/.grass$GMAJOR/addons/modules.xml $TARGETDIR/modules.xml
 
 ############################################
 # create sitemaps to expand the hugo sitemap
@@ -304,4 +315,3 @@ echo "Copied HTML ${GVERSION} progman to https://grass.osgeo.org/programming${GV
 echo "Copied Addons ${GVERSION} to https://grass.osgeo.org/grass${VERSION}/manuals/addons/"
 
 exit 0
-


### PR DESCRIPTION
Generate addons modules.xml file on osgeo lxd container server. Requires this [PR ](https://github.com/OSGeo/grass/pull/2054) to be applied before. 

Note:
build-xml.py script I took over from this [PR](https://github.com/OSGeo/grass-addons/pull/220) with small modification.
