### PR TITLE
r.mapcalc.tiled: use option nprocs instead of processes in backwards compatible way

### DIFF
--- a/src/raster/r.mapcalc.tiled/r.mapcalc.tiled.html
+++ b/src/raster/r.mapcalc.tiled/r.mapcalc.tiled.html
@@ -12,7 +12,7 @@ the output map name with the parameter <b>output</b>
 
 <p>
 Tiles can be defined with the <b>width</b>, <b>height</b> and 
-<b>overlap</b> parameters. If <b>processes</b> is higher than one, these tiles 
+<b>overlap</b> parameters. If <b>nprocs</b> is higher than one, these tiles 
 will be processed in parallel.
 
 <p>
@@ -31,7 +31,7 @@ Run <b>r.mapcalc</b> over tiles with size 1000x1000 using 4 parallel processes
 <div class="code"><pre> 
 g.region raster=ortho_2001_t792_1m
 r.mapcalc.tiled expression="bright_pixels = if(ortho_2001_t792_1m > 200, 1, 0)" \
-   width=1000 height=1000 processes=4
+   width=1000 height=1000 nprocs=4
 </pre></div>
 
 <h2>SEE ALSO</h2>

--- a/src/raster/r.mapcalc.tiled/r.mapcalc.tiled.py
+++ b/src/raster/r.mapcalc.tiled/r.mapcalc.tiled.py
@@ -59,11 +59,20 @@
 #%end
 #
 #%option
-#% key: processes
+#% key: nprocs
 #% type: integer
 #% description: Number of r.mapcalc processes to run in parallel
-#% answer: 1
-#% required: yes
+#% required: no
+#% options: 1-
+#%end
+#
+#%option
+#% key: processes
+#% type: integer
+#% description: Number of r.mapcalc processes to run in parallel, use nprocs option instead
+#% label: This option is obsolete and replaced by nprocs
+#% required: no
+#% options: 1-
 #%end
 #
 #%option
@@ -72,7 +81,10 @@
 #% description: Mapset prefix
 #% required: no
 #%end
-
+#
+#%rules
+#% exclusive: processes,nprocs
+#%end
 
 import math
 import grass.script as gscript
@@ -108,7 +120,16 @@ def main():
     width = int(options["width"])
     height = int(options["height"])
     overlap = int(options["overlap"])
-    processes = int(options["processes"])
+    processes = options["nprocs"]
+    if not processes:
+        processes = options["processes"]
+        if processes:
+            gscript.warning(_("Option processes is obsolete, use nprocs instead."))
+    try:
+        processes = int(processes)
+    except ValueError:
+        processes = 1
+
     output = None
     if options["output"]:
         output = options["output"]

--- a/src/raster/r.mapcalc.tiled/tests/test.py
+++ b/src/raster/r.mapcalc.tiled/tests/test.py
@@ -108,7 +108,7 @@ with open(conf["csvfile"], "w", newline="") as f:
                 expression=expression,
                 width=wh,
                 height=wh,
-                processes=conf["nprocs"],
+                nprocs=conf["nprocs"],
                 overwrite=True,
             )
             end = time.time()


### PR DESCRIPTION
Addresses #671.