### PR TITLE
CI: Fix names of checkout steps for core and addons inversion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,14 @@ jobs:
 
     steps:
 
-    - name: Checkout addons
+    - name: Checkout core
       uses: actions/checkout@v2
       with:
         repository: OSGeo/grass
         ref: ${{ matrix.grass-version }}
         path: grass
 
-    - name: Checkout core
+    - name: Checkout addons
       uses: actions/checkout@v2
       with:
         path: grass-addons


### PR DESCRIPTION
While reading the CI build output, I observed that the names of the checkout steps for the action "checkout@v2" were inverted for the last two years. I checked the[ actions documentation](https://github.com/actions/checkout) to make sure, and it was indeed an inversion.

So the simple fix is changing the names (labels), so it should be non-breaking if I didn't miss anything.