### PR TITLE
r.in.nasadem: fix name 'srid' is not defined

### DIFF
--- a/src/raster/r.in.nasadem/r.in.nasadem.py
+++ b/src/raster/r.in.nasadem/r.in.nasadem.py
@@ -347,7 +347,6 @@ def createTMPlocation(epsg=4326):
     else:
         currepsg = proj["srid"].split("EPSG:")[1]
 
-    currepsg = ":".join(proj["srid"].split(":")[-1:])
     if currepsg != str(epsg):
         grass.fatal("Creation of temporary location failed!")
 

--- a/src/raster/r.in.nasadem/r.in.nasadem.py
+++ b/src/raster/r.in.nasadem/r.in.nasadem.py
@@ -347,7 +347,7 @@ def createTMPlocation(epsg=4326):
     else:
         currepsg = proj["srid"].split("EPSG:")[1]
 
-    currepsg = ":".join(srid.split(":")[-1:])
+    currepsg = ":".join(proj["srid"].split(":")[-1:])
     if currepsg != str(epsg):
         grass.fatal("Creation of temporary location failed!")
 


### PR DESCRIPTION
This PR fixes the Python error `NameError: name 'srid' is not defined`:

```
GRASS eu_laea_epsg3035/nasadem:~ > 
r.in.nasadem user=xxxx password=yyyyy output=nasadem memory=4000 method=bilinear_f resolution=30
Traceback (most recent call last):
  File "/home/mundialis/.grass8/addons/scripts/r.in.nasadem", line 645, in <module>
    main()
  File "/home/mundialis/.grass8/addons/scripts/r.in.nasadem", line 490, in main
    SRCGISRC, TMPLOC = createTMPlocation()
  File "/home/mundialis/.grass8/addons/scripts/r.in.nasadem", line 350, in createTMPlocation
    currepsg = ":".join(srid.split(":")[-1:])
NameError: name 'srid' is not defined
ERROR: Region <r_in_nasadem_region_285028> not found
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/home/mundialis/.grass8/addons/scripts/r.in.nasadem", line 314, in cleanup
    grass.run_command("g.region", region=tmpregionname)
  File "/home/mundialis/software/grass80/dist.x86_64-pc-linux-gnu/etc/python/grass/script/core.py", line 541, in run_command
    return handle_errors(returncode, result=None, args=args, kwargs=kwargs)
  File "/home/mundialis/software/grass80/dist.x86_64-pc-linux-gnu/etc/python/grass/script/core.py", line 429, in handle_errors
    raise CalledModuleError(module=module, code=code, returncode=returncode)
grass.exceptions.CalledModuleError: Module run `g.region region=r_in_nasadem_region_285028` ended with an error.
The subprocess ended with a non-zero return code: 1. See errors above the traceback or in the error output.
```