### PR TITLE
Linguistic revision in r.convergence

### DIFF
--- a/src/raster/r.convergence/main.c
+++ b/src/raster/r.convergence/main.c
@@ -73,7 +73,7 @@ int main(int argc, char **argv)
     flag_slope = G_define_flag();
     flag_slope->key = 's';
     flag_slope->description =
-	_("Add slope convergence (radically slow down calculation time)");
+	_("Add slope convergence (radically slows down calculation time)");
 
     if (G_parser(argc, argv))
 	exit(EXIT_FAILURE);

--- a/src/raster/r.convergence/r.convergence.html
+++ b/src/raster/r.convergence/r.convergence.html
@@ -38,8 +38,8 @@ due to its distance, where distance in cells:
 
 <dt><b>window</b></dt>
 <dd>Window size. Must be odd. For now there are no limits in window size. 
-r.convergence uses the window size instead of classical radius for 
-compatibility with other GRASS programs.</dd>
+<em>r.convergence</em> uses the window size instead of classical radius for 
+compatibility with other GRASS GIS commands.</dd>
 
 
 <dt><b>output</b></dt>

--- a/src/raster/r.convergence/r.convergence.html
+++ b/src/raster/r.convergence/r.convergence.html
@@ -17,7 +17,7 @@ acos(cos(convergence) * modifier)
 
 <dt><b>input</b></dt>
 <dd>Digital elevation model. Data can be of any type and any projection. 
-To calculate relief convergence, r.convergence uses real distances 
+To calculate relief convergence, <em>r.convergence</em> uses real distances 
 which is recalculated into cell distance, according formula:<br>
 <code>distance_between_current_cell_and_target_cell/distance_between_current_cell_and_nearest_neighbour_cell.</code>
 It is important if convergence is calculated for large areas in Lat/Lon 

--- a/src/raster/r.convergence/r.convergence.html
+++ b/src/raster/r.convergence/r.convergence.html
@@ -1,51 +1,80 @@
 <h2>OPTIONS</h2>
 <dl>
 <dt><b>-s</b></dt>
-<dd>Increase convergence if slope value is high. Slope parameter radically slow down computation time, especially if window parameter is high. If slope is used addational modifier is used according to formula: sin(current)*sin(target) + cos(current)*cos(target). if slope of current and target cells are equal. The modifier is 1. If not, the modifier is applied with formula: acos(cos(convergence) * modifier)  </dd>
+<dd>Increase convergence if slope value is high. 
+Slope parameter radically slows down computation time, 
+especially if the window parameter is high. 
+If slope is used, a slope modifier is used according to the formula: 
+sin(current)*sin(target) + cos(current)*cos(target). 
+If the slope of current and target cells are equal, 
+this modifier's value will be 1. 
+The modifier is applied with the formula: 
+acos(cos(convergence) * modifier)
+</dd>
+
 <dt><b>-c</b></dt>
-<dd>use circular window instead of suqare (default)</dd>
+<dd>Use circular window instead of square (default)</dd>
 
 <dt><b>input</b></dt>
-<dd>Digital elevation model. Data can be of any type and any projection. To calculate relief convergnece, r.convergence uses real distance which is recalculated into cell distance, according formula: <br><code>distance_between_current_cell_and_traget_cell/distance_between_current_cell_and_nearest_neighbour_cell.</code> It is important if convergence is calculated for large areas in LatLong projecton.
+<dd>Digital elevation model. Data can be of any type and any projection. 
+To calculate relief convergence, r.convergence uses real distances 
+which is recalculated into cell distance, according formula:<br>
+<code>distance_between_current_cell_and_target_cell/distance_between_current_cell_and_nearest_neighbour_cell.</code>
+It is important if convergence is calculated for large areas in Lat/Lon 
+projection.
 </dd>
 
 <dt><b>weights</b></dt>
-<dd>Parameter describing the reduction of the impact of the cell due to its distance, where distance in cells:
+<dd>Parameter describing the reduction of the impact of the cell 
+due to its distance, where distance in cells:
 <ul>
-<li><b>standard:</b>no decay
-<li><b>inverse:</b>distance modifier is calculated as 1/x
-<li><b>power:</b>distance modifier is calculated as 1/(x*x)
-<li><b>power:</b>distance modifier is calculated as 1/(x*x)
-<li><b>gentle:</b>distance modifier is calculated as 1/((1-x)/(1+x))
+<li><b>standard:</b> no decay</li>
+<li><b>inverse:</b> distance modifier is calculated as 1/x</li>
+<li><b>power:</b> distance modifier is calculated as 1/(x*x)</li>
+<li><b>power:</b> distance modifier is calculated as 1/(x*x)</li>
+<li><b>gentle:</b> distance modifier is calculated as 1/((1-x)/(1+x))</li>
 </ul>
+</dd>
 
 <dt><b>window</b></dt>
-<dd>window size. Must be odd. For now there is no limits in window size. r.convergence uses window size instead of classical radius for compatibility with other GRASS programs.</dd>
+<dd>Window size. Must be odd. For now there are no limits in window size. 
+r.convergence uses the window size instead of classical radius for 
+compatibility with other GRASS programs.</dd>
 
 
 <dt><b>output</b></dt>
-<dd>Map of convergence index. The values ranges from -100 (max divergent, real peaks and ridges) by 0 (planar areas) to 100 (max convergent, real pits and channels). Classical convergence index presented with degrees (-90 to 90)</dd>
-
+<dd>Map of convergence index. 
+The values ranges from -100 (max divergent, real peaks and ridges) 
+by 0 (planar areas) to 100 (max convergent, real pits and channels). 
+Classical convergence index presented with degrees (-90 to 90)</dd>
+</dl>
 
 <h2>DESCRIPTION</h2>
 
 <h3>How convergence index is calculated (3 x 3 window):</h3>
-<center>
-<img src="conv.png" border="1"><br>
-</center>
+<div align="center"  style="margin: 10px">
+<a href="conv.png">
+<img src="conv.png"
+     alt="Illustrations of convergence index values.
+     For divergent case, index is -100.
+     For convergent case, index is +100.
+     For planar case, index is 0."></a>
+<br>
+<i>Figure 1: Convergence index for maximum divergence, maximum convergence, and planar</i>
+</div>
 Convergence index is a terrain parameter which shows the structure of 
 the relief as a set of convergent areas (channels) and divergent areas 
 (ridges). It represents the agreement of aspect direction of 
 surrounding cells with the theoretical matrix direction. Convergence 
 index is mean (or weighted mean if weights are used) aspect difference 
 between real aspect and theoretical maximum divergent direction matrix 
-representing ideal peak (see figure) minus 90 degres. So if there is 
+representing ideal peak (see figure) minus 90 degrees. So if there is 
 maximum agreement with divergent matrix the convergence index is (0 - 
 90) * 10/9 = -100. If there is ideal sink (maximum convergence) the 
-convergence index is (180 -90) * 10/9 = 100. Slope and aspect ere 
-calculated internaly with the same formula as in r.slope.aspect 
+convergence index is (180 -90) * 10/9 = 100. Slope and aspect are 
+calculated internally with the same formula as in r.slope.aspect. 
 Convergence index is very useful for analysis of lineaments especially 
-represented by ridges or chanel systems as well as valley recognition 
+represented by ridges or channel systems as well as valley recognition 
 tool.
 
 
@@ -65,7 +94,7 @@ Journal of Hydrology, 187(1-2), 145-156 .</p>
 <p>
 Bauer J., Rohdenburg H., Bork H.-R., (1985), Ein Digitales Reliefmodell als Vorraussetzung fuer ein deterministisches Modell der Wasser- und Stoff-Fluesse, <i>IN: Bork, H.-R., Rohdenburg, H., Landschaftsgenese und Landschaftsoekologie, Parameteraufbereitung fuer deterministische Gebiets-Wassermodelle, Grundlagenarbeiten zu Analyse von Agrar-Oekosystemen</i>, 1-15.
 <p>
-Böhner J., Blaschke T., Montanarella, L. (eds.) (2008). SAGA Seconds Out. Hamburger Beiträge zur Physischen Geographie und Landschaftsökologie, 19: 113 s.</p>
+B&ouml;hner J., Blaschke T., Montanarella, L. (eds.) (2008). SAGA Seconds Out. Hamburger Beitr&auml;ge zur Physischen Geographie und Landschafts&ouml;kologie, 19: 113 s.</p>
 
 <h2>AUTHOR</h2>
 Jarek Jasiewicz
@@ -74,3 +103,4 @@ Jarek Jasiewicz
 <p>
 <i>Last changed: $Date$</i>
 -->
+

--- a/src/raster/r.convergence/r.convergence.html
+++ b/src/raster/r.convergence/r.convergence.html
@@ -72,7 +72,7 @@ representing ideal peak (see figure) minus 90 degrees. So if there is
 maximum agreement with divergent matrix the convergence index is (0 - 
 90) * 10/9 = -100. If there is ideal sink (maximum convergence) the 
 convergence index is (180 -90) * 10/9 = 100. Slope and aspect are 
-calculated internally with the same formula as in r.slope.aspect. 
+calculated internally with the same formula as in <em>r.slope.aspect</em>. 
 Convergence index is very useful for analysis of lineaments especially 
 represented by ridges or channel systems as well as valley recognition 
 tool.


### PR DESCRIPTION
Since the changes are bigger than only simple spelling fixes for this addon, I created a pull request to discuss the changes made in the description of the slope flag, and with the figure. Some HTML elements were also invalid, so I closed the tags to have a valid file. I changed some characters containing umlauts with HTML entities since while the file is UTF-8, the deployed webpage has charset iso-8859-1, making these characters appear as Mojibake.

The original sentence was hard to understand, even by me and studying the code, so I'd like a little feedback to let me know if it still has the same meaning, or if the new wording is more appropriate now.
