### PR TITLE
Addon manual pages: remove unneeded SVN Date entry

### DIFF
--- a/src/db/db.join/db.join.html
+++ b/src/db/db.join/db.join.html
@@ -37,14 +37,9 @@ cat|label|id|shortname|longname
 <a href="https://grass.osgeo.org/grass-stable/manuals/db.select.html">db.select</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/v.db.join.html">v.db.join</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/v.db.update.html">v.db.update</a><br>
-<a href="sql.html">GRASS SQL interface</a>
+<a href="https://grass.osgeo.org/grass-stable/manuals/sql.html">GRASS SQL interface</a>
 </em>
 
 <h2>AUTHOR</h2>
 
 Markus Neteler
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/display/d.explanation.plot/d.explanation.plot.html
+++ b/src/display/d.explanation.plot/d.explanation.plot.html
@@ -92,11 +92,6 @@ d.explanation.plot a=input_1 b=input_2 c=result
   <a href="https://grass.osgeo.org/grass-stable/manuals/v.mkgrid.html">v.mkgrid</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Vaclav Petras, <a href="http://gis.ncsu.edu/osgeorel/">NCSU GeoForAll Lab</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/display/d.frame/d.frame.html
+++ b/src/display/d.frame/d.frame.html
@@ -85,7 +85,7 @@ d.mon -r
   <a href="https://grass.osgeo.org/grass-stable/manuals/variables.html#list-of-selected-grass-environment-variables-for-rendering">GRASS environment variables for
   rendering</a> (GRASS_RENDER_FRAME)
   
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Martin Landa, Czech Technical University in Prague, Czech Republic
 
@@ -95,8 +95,3 @@ James Westervelt, U.S. Army Construction Engineering Research
 Laboratory<br>
 Michael Shapiro, U.S. Army Construction Engineering 
 Research Laboratory
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/display/d.mon2/d.mon2.html
+++ b/src/display/d.mon2/d.mon2.html
@@ -23,10 +23,6 @@ then just hit reload in your web browser whenever a refresh is needed.
 
 
 <h2>AUTHOR</h2>
+
 Hamish Bowman<br>
 Dunedin, New Zealand
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/display/d.region.grid/d.region.grid.html
+++ b/src/display/d.region.grid/d.region.grid.html
@@ -141,11 +141,6 @@ d.region.grid region=study_area
   <a href="https://grass.osgeo.org/grass-stable/manuals/v.mkgrid.html">v.mkgrid</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Vaclav Petras, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll Lab</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/display/d.vect.colbp/d.vect.colbp.html
+++ b/src/display/d.vect.colbp/d.vect.colbp.html
@@ -64,10 +64,6 @@ d.vect.colbp -h --overwrite map=schools_wake column=CORECAPACI where="CORECAPACI
 
 
 <h2>AUTHOR</h2>
+
 Paulo van Breugel<br>
 Based on the d.vect.colhist addon by Moritz Lennert  
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/display/d.vect.colhist/d.vect.colhist.html
+++ b/src/display/d.vect.colhist/d.vect.colhist.html
@@ -22,14 +22,10 @@ d.vect.colhist map=censusblk_swwake column=MEDIAN_AGE where="TOTAL_POP>0"
 </pre></div>
 
 <center>
-	                <img src="d_vect_colhist.png" border="1"><br>
-	                Histogram of median age values of census blocks
+<img src="d_vect_colhist.png" border="1"><br>
+Histogram of median age values of census blocks
 </center>
 
 <h2>AUTHOR</h2>
- Moritz Lennert
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Moritz Lennert

--- a/src/display/d.vect.thematic2/d.vect.thematic2.html
+++ b/src/display/d.vect.thematic2/d.vect.thematic2.html
@@ -113,14 +113,8 @@ d.vect.thematic2 -l precip_30ynormals column=annual type=point
 <h2>AUTHORS</h2>
 
 Michael Barton, Arizona State University
-
 <p>
 Various updates by:<br>
 Daniel Cavelo Aros,<br>
 Martin Landa,<br>
 Jachym Cepicky
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/general/g.citation/g.citation.html
+++ b/src/general/g.citation/g.citation.html
@@ -74,8 +74,3 @@ g.citation -s format=citeproc vsep="< p>" -a > all.html
 Vaclav Petras, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU GeoForAll Lab</a> (ORCID: 0000-0001-5566-9236)<br>
 Peter Loewe, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU GeoForAll Lab</a> (ORCID: 0000-0003-2257-0517)<br>
 Markus Neteler, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU GeoForAll Lab</a> (ORCID: 0000-0003-1916-1966)
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/general/g.copyall/g.copyall.html
+++ b/src/general/g.copyall/g.copyall.html
@@ -32,8 +32,3 @@ g.copyall mapset=test datatype=vect filter="s*"
 <h2>AUTHOR</h2>
 
 Michael Barton (Arizona State University, USA)
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/general/g.download.location/g.download.location.html
+++ b/src/general/g.download.location/g.download.location.html
@@ -20,11 +20,6 @@ Other locations or any other files are ignored.
   <a href="g.proj.all.html">g.proj.all</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Vaclav Petras, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU GeoForAll Lab</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/general/g.isis3mt/g.isis3mt.html
+++ b/src/general/g.isis3mt/g.isis3mt.html
@@ -7,12 +7,7 @@
 
 The ISIS3 user should use  matchmap=yes in cam2map
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Alessandro Frigeri, INA, Ispra, Italy
 Added to GRASS 7 by Yann Chemin
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/general/g.proj.all/g.proj.all.html
+++ b/src/general/g.proj.all/g.proj.all.html
@@ -26,8 +26,3 @@ g.proj.all resolution=50 location=nc_spm_08 mapset=landsat
 
 Anna Petrasova, <a href="http://gis.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>,<br>
 Vaclav Petras, <a href="http://gis.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/general/g.projpicker/g.projpicker.html
+++ b/src/general/g.projpicker/g.projpicker.html
@@ -539,8 +539,3 @@ g.projpicker -g query="postfix 34.2348,-83.8677 33.749,-84.388 not and"
 <h2>AUTHOR</h2>
 
 <a href="mailto:grass4u@gmail com">Huidae Cho</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/general/g.rename.many/g.rename.many.html
+++ b/src/general/g.rename.many/g.rename.many.html
@@ -94,8 +94,3 @@ on input and puts it twice on one line on the output separated by comma.
 <h2>AUTHOR</h2>
 
 Vaclav Petras, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/gui/wxpython/wx.metadata/db.csw.run/db.csw.run.html
+++ b/src/gui/wxpython/wx.metadata/db.csw.run/db.csw.run.html
@@ -20,15 +20,9 @@
     See also related <a href="http://grasswiki.osgeo.org/wiki/ISO/INSPIRE_Metadata_Support">wiki page</a>.
 
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
-Matej
-Krejci, <a href="http://geo.fsv.cvut.cz/gwiki/osgeorel">OSGeoREL</a>
+Matej Krejci, <a href="http://geo.fsv.cvut.cz/gwiki/osgeorel">OSGeoREL</a>
 at the Czech Technical University in Prague, developed
 during <a href="http://trac.osgeo.org/grass/wiki/GSoC/2014/MetadataForGRASS">Google
     Summer of Code 2014</a> (mentors: Margherita Di Leo, Martin Landa)
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/gui/wxpython/wx.metadata/g.gui.cswbrowser/g.gui.cswbrowser.html
+++ b/src/gui/wxpython/wx.metadata/g.gui.cswbrowser/g.gui.cswbrowser.html
@@ -81,15 +81,9 @@ contains uri of WMS, WFS or WMS, module allows to add them directly with using u
     See also related <a href="http://grasswiki.osgeo.org/wiki/ISO/INSPIRE_Metadata_Support">wiki page</a>.
 
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Matej Krejci, <a href="http://geo.fsv.cvut.cz/gwiki/osgeorel">OSGeoREL</a>
 at the Czech Technical University in Prague, developed
 during <a href="http://trac.osgeo.org/grass/wiki/GSoC/2014/MetadataForGRASS">Google
     Summer of Code 2015</a> (mentors: Martin Landa)
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
-

--- a/src/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.html
+++ b/src/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.html
@@ -120,14 +120,9 @@ Missing values are replaced by "Unknown" string.
     See also related <a href="http://grasswiki.osgeo.org/wiki/ISO/INSPIRE_Metadata_Support">wiki page</a>.
 
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Matej Krejci, <a href="http://geo.fsv.cvut.cz/gwiki/osgeorel">OSGeoREL</a>
 at the Czech Technical University in Prague, developed
 during <a href="http://trac.osgeo.org/grass/wiki/GSoC/2014/MetadataForGRASS">Google
     Summer of Code 2014</a> (mentors: Margherita Di Leo, Martin Landa)
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/gui/wxpython/wx.metadata/m.csw.update/m.csw.update.html
+++ b/src/gui/wxpython/wx.metadata/m.csw.update/m.csw.update.html
@@ -7,7 +7,9 @@ If the <b>-p</b> flag is used only printing instead of writing is done.
 The module also allows validate the connections resources XML file against
 XSD schema, remove invalid and not active CSW connections resources
 candidates.
+
 <h2>NOTES</h2>
+
 For dependencies and installation instructions see the
 <a href="https://grasswiki.osgeo.org/wiki/ISO/INSPIRE_Metadata_Support">
 wiki page</a>.
@@ -17,7 +19,9 @@ Stored new connections resources candidates are only those being active and vali
 Default source of the new candidates is a spreadsheet file (*.ods), which
 is to be stored in the module's <i>config/</i> directory. It is possible to use
 the updated document directly from the web address, see <b>-w</b> flag.
+
 <h2>EXAMPLES</h2>
+
 Import and store new resources connections candidates (default):
 <div class="code"><pre>
 m.csw.update url=API-cases.ods
@@ -46,6 +50,7 @@ CSWs):
 <div class="code"><pre>
 m.csw.update -xc
 </pre></div>
+
 <h2>SEE ALSO</h2>
 <em>
 <a href="g.gui.cswbrowser.html">g.gui.cswbrowser</a>,
@@ -60,7 +65,3 @@ wiki page</a>.
 <h2>AUTHOR</h2>
 
 Tomas Zigo
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/gui/wxpython/wx.metadata/r.info.iso/r.info.iso.html
+++ b/src/gui/wxpython/wx.metadata/r.info.iso/r.info.iso.html
@@ -67,15 +67,9 @@ r.info.iso map=elevation profile=inspire
     See also related <a href="http://grasswiki.osgeo.org/wiki/ISO/INSPIRE_Metadata_Support">wiki page</a>.
 
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Matej Krejci, <a href="http://geo.fsv.cvut.cz/gwiki/osgeorel">OSGeoREL</a>
 at the Czech Technical University in Prague, developed
 during <a href="http://trac.osgeo.org/grass/wiki/GSoC/2014/MetadataForGRASS">Google
     Summer of Code 2014</a> (mentors: Margherita Di Leo, Martin Landa)
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
-

--- a/src/gui/wxpython/wx.metadata/t.info.iso/t.info.iso.html
+++ b/src/gui/wxpython/wx.metadata/t.info.iso/t.info.iso.html
@@ -21,14 +21,9 @@ to <a href="http://www.iso.org/iso/catalogue_detail.htm?csnumber=26020">ISO
     See also related <a href="http://grasswiki.osgeo.org/wiki/ISO/INSPIRE_Metadata_Support">wiki page</a>.
 
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Matej Krejci, <a href="http://geo.fsv.cvut.cz/gwiki/osgeorel">OSGeoREL</a>
 at the Czech Technical University in Prague, developed
 during <a href="http://trac.osgeo.org/grass/wiki/GSoC/2014/MetadataForGRASS">Google
-    Summer of Code 2014</a> (mentors: Margherita Di Leo, Martin Landa)
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Summer of Code 2014</a> (mentors: Margherita Di Leo, Martin Landa)

--- a/src/gui/wxpython/wx.metadata/v.info.iso/v.info.iso.html
+++ b/src/gui/wxpython/wx.metadata/v.info.iso/v.info.iso.html
@@ -68,15 +68,9 @@ v.info.iso map=basins profile=inspire
     See also related <a href="http://grasswiki.osgeo.org/wiki/ISO/INSPIRE_Metadata_Support">wiki page</a>.
 
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Matej Krejci, <a href="http://geo.fsv.cvut.cz/gwiki/osgeorel">OSGeoREL</a>
 at the Czech Technical University in Prague, developed
 during <a href="http://trac.osgeo.org/grass/wiki/GSoC/2014/MetadataForGRASS">Google
     Summer of Code 2014</a> (mentors: Margherita Di Leo, Martin Landa)
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
-

--- a/src/gui/wxpython/wx.mwprecip/g.gui.mwprecip.html
+++ b/src/gui/wxpython/wx.mwprecip/g.gui.mwprecip.html
@@ -5,6 +5,6 @@ to obtain derived precipitation data.
 
 <h2>NOTES</h2>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Matej Krejci, <a href="http://geo.fsv.cvut.cz/gwiki/osgeorel">OSGeoREL</a>

--- a/src/gui/wxpython/wx.mwprecip/g.gui.mwprecip.html
+++ b/src/gui/wxpython/wx.mwprecip/g.gui.mwprecip.html
@@ -5,11 +5,6 @@ to obtain derived precipitation data.
 
 <h2>NOTES</h2>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Matej Krejci, <a href="http://geo.fsv.cvut.cz/gwiki/osgeorel">OSGeoREL</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.ann.maskrcnn/i.ann.maskrcnn.detect/i.ann.maskrcnn.detect.html
+++ b/src/imagery/i.ann.maskrcnn/i.ann.maskrcnn.detect/i.ann.maskrcnn.detect.html
@@ -74,15 +74,10 @@ i.ann.maskrcnn.detect band1=map1.red band2=map1.green band3=map1.blue classes=bu
 <h2>SEE ALSO</h2>
 
 <em>
-    <a href="i.ann.maskrcnn.html">Mask R-CNN in GRASS GIS</a>,
-    <a href="i.ann.maskrcnn.train.html">i.ann.maskrcnn.train</a>
+<a href="i.ann.maskrcnn.html">Mask R-CNN in GRASS GIS</a>,
+<a href="i.ann.maskrcnn.train.html">i.ann.maskrcnn.train</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Ondrej Pesek
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.ann.maskrcnn/i.ann.maskrcnn.html
+++ b/src/imagery/i.ann.maskrcnn/i.ann.maskrcnn.html
@@ -49,15 +49,10 @@ g.extension extension=maskrcnn
 <h2>MODULES</h2>
 
 <em>
-    <a href="i.ann.maskrcnn.train.html">i.ann.maskrcnn.train</a>,
-    <a href="i.ann.maskrcnn.detect.html">i.ann.maskrcnn.detect</a>
+<a href="i.ann.maskrcnn.train.html">i.ann.maskrcnn.train</a>,
+<a href="i.ann.maskrcnn.detect.html">i.ann.maskrcnn.detect</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Ondrej Pesek
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.ann.maskrcnn/i.ann.maskrcnn.train/i.ann.maskrcnn.train.html
+++ b/src/imagery/i.ann.maskrcnn/i.ann.maskrcnn.train/i.ann.maskrcnn.train.html
@@ -144,15 +144,10 @@ i.ann.maskrcnn.train training_dataset=/home/user/Documents/crops classes=corn,ri
 <h2>SEE ALSO</h2>
 
 <em>
-    <a href="i.ann.maskrcnn.html">Mask R-CNN in GRASS GIS</a>,
-    <a href="i.ann.maskrcnn.detect.html">i.ann.maskrcnn.detect</a>
+<a href="i.ann.maskrcnn.html">Mask R-CNN in GRASS GIS</a>,
+<a href="i.ann.maskrcnn.detect.html">i.ann.maskrcnn.detect</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Ondrej Pesek
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.cutlines/i.cutlines.html
+++ b/src/imagery/i.cutlines/i.cutlines.html
@@ -118,8 +118,3 @@ Revista Brasileira de Cartografia 68 (6),
 <h2>AUTHOR</h2> 
 
 Moritz Lennert
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.cva/i.cva.html
+++ b/src/imagery/i.cva/i.cva.html
@@ -177,8 +177,3 @@ r.colors map=CVA_87_02_change rules=i_cva_color_rules.csv
 <h2>AUTHOR</h2>
 
 Anna Zanchetta
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.destripe/i.destripe.html
+++ b/src/imagery/i.destripe/i.destripe.html
@@ -15,16 +15,11 @@ Input:
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="i.rotate.html">i.rotate</a><br>
+<a href="i.rotate.html">i.rotate</a>
 </em>
 
 <h2>REFERENCES</h2>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Yann Chemin, International Water Management Institute, Sri Lanka.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.eb.deltat/i.eb.deltat.html
+++ b/src/imagery/i.eb.deltat/i.eb.deltat.html
@@ -10,15 +10,10 @@ Additionally, it is worth menitoning that Pawan only created this map once, and 
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="i.eb.h0.html">i.eb.h0</a><br>
+<a href="i.eb.h0.html">i.eb.h0</a>
 </em>
 
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
-Yann Chemin, Asian Institute of Technology, Thailand<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Yann Chemin, Asian Institute of Technology, Thailand

--- a/src/imagery/i.eb.hsebal95/i.eb.hsebal95.html
+++ b/src/imagery/i.eb.hsebal95/i.eb.hsebal95.html
@@ -71,11 +71,12 @@ example:
 
 
 <h2>SEE ALSO</h2>
-<ul>
-  <li><a href=i.eb.h_iter.html>i.eb.h_iter</a>,
-      <a href=i.eb.h0.html>i.eb.h0</a>
-      <a href=i.evapo.pm.html>i.evapo.pm</a>
-</ul>
+
+<em>
+<a href=i.eb.h_iter.html>i.eb.h_iter</a>,
+<a href=i.eb.h0.html>i.eb.h0</a>,
+<a href=i.evapo.pm.html>i.evapo.pm</a>
+</em>
 
 <h2>REFERENCES</h2>
 
@@ -98,8 +99,3 @@ Yann Chemin
 <br>International Water management Institute, Colombo, Sri Lanka.
 
 <p>Contact: <a href="mailto:y.chemin@cgiar.org"> Yann Chemin</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.eb.z0m/i.eb.z0m.html
+++ b/src/imagery/i.eb.z0m/i.eb.z0m.html
@@ -46,8 +46,3 @@ in: Irmak, A. (Ed.), Evapotranspiration - Remote Sensing and Modeling. InTech.
 <h2>AUTHOR</h2>
 
 Yann Chemin
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.eb.z0m0/i.eb.z0m0.html
+++ b/src/imagery/i.eb.z0m0/i.eb.z0m0.html
@@ -16,18 +16,13 @@ If you happen to have a vegetation height (hv) map, then z0m=hv/7 and z0h=0.1*z0
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="i.eb.h0.html">i.eb.h0</a><br>
-<a href="i.eb.h_SEBAL95.html">i.eb.h_SEBAL95</a><br>
-<a href="i.eb.h_iter.html">i.eb.h_iter</a><br>
-<a href="i.eb.z0m.html">i.eb.z0m</a><br>
+<a href="i.eb.h0.html">i.eb.h0</a>,
+<a href="i.eb.h_SEBAL95.html">i.eb.h_SEBAL95</a>,
+<a href="i.eb.h_iter.html">i.eb.h_iter</a>,
+<a href="i.eb.z0m.html">i.eb.z0m</a>
 </em>
 
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
-Yann Chemin, International Rice Research Institute, The Philippines<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Yann Chemin, International Rice Research Institute, The Philippines

--- a/src/imagery/i.edge/i.edge.html
+++ b/src/imagery/i.edge/i.edge.html
@@ -138,8 +138,3 @@ Sensing 33.B3/2; PART 3 (2000), pp. 1063–1070.</li>
 
 Anna Kratochvilova,
 Vaclav Petras
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.evapo.potrad/i.evapo.potrad.html
+++ b/src/imagery/i.evapo.potrad/i.evapo.potrad.html
@@ -24,9 +24,9 @@ Slope/aspect correction to be screened and tested by somebody in the known.
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="https://grass.osgeo.org/grass-stable/manuals/r.sun.html">r.sun</a><br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/i.albedo.html">i.albedo</a><br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/i.eb.eta.html">i.eb.eta</a><br>
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.sun.html">r.sun</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/i.albedo.html">i.albedo</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/i.eb.eta.html">i.eb.eta</a>
 </em>
 
 
@@ -47,9 +47,4 @@ in: Irmak, A. (Ed.), Evapotranspiration - Remote Sensing and Modeling. InTech.
 
 <h2>AUTHOR</h2>
 
-Yann Chemin, International Rice Research Institute, The Philippines<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Yann Chemin, International Rice Research Institute, The Philippines

--- a/src/imagery/i.evapo.senay/i.evapo.senay.html
+++ b/src/imagery/i.evapo.senay/i.evapo.senay.html
@@ -33,11 +33,11 @@ be very sensitive to the kind of pixel sample you feed it with.
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="https://grass.osgeo.org/grass-stable/manuals/r.sun.html">r.sun</a><br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/i.albedo.html">i.albedo</a><br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/i.eb.eta.html">i.eb.eta</a><br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/i.eb.evapfr.html">i.eb.evapfr</a><br>
-<a href="i.evapo.potrad.html">i.evapo.potrad</a><br>
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.sun.html">r.sun</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/i.albedo.html">i.albedo</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/i.eb.eta.html">i.eb.eta</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/i.eb.evapfr.html">i.eb.evapfr</a>,
+<a href="i.evapo.potrad.html">i.evapo.potrad</a>
 </em>
 
 
@@ -55,9 +55,4 @@ in: Irmak, A. (Ed.), Evapotranspiration - Remote Sensing and Modeling. InTech.
 
 <h2>AUTHOR</h2>
 
-Yann Chemin, International Rice Research Institute, The Philippines.<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Yann Chemin, International Rice Research Institute, The Philippines.

--- a/src/imagery/i.evapo.zk/i.evapo.zk.html
+++ b/src/imagery/i.evapo.zk/i.evapo.zk.html
@@ -103,9 +103,4 @@ in: Irmak, A. (Ed.), Evapotranspiration - Remote Sensing and Modeling. InTech.
 
 <h2>AUTHOR</h2>
 
-Yann Chemin, GRASS Development team, 2011
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Yann Chemin, GRASS Development Team, 2011

--- a/src/imagery/i.feotio2/i.feotio2.html
+++ b/src/imagery/i.feotio2/i.feotio2.html
@@ -60,11 +60,6 @@ Initially created for Clementine data.
 (3) Lawrence, DJ and Feldman, WC and Elphic, RC and Little, RC and Prettyman, TH and Maurice, S and Lucey, PG and Binder, AB, 2002. Iron abundances on the lunar surface as measured by the Lunar Prospector gamma-ray and neutron spectrometers. Journal of Geophysical Research: Planets (1991--2012), 107(E12):13-1.
 
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Yann Chemin (B.Sc. student), Birkbeck, University of London.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.fusion.hpf/i.fusion.hpf.html
+++ b/src/imagery/i.fusion.hpf/i.fusion.hpf.html
@@ -134,6 +134,7 @@ PHOTOGRAMMETRIC ENGINEERING &amp; REMOTE SENSING, 74(9):1107--1118.</li>
 </ul>
 
 <h2>SEE ALSO</h2>
+
 <em>
 <a href="https://grass.osgeo.org/grass-stable/manuals/i.pansharpen.html">i.pansharpen</a>
 </em>
@@ -143,8 +144,3 @@ PHOTOGRAMMETRIC ENGINEERING &amp; REMOTE SENSING, 74(9):1107--1118.</li>
 
 Nikos Alexandris<br>
 Panagiotis Mavrogiorgos
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.gabor/i.gabor.html
+++ b/src/imagery/i.gabor/i.gabor.html
@@ -177,10 +177,8 @@ raster map at a time in memory.
     <a href="https://grass.osgeo.org/grass-stable/manuals/i.segment.html">i.segment</a>
 </em>
 
-<h2>AUTHOR</h2>
-<a href="mailto:ocsmit@protonmail.com">Owen Smith</a>
-
 <h2>REFERENCES</h2>
+
 <ul>
     <li>Gabor, D. (1946). <em>Theory of communication.</em> Journal of the
         Institute of Electrical Engineers, 93, 429–457.</li>
@@ -199,7 +197,6 @@ raster map at a time in memory.
         Applied Remote Sensing, 11(1), 015019.</li>
 </ul>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+<h2>AUTHOR</h2>
+
+<a href="mailto:ocsmit@protonmail.com">Owen Smith</a>

--- a/src/imagery/i.gcp/i.gcp.html
+++ b/src/imagery/i.gcp/i.gcp.html
@@ -90,8 +90,3 @@ Processing manual</a></em>
 <h2>AUTHOR</h2>
 
 <a href="mailto:grass4u@gmail com">Huidae Cho</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.gravity/i.gravity.html
+++ b/src/imagery/i.gravity/i.gravity.html
@@ -27,18 +27,13 @@
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="i.latlon.html">i.latlon</a><br>
+<a href="i.latlon.html">i.latlon</a>
 </em>
 
 <h2>REFERENCES</h2>
 
-  <p>[1] Mussett, A.E. and Khan, M.A, M.A. Looking into the Earth: An Introduction to Geological Geophysics.
+[1] Mussett, A.E. and Khan, M.A, M.A. Looking into the Earth: An Introduction to Geological Geophysics.
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Yann Chemin, University of London at Birkbeck, United Kingdom.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.histo.match/i.histo.match.html
+++ b/src/imagery/i.histo.match/i.histo.match.html
@@ -47,8 +47,3 @@ based on original PERL code was
 developed by: Laura Zampa (2004), student of Dipartimento di Informatica e 
 Telecomunicazioni, Facolta' di Ingegneria, University of Trento and ITC-irst, 
 Trento (Italy)
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.image.bathymetry/i.image.bathymetry.html
+++ b/src/imagery/i.image.bathymetry/i.image.bathymetry.html
@@ -75,12 +75,7 @@ Additional_band1='B4' nir_band='B5' band_for_correction='B5'
 calibration_points='Calibration_points'  calibration_column='value' 
 depth_estimate='output' 
 </pre></div> 
-<h2>AUTHORS</h2>
-Vinayaraj Poliyapram (email:<em>vinay223333@gmail.com</em>), Luca 
-Delucchi and Venkatesh Raghavan
 
-<h2>SEE ALSO</h2>
-<em>r.gwr</em> and <em>r.regression.multi</em>
 
 <h2>REFERENCES</h2>
 <ul>
@@ -95,7 +90,14 @@ Geosciences and Remote Sensing, 52(1) : 465-476, Accessed January 2013,
 doi:10.1109/TGRS.2013.2241772.
 </ul>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+<h2>SEE ALSO</h2>
+
+<em>
+<a href="r.gwr.html">r.gwr</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.regression.multi.html">r.regression.multi</a>
+</em>
+
+<h2>AUTHORS</h2>
+
+Vinayaraj Poliyapram (email:<em>vinay223333@gmail.com</em>),
+Luca Delucchi and Venkatesh Raghavan

--- a/src/imagery/i.in.probav/i.in.probav.html
+++ b/src/imagery/i.in.probav/i.in.probav.html
@@ -48,9 +48,4 @@ i.in.probav input=c_gls_NDVI300_201611010000_GLOBE_PROBAV_V1.0.1.nc \
 
 <h2>AUTHOR</h2>
 
-Jonas Strobel<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Jonas Strobel

--- a/src/imagery/i.landsat/i.landsat.download/i.landsat.download.html
+++ b/src/imagery/i.landsat/i.landsat.download/i.landsat.download.html
@@ -179,8 +179,3 @@ i.landsat.download settings=credentials.txt \
 <h2>AUTHOR</h2>
 
 <a href="https://veroandreo.gitlab.io/" target="_blank">Veronica Andreo</a>, CONICET, Argentina.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.landsat/i.landsat.html
+++ b/src/imagery/i.landsat/i.landsat.html
@@ -49,7 +49,3 @@ The <em>i.landsat</em> toolset consists of three modules:
 
 <a href="https://veroandreo.gitlab.io/" target="_blank">Veronica Andreo</a>, CONICET, Argentina.<br>
 Stefan Blumentrath, Norwegian Institute for Nature Research, Oslo (Norway)
-
-<h2>SOURCE CODE</h2>
-
-<p>Available at: <a href="https://github.com/OSGeo/grass-addons/tree/grass8/src/imagery/i.landsat">i.landsat source code</a> (<a href="https://github.com/OSGeo/grass-addons/commits/grass8/src/imagery/i.landsat">history</a>)</p>

--- a/src/imagery/i.landsat/i.landsat.html
+++ b/src/imagery/i.landsat/i.landsat.html
@@ -49,3 +49,7 @@ The <em>i.landsat</em> toolset consists of three modules:
 
 <a href="https://veroandreo.gitlab.io/" target="_blank">Veronica Andreo</a>, CONICET, Argentina.<br>
 Stefan Blumentrath, Norwegian Institute for Nature Research, Oslo (Norway)
+
+<h2>SOURCE CODE</h2>
+
+<p>Available at: <a href="https://github.com/OSGeo/grass-addons/tree/grass8/src/imagery/i.landsat">i.landsat source code</a> (<a href="https://github.com/OSGeo/grass-addons/commits/grass8/src/imagery/i.landsat">history</a>)</p>

--- a/src/imagery/i.landsat/i.landsat.html
+++ b/src/imagery/i.landsat/i.landsat.html
@@ -47,15 +47,9 @@ The <em>i.landsat</em> toolset consists of three modules:
 
 <h2>AUTHORS</h2>
 
-<a href="https://veroandreo.gitlab.io/" target="_blank">Veronica Andreo</a>, CONICET, Argentina.
-
+<a href="https://veroandreo.gitlab.io/" target="_blank">Veronica Andreo</a>, CONICET, Argentina.<br>
 Stefan Blumentrath, Norwegian Institute for Nature Research, Oslo (Norway)
 
 <h2>SOURCE CODE</h2>
 
 <p>Available at: <a href="https://github.com/OSGeo/grass-addons/tree/grass8/src/imagery/i.landsat">i.landsat source code</a> (<a href="https://github.com/OSGeo/grass-addons/commits/grass8/src/imagery/i.landsat">history</a>)</p>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.landsat/i.landsat.import/i.landsat.import.html
+++ b/src/imagery/i.landsat/i.landsat.import/i.landsat.import.html
@@ -193,8 +193,3 @@ t.register input=landsat_ts file=t_register.txt
 <h2>AUTHOR</h2>
 
 <a href="https://veroandreo.gitlab.io/" target="_blank">Veronica Andreo</a>, CONICET, Argentina.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.landsat/i.landsat.qa/i.landsat.qa.html
+++ b/src/imagery/i.landsat/i.landsat.qa/i.landsat.qa.html
@@ -199,9 +199,4 @@ Landsat Collection 2 Level 1 Quality Assessment bands</a></em>
 
 <h2>AUTHOR</h2>
 
-<p>Stefan Blumentrath, Norwegian Institute for Nature Research, Oslo (Norway)</p>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Stefan Blumentrath, Norwegian Institute for Nature Research, Oslo (Norway)

--- a/src/imagery/i.lmf/i.lmf.html
+++ b/src/imagery/i.lmf/i.lmf.html
@@ -35,11 +35,6 @@ strength, for my actual experience with VIs curves.
 </em>
 
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
-Yann Chemin, International Rice Research Institute, The Philippines<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Yann Chemin, International Rice Research Institute, The Philippines

--- a/src/imagery/i.lswt/i.lswt.html
+++ b/src/imagery/i.lswt/i.lswt.html
@@ -50,9 +50,5 @@ explained below, uses the same split window technique implemented here:
 </em>
 
 <h2>AUTHOR</h2>
-Sajid Pareeth; Fondazione Edmund Mach, Italy
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Sajid Pareeth; Fondazione Edmund Mach, Italy

--- a/src/imagery/i.modis/i.modis.download/i.modis.download.html
+++ b/src/imagery/i.modis/i.modis.download/i.modis.download.html
@@ -148,8 +148,3 @@ i.modis.download -g settings=$HOME/.grass8/i.modis/SETTING startday=2011-05-01 e
 <h2>AUTHOR</h2>
 
 Luca Delucchi, Google Summer of Code 2011; subsequently updated.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.modis/i.modis.html
+++ b/src/imagery/i.modis/i.modis.html
@@ -340,8 +340,3 @@ Luca Delucchi, Initial version: Google Summer of Code 2011; subsequently updated
 
 <h2>SOURCE CODE</h2>
 <p>Available at: <a href="https://github.com/OSGeo/grass-addons/tree/master/grass8/imagery/i.modis">i.modis source code</a> (<a href="https://github.com/OSGeo/grass-addons/commits/grass8/src/imagery/i.modis">history</a>)</p>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.modis/i.modis.html
+++ b/src/imagery/i.modis/i.modis.html
@@ -334,9 +334,6 @@ library. Please install it beforehand.
  <li> <a href="https://lpdaac.usgs.gov/product_search/">MODIS Land products table</a></li>
 </ul>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Luca Delucchi, Initial version: Google Summer of Code 2011; subsequently updated by further authors
-
-<h2>SOURCE CODE</h2>
-<p>Available at: <a href="https://github.com/OSGeo/grass-addons/tree/master/grass8/imagery/i.modis">i.modis source code</a> (<a href="https://github.com/OSGeo/grass-addons/commits/grass8/src/imagery/i.modis">history</a>)</p>

--- a/src/imagery/i.modis/i.modis.html
+++ b/src/imagery/i.modis/i.modis.html
@@ -337,3 +337,7 @@ library. Please install it beforehand.
 <h2>AUTHORS</h2>
 
 Luca Delucchi, Initial version: Google Summer of Code 2011; subsequently updated by further authors
+
+<h2>SOURCE CODE</h2>
+
+<p>Available at: <a href="https://github.com/OSGeo/grass-addons/tree/grass8/src/imagery/i.modis">i.modis source code</a> (<a href="https://github.com/OSGeo/grass-addons/commits/grass8/src/imagery/i.modis">history</a>)</p>

--- a/src/imagery/i.modis/i.modis.import/i.modis.import.html
+++ b/src/imagery/i.modis/i.modis.import/i.modis.import.html
@@ -220,8 +220,3 @@ t.register input=LST_Day_daily file=$HOME/list_for_tregister.csv
 <h2>AUTHOR</h2>
 
 Luca Delucchi, Google Summer of Code 2011; subsequently updated.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.nightlights.intercalibration/i.nightlights.intercalibration.html
+++ b/src/imagery/i.nightlights.intercalibration/i.nightlights.intercalibration.html
@@ -175,8 +175,3 @@ Satellite + Year!
 <h2>AUTHOR</h2>
 
 Nikos Alexandris
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.ortho.corr/i.ortho.corr.html
+++ b/src/imagery/i.ortho.corr/i.ortho.corr.html
@@ -61,8 +61,3 @@ i.ortho.corr input=image.photo tiles=tile_images osuffix=.photo csuffix=.camera
 <h2>AUTHOR</h2>
 
 Luca Delucchi, Fondazione E. Mach (Italy)
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.points.auto/i.points.auto.html
+++ b/src/imagery/i.points.auto/i.points.auto.html
@@ -55,11 +55,7 @@ Processing manual</a></em>
 
 
 <h2>AUTHORS</h2>
+
 Ivan Michelazzi<br>
 Luca Miori<br>
 Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.pr/i.pr_features/description.html
+++ b/src/imagery/i.pr/i.pr_features/description.html
@@ -17,8 +17,3 @@ This module allows for the calculation of a range of statistics pertaining to th
 Stefano Merler, FBK, Trento, Italy<br>
 Documentation: Daniel McInerney (daniel.mcinerney ucd.ie)
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
-

--- a/src/imagery/i.pr/i.pr_training/description.html
+++ b/src/imagery/i.pr/i.pr_training/description.html
@@ -84,8 +84,3 @@ The output of this module will be an ascii file of type xy.z. The number of colu
 
 Stefano Merler, FBK, Trento, Italy<br>
 Documentation: Daniel McInerney (daniel.mcinerney ucd.ie)
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.rh/i.rh.html
+++ b/src/imagery/i.rh/i.rh.html
@@ -15,17 +15,12 @@ https://www.researchgate.net/publication/227247013_High-resolution_Surface_Relat
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="https://grass.osgeo.org/grass-stable/manuals/i.vi.html">i.vi</a><br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/i.albedo.html">i.albedo</a><br>
-<a href="i.wi.html">i.wi</a><br>
+<a href="https://grass.osgeo.org/grass-stable/manuals/i.vi.html">i.vi</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/i.albedo.html">i.albedo</a>,
+<a href="i.wi.html">i.wi</a>
 </em>
 
 
 <h2>AUTHOR</h2>
 
-Yann Chemin, Plumergat, France<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Yann Chemin, Plumergat, France

--- a/src/imagery/i.rotate/i.rotate.html
+++ b/src/imagery/i.rotate/i.rotate.html
@@ -1,27 +1,22 @@
-<H2>DESCRIPTION</H2>
+<h2>DESCRIPTION</h2>
 
-<EM>i.rotate</EM> rotates an input raster by a clockwise angle.
+<em>i.rotate</em> rotates an input raster by a clockwise angle.
 
-<H2>NOTES</H2>
+<h2>NOTES</h2>
 
 <p>
 
-<H2>TODO</H2>
+<h2>TODO</h2>
 
 Checking if all pixels in the output raster are populated; if not, apply
 an NN algorithm.
 
-<H2>SEE ALSO</H2>
+<h2>SEE ALSO</hH2>
 
 <em>
-<A HREF="r.flip.html">r.flip</A><br>
+<a href="r.flip.html">r.flip</a>
 </em>
 
-<H2>AUTHORS</H2>
+<H2>AUTHOR</H2>
 
-Yann Chemin, CGIAR, Sri Lanka<BR>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Yann Chemin, CGIAR, Sri Lanka

--- a/src/imagery/i.rotate/i.rotate.html
+++ b/src/imagery/i.rotate/i.rotate.html
@@ -11,7 +11,7 @@
 Checking if all pixels in the output raster are populated; if not, apply
 an NN algorithm.
 
-<h2>SEE ALSO</hH2>
+<h2>SEE ALSO</h2>
 
 <em>
 <a href="r.flip.html">r.flip</a>

--- a/src/imagery/i.sar.speckle/i.sar.speckle.html
+++ b/src/imagery/i.sar.speckle/i.sar.speckle.html
@@ -21,8 +21,3 @@ radar images. Optical engineering, 25(5), 255636.
 <h2>AUTHOR</h2> 
 
 Margherita Di Leo
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.segment.gsoc/i.segment.gsoc.html
+++ b/src/imagery/i.segment.gsoc/i.segment.gsoc.html
@@ -218,11 +218,7 @@ GRASS GIS</a> is also available on the wiki.
 </em>
 
 <h2>AUTHORS</h2>
+
 Eric Momsen - North Dakota State University
 <p>
 GSoC mentor: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.segment.hierarchical/i.segment.hierarchical.html
+++ b/src/imagery/i.segment.hierarchical/i.segment.hierarchical.html
@@ -16,8 +16,3 @@ TODO
 <h2>AUTHOR</h2>
 
 Pietro Zambelli (University of Trento)
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.segment.stats/i.segment.stats.html
+++ b/src/imagery/i.segment.stats/i.segment.stats.html
@@ -98,8 +98,3 @@ i.segment.stats map=ls_pan_seg01 csvfile=segstats.csv vectormap=ls_pan_seg01 \
 <h2>AUTHOR</h2>
 
 Moritz Lennert
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.segment.uspo/i.segment.uspo.html
+++ b/src/imagery/i.segment.uspo/i.segment.uspo.html
@@ -114,16 +114,13 @@ Geo-Information, 4(4), pp. 2292-2305, <a href="http://dx.doi.org/10.3390/ijgi404
 
 <h2>SEE ALSO</h2>
 
-<a href="https://grass.osgeo.org/grass-stable/manuals/i.segment.html">i.segment</a>,<br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/i.group.html">i.group</a>,<br>
-<a href="i.segment.hierarchical.html">i.segment.hierarchical</a>,<br>
-<a href="r.neighborhoodmatrix.html">r.neighborhoodmatrix</a><br>
+<em>
+<a href="https://grass.osgeo.org/grass-stable/manuals/i.segment.html">i.segment</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/i.group.html">i.group</a>,
+<a href="i.segment.hierarchical.html">i.segment.hierarchical</a>,
+<a href="r.neighborhoodmatrix.html">r.neighborhoodmatrix</a>
+</em>
 
 <h2>AUTHOR</h2> 
 
 Moritz Lennert
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.sentinel/i.sentinel.coverage/i.sentinel.coverage.html
+++ b/src/imagery/i.sentinel/i.sentinel.coverage/i.sentinel.coverage.html
@@ -83,8 +83,3 @@ t.sentinel.import settings=credentials.txt s2names=s2names.txt nprocs=4 \
 
 Anika Weinmann, <a href="https://www.mundialis.de/">mundialis</a>
 
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.html
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.html
@@ -465,14 +465,10 @@ The UUID is shown in the server answer under 'Id'.
 See also <a href="https://training.gismentors.eu/grass-gis-workshop-jena/units/20.html">GRASS
 GIS Workshop in Jena</a> for usage examples.
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Martin Landa, <a href="http://geomatics.fsv.cvut.cz/research/geoforall/">GeoForAll
 Lab</a>, CTU in Prague, Czech Republic with support
 of <a href="https://opengeolabs.cz/en/home/">OpenGeoLabs</a> company
 <br>
 Guido Riembauer, <a href="https://www.mundialis.de/">mundialis</a> (USGS and GCS provider support)
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.sentinel/i.sentinel.html
+++ b/src/imagery/i.sentinel/i.sentinel.html
@@ -57,8 +57,3 @@ Roberta Fagandini, GSoC 2018 student, Italy
 <p>
 Anika Weinmann, Guido Riembauer, Markus Neteler, <a href="https://www.mundialis.de/">mundialis</a>, Germany
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
-

--- a/src/imagery/i.sentinel/i.sentinel.html
+++ b/src/imagery/i.sentinel/i.sentinel.html
@@ -56,4 +56,3 @@ of <a href="http://opengeolabs.cz/en/home/">OpenGeoLabs</a> company
 Roberta Fagandini, GSoC 2018 student, Italy
 <p>
 Anika Weinmann, Guido Riembauer, Markus Neteler, <a href="https://www.mundialis.de/">mundialis</a>, Germany
-

--- a/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.html
+++ b/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.html
@@ -304,13 +304,8 @@ T33UVR_20181205T101401_B06|2018-12-05 10:16:43.275000|S2_6
 See also <a href="https://training.gismentors.eu/grass-gis-workshop-jena/units/20.html">GRASS
 GIS Workshop in Jena</a> for usage examples.
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Martin Landa, <a href="http://geomatics.fsv.cvut.cz/research/geoforall/">GeoForAll
 Lab</a>, CTU in Prague, Czech Republic with support
 of <a href="https://opengeolabs.cz/en/home/">OpenGeoLabs</a> company
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.sentinel/i.sentinel.mask/i.sentinel.mask.html
+++ b/src/imagery/i.sentinel/i.sentinel.mask/i.sentinel.mask.html
@@ -228,8 +228,3 @@ Fennoscandia. Remote Sens., 9, 806. (<a href="https://www.mdpi.com/2072-4292/9/8
 Roberta Fagandini, GSoC 2018 student<br>
 <a href="https://wiki.osgeo.org/wiki/User:Mlennert">Moritz Lennert</a><br>
 <a href="https://wiki.osgeo.org/wiki/User:Robertomarzocchi">Roberto Marzocchi</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.sentinel/i.sentinel.parallel.download/i.sentinel.parallel.download.html
+++ b/src/imagery/i.sentinel/i.sentinel.parallel.download/i.sentinel.parallel.download.html
@@ -17,8 +17,3 @@ products which footprint intersects the current computation region extent
 <h2>AUTHOR</h2>
 
 Guido Riembauer, <a href="https://www.mundialis.de/">mundialis</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.sentinel/i.sentinel.preproc/i.sentinel.preproc.html
+++ b/src/imagery/i.sentinel/i.sentinel.preproc/i.sentinel.preproc.html
@@ -377,8 +377,3 @@ Sentinel User Guide</a>.</li>
 Roberta Fagandini, GSoC 2018 student<br>
 <a href="https://wiki.osgeo.org/wiki/User:Mlennert">Moritz Lennert</a><br> 
 <a href="https://wiki.osgeo.org/wiki/User:Robertomarzocchi">Roberto Marzocchi</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.spec.sam/i.spec.sam.html
+++ b/src/imagery/i.spec.sam/i.spec.sam.html
@@ -33,8 +33,3 @@ fusion and classification. International Journal of Geoinformatics, 1(1), pp. 51
 Markus Neteler, University of Hannover, 1999
 <br>
 Updated to GRASS GIS 7: Yann Chemin, 2015
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.spec.unmix/i.spec.unmix.html
+++ b/src/imagery/i.spec.unmix/i.spec.unmix.html
@@ -129,13 +129,8 @@ fusion and classification. International Journal of Geoinformatics, 1(1), pp. 51
 <li> http://lib.stat.cmu.edu/general/XGobi/</li>
 </ul>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Markus Neteler, University of Hannover, 1999
 <p>
 Mohammed Rashad  (rashadkm gmail.com) (2012, update to GRASS 7)
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.superpixels.slic/i.superpixels.slic.html
+++ b/src/imagery/i.superpixels.slic/i.superpixels.slic.html
@@ -215,10 +215,5 @@ and Machine Intelligence, 34(11), 2274 - 2282. <br>
 
 <h2>AUTHORS</h2>
 
-Rashad Kanavath, India <br>
+Rashad Kanavath, India<br>
 Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.theilsen/i.theilsen.html
+++ b/src/imagery/i.theilsen/i.theilsen.html
@@ -11,13 +11,8 @@ It is known for its resistance to outliers.
 
 <H2>REFERENCES</H2>
 
-https://en.wikipedia.org/wiki/Theil-Sen_estimator
+<a href="https://en.wikipedia.org/wiki/Theil-Sen_estimator">https://en.wikipedia.org/wiki/Theil-Sen_estimator</a>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Yann Chemin, IWMI, Sri Lanka.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.variance/i.variance.html
+++ b/src/imagery/i.variance/i.variance.html
@@ -145,17 +145,14 @@ Woodcock, C.E., Strahler, A.H., 1987. The factor of scale in remote sensing.
 
 <h2>SEE ALSO</h2>
 
-<a href="https://grass.osgeo.org/grass-stable/manuals/r.resamp.stats.html">r.resamp.stats</a>,<br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/r.neighbors.html">r.neighbors</a>,<br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/r.univar.html">r.univar</a>,<br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/i.segment.html">i.segment</a>,<br>
+<em>
+<a href="https://grass.osgeo.org/grass-stable/manuals/i.segment.html">i.segment</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.resamp.stats.html">r.resamp.stats</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.neighbors.html">r.neighbors</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.univar.html">r.univar</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/r.texture.html">r.texture</a>
+</em>
 
 <h2>AUTHOR</h2> 
 
 Moritz Lennert
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.vi.mpi/i.vi.mpi.html
+++ b/src/imagery/i.vi.mpi/i.vi.mpi.html
@@ -51,14 +51,10 @@ Snail Mail:  Terrill Ray<br>
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="https://grass.osgeo.org/grass-stable/manuals/i.albedo.html">i.albedo</a><br>
+<a href="https://grass.osgeo.org/grass-stable/manuals/i.albedo.html">i.albedo</a>
 </em>
 
 
-<h2>AUTHORS</h2>
-GRASS Development Team.
+<h2>AUTHOR</h2>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+GRASS Development Team.

--- a/src/imagery/i.water/i.water.html
+++ b/src/imagery/i.water/i.water.html
@@ -21,17 +21,11 @@ Roy D.P., Jin Y., Lewis P.E., Justice C.O. (2005). Prototyping a global algorith
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="https://grass.osgeo.org/grass-stable/manuals/i.vi.html">i.vi</a><br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/i.albedo.html">i.albedo</a><br>
-<a href="i.wi.html">i.wi</a><br>
+<a href="https://grass.osgeo.org/grass-stable/manuals/i.vi.html">i.vi</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/i.albedo.html">i.albedo</a>
+<a href="i.wi.html">i.wi</a>
 </em>
-
 
 <h2>AUTHOR</h2>
 
-Yann Chemin, International Rice Research Insitute, The Philippines<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Yann Chemin, International Rice Research Insitute, The Philippines

--- a/src/imagery/i.wavelet/i.wavelet.html
+++ b/src/imagery/i.wavelet/i.wavelet.html
@@ -17,11 +17,6 @@ More wavelet families to be included.
   <a href="i.lmf.html">i.lmf</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Yann Chemin, International Water Management Institute
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.wi/i.wi.html
+++ b/src/imagery/i.wi/i.wi.html
@@ -63,15 +63,10 @@ Find other water indices and add them.
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="https://grass.osgeo.org/grass-stable/manuals/i.vi.html">i.vi</a><br>
+<a href="https://grass.osgeo.org/grass-stable/manuals/i.vi.html">i.vi</a>
 </em>
 
 
 <h2>AUTHOR</h2>
 
 Yann Chemin
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/imagery/i.zero2null/i.zero2null.html
+++ b/src/imagery/i.zero2null/i.zero2null.html
@@ -69,9 +69,4 @@ d.rast.num T32ULA_20190724T103029_B04_10m text_color=blue
 
 Markus Metz, mundialis
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
-
 

--- a/src/imagery/i.zero2null/i.zero2null.html
+++ b/src/imagery/i.zero2null/i.zero2null.html
@@ -69,4 +69,3 @@ d.rast.num T32ULA_20190724T103029_B04_10m text_color=blue
 
 Markus Metz, mundialis
 
-

--- a/src/misc/m.csv.clean/m.csv.clean.html
+++ b/src/misc/m.csv.clean/m.csv.clean.html
@@ -55,8 +55,3 @@ grass --tmp-location XY --exec m.csv.clean input=sampling_sites_raw.csv output=s
 <h2>AUTHOR</h2>
 
 Vaclav Petras, <a href="http://geospatial.ncsu.edu/">NCSU Center for Geospatial Analytics</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/misc/m.eigensystem/m.eigensystem.html
+++ b/src/misc/m.eigensystem/m.eigensystem.html
@@ -143,9 +143,9 @@ i.pca in=spot.ms.1,spot.ms.2,spot.ms.3 out=spot_pca
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="https://grass.osgeo.org/grass-stable/manuals/i.pca.html">i.pca</a><br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/r.covar.html">r.covar</a><br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/r.mapcalc.html">r.mapcalc</a><br>
+<a href="https://grass.osgeo.org/grass-stable/manuals/i.pca.html">i.pca</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.covar.html">r.covar</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.mapcalc.html">r.mapcalc</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/r.rescale.html">r.rescale</a>
 </em>
 
@@ -155,8 +155,3 @@ i.pca in=spot.ms.1,spot.ms.2,spot.ms.3 out=spot_pca
 This code uses routines from the EISPACK system.<br>
 The interface was coded by Michael Shapiro, U.S.Army Construction Engineering
  Research Laboratory
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/misc/m.gcp.filter/m.gcp.filter.html
+++ b/src/misc/m.gcp.filter/m.gcp.filter.html
@@ -69,15 +69,11 @@ the higher coefficients equal to zero.
 
 <h2>SEE ALSO</h2>
 
-<em><a href="m.transform.html">m.transform</a></em>, 
-<em><a href="https://grass.osgeo.org/grass-stable/manuals/i.rectify.html">i.rectify</a></em>
+<em>
+<a href="m.transform.html">m.transform</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/i.rectify.html">i.rectify</a>
+</em>
 
-
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.accumulate/r.accumulate.html
+++ b/src/raster/r.accumulate/r.accumulate.html
@@ -303,8 +303,3 @@ Huidae Cho, September 2020. <em>A Recursive Algorithm for Calculating the Longes
 <h2>AUTHOR</h2>
 
 <a href="mailto:grass4u@gmail com">Huidae Cho</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.agent/r.agent.aco/r.agent.aco.html
+++ b/src/raster/r.agent/r.agent.aco/r.agent.aco.html
@@ -73,11 +73,6 @@ Implement other ABM scenarios.
 
 <h2>SEE ALSO</h2>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Michael Lustenberger inofix.ch
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.agent/r.agent.html
+++ b/src/raster/r.agent/r.agent.html
@@ -25,11 +25,6 @@ Agents wander around on the terrain, marking paths to new locations.</li>
 Agents wander around on the terrain, marking paths to new locations.</li>
 </ul>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Michael Lustenberger inofix.ch
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.basin/r.basin.html
+++ b/src/raster/r.basin/r.basin.html
@@ -210,8 +210,3 @@ Geomatics Workbooks</a>, n. 9</em></li>
 <h2>AUTHORS</h2>
 
 Margherita Di Leo (grass-dev AT lists DOT osgeo DOT org ), Massimo Di Stefano
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.bioclim/r.bioclim.html
+++ b/src/raster/r.bioclim/r.bioclim.html
@@ -89,8 +89,3 @@ r.bioclim tmin=`g.list type=rast pat=tmin_* map=. sep=,` \
 <h2>AUTHOR</h2>
 
 Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.bitpattern/r.bitpattern.html
+++ b/src/raster/r.bitpattern/r.bitpattern.html
@@ -41,15 +41,10 @@ image using <em>r.mapcalc</em> (OR and NOT operators).
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="i.modis.qc.html">i.modis.qc</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/i.modis.qc.html">i.modis.qc</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/r.mapcalc.html">r.mapcalc</a>
 </em>
 
 <h2>AUTHORS</h2>
 
 Radim Blazek, Markus Neteler
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.catchment/r.catchment.html
+++ b/src/raster/r.catchment/r.catchment.html
@@ -96,8 +96,3 @@ sigma=15 area=5000000 map_val=1
 Isaac Ullah
 <p>
 Updated for GRASS 7, 23, Feb. 2015.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.category.trim/r.category.trim.html
+++ b/src/raster/r.category.trim/r.category.trim.html
@@ -83,8 +83,3 @@ r.colors.out_sld</a>
 <h2>AUTHOR</h2>
 
 Paulo van Breugel, paulo at ecodiv.earth
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.cell.area/r.cell.area.html
+++ b/src/raster/r.cell.area/r.cell.area.html
@@ -17,8 +17,3 @@ This module is useful for determining the flow accumulation area to weight flow 
 <h2>AUTHOR</h2>
 
 Andrew D. Wickert<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.centroids/r.centroids.html
+++ b/src/raster/r.centroids/r.centroids.html
@@ -42,8 +42,3 @@ r.centroids input=basin_50K output=centroids50K
 <h2>AUTHOR</h2>
 
 Caitlin Haedrich, <i>Center for Geospatial Analytics, North Carolina State University</i>, January, 2021.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.change.info/r.change.info.html
+++ b/src/raster/r.change.info/r.change.info.html
@@ -224,9 +224,4 @@ Shannon, C.E. 1948. A Mathematical Theory of Communication. Bell System Technica
 <h2>AUTHOR</h2>
 
 Markus Metz 
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
   

--- a/src/raster/r.clip/r.clip.html
+++ b/src/raster/r.clip/r.clip.html
@@ -194,8 +194,3 @@ cells=2025000
 <h2>AUTHOR</h2>
 
 Vaclav Petras, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU GeoForAll Lab</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.colors.contrastbrightness/r.colors.contrastbrightness.html
+++ b/src/raster/r.colors.contrastbrightness/r.colors.contrastbrightness.html
@@ -43,9 +43,5 @@ r.colors.contrastbrightness min=0.0 max=255.0 contrast=1.0 brightness=100.0 inpu
 
 
 <h2>AUTHOR</h2>
-Yann Chemin, <a href="http://jrc.it/">JRC, Ispra, Italy</a><br>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Yann Chemin, <a href="http://jrc.it/">JRC, Ispra, Italy</a>

--- a/src/raster/r.colors.cubehelix/r.colors.cubehelix.html
+++ b/src/raster/r.colors.cubehelix/r.colors.cubehelix.html
@@ -122,9 +122,5 @@ function documentation and an
 <a href="https://stanford.edu/~mwaskom/software/seaborn/examples/cubehelix_palette.html">example
 
 <h2>AUTHOR</h2>
-Vaclav Petras, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU OSGeoREL</a><br>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Vaclav Petras, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>

--- a/src/raster/r.colors.matplotlib/r.colors.matplotlib.html
+++ b/src/raster/r.colors.matplotlib/r.colors.matplotlib.html
@@ -199,10 +199,6 @@ so it works for example with files from the
 <a href="http://matplotlib.org/examples/color/colormaps_reference.html">colormaps_reference</a>
 example in Matplotlib documentation
 
-<h2>AUTHORS</h2>
-Vaclav Petras, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU OSGeoREL</a><br>
+<h2>AUTHOR</h2>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Vaclav Petras, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>

--- a/src/raster/r.confusionmatrix/r.confusionmatrix.html
+++ b/src/raster/r.confusionmatrix/r.confusionmatrix.html
@@ -31,8 +31,3 @@ r.confusionmatrix classification=classified raster_reference=trainingmap csvfile
 <h2>AUTHOR</h2>
 
 Anika Bettge, mundialis GmbH &amp; Co. KG
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.connectivity/r.connectivity.corridors/r.connectivity.corridors.html
+++ b/src/raster/r.connectivity/r.connectivity.corridors/r.connectivity.corridors.html
@@ -121,9 +121,5 @@ g.remove type=raster pattern=hws_connectivity_patch_*
 </em>
 
 <h2>AUTHOR</h2>
-Stefan Blumentrath, Norwegian Institute for Nature Research (NINA)
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Stefan Blumentrath, Norwegian Institute for Nature Research (NINA)

--- a/src/raster/r.connectivity/r.connectivity.distance/r.connectivity.distance.html
+++ b/src/raster/r.connectivity/r.connectivity.distance/r.connectivity.distance.html
@@ -262,10 +262,6 @@ naturforskning (NINA), Trondheim.
 <a href="r.connectivity.corridors.html">r.connectivity.corridors</a>
 
 <h2>AUTHOR</h2>
-Stefan Blumentrath, Norwegian Institute for Nature Research, Oslo, Norway
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Stefan Blumentrath, Norwegian Institute for Nature Research, Oslo, Norway
 

--- a/src/raster/r.connectivity/r.connectivity.html
+++ b/src/raster/r.connectivity/r.connectivity.html
@@ -73,11 +73,6 @@ naturforskning (NINA), Trondheim.
   <a href="https://grass.osgeo.org/grass-stable/manuals/v.distance.html">v.distance</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 For authors, please refer to each module of r.connectivity.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.connectivity/r.connectivity.network/r.connectivity.network.html
+++ b/src/raster/r.connectivity/r.connectivity.network/r.connectivity.network.html
@@ -448,9 +448,5 @@ http://cran.r-project.org/web/packages/igraph/index.html</a></dt>
 </em>
 
 <h2>AUTHOR</h2>
-Stefan Blumentrath, Norwegian Institute for Nature Research (NINA)
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Stefan Blumentrath, Norwegian Institute for Nature Research (NINA)

--- a/src/raster/r.convergence/r.convergence.html
+++ b/src/raster/r.convergence/r.convergence.html
@@ -97,10 +97,6 @@ Bauer J., Rohdenburg H., Bork H.-R., (1985), Ein Digitales Reliefmodell als Vorr
 B&ouml;hner J., Blaschke T., Montanarella, L. (eds.) (2008). SAGA Seconds Out. Hamburger Beitr&auml;ge zur Physischen Geographie und Landschafts&ouml;kologie, 19: 113 s.</p>
 
 <h2>AUTHOR</h2>
-Jarek Jasiewicz
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Jarek Jasiewicz
 

--- a/src/raster/r.cpt2grass/r.cpt2grass.html
+++ b/src/raster/r.cpt2grass/r.cpt2grass.html
@@ -86,10 +86,6 @@ d.legend raster=elevation labelnum=10 at=5,50,7,10
 </em>
 
 <h2>AUTHORS</h2>
+
 Anna Petrasova, <a href="http://gis.ncsu.edu/osgeorel/">NCSU OSGeoREL</a><br>
 Hamish Bowman (original Bash script)
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.crater/r.crater.html
+++ b/src/raster/r.crater/r.crater.html
@@ -58,9 +58,5 @@ argv[9]: [optional] enter the final crater diameter in m
 </em>
 
 <h2>AUTHOR</h2>
-Yann Chemin
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Yann Chemin

--- a/src/raster/r.denoise/r.denoise.html
+++ b/src/raster/r.denoise/r.denoise.html
@@ -69,7 +69,7 @@ pip install pyproj
 <a href="https://grass.osgeo.org/grass-stable/manuals/r.topidx.html">r.topidx</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 John A Stevenson<br>
 johnalexanderstevenson <i>at</i> yahoo <i>dot</i> co <i>dot</i> uk<br><br>
 
@@ -80,8 +80,3 @@ by <a href="http://www.epsrc.ac.uk">EPSRC</a> Grant no. EP/C007972/1
 Module ported to Python by <a href="http://carlosgrohmann.com/">Carlos
 H. Grohmann</a><br>
 Institute of Energy and Environment, University of Sao Paulo, Brazil<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.divergence/r.divergence.html
+++ b/src/raster/r.divergence/r.divergence.html
@@ -47,12 +47,7 @@ EOF
 
 <em><a href="https://grass.osgeo.org/grass-stable/manuals/r.slope.aspect.html">r.slope.aspect</a></em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Anna Petrasova, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU OSGeoREL</a><br>
 Helena Mitasova, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.diversity/r.diversity.html
+++ b/src/raster/r.diversity/r.diversity.html
@@ -66,8 +66,3 @@ r.diversity input=ndvi_map prefix=diversity size=3,9 exclude=pielou alpha=3
 <h2>AUTHOR</h2>
 
 Luca Delucchi and Duccio Rocchini, Fondazione E. Mach (Italy)
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.diversity/r.diversity.html
+++ b/src/raster/r.diversity/r.diversity.html
@@ -63,6 +63,6 @@ r.diversity input=ndvi_map prefix=diversity size=3,9 exclude=pielou alpha=3
 <a href="https://grass.osgeo.org/grass-stable/manuals/r.li.simpson.html">r.li.simpson</a>
 </em> 
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Luca Delucchi and Duccio Rocchini, Fondazione E. Mach (Italy)

--- a/src/raster/r.edm.eval/r.edm.eval.html
+++ b/src/raster/r.edm.eval/r.edm.eval.html
@@ -32,10 +32,6 @@
 
 
 <h2>AUTHOR</h2>
-Paulo van Breugel <a href="https://ecodiv.earth/contact.html">ecodiv.earth/contact.html</a>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Paulo van Breugel <a href="https://ecodiv.earth/contact.html">ecodiv.earth/contact.html</a>
 

--- a/src/raster/r.euro.ecosystem/r.euro.ecosystem.html
+++ b/src/raster/r.euro.ecosystem/r.euro.ecosystem.html
@@ -50,8 +50,3 @@ Raster data definition rules are donated by EEA.
 <h2>AUTHOR</h2>
 
 Helmut Kudrnovsky
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.exdet/r.exdet.html
+++ b/src/raster/r.exdet/r.exdet.html
@@ -117,8 +117,3 @@ https://grass.osgeo.org/grass70/manuals/addons/r.exdet.html</li></ul>
 <h2>AUTHOR</h2>
 
 Paulo van Breugel, paulo at ecodiv.earth
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.fill.category/r.fill.category.html
+++ b/src/raster/r.fill.category/r.fill.category.html
@@ -71,8 +71,3 @@ It removes all water pixels in 38 iterations. A <i>drought.mpg</i> MPEG file con
 
 Paolo Zatelli and Stefano Gobbi,
 DICAM, University of Trento, Italy.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.findtheriver/r.findtheriver.html
+++ b/src/raster/r.findtheriver/r.findtheriver.html
@@ -41,4 +41,4 @@ pixels were found, nothing is printed.</p>
 <h2>AUTHORS</h2>
 
 <a href="mailto:brian_miles@unc edu">Brian Miles</a><br>
-Update to GRASS 7 by <a href="mailto:grass4u@gmail com">Huidae Cho</a>
+Updated to GRASS 7 by <a href="mailto:grass4u@gmail com">Huidae Cho</a>

--- a/src/raster/r.findtheriver/r.findtheriver.html
+++ b/src/raster/r.findtheriver/r.findtheriver.html
@@ -42,8 +42,3 @@ pixels were found, nothing is printed.</p>
 
 <a href="mailto:brian_miles@unc edu">Brian Miles</a><br>
 Update to GRASS 7 by <a href="mailto:grass4u@gmail com">Huidae Cho</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.flexure/r.flexure.html
+++ b/src/raster/r.flexure/r.flexure.html
@@ -57,9 +57,4 @@ van Wees, J. D., and S. Cloetingh (1994), A Finite-Difference Technique to Incor
 
 <h2>AUTHOR</h2>
 
-Andrew D. Wickert<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Andrew D. Wickert

--- a/src/raster/r.flip/r.flip.html
+++ b/src/raster/r.flip/r.flip.html
@@ -14,10 +14,6 @@ Added flags for East-West flip (w) and both N-S and E-W (b).
 </em>
 
 
-<h2>AUTHORS</h2>
-Yann Chemin, International Water Management Institute, Sri Lanka
+<h2>AUTHOR</h2>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Yann Chemin, International Water Management Institute, Sri Lanka

--- a/src/raster/r.flowfill/r.flowfill.html
+++ b/src/raster/r.flowfill/r.flowfill.html
@@ -12,9 +12,4 @@ Callaghan, K.~L., and A.~D. Wickert (in revision), Computing water flow through 
 
 <h2>AUTHORS</h2>
 
-Kerry L. Callaghan, Andrew D. Wickert<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Kerry L. Callaghan, Andrew D. Wickert

--- a/src/raster/r.forestfrag/r.forestfrag.html
+++ b/src/raster/r.forestfrag/r.forestfrag.html
@@ -100,6 +100,11 @@ r.forestfrag.sh</a> script, with as extra options user-defined
 moving window size, option to trim the region (by default it
 respects the region) and a better handling of no-data cells.
 
+<h2>REFERENCES</h2>
+Riitters, K., J. Wickham, R. O'Neill, B. Jones,
+and E. Smith. 2000. Global-scale patterns of forest fragmentation.
+Conservation Ecology 4(2): 3. [online] URL:
+<a href="https://www.consecol.org/vol4/iss2/art3/">https://www.consecol.org/vol4/iss2/art3/</a>
 
 <h2>AUTHORS</h2>
 
@@ -109,14 +114,3 @@ respects the region) and a better handling of no-data cells.
 <li>Paulo van Breugel (Python version, user-defined moving window size)</li>
 <li>Vaclav Petras (major code clean up)</li>
 </ul>
-
-<h2>REFERENCES</h2>
-Riitters, K., J. Wickham, R. O'Neill, B. Jones,
-and E. Smith. 2000. Global-scale patterns of forest fragmentation.
-Conservation Ecology 4(2): 3. [online] URL:
-<a href="https://www.consecol.org/vol4/iss2/art3/">https://www.consecol.org/vol4/iss2/art3/</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.forestfrag/r.forestfrag.html
+++ b/src/raster/r.forestfrag/r.forestfrag.html
@@ -108,9 +108,8 @@ Conservation Ecology 4(2): 3. [online] URL:
 
 <h2>AUTHORS</h2>
 
-<ul>
-<li>Emmanuel Sambale (original shell version)</li>
-<li>Stefan Sylla (original shell version)</li>
-<li>Paulo van Breugel (Python version, user-defined moving window size)</li>
-<li>Vaclav Petras (major code clean up)</li>
-</ul>
+
+Emmanuel Sambale (original shell version)<br>
+Stefan Sylla (original shell version)<br>
+Paulo van Breugel (Python version, user-defined moving window size)<br>
+Vaclav Petras (major code clean up)

--- a/src/raster/r.futures/r.futures.calib/r.futures.calib.html
+++ b/src/raster/r.futures/r.futures.calib/r.futures.calib.html
@@ -136,8 +136,4 @@ g.extension r.object.geometry
 
 <h2>AUTHOR</h2>
 
-Anna Petrasova, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll</a><br>
-
-<!--
-<p><i>Last changed: $Date$</i>
--->
+Anna Petrasova, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll</a>

--- a/src/raster/r.futures/r.futures.demand/r.futures.demand.html
+++ b/src/raster/r.futures/r.futures.demand/r.futures.demand.html
@@ -135,9 +135,4 @@ simulation_times=`seq -s, 2011 2035` plot=plot_demand.pdf demand=demand.csv
 
 <h2>AUTHOR</h2>
 
-Anna Petrasova, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll</a><br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Anna Petrasova, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll</a>

--- a/src/raster/r.futures/r.futures.devpressure/r.futures.devpressure.html
+++ b/src/raster/r.futures/r.futures.devpressure/r.futures.devpressure.html
@@ -83,9 +83,4 @@ r.futures.devpressure input=developed output=pressure gamma=1.5 size=10 method=g
 
 <h2>AUTHOR</h2>
 
-Anna Petrasova, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll</a><br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Anna Petrasova, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll</a>

--- a/src/raster/r.futures/r.futures.html
+++ b/src/raster/r.futures/r.futures.html
@@ -226,11 +226,6 @@ Jennifer A. Koch **<br>
 Vaclav Petras, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll</a><br>
 
 <p>
-<em>Developement pressure, demand and calibration and preprocessing modules:</em><br>
+<em>Development pressure, demand and calibration and preprocessing modules:</em><br>
 
 Anna Petrasova, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll</a><br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.futures/r.futures.parallelpga/r.futures.parallelpga.html
+++ b/src/raster/r.futures/r.futures.parallelpga/r.futures.parallelpga.html
@@ -51,9 +51,4 @@ happening on the subregion boundary.
 
 <h2>AUTHOR</h2>
 
-Anna Petrasova, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll</a><br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Anna Petrasova, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll</a>

--- a/src/raster/r.futures/r.futures.potential/r.futures.potential.html
+++ b/src/raster/r.futures/r.futures.potential/r.futures.potential.html
@@ -79,9 +79,4 @@ In case there is only one subregion, R function <em>glm</em> is used instead of 
 
 <h2>AUTHOR</h2>
 
-Anna Petrasova, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll</a><br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Anna Petrasova, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll</a>

--- a/src/raster/r.futures/r.futures.potsurface/r.futures.potsurface.html
+++ b/src/raster/r.futures/r.futures.potsurface/r.futures.potsurface.html
@@ -57,9 +57,4 @@ representing developed (red) and undeveloped (green) cells over it.
 
 <h2>AUTHOR</h2>
 
-Anna Petrasova, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll</a><br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Anna Petrasova, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll</a>

--- a/src/raster/r.fuzzy.logic/r.fuzzy.logic.html
+++ b/src/raster/r.fuzzy.logic/r.fuzzy.logic.html
@@ -89,9 +89,5 @@ R~package version~1.0, URL <a href="http://CRAN.R-project.org/package=sets">http
 </ul>
 
 <h2>AUTHOR</h2>
-Jarek  Jasiewicz
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Jarek  Jasiewicz

--- a/src/raster/r.fuzzy.set/r.fuzzy.set.html
+++ b/src/raster/r.fuzzy.set/r.fuzzy.set.html
@@ -150,9 +150,5 @@ R~package version~1.0, URL <a href="http://CRAN.R-project.org/package=sets">http
 </ul>
 
 <h2>AUTHOR</h2>
-Jarek Jasiewicz
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Jarek Jasiewicz

--- a/src/raster/r.fuzzy.system/r.fuzzy.system.html
+++ b/src/raster/r.fuzzy.system/r.fuzzy.system.html
@@ -328,9 +328,5 @@ R~package version~1.0, URL <a href="http://CRAN.R-project.org/package=sets">http
 </ul>
 
 <h2>AUTHOR</h2>
-Jarek Jasiewicz
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Jarek Jasiewicz

--- a/src/raster/r.gdd/r.gdd.html
+++ b/src/raster/r.gdd/r.gdd.html
@@ -121,8 +121,3 @@ r.gdd in=MOD11A1.Day,MOD11A1.Night,MYD11A1.Day,MYD11A1.Night out=MCD11A1.GDD \
 <h2>AUTHOR</h2>
 
 Markus Metz (based on r.series)
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.gradient/r.gradient.html
+++ b/src/raster/r.gradient/r.gradient.html
@@ -29,13 +29,8 @@ set also the <em>percentile</em> option to set the slope of the gradient.
   </pre>
 </div>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Luca Delucchi, Fondazione E. Mach (Italy)
 <p>
 Thanks to Johannes Radinger for the code of horizontal and vertical gradient
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.co2/r.green.biomassfor.co2.html
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.co2/r.green.biomassfor.co2.html
@@ -15,12 +15,8 @@ Compute the CO2 emissions of using biomass forestry residuals for energy product
 </em>
 
 <h2>AUTHORS</h2>
+
 Francesco Geri,
 Pietro Zambelli,
 Sandro Sacchelli,
 Marco Ciolli
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.financial/r.green.biomassfor.financial.html
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.financial/r.green.biomassfor.financial.html
@@ -15,14 +15,10 @@ Compute the biomass forestry residual potential considering the economic constra
 </em>
 
 <h2>AUTHORS</h2>
+
 Francesco Geri,
 Pietro Zambelli,
 Sandro Sacchelli,
 Marco Ciolli
-
+<br>
 Code rewritten by Giulia Garegnani
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.html
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.html
@@ -59,8 +59,3 @@ Francesco Geri,
 Pietro Zambelli,
 Sandro Sacchelli,
 Marco Ciolli
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.impact/r.green.biomassfor.impact.html
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.impact/r.green.biomassfor.impact.html
@@ -15,12 +15,8 @@ Compute the impact of using biomass forestry residuals for energy production.
 </em>
 
 <h2>AUTHORS</h2>
+
 Francesco Geri,
 Pietro Zambelli,
 Sandro Sacchelli,
 Marco Ciolli
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.legal/r.green.biomassfor.legal.html
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.legal/r.green.biomassfor.legal.html
@@ -34,16 +34,12 @@ Sacchelli, S., Zambelli, P., Zatelli, P., Ciolli, M., 2013. Biomasfor - an open-
 <h2>SEE ALSO</h2>
 <em>
   <a href="r.green.biomassfor.theoretical.html">r.green.biomassfor.theoretical</a>,
-  <a href="r.green.biomassfor.technical.html">r.green.biomassfor.technical</a>,
+  <a href="r.green.biomassfor.technical.html">r.green.biomassfor.technical</a>
 </em>
 
 <h2>AUTHORS</h2>
+
 Francesco Geri,
 Pietro Zambelli,
 Sandro Sacchelli,
 Marco Ciolli
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.recommended/r.green.biomassfor.recommended.html
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.recommended/r.green.biomassfor.recommended.html
@@ -14,7 +14,7 @@ Compute the biomass forestry residual potential considering extra constraints.
   <a href="r.green.biomassfor.html">r.green.biomassfor</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Francesco Geri,
 Pietro Zambelli,

--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.recommended/r.green.biomassfor.recommended.html
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.recommended/r.green.biomassfor.recommended.html
@@ -14,13 +14,9 @@ Compute the biomass forestry residual potential considering extra constraints.
   <a href="r.green.biomassfor.html">r.green.biomassfor</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Francesco Geri,
 Pietro Zambelli,
 Sandro Sacchelli,
 Marco Ciolli
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.technical/r.green.biomassfor.technical.html
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.technical/r.green.biomassfor.technical.html
@@ -16,12 +16,8 @@ constraints of different harvesting techniques.
 </em>
 
 <h2>AUTHORS</h2>
+
 Francesco Geri,
 Pietro Zambelli,
 Sandro Sacchelli,
 Marco Ciolli
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.theoretical/r.green.biomassfor.theoretical.html
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.theoretical/r.green.biomassfor.theoretical.html
@@ -35,16 +35,12 @@ Sacchelli, S., Zambelli, P., Zatelli, P., Ciolli, M., 2013. Biomasfor - an open-
 <h2>SEE ALSO</h2>
 <em>
   <a href="r.green.biomassfor.legal.html">r.green.biomassfor.legal</a>,
-  <a href="r.green.biomassfor.technical.html">r.green.biomassfor.technical</a>,
+  <a href="r.green.biomassfor.technical.html">r.green.biomassfor.technical</a>
 </em>
 
 <h2>AUTHORS</h2>
+
 Francesco Geri,
 Pietro Zambelli,
 Sandro Sacchelli,
 Marco Ciolli
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.green/r.green.gshp/r.green.gshp.html
+++ b/src/raster/r.green/r.green.gshp/r.green.gshp.html
@@ -75,8 +75,3 @@ pp. 765-773
 <h2>AUTHORS</h2>
 
 For authors and references, please refer to the respective module of <em>r.green</em>.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.green/r.green.gshp/r.green.gshp.html
+++ b/src/raster/r.green/r.green.gshp/r.green.gshp.html
@@ -72,6 +72,6 @@ pp. 765-773
 </a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 For authors and references, please refer to the respective module of <em>r.green</em>.

--- a/src/raster/r.green/r.green.gshp/r.green.gshp.technical/r.green.gshp.technical.html
+++ b/src/raster/r.green/r.green.gshp/r.green.gshp.technical/r.green.gshp.technical.html
@@ -1,28 +1,22 @@
 <h2>DESCRIPTION</h2>
-<em>r.green.gshp.technical</em> calculates the lenght of the borehole for Groud Source Heat Pump plants.<br><br>
+<em>r.green.gshp.technical</em> calculates the lenght of the borehole for Groud Source Heat Pump plants.
 
 <h2>NOTES</h2>
 
-The required inputs are the ground source conductivity and the ground loads.<br><br>
+The required inputs are the ground source conductivity and the ground loads.
 
 
 <h2>EXAMPLES</h2>
 
-
-<div class="code"><pre>python r.green.gshp.technical.py --overwrite ground_conductivity=g_conductivity ground_diffusivity_rast=g_diffusivity ground_temp_rast=g_temperature g_loads_6h_rast=g_loads_6h g_loads_1m_rast=g_loads_1m g_loads_1y_rast=g_loads_1y fluid_capacity=4000. fluid_massflow=0.074 fluid_inlettemp=4.44 bh_radius=0.054 pipe_inner_radius=0.01365 pipe_outer_radius=0.0167 bh_convection=1000. pipe_distance=0.0471 k_pipe=0.45 k_grout=1.73 field_distance=6.1 field_number=120 field_ratio=1.2 bhe_length=len_bhe bhe_field_length=len_bhe_field -d --o</pre></div><br>
+<div class="code"><pre>python r.green.gshp.technical.py --overwrite ground_conductivity=g_conductivity ground_diffusivity_rast=g_diffusivity ground_temp_rast=g_temperature g_loads_6h_rast=g_loads_6h g_loads_1m_rast=g_loads_1m g_loads_1y_rast=g_loads_1y fluid_capacity=4000. fluid_massflow=0.074 fluid_inlettemp=4.44 bh_radius=0.054 pipe_inner_radius=0.01365 pipe_outer_radius=0.0167 bh_convection=1000. pipe_distance=0.0471 k_pipe=0.45 k_grout=1.73 field_distance=6.1 field_number=120 field_ratio=1.2 bhe_length=len_bhe bhe_field_length=len_bhe_field -d
+</pre></div>
 
 
 <h2>SEE ALSO</h2>
 <em>
-<a href="r.green.gshp.technical.html">r.green.gshp.technical</a><br>
+<a href="r.green.gshp.technical.html">r.green.gshp.technical</a>
 </em>
 
-<h2>AUTHORS</h2>
-Pietro Zambelli (Eurac Research, Bolzano, Italy)<br>
+<h2>AUTHOR</h2>
 
-<h2>REFERENCES</h2>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Pietro Zambelli (Eurac Research, Bolzano, Italy)

--- a/src/raster/r.green/r.green.gshp/r.green.gshp.theoretical/r.green.gshp.theoretical.html
+++ b/src/raster/r.green/r.green.gshp/r.green.gshp.theoretical/r.green.gshp.theoretical.html
@@ -44,16 +44,6 @@ r.green.gshp.theoretical \
     energy=gpot_energy \
 </pre></div><br>
 
-
-<h2>SEE ALSO</h2>
-<em>
-<a href="r.green.html">r.green.hydro.technical</a><br>
-<a href="r.green.gshp.technical.html">r.green.hydro.technical</a><br>
-</em>
-
-<h2>AUTHORS</h2>
-Pietro Zambelli (Eurac Research, Bolzano, Italy), Tested by and manual written by Giulia Garegnani<br>
-
 <h2>REFERENCES</h2>
 Alessandro Casasso, Rajandrea Sethi, 2016,<br>
 "G.POT: A quantitative method for the assessment and mapping of the
@@ -61,7 +51,12 @@ shallow geothermal potential"<br>
 Energy 106, p 765 -- <br>
 <a href="http://dx.doi.org/10.1016/j.energy.2016.03.091">http://dx.doi.org/10.1016/j.energy.2016.03.091</a><br>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+<h2>SEE ALSO</h2>
+<em>
+<a href="r.green.html">r.green.hydro.technical</a>,
+<a href="r.green.gshp.technical.html">r.green.hydro.technical</a>
+</em>
+
+<h2>AUTHORS</h2>
+
+Pietro Zambelli (Eurac Research, Bolzano, Italy), Tested by and manual written by Giulia Garegnani

--- a/src/raster/r.green/r.green.html
+++ b/src/raster/r.green/r.green.html
@@ -69,11 +69,6 @@ The basis for creating the modules to calculate the energy potential is shown in
 <a href="r.green.hydro.html">r.green.hydro</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 For authors and references, please refer to the respective module of <em>r.green</em>.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.closest/r.green.hydro.closest.html
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.closest/r.green.hydro.closest.html
@@ -2,10 +2,5 @@
 
 <h2>SEE ALSO</h2>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 Pietro Zambelli
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.closest/r.green.hydro.closest.html
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.closest/r.green.hydro.closest.html
@@ -3,4 +3,5 @@
 <h2>SEE ALSO</h2>
 
 <h2>AUTHOR</h2>
+
 Pietro Zambelli

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.delplants/r.green.hydro.delplants.html
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.delplants/r.green.hydro.delplants.html
@@ -35,10 +35,6 @@ Output vector map in black : streams of Mis Valley without the existing plants (
 </em>
 
 <h2>AUTHORS</h2>
-Giulia Garegnani and Pietro Zambelli (Eurac Research, Bolzano, Italy), Manual written by Julie Gros.<br>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Giulia Garegnani and Pietro Zambelli (Eurac Research, Bolzano, Italy), Manual written by Julie Gros.
 

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.discharge/r.green.hydro.discharge.html
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.discharge/r.green.hydro.discharge.html
@@ -74,13 +74,9 @@ Values of MFD and natural discharge (in m<SUP>3</SUP>/s) at the white point
 Piano stralcio per la gestione delle risorse idriche del bacino del Piave - Misure di Salvaguardia</i><br>
 from Autorit&agrave; di bacino dei fiumi Isonzo, Tagliamento, Livenza, Piave, Brenta-Bacchiglione
 
-
 <h2>AUTHORS</h2>
-Giulia Garegnani (Eurac Research, Bolzano, Italy), Sara Biscaini (University of Trento, Italy), Manual written by Julie Gros.<br>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Giulia Garegnani (Eurac Research, Bolzano, Italy), Sara Biscaini (University of Trento, Italy),
+manual written by Julie Gros.
 
 

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.financial/r.green.hydro.financial.html
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.financial/r.green.hydro.financial.html
@@ -226,12 +226,7 @@ The excavation costs are found in the price list of the Piedmont Region for publ
 The costs of intake and civil works are based on analysis of technical documents for mini-hydro projects in Italy<br><br>
 The calculation of the yearly maintenance cost is based on the report AEEG for the Polytechnic University of Milan<br><br>
 
-
-
 <h2>AUTHORS</h2>
-Pietro Zambelli (Eurac Research, Bolzano, Italy), Sandro Sacchelli (University of Florence, Italy), Manual written by Julie Gros.<br>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Pietro Zambelli (Eurac Research, Bolzano, Italy), Sandro Sacchelli (University of Florence, Italy),
+manual written by Julie Gros.

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.html
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.html
@@ -71,8 +71,3 @@ The <em>r.green.hydro</em> suite consists of the following six different parts:<
 <h2>AUTHORS</h2>
 
 For authors and references, please refer to the respective modules of <em>r.green</em>.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.html
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.html
@@ -68,6 +68,6 @@ The <em>r.green.hydro</em> suite consists of the following six different parts:<
 <a href="r.green.html">r.green</a> - overview page
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 For authors and references, please refer to the respective modules of <em>r.green</em>.

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.optimal/r.green.hydro.optimal.html
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.optimal/r.green.hydro.optimal.html
@@ -61,7 +61,7 @@ Output vector maps potentialplants (in blue) and potentialpoints (in red)
 <a href="r.green.hydro.financial.html">r.green.hydro.financial</a><br>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Giulia Garegnani (Eurac Research, Bolzano, Italy), Manual written by Julie Gros.<br>
 

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.optimal/r.green.hydro.optimal.html
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.optimal/r.green.hydro.optimal.html
@@ -61,11 +61,7 @@ Output vector maps potentialplants (in blue) and potentialpoints (in red)
 <a href="r.green.hydro.financial.html">r.green.hydro.financial</a><br>
 </em>
 
-<h2>AUTHORS</h2>
-Giulia Garegnani (Eurac Research, Bolzano, Italy), Manual written by Julie Gros.<br>
+<h2>AUTHOR</h2>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Giulia Garegnani (Eurac Research, Bolzano, Italy), Manual written by Julie Gros.<br>
 

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.planning/r.green.hydro.planning.html
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.planning/r.green.hydro.planning.html
@@ -219,7 +219,7 @@ output vector map: superimposition of the potential segments vector file (potent
 <a href="r.green.hydro.financial.html">r.green.hydro.financial</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Giulia Garegnani (Eurac Research, Bolzano, Italy), Manual written by Julie Gros.
 

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.planning/r.green.hydro.planning.html
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.planning/r.green.hydro.planning.html
@@ -210,20 +210,16 @@ output vector map: superimposition of the potential segments vector file (potent
 
 <h2>SEE ALSO</h2>
 <em>
-<a href="r.green.hydro.discharge.html">r.green.hydro.discharge</a><br>
-<a href="r.green.hydro.delplants.html">r.green.hydro.delplants</a><br>
-<a href="r.green.hydro.theoretical.html">r.green.hydro.theoretical</a><br>
-<a href="r.green.hydro.optimal.html">r.green.hydro.optimal</a><br>
-<a href="r.green.hydro.structure.html">r.green.hydro.structure</a><br>
-<a href="r.green.hydro.technical.html">r.green.hydro.technical</a><br>
-<a href="r.green.hydro.financial.html">r.green.hydro.financial</a><br>
+<a href="r.green.hydro.discharge.html">r.green.hydro.discharge</a>,
+<a href="r.green.hydro.delplants.html">r.green.hydro.delplants</a>,
+<a href="r.green.hydro.theoretical.html">r.green.hydro.theoretical</a>,
+<a href="r.green.hydro.optimal.html">r.green.hydro.optimal</a>,
+<a href="r.green.hydro.structure.html">r.green.hydro.structure</a>,
+<a href="r.green.hydro.technical.html">r.green.hydro.technical</a>,
+<a href="r.green.hydro.financial.html">r.green.hydro.financial</a>
 </em>
 
-<h2>AUTHORS</h2>
-Giulia Garegnani (Eurac Research, Bolzano, Italy), Manual written by Julie Gros.<br>
+<h2>AUTHOR</h2>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Giulia Garegnani (Eurac Research, Bolzano, Italy), Manual written by Julie Gros.
 

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.recommended/r.green.hydro.recommended.html
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.recommended/r.green.hydro.recommended.html
@@ -219,11 +219,7 @@ output vector map: superimposition of the potential segments vector file (potent
 <a href="r.green.hydro.financial.html">r.green.hydro.financial</a><br>
 </em>
 
-<h2>AUTHORS</h2>
-Giulia Garegnani (Eurac Research, Bolzano, Italy), Manual written by Julie Gros.<br>
+<h2>AUTHOR</h2>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Giulia Garegnani (Eurac Research, Bolzano, Italy), Manual written by Julie Gros.
 

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.recommended/r.green.hydro.recommended.html
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.recommended/r.green.hydro.recommended.html
@@ -219,7 +219,7 @@ output vector map: superimposition of the potential segments vector file (potent
 <a href="r.green.hydro.financial.html">r.green.hydro.financial</a><br>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Giulia Garegnani (Eurac Research, Bolzano, Italy), Manual written by Julie Gros.
 

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.structure/r.green.hydro.structure.html
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.structure/r.green.hydro.structure.html
@@ -50,12 +50,10 @@ Output vector map structplants in black
 </em>
 
 <h2>REFERENCE</h2>
-Picture of the plant structure taken from Micro-hydropower Systems - A Buyer's Guide, Natural Resources Canada, 2004<br>
 
-<h2>AUTHORS</h2>
-Pietro Zambelli (Eurac Research, Bolzano, Italy), Manual written by Julie Gros.<br>
+Picture of the plant structure taken from Micro-hydropower Systems - A Buyer's 
+Guide, Natural Resources Canada, 2004
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+<h2>AUTHOR</h2>
+
+Pietro Zambelli (Eurac Research, Bolzano, Italy), Manual written by Julie Gros.

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.structure/r.green.hydro.structure.html
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.structure/r.green.hydro.structure.html
@@ -54,6 +54,6 @@ Output vector map structplants in black
 Picture of the plant structure taken from Micro-hydropower Systems - A Buyer's 
 Guide, Natural Resources Canada, 2004
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Pietro Zambelli (Eurac Research, Bolzano, Italy), Manual written by Julie Gros.

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.technical/r.green.hydro.technical.html
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.technical/r.green.hydro.technical.html
@@ -127,9 +127,6 @@ Picture of the plant structure taken from Micro-hydropower Systems - A Buyer's G
 Sources for the theory : Courses of French engineering schools ENSE3 Grenoble-INP (Hydraulique des ecoulements en charge) and ENGEES Strasbourg (Hydraulique a surface libre)
 
 <h2>AUTHORS</h2>
-Giulia Garegnani (Eurac Research, Bolzano, Italy), Julie Gros (Eurac Research, Bolzano, Italy), Manual written by Julie Gros.<br>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Giulia Garegnani (Eurac Research, Bolzano, Italy), Julie Gros (Eurac Research, Bolzano, Italy),
+manual written by Julie Gros.

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.theoretical/r.green.hydro.theoretical.html
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.theoretical/r.green.hydro.theoretical.html
@@ -102,9 +102,5 @@ output vector map with basin potential
 </em>
 
 <h2>AUTHORS</h2>
-Giulia Garegnani (Eurac Research, Bolzano, Italy), Manual written by Sabrina Scheunert.<br>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Giulia Garegnani (Eurac Research, Bolzano, Italy), Manual written by Sabrina Scheunert.<br>

--- a/src/raster/r.green/r.green.install/r.green.install.html
+++ b/src/raster/r.green/r.green.install/r.green.install.html
@@ -103,8 +103,3 @@ Close GRASS and restart the programm to have in the the menu the session energy 
 <h2>AUTHOR</h2>
 
 Pietro Zambelli (Eurac Research, Bolzano, Italy)
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.gsflow.hydrodem/r.gsflow.hydrodem.html
+++ b/src/raster/r.gsflow.hydrodem/r.gsflow.hydrodem.html
@@ -23,9 +23,4 @@ Francisco, CA.
 
 <h2>AUTHOR</h2>
 
-Andrew D. Wickert<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Andrew D. Wickert

--- a/src/raster/r.gwr/r.gwr.html
+++ b/src/raster/r.gwr/r.gwr.html
@@ -131,8 +131,3 @@ R package
 <h2>AUTHOR</h2>
 
 Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.hants/r.hants.html
+++ b/src/raster/r.hants/r.hants.html
@@ -238,8 +238,3 @@ DOI: <a href=http://dx.doi.org/10.1080/014311600209814>10.1080/014311600209814</
 <h2>AUTHOR</h2>
 
 Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.hazard.flood/r.hazard.flood.html
+++ b/src/raster/r.hazard.flood/r.hazard.flood.html
@@ -72,11 +72,6 @@ n.10, 2011.
 Digital Elevation Models, Journal of Hydrologic Engineering, 
 (10.1061/(ASCE)HE.1943-5584.0000367), 2011.</em>
 
-
 <h2>AUTHOR</h2>
-Margherita Di Leo (dileomargherita AT gmail DOT com)
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Margherita Di Leo (dileomargherita AT gmail DOT com)

--- a/src/raster/r.houghtransform/r.houghtransform.html
+++ b/src/raster/r.houghtransform/r.houghtransform.html
@@ -170,7 +170,6 @@ map to <em>r.houghtransform</em> module.
 <h2>REFERENCES</h2>
 
 <ul>
-
 <li>
 M. Fiala. <i>Identify and Remove Hough Transform Method</i>. In: Proc. Vision
 Interface. 2003, pp. 184-187. url:
@@ -184,16 +183,10 @@ enhance the progressive probabilistic Hough transform</i>. In: Pattern
 Recognition, 2000. Proceedings. 15th International Conference on. Vol. 3.
 IEEE. 2000, pp. 560-563.
 </li>
-
 </ul>
 
 <h2>AUTHORS</h2>
 
 Anna Kratochvilova,
 Vaclav Petras
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
 

--- a/src/raster/r.hydrodem/r.hydrodem.html
+++ b/src/raster/r.hydrodem/r.hydrodem.html
@@ -79,9 +79,5 @@ DOI: <a href=http://dx.doi.org/10.1002/hyp.5835>10.1002/hyp.5835</a>
 </em>
 
 <h2>AUTHOR</h2>
-Markus Metz
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Markus Metz

--- a/src/raster/r.hypso/r.hypso.html
+++ b/src/raster/r.hypso/r.hypso.html
@@ -49,9 +49,5 @@ GIS environment), <a href="http://geomatica.como.polimi.it/workbooks/">Geomatics
 n. 9 (2010)</em>
 
 <h2>AUTHORS</h2>
-<p>Margherita Di Leo (grass-dev AT lists DOT osgeo DOT org), Massimo Di Stefano, Francesco Di Stefano
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Margherita Di Leo (grass-dev AT lists DOT osgeo DOT org), Massimo Di Stefano, Francesco Di Stefano

--- a/src/raster/r.in.nasadem/r.in.nasadem.html
+++ b/src/raster/r.in.nasadem/r.in.nasadem.html
@@ -81,12 +81,7 @@ M. Neteler, 2005. <a href="https://grass.osgeo.org/newsletter/GRASSNews_vol3.pdf
 <i><a href="https://grass.osgeo.org/newsletter/">GRASS Newsletter</a></i>, Vol.3, pp. 2-6, June 2005. ISSN 1614-8746.
 
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Markus Metz<br>
 Reprojection support: Anika Bettge, mundialis
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.in.nasadem/r.in.nasadem.html
+++ b/src/raster/r.in.nasadem/r.in.nasadem.html
@@ -81,7 +81,7 @@ M. Neteler, 2005. <a href="https://grass.osgeo.org/newsletter/GRASSNews_vol3.pdf
 <i><a href="https://grass.osgeo.org/newsletter/">GRASS Newsletter</a></i>, Vol.3, pp. 2-6, June 2005. ISSN 1614-8746.
 
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Markus Metz<br>
 Reprojection support: Anika Bettge, mundialis

--- a/src/raster/r.in.ogc/r.in.ogc.coverages/r.in.ogc.coverages.html
+++ b/src/raster/r.in.ogc/r.in.ogc.coverages/r.in.ogc.coverages.html
@@ -20,7 +20,3 @@ More info about <a href="https://ogcapi.ogc.org/coverages/" target="blank">OGC A
 <h2>AUTHOR</h2>
 
 Luca Delucchi, Fondazione Edmund Mach, during Joint OGC OSGeo ASF Code Sprint 2021.
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.in.ogc/r.in.ogc.html
+++ b/src/raster/r.in.ogc/r.in.ogc.html
@@ -39,10 +39,6 @@ g.extension r.in.ogc
 <a href="v.in.ogc.html">v.in.ogc</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Luca Delucchi, Fondazione Edmund Mach, during Joint OGC OSGeo ASF Code Sprint 2021.
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.in.pdal/r.in.pdal.html
+++ b/src/raster/r.in.pdal/r.in.pdal.html
@@ -136,8 +136,3 @@ Vaclav Petras,
 (projection, computational region)
 <p>
 Documentation: Markus Neteler, mundialis GmbH &amp; Co. KG
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.in.srtm.region/r.in.srtm.region.html
+++ b/src/raster/r.in.srtm.region/r.in.srtm.region.html
@@ -77,8 +77,3 @@ M. Neteler, 2005. <a href="https://grass.osgeo.org/newsletter/GRASSNews_vol3.pdf
 
 Markus Metz<br>
 Reprojection support: Anika Bettge, mundialis
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.in.wcs/r.in.wcs.html
+++ b/src/raster/r.in.wcs/r.in.wcs.html
@@ -11,8 +11,3 @@
 <h2>AUTHOR</h2>
 
 Martin Zbinden
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.jpdf/r.jpdf.html
+++ b/src/raster/r.jpdf/r.jpdf.html
@@ -47,8 +47,3 @@ selecting map names.
 <h2>AUTHOR</h2>
 
 Thomas Huld
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.lake.series/r.lake.series.html
+++ b/src/raster/r.lake.series/r.lake.series.html
@@ -87,8 +87,3 @@ different areas).
 
 Vaclav Petras, <a href="http://gis.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>,<br>
 Maris Nartiss (author of <em><a href="https://grass.osgeo.org/grass-stable/manuals/r.lake.html">r.lake</a></em>)
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.landscape.evol.old/r.landscape.evol.old.html
+++ b/src/raster/r.landscape.evol.old/r.landscape.evol.old.html
@@ -369,6 +369,6 @@ Losses - A Guide to Conservation Planning. USDA Agriculture Handbook
 282. 
 
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Isaac I. Ullah, C. Michael Barton, and Helena Mitasova

--- a/src/raster/r.landscape.evol.old/r.landscape.evol.old.html
+++ b/src/raster/r.landscape.evol.old/r.landscape.evol.old.html
@@ -369,10 +369,6 @@ Losses - A Guide to Conservation Planning. USDA Agriculture Handbook
 282. 
 
 
-<h2>AUTHORS</h2>
-Isaac I. Ullah, C. Michael Barton, and Helena Mitasova
+<h2>AUTHOR</h2>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Isaac I. Ullah, C. Michael Barton, and Helena Mitasova

--- a/src/raster/r.le.patch/r.le.patch.html
+++ b/src/raster/r.le.patch/r.le.patch.html
@@ -35,8 +35,3 @@ manual: Quantitative analysis of landscape structures</a> (GRASS 5; 2001)
 
 William L. Baker Department of Geography and Recreation University of
 Wyoming Laramie, Wyoming 82071 U.S.A.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.le.pixel/r.le.pixel.html
+++ b/src/raster/r.le.pixel/r.le.pixel.html
@@ -34,8 +34,3 @@ manual: Quantitative analysis of landscape structures</a> (GRASS 5; 2001)
 
 William L. Baker Department of Geography and Recreation University of
 Wyoming Laramie, Wyoming 82071 U.S.A.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.le.setup/r.le.setup.html
+++ b/src/raster/r.le.setup/r.le.setup.html
@@ -466,8 +466,3 @@ manual: Quantitative analysis of landscape structures</a> (GRASS 5; 2001)
 
 William L. Baker Department of Geography and Recreation University of
 Wyoming Laramie, Wyoming 82071 U.S.A.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.le.trace/r.le.trace.html
+++ b/src/raster/r.le.trace/r.le.trace.html
@@ -38,8 +38,3 @@ manual: Quantitative analysis of landscape structures</a> (GRASS 5; 2001)
 
 William L. Baker Department of Geography and Recreation University of
 Wyoming Laramie, Wyoming 82071 U.S.A.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.learn.ml/r.learn.ml.html
+++ b/src/raster/r.learn.ml/r.learn.ml.html
@@ -69,9 +69,5 @@ r.category rf_classification
 <p>Scikit-learn: Machine Learning in Python, Pedregosa et al., JMLR 12, pp. 2825-2830, 2011.</p>
 
 <h2>AUTHOR</h2>
-Steven Pawley
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Steven Pawley

--- a/src/raster/r.local.relief/r.local.relief.html
+++ b/src/raster/r.local.relief/r.local.relief.html
@@ -140,8 +140,3 @@ and custom red (negative values) and blue (positive values) color table
 <p>
 Vaclav Petras, <a href="http://gis.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>,<br>
 Eric Goddard
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.mapcalc.tiled/r.mapcalc.tiled.html
+++ b/src/raster/r.mapcalc.tiled/r.mapcalc.tiled.html
@@ -41,8 +41,3 @@ r.mapcalc.tiled expression="bright_pixels = if(ortho_2001_t792_1m > 200, 1, 0)" 
 <h2>AUTHOR</h2> 
 
 Moritz Lennert
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.massmov/r.massmov.html
+++ b/src/raster/r.massmov/r.massmov.html
@@ -81,8 +81,3 @@ incline. Journal of Fluid Mechanics 199:177-215</p>
 
 <p><i>The current version of the program (ported to GRASS7.0)</i>:
 <br>Monia Molinari, Massimiliano Cannata, Santiago Begueria.<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.maxent.lambdas/r.maxent.lambdas.html
+++ b/src/raster/r.maxent.lambdas/r.maxent.lambdas.html
@@ -94,8 +94,3 @@ Distributions, 17:43-57, 2011.</li>
 
 Stefan Blumentrath, Norwegian Institute for Nature Research (NINA),
 <a href="http://www.nina.no">http://www.nina.no</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.mblend/r.mblend.html
+++ b/src/raster/r.mblend/r.mblend.html
@@ -49,6 +49,6 @@ To report bugs, propose new features or discuss the funcioning of this add-on, v
 
 Lu&#237;s Moreira de Sousa<br>
 ISRIC - World Soil Information
-<br><br>
+<br>
 Jo&atilde;o Paulo Leit&atilde;o<br>
 EAWAG: Swiss Federal Institute of Aquatic Science and Technology.

--- a/src/raster/r.mblend/r.mblend.html
+++ b/src/raster/r.mblend/r.mblend.html
@@ -45,7 +45,7 @@ J.P. Leit&atilde;o, D. Prodanovic, C. Maksimovic, <a href=http://www.sciencedire
 
 To report bugs, propose new features or discuss the funcioning of this add-on, visit the project repository at <a href=https://github.com/ldesousa/r.mblend>GitHub</a>.
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Lu&#237;s Moreira de Sousa<br>
 ISRIC - World Soil Information

--- a/src/raster/r.mblend/r.mblend.html
+++ b/src/raster/r.mblend/r.mblend.html
@@ -45,15 +45,10 @@ J.P. Leit&atilde;o, D. Prodanovic, C. Maksimovic, <a href=http://www.sciencedire
 
 To report bugs, propose new features or discuss the funcioning of this add-on, visit the project repository at <a href=https://github.com/ldesousa/r.mblend>GitHub</a>.
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Lu&#237;s Moreira de Sousa<br>
 ISRIC - World Soil Information
 <br><br>
 Jo&atilde;o Paulo Leit&atilde;o<br>
 EAWAG: Swiss Federal Institute of Aquatic Science and Technology.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.mcda.ahp/r.mcda.ahp.html
+++ b/src/raster/r.mcda.ahp/r.mcda.ahp.html
@@ -26,11 +26,8 @@ The first row and first column are related to the first criteria (reclass_slope 
 <a href="r.in.drsa.html">r.in.drsa</a>
 <a href="r.to.drsa.html">r.to.drsa</a>
 </em>
+
 <h2>AUTHORS</h2>
+
 Antonio Boggia - Gianluca Massei<br>
 Department of Economics and Appraisal - University of Perugia - Italy
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.mcda.electre/r.mcda.electre.html
+++ b/src/raster/r.mcda.electre/r.mcda.electre.html
@@ -39,10 +39,6 @@ Volume 146, 15 December 2014, Pages 491-504, ISSN 0301-4797</p>
 <em>r.mcda.fuzzy, r.mcda.regime, r.mcda.roughet, r.mapcalc</em>
 
 <h2>AUTHORS</h2>
+
 Antonio Boggia - Gianluca Massei<br>
 Department of Economics and Appraisal - University of Perugia - Italy 
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.mcda.input/r.mcda.input.html
+++ b/src/raster/r.mcda.input/r.mcda.input.html
@@ -25,12 +25,7 @@ and returns maps of the rules </p>
 <a href="r.mcda.output.html">r.mcda.output</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Antonio Boggia - Gianluca Massei<br>
 Department of Economics and Appraisal - University of Perugia - Italy 
-<p>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.mcda.input/r.mcda.input.html
+++ b/src/raster/r.mcda.input/r.mcda.input.html
@@ -25,7 +25,7 @@ and returns maps of the rules </p>
 <a href="r.mcda.output.html">r.mcda.output</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Antonio Boggia - Gianluca Massei<br>
 Department of Economics and Appraisal - University of Perugia - Italy 

--- a/src/raster/r.mcda.output/r.mcda.output.html
+++ b/src/raster/r.mcda.output/r.mcda.output.html
@@ -30,10 +30,6 @@ current region settings. See the <em>g.region</em> module for details.
 </em>
 
 <h2>AUTHORS</h2>
+
 Antonio Boggia - Gianluca Massei<br>
 Department of Economics and Appraisal - University of Perugia - Italy 
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.mcda.promethee/r.mcda.promethee.html
+++ b/src/raster/r.mcda.promethee/r.mcda.promethee.html
@@ -31,10 +31,6 @@ Volume 146, 15 December 2014, Pages 491-504, ISSN 0301-4797</p>
 <em>r.mcda.ahp, r.mcda.electre, r.mcda.roughet, r.mapcalc</em>
 
 <h2>AUTHORS</h2>
+
 Antonio Boggia - Gianluca Massei<br>
 Department of Economics and Appraisal - University of Perugia - Italy 
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.mcda.roughset/r.mcda.roughset.html
+++ b/src/raster/r.mcda.roughset/r.mcda.roughset.html
@@ -23,7 +23,7 @@
 <h2>SEE ALSO</h2>
 <p><em>r.mcda.fuzzy, r.mcda.electre, r.mcda.regime, r.to.drsa, r.in.drsa</em></P>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Antonio Boggia - Gianluca Massei<br>
 Department of Economics and Appraisal - University of Perugia - Italy 

--- a/src/raster/r.mcda.roughset/r.mcda.roughset.html
+++ b/src/raster/r.mcda.roughset/r.mcda.roughset.html
@@ -23,11 +23,7 @@
 <h2>SEE ALSO</h2>
 <p><em>r.mcda.fuzzy, r.mcda.electre, r.mcda.regime, r.to.drsa, r.in.drsa</em></P>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Antonio Boggia - Gianluca Massei<br>
 Department of Economics and Appraisal - University of Perugia - Italy 
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.mcda.topsis/r.mcda.topsis.html
+++ b/src/raster/r.mcda.topsis/r.mcda.topsis.html
@@ -14,10 +14,6 @@
 <p><em>r.mcda.fuzzy, r.mcda.electre, r.mcda.roughset, r.to.drsa, r.in.drsa</em></P>
 
 <h2>AUTHORS</h2>
+
 Antonio Boggia - Gianluca Massei<br>
 Department of Economics and Appraisal - University of Perugia - Italy 
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.meb/r.meb.html
+++ b/src/raster/r.meb/r.meb.html
@@ -100,8 +100,3 @@ ONE 10(4): e0121444. doi: 10.1371/journal.pone.0121444
 <h2>AUTHOR</h2>
 
 Paulo van Breugel, paulo at ecodiv.earth
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.mess/r.mess.html
+++ b/src/raster/r.mess/r.mess.html
@@ -153,8 +153,3 @@ Efforts in Eastern Africa. PLoS ONE 10: e0121444.
 <h2>AUTHOR</h2>
 
 Paulo van Breugel, paulo at ecodiv.earth
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.mregression.series/r.mregression.series.html
+++ b/src/raster/r.mregression.series/r.mregression.series.html
@@ -163,8 +163,3 @@ This rasters contains the fitted coefitients.
 <h2>AUTHOR</h2>
 
 Dmitry Kolesov
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.neighborhoodmatrix/r.neighborhoodmatrix.html
+++ b/src/raster/r.neighborhoodmatrix/r.neighborhoodmatrix.html
@@ -77,11 +77,7 @@ r.neighborhoodmatrix -l n=bc_int sep=comma output=county_neighbors.csv
 <a href="v.neighborhoodmatrix.html">v.neighborhoodmatrix</a>
 </em>
 
-<h2>AUTHOR</h2>
- C-Version: Markus Metz
- Original Python-Version: Moritz Lennert
+<h2>AUTHORS</h2>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Original Python-Version: Moritz Lennert<br>
+C-Version: Markus Metz

--- a/src/raster/r.niche.similarity/r.niche.similarity.html
+++ b/src/raster/r.niche.similarity/r.niche.similarity.html
@@ -50,8 +50,3 @@ http://CRAN.R-project.org/package=phyloclim</li>
 <h2>AUTHOR</h2>
 
 Paulo van Breugel, paulo at ecodiv.org
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.northerness.easterness/r.northerness.easterness.html
+++ b/src/raster/r.northerness.easterness/r.northerness.easterness.html
@@ -45,6 +45,12 @@ The color of these raster maps are set to <em>grey</em>.
  </pre>
 </div>
 
+<h2>REFERENCES</h2>
+
+Olaya, V. 2009. Basic Land-Surface Parameters. In: Hengl, T. &amp; Reuter,
+H.I. (eds.) 2009. Geomorphometry. Concepts, Software, Applications.
+Developments in Soil Science, Volume 33. Elsevier.
+
 <h2>SEE ALSO</h2>
 
 <em>
@@ -52,17 +58,7 @@ The color of these raster maps are set to <em>grey</em>.
 <a href="https://grass.osgeo.org/grass-stable/manuals/r.slope.aspect.html">r.slope.aspect</a>
 </em>
 
-<h2>REFERENCES</h2>
-
-Olaya, V. 2009. Basic Land-Surface Parameters. In: Hengl, T. & Reuter, 
-H.I. (eds.) 2009. Geomorphometry. Concepts, Software, Applications. 
-Developments in Soil Science, Volume 33. Elsevier.
 
 <h2>AUTHOR</h2>
 
 Helmut Kudrnovsky
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.null.all/r.null.all.html
+++ b/src/raster/r.null.all/r.null.all.html
@@ -50,8 +50,6 @@ r.null.all setnull=0 exclude=".*1" matching=extended -d
   <a href="g.rename.many.html">g.rename.many</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Vaclav Petras, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll Lab</a>
-
-<p><i>Last changed: $Date$</i>

--- a/src/raster/r.object.activelearning/r.object.activelearning.html
+++ b/src/raster/r.object.activelearning/r.object.activelearning.html
@@ -184,9 +184,5 @@ Symposium. doi:10.1109/igarss.2009.5417857<br>
 
 
 <h2>AUTHOR</h2> 
-Lucas Lef&egrave;vre (ULB, Brussels, Belgium)
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Lucas Lef&egrave;vre (ULB, Brussels, Belgium)

--- a/src/raster/r.object.geometry/r.object.geometry.html
+++ b/src/raster/r.object.geometry/r.object.geometry.html
@@ -54,8 +54,3 @@ r.object.geometry input=soilsID output=soils_geom.txt
 
 Moritz Lennert<br>
 Markus Metz (diagonal clump tracing)
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.object.spatialautocor/r.object.spatialautocor.html
+++ b/src/raster/r.object.spatialautocor/r.object.spatialautocor.html
@@ -43,8 +43,3 @@ Geary, R.C., 1954. The Contiguity Ratio and Statistical Mapping. The Incorporate
 <h2>AUTHOR</h2> 
 
 Moritz Lennert
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.object.thickness/r.object.thickness.html
+++ b/src/raster/r.object.thickness/r.object.thickness.html
@@ -71,12 +71,7 @@ Thickness in pixels: min 0.053524  max 103.945479  mean 10.563481
 </em>
 
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Paolo Zatelli,
 DICAM, University of Trento, Italy.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.out.kde/r.out.kde.html
+++ b/src/raster/r.out.kde/r.out.kde.html
@@ -42,10 +42,6 @@ r.out.kde input=schools_density background=relief method=logistic output=output.
 
 <a href="https://en.wikipedia.org/wiki/Logistic_function">Logistic function</a>
 
-<h2>AUTHORS</h2>
-Anna Petrasova, <a href="http://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll lab</a>
+<h2>AUTHOR</h2>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Anna Petrasova, <a href="http://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll lab</a>

--- a/src/raster/r.out.legend/r.out.legend.html
+++ b/src/raster/r.out.legend/r.out.legend.html
@@ -199,14 +199,9 @@ at a resolution of 150 ppi this is:
 <em><a href="https://grass.osgeo.org/grass-stable/manuals/d.legend">d.legend</a></em>,
 <em><a href="https://grass.osgeo.org/grass-stable/manuals/d.font">d.font</a></em>,
 <em><a href="https://grass.osgeo.org/grass-stable/manuals/d.out.file.html">d.out.file</a></em>,
-<em><a href="ps.map.html">ps.map</a></em>,
+<em><a href="https://grass.osgeo.org/grass-stable/manuals/ps.map.html">ps.map</a></em>,
 <em><a href="r.category.trim.html">r.category.trim</a></em>
 
 <h2>AUTHOR</h2>
 
 Paulo van Breugel, paulo at ecodiv.org
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.out.maxent_swd/r.out.maxent_swd.html
+++ b/src/raster/r.out.maxent_swd/r.out.maxent_swd.html
@@ -49,10 +49,6 @@ Distributions, 17:43-57, 2011.</li>
 </ul>
 
 <h2>AUTHOR</h2>
+
 Stefan Blumentrath, Norwegian Institute for Nature Research (NINA),
 <a href="http://www.nina.no">http://www.nina.no</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.out.ntv2/r.out.ntv2.html
+++ b/src/raster/r.out.ntv2/r.out.ntv2.html
@@ -29,9 +29,5 @@ fields are set to, respectively, current date and time, in YYYYMMDD and HHMMSS f
 <a href="https://github.com/Esri/ntv2-file-routines">NTv2 format description by ESRI</a>
 
 <h2>AUTHOR</h2>
-Maciej Sieczka
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Maciej Sieczka

--- a/src/raster/r.out.tiff/r.out.tiff.html
+++ b/src/raster/r.out.tiff/r.out.tiff.html
@@ -37,11 +37,7 @@ operations.
 </em>
 
 <h2>AUTHOR</h2>
+
 Michael Shapiro,
 U.S. Army Construction Engineering Research Laboratory
 <p>GRASS 5.0 team
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.patch.smooth/r.patch.smooth.html
+++ b/src/raster/r.patch.smooth/r.patch.smooth.html
@@ -54,6 +54,7 @@ This option requires more testing.
 <a href="https://grass.osgeo.org/grass-stable/manuals/r.grow.distance.html">r.grow.distance</a>
 
 <h2>REFERENCES</h2>
+
 Anna Petrasova, Helena Mitasova, Vaclav Petras, Justyna Jeziorska.
 <a href="https://link.springer.com/article/10.1186/s40965-017-0019-2">
 Fusion of high-resolution DEMs for water flow modeling</a> (2017).
@@ -63,8 +64,3 @@ Open Geospatial Data, Software and Standards.
 <h2>AUTHOR</h2>
 
 Anna Petrasova, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU OSGeoREL</a><br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.corearea/r.pi.corearea.html
+++ b/src/raster/r.pi/r.pi.corearea/r.pi.corearea.html
@@ -107,7 +107,7 @@ landclass96_corearea_map: a map showing the edge depths
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>

--- a/src/raster/r.pi/r.pi.corearea/r.pi.corearea.html
+++ b/src/raster/r.pi/r.pi.corearea/r.pi.corearea.html
@@ -107,7 +107,8 @@ landclass96_corearea_map: a map showing the edge depths
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>
 Department of Remote Sensing<br>
@@ -115,8 +116,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.corr.mw/r.pi.corr.mw.html
+++ b/src/raster/r.pi/r.pi.corr.mw/r.pi.corr.mw.html
@@ -34,7 +34,8 @@ r.colors corrwin1 col=bgyr
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>
 Department of Remote Sensing<br>
@@ -42,8 +43,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.corr.mw/r.pi.corr.mw.html
+++ b/src/raster/r.pi/r.pi.corr.mw/r.pi.corr.mw.html
@@ -34,7 +34,7 @@ r.colors corrwin1 col=bgyr
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>

--- a/src/raster/r.pi/r.pi.csr.mw/r.pi.csr.mw.html
+++ b/src/raster/r.pi/r.pi.csr.mw/r.pi.csr.mw.html
@@ -49,7 +49,7 @@ r.pi.csr.mw input=randompoints keyval=5 n=1000 method=clark_evans size=7 output=
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>

--- a/src/raster/r.pi/r.pi.csr.mw/r.pi.csr.mw.html
+++ b/src/raster/r.pi/r.pi.csr.mw/r.pi.csr.mw.html
@@ -49,7 +49,8 @@ r.pi.csr.mw input=randompoints keyval=5 n=1000 method=clark_evans size=7 output=
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>
 Department of Remote Sensing<br>
@@ -57,8 +58,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.energy.pr/r.pi.energy.pr.html
+++ b/src/raster/r.pi/r.pi.energy.pr/r.pi.energy.pr.html
@@ -77,7 +77,7 @@ r.pi.energy input=landclass96 output=energyiter keyval=5 n=1000 step_length=5 en
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>

--- a/src/raster/r.pi/r.pi.energy.pr/r.pi.energy.pr.html
+++ b/src/raster/r.pi/r.pi.energy.pr/r.pi.energy.pr.html
@@ -77,7 +77,8 @@ r.pi.energy input=landclass96 output=energyiter keyval=5 n=1000 step_length=5 en
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>
 Department of Remote Sensing<br>
@@ -85,8 +86,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.energy/r.pi.energy.html
+++ b/src/raster/r.pi/r.pi.energy/r.pi.energy.html
@@ -77,7 +77,7 @@ r.pi.energy input=landclass96 output=energyiter keyval=5 n=1000 step_length=5 en
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>

--- a/src/raster/r.pi/r.pi.energy/r.pi.energy.html
+++ b/src/raster/r.pi/r.pi.energy/r.pi.energy.html
@@ -77,7 +77,8 @@ r.pi.energy input=landclass96 output=energyiter keyval=5 n=1000 step_length=5 en
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>
 Department of Remote Sensing<br>
@@ -85,8 +86,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.enn.pr/r.pi.enn.pr.html
+++ b/src/raster/r.pi/r.pi.enn.pr/r.pi.enn.pr.html
@@ -37,7 +37,7 @@ r.pi.enn.pr input=landclass96 output=dist_iter keyval=5 method=distance statmeth
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>

--- a/src/raster/r.pi/r.pi.enn.pr/r.pi.enn.pr.html
+++ b/src/raster/r.pi/r.pi.enn.pr/r.pi.enn.pr.html
@@ -37,7 +37,8 @@ r.pi.enn.pr input=landclass96 output=dist_iter keyval=5 method=distance statmeth
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>
 Department of Remote Sensing<br>
@@ -45,8 +46,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.enn/r.pi.enn.html
+++ b/src/raster/r.pi/r.pi.enn/r.pi.enn.html
@@ -122,7 +122,7 @@ r.pi.enn input=landclass96 output=dist10b.c5 keyval=5 method=path_distance numbe
 <a href="https://grass.osgeo.org/grass-stable/manuals/r.li.setup.html">r.li</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>

--- a/src/raster/r.pi/r.pi.enn/r.pi.enn.html
+++ b/src/raster/r.pi/r.pi.enn/r.pi.enn.html
@@ -122,7 +122,8 @@ r.pi.enn input=landclass96 output=dist10b.c5 keyval=5 method=path_distance numbe
 <a href="https://grass.osgeo.org/grass-stable/manuals/r.li.setup.html">r.li</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>
 Department of Remote Sensing<br>
@@ -130,8 +131,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.export/r.pi.export.html
+++ b/src/raster/r.pi/r.pi.export/r.pi.export.html
@@ -60,7 +60,7 @@ column is holding the actual patch index value (here area; e.g. patch
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>

--- a/src/raster/r.pi/r.pi.export/r.pi.export.html
+++ b/src/raster/r.pi/r.pi.export/r.pi.export.html
@@ -60,7 +60,8 @@ column is holding the actual patch index value (here area; e.g. patch
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>
 Department of Remote Sensing<br>
@@ -68,8 +69,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.fnn/r.pi.fnn.html
+++ b/src/raster/r.pi/r.pi.fnn/r.pi.fnn.html
@@ -118,7 +118,7 @@ r.pi.fnn input=landclass96 keyval=5 costmap=cost_raster output=fnn1 method=dista
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>

--- a/src/raster/r.pi/r.pi.fnn/r.pi.fnn.html
+++ b/src/raster/r.pi/r.pi.fnn/r.pi.fnn.html
@@ -118,7 +118,8 @@ r.pi.fnn input=landclass96 keyval=5 costmap=cost_raster output=fnn1 method=dista
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>
 Department of Remote Sensing<br>
@@ -126,8 +127,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.graph.dec/r.pi.graph.dec.html
+++ b/src/raster/r.pi/r.pi.graph.dec/r.pi.graph.dec.html
@@ -35,7 +35,8 @@ g.region -d
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>
 Department of Remote Sensing<br>
@@ -43,8 +44,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.graph.dec/r.pi.graph.dec.html
+++ b/src/raster/r.pi/r.pi.graph.dec/r.pi.graph.dec.html
@@ -35,7 +35,7 @@ g.region -d
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>

--- a/src/raster/r.pi/r.pi.graph.pr/r.pi.graph.pr.html
+++ b/src/raster/r.pi/r.pi.graph.pr/r.pi.graph.pr.html
@@ -35,7 +35,8 @@ g.region -d
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>
 Department of Remote Sensing<br>
@@ -43,8 +44,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.graph.pr/r.pi.graph.pr.html
+++ b/src/raster/r.pi/r.pi.graph.pr/r.pi.graph.pr.html
@@ -35,7 +35,7 @@ g.region -d
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>

--- a/src/raster/r.pi/r.pi.graph.red/r.pi.graph.red.html
+++ b/src/raster/r.pi/r.pi.graph.red/r.pi.graph.red.html
@@ -35,7 +35,8 @@ g.region -d
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>
 Department of Remote Sensing<br>
@@ -43,8 +44,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.graph.red/r.pi.graph.red.html
+++ b/src/raster/r.pi/r.pi.graph.red/r.pi.graph.red.html
@@ -35,7 +35,7 @@ g.region -d
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>

--- a/src/raster/r.pi/r.pi.graph/r.pi.graph.html
+++ b/src/raster/r.pi/r.pi.graph/r.pi.graph.html
@@ -47,7 +47,8 @@ is resulting in a total of 66 clusters.
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>
 Department of Remote Sensing<br>
@@ -55,8 +56,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.graph/r.pi.graph.html
+++ b/src/raster/r.pi/r.pi.graph/r.pi.graph.html
@@ -47,7 +47,7 @@ is resulting in a total of 66 clusters.
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>

--- a/src/raster/r.pi/r.pi.grow/r.pi.grow.html
+++ b/src/raster/r.pi/r.pi.grow/r.pi.grow.html
@@ -35,7 +35,8 @@ g.region -d
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>
 Department of Remote Sensing<br>
@@ -43,8 +44,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.grow/r.pi.grow.html
+++ b/src/raster/r.pi/r.pi.grow/r.pi.grow.html
@@ -35,7 +35,7 @@ g.region -d
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>

--- a/src/raster/r.pi/r.pi.html
+++ b/src/raster/r.pi/r.pi.html
@@ -199,7 +199,7 @@ Moreover its capabilities are yet limited and can not be compared to such of e.g
 Fragstats, however every user is invited to extend, modify or fix the
 functionality of <em>r.pi</em> as long as the new code comply with the GPL.
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Martin Wegmann <br>

--- a/src/raster/r.pi/r.pi.html
+++ b/src/raster/r.pi/r.pi.html
@@ -199,7 +199,8 @@ Moreover its capabilities are yet limited and can not be compared to such of e.g
 Fragstats, however every user is invited to extend, modify or fix the
 functionality of <em>r.pi</em> as long as the new code comply with the GPL.
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Martin Wegmann <br>
 Department of Remote Sensing <br>
@@ -207,8 +208,3 @@ Department of Remote Sensing <br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.import/r.pi.import.html
+++ b/src/raster/r.pi/r.pi.import/r.pi.import.html
@@ -57,7 +57,7 @@ r.pi.import input=resid.for.GRASS raster=landclass96 output=resid.AB keyval=5 id
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>

--- a/src/raster/r.pi/r.pi.import/r.pi.import.html
+++ b/src/raster/r.pi/r.pi.import/r.pi.import.html
@@ -57,7 +57,8 @@ r.pi.import input=resid.for.GRASS raster=landclass96 output=resid.AB keyval=5 id
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>
 Department of Remote Sensing<br>
@@ -65,8 +66,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.index/r.pi.index.html
+++ b/src/raster/r.pi/r.pi.index/r.pi.index.html
@@ -115,7 +115,7 @@ r.pi.index input=landclass96 output=landclass96_forestclass5_ENN keyval=5 method
 Landscapes with more than 10 000 individual patches might cause a memory
 allocation error depending on the user's system.
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>

--- a/src/raster/r.pi/r.pi.index/r.pi.index.html
+++ b/src/raster/r.pi/r.pi.index/r.pi.index.html
@@ -115,7 +115,8 @@ r.pi.index input=landclass96 output=landclass96_forestclass5_ENN keyval=5 method
 Landscapes with more than 10 000 individual patches might cause a memory
 allocation error depending on the user's system.
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>
 Department of Remote Sensing<br>
@@ -123,8 +124,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.lm/r.pi.lm.html
+++ b/src/raster/r.pi/r.pi.lm/r.pi.lm.html
@@ -35,7 +35,8 @@ g.region -d
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>
 Department of Remote Sensing<br>
@@ -43,8 +44,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.lm/r.pi.lm.html
+++ b/src/raster/r.pi/r.pi.lm/r.pi.lm.html
@@ -35,7 +35,7 @@ g.region -d
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>

--- a/src/raster/r.pi/r.pi.neigh/r.pi.neigh.html
+++ b/src/raster/r.pi/r.pi.neigh/r.pi.neigh.html
@@ -23,7 +23,8 @@ g.region -d
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>
 Department of Remote Sensing<br>
@@ -31,8 +32,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.neigh/r.pi.neigh.html
+++ b/src/raster/r.pi/r.pi.neigh/r.pi.neigh.html
@@ -23,7 +23,7 @@ g.region -d
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>

--- a/src/raster/r.pi/r.pi.nlm.circ/r.pi.nlm.circ.html
+++ b/src/raster/r.pi/r.pi.nlm.circ/r.pi.nlm.circ.html
@@ -70,7 +70,7 @@ g.region -d
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>

--- a/src/raster/r.pi/r.pi.nlm.circ/r.pi.nlm.circ.html
+++ b/src/raster/r.pi/r.pi.nlm.circ/r.pi.nlm.circ.html
@@ -70,7 +70,8 @@ g.region -d
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>
 Department of Remote Sensing<br>
@@ -78,8 +79,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.nlm.stats/r.pi.nlm.stats.html
+++ b/src/raster/r.pi/r.pi.nlm.stats/r.pi.nlm.stats.html
@@ -22,7 +22,8 @@ g.region -d
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>
 Department of Remote Sensing<br>
@@ -30,8 +31,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.nlm.stats/r.pi.nlm.stats.html
+++ b/src/raster/r.pi/r.pi.nlm.stats/r.pi.nlm.stats.html
@@ -22,7 +22,7 @@ g.region -d
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>

--- a/src/raster/r.pi/r.pi.nlm/r.pi.nlm.html
+++ b/src/raster/r.pi/r.pi.nlm/r.pi.nlm.html
@@ -41,7 +41,7 @@ r.pi.nlm input=landclass96 output=nlm.2 keyval=5
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>

--- a/src/raster/r.pi/r.pi.nlm/r.pi.nlm.html
+++ b/src/raster/r.pi/r.pi.nlm/r.pi.nlm.html
@@ -41,7 +41,8 @@ r.pi.nlm input=landclass96 output=nlm.2 keyval=5
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>
 Department of Remote Sensing<br>
@@ -49,8 +50,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.odc/r.pi.odc.html
+++ b/src/raster/r.pi/r.pi.odc/r.pi.odc.html
@@ -86,7 +86,7 @@ r.pi.odc input=landclass96 output=odc keyval=5 ratio=odd_area stats=average neig
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>

--- a/src/raster/r.pi/r.pi.odc/r.pi.odc.html
+++ b/src/raster/r.pi/r.pi.odc/r.pi.odc.html
@@ -86,7 +86,8 @@ r.pi.odc input=landclass96 output=odc keyval=5 ratio=odd_area stats=average neig
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>
 Department of Remote Sensing<br>
@@ -94,8 +95,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.prob.mw/r.pi.prob.mw.html
+++ b/src/raster/r.pi/r.pi.prob.mw/r.pi.prob.mw.html
@@ -35,7 +35,7 @@ g.region -d
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann <br>

--- a/src/raster/r.pi/r.pi.prob.mw/r.pi.prob.mw.html
+++ b/src/raster/r.pi/r.pi.prob.mw/r.pi.prob.mw.html
@@ -35,7 +35,8 @@ g.region -d
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann <br>
 Department of Remote Sensing <br>
@@ -43,8 +44,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.prox/r.pi.prox.html
+++ b/src/raster/r.pi/r.pi.prox/r.pi.prox.html
@@ -22,7 +22,8 @@ g.region -d
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>
 Department of Remote Sensing<br>
@@ -30,8 +31,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.prox/r.pi.prox.html
+++ b/src/raster/r.pi/r.pi.prox/r.pi.prox.html
@@ -22,7 +22,7 @@ g.region -d
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann<br>

--- a/src/raster/r.pi/r.pi.rectangle/r.pi.rectangle.html
+++ b/src/raster/r.pi/r.pi.rectangle/r.pi.rectangle.html
@@ -45,7 +45,8 @@ g.region -d
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann <br>
 Department of Remote Sensing <br>
@@ -53,8 +54,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.rectangle/r.pi.rectangle.html
+++ b/src/raster/r.pi/r.pi.rectangle/r.pi.rectangle.html
@@ -45,7 +45,7 @@ g.region -d
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann <br>

--- a/src/raster/r.pi/r.pi.searchtime.mw/r.pi.searchtime.mw.html
+++ b/src/raster/r.pi/r.pi.searchtime.mw/r.pi.searchtime.mw.html
@@ -69,7 +69,7 @@ r.pi.searchtime.mw input=landclass96 output=searchtime1 keyval=5 step_length=5 s
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann <br>

--- a/src/raster/r.pi/r.pi.searchtime.mw/r.pi.searchtime.mw.html
+++ b/src/raster/r.pi/r.pi.searchtime.mw/r.pi.searchtime.mw.html
@@ -69,7 +69,8 @@ r.pi.searchtime.mw input=landclass96 output=searchtime1 keyval=5 step_length=5 s
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann <br>
 Department of Remote Sensing <br>
@@ -77,8 +78,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.searchtime.pr/r.pi.searchtime.pr.html
+++ b/src/raster/r.pi/r.pi.searchtime.pr/r.pi.searchtime.pr.html
@@ -77,6 +77,7 @@ r.pi.searchtime.pr input=landclass96 output=searchtime1 keyval=5 step_length=5 s
 </em>
 
 <h2>AUTHORS</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann <br>
 Department of Remote Sensing <br>
@@ -84,8 +85,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.pi/r.pi.searchtime/r.pi.searchtime.html
+++ b/src/raster/r.pi/r.pi.searchtime/r.pi.searchtime.html
@@ -94,7 +94,7 @@ r.pi.searchtime input=landclass96 output=searchtime1 keyval=5 step_length=5 stat
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann <br>

--- a/src/raster/r.pi/r.pi.searchtime/r.pi.searchtime.html
+++ b/src/raster/r.pi/r.pi.searchtime/r.pi.searchtime.html
@@ -94,7 +94,8 @@ r.pi.searchtime input=landclass96 output=searchtime1 keyval=5 step_length=5 stat
 <a href="r.pi.html">r.pi</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
+
 Programming: Elshad Shirinov<br>
 Scientific concept: Dr. Martin Wegmann <br>
 Department of Remote Sensing <br>
@@ -102,8 +103,3 @@ Remote Sensing and Biodiversity Unit<br>
 University of Wuerzburg, Germany
 <p>
 Port to GRASS GIS 7: Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.popgrowth/r.popgrowth.html
+++ b/src/raster/r.popgrowth/r.popgrowth.html
@@ -9,18 +9,13 @@ Available models for populations growth: Exponential growth and the Ricker model
 
 <h2>EXAMPLES</h2>
 
-
+TBD.
 
 <h2>SEE ALSO</h2>
 
 
 <h2>AUTHOR</h2>
+
 Johannes Radinger<br>
 <i>Leibniz-Institute of Freshwater Ecology and Inland Fisheries (IGB)<br>
 Berlin, Germany</i>
-<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.quantile.ref/r.quantile.ref.html
+++ b/src/raster/r.quantile.ref/r.quantile.ref.html
@@ -63,8 +63,3 @@ The quantile corresponding to the value 5 is 0.8.
 <h2>AUTHOR</h2>
 
 Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.random.weight/r.random.weight.html
+++ b/src/raster/r.random.weight/r.random.weight.html
@@ -30,15 +30,10 @@ See <a href="https://pvanb.wordpress.com/2014/05/30/weighted_random_sample_of_ra
 <h2>See also</h2>
 <em>
 <a href="https://grass.osgeo.org/grass-stable/manuals/r.random.html">r.random</a>,
-<a href="https://grass.osgeo.org/grass-stable/manuals/r.random.cells.html">r.random.cells</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.random.cells.html">r.random.cells</a>
 </em>
 
 
 <h2>AUTHOR</h2>
 
 Paulo van Breugel, paulo at ecodiv.org
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
---> 

--- a/src/raster/r.recode.attr/r.recode.attr.html
+++ b/src/raster/r.recode.attr/r.recode.attr.html
@@ -46,8 +46,3 @@ ranges of values to one value or a new range of values)
 <h2>AUTHOR</h2>
 
 Paulo van Breugel, paulo at ecodiv.org
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.regression.series/r.regression.series.html
+++ b/src/raster/r.regression.series/r.regression.series.html
@@ -112,8 +112,3 @@ r.regression.series x=xone,xtwo,xthree,xfour y=yone,ytwo,ythree,yfour \
 <h2>AUTHOR</h2>
 
 Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.resamp.tps/r.resamp.tps.html
+++ b/src/raster/r.resamp.tps/r.resamp.tps.html
@@ -83,11 +83,6 @@ TPS interpolation are always completely loaded to memory.
 <a href="https://grass.osgeo.org/grass-stable/manuals/v.surf.idw.html">v.surf.idw</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.richdem.breachdepressions/r.richdem.breachdepressions.html
+++ b/src/raster/r.richdem.breachdepressions/r.richdem.breachdepressions.html
@@ -12,9 +12,4 @@ PLACEHOLDER
 
 <h2>AUTHORS</h2>
 
-Richard Barnes (algorithm and codebase), Andrew D. Wickert (GRASS frontend)<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Richard Barnes (algorithm and codebase), Andrew D. Wickert (GRASS frontend)

--- a/src/raster/r.richdem.filldepressions/r.richdem.filldepressions.html
+++ b/src/raster/r.richdem.filldepressions/r.richdem.filldepressions.html
@@ -13,8 +13,3 @@ PLACEHOLDER
 <h2>AUTHORS</h2>
 
 Richard Barnes (algorithm and codebase), Andrew D. Wickert (GRASS frontend)<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.richdem.flowaccumulation/r.richdem.flowaccumulation.html
+++ b/src/raster/r.richdem.flowaccumulation/r.richdem.flowaccumulation.html
@@ -13,8 +13,3 @@ PLACEHOLDER
 <h2>AUTHORS</h2>
 
 Richard Barnes (algorithm and codebase), Andrew D. Wickert (GRASS frontend)<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.richdem.resolveflats/r.richdem.resolveflats.html
+++ b/src/raster/r.richdem.resolveflats/r.richdem.resolveflats.html
@@ -8,14 +8,9 @@ PLACEHOLDER
 
 <h2>SEE ALSO</h2>
 
-<a href="https://grass.osgeo.org/grass-stable/manuals/r.fill.dir">r.fill.dir</a><br>
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.fill.dir.html">r.fill.dir</a><br>
 
 <h2>AUTHORS</h2>
 
 Richard Barnes (algorithm and codebase), Andrew D. Wickert (GRASS frontend)<br>
 
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.richdem.terrainattribute/r.richdem.terrainattribute.html
+++ b/src/raster/r.richdem.terrainattribute/r.richdem.terrainattribute.html
@@ -14,8 +14,3 @@ PLACEHOLDER
 
 Richard Barnes (algorithm and codebase), Andrew D. Wickert (GRASS frontend)<br>
 
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.roughness.vector/r.roughness.vector.html
+++ b/src/raster/r.roughness.vector/r.roughness.vector.html
@@ -88,8 +88,3 @@ target="_blank">http://carlosgrohmann.com</a>)
 <br>
 Helmut Kudrnovsky
 <p>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.roughness.vector/r.roughness.vector.html
+++ b/src/raster/r.roughness.vector/r.roughness.vector.html
@@ -87,4 +87,3 @@ University of S&atilde;o Paulo, Brazil. (<a href="http://carlosgrohmann.com"
 target="_blank">http://carlosgrohmann.com</a>) 
 <br>
 Helmut Kudrnovsky
-<p>

--- a/src/raster/r.sample.category/r.sample.category.html
+++ b/src/raster/r.sample.category/r.sample.category.html
@@ -108,8 +108,3 @@ cat,landclass96,elevation,geology_30m
 
 Vaclav Petras, <a href="http://gis.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>,<br>
 Anna Petrasova, <a href="http://gis.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.seasons/r.seasons.html
+++ b/src/raster/r.seasons/r.seasons.html
@@ -172,14 +172,11 @@ r.colors map=ndvi_season2_start1,ndvi_season2_end1 color=viridis
 
 <h2>SEE ALSO</h2>
 
-<em><a href="https://grass.osgeo.org/grass-stable/manuals/r.series.html">r.series</a></em>, 
-<em><a href="r.hants.html">r.hants</a></em>
+<em>
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.series.html">r.series</a>,
+<a href="r.hants.html">r.hants</a>
+</em>
 
 <h2>AUTHOR</h2>
 
 Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.series.decompose/r.series.decompose.html
+++ b/src/raster/r.series.decompose/r.series.decompose.html
@@ -144,8 +144,3 @@ r.mapcals "ndvi03jan = coef.const + coef.time*T +\
 <h2>AUTHOR</h2>
 
 Dmitry Kolesov
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.series.diversity/r.series.diversity.html
+++ b/src/raster/r.series.diversity/r.series.diversity.html
@@ -194,9 +194,5 @@ max=0.5658
 
 
 <h2>AUTHOR</h2>
-Paulo van Breugel, paulo at ecodiv dot earth
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Paulo van Breugel, paulo at ecodiv dot earth

--- a/src/raster/r.series.filter/r.series.filter.html
+++ b/src/raster/r.series.filter/r.series.filter.html
@@ -118,8 +118,3 @@ href="https://doi.org/10.1016/j.rse.2004.03.014">10.1016/j.rse.2004.03.014</a>.
 <h2>AUTHOR</h2>
 
 Dmitry Kolesov
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.series.lwr/r.series.lwr.html
+++ b/src/raster/r.series.lwr/r.series.lwr.html
@@ -259,8 +259,3 @@ doi:<a href="http://dx.doi.org/10.2307/2289282">10.2307/2289282</a>
 <h2>AUTHOR</h2>
 
 Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.shaded.pca/r.shaded.pca.html
+++ b/src/raster/r.shaded.pca/r.shaded.pca.html
@@ -79,8 +79,3 @@ Devereux, B. J., Amable, G. S., & Crow, P. P. (2008). Visualisation of LiDAR ter
 <h2>AUTHOR</h2>
 
 Vaclav Petras, <a href="http://gis.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.shalstab/r.shalstab.html
+++ b/src/raster/r.shalstab/r.shalstab.html
@@ -42,7 +42,7 @@ A map for of critical rainfall map (mm/day).
 Montgomery, D. R. and Dietrich, W. E.: A physically based model for the
 topographic control of shallow landsliding,Water Resour. Res., 30, 1153-1171, 1994.
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Andrea Filipello, University of Turin, Italy mail<br>
 Daniele Strigaro, University of Milan, Italy mail

--- a/src/raster/r.shalstab/r.shalstab.html
+++ b/src/raster/r.shalstab/r.shalstab.html
@@ -37,17 +37,12 @@ A landslide susceptibility map (value range from 1 to 7):
 
 A map for of critical rainfall map (mm/day).
 
-<h2>AUTHORS</h2>
-
-<p>Andrea Filipello, University of Turin, Italy mail</p>
-<p>Daniele Strigaro, University of Milan, Italy mail</p>
-
 <h2>REFERENCES</h2>
 
-<p>Montgomery, D. R. and Dietrich, W. E.: A physically based model for the
-topographic control of shallow landsliding,Water Resour. Res., 30, 1153-1171, 1994.</p>
+Montgomery, D. R. and Dietrich, W. E.: A physically based model for the
+topographic control of shallow landsliding,Water Resour. Res., 30, 1153-1171, 1994.
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+<h2>AUTHOR</h2>
+
+Andrea Filipello, University of Turin, Italy mail<br>
+Daniele Strigaro, University of Milan, Italy mail

--- a/src/raster/r.shalstab/r.shalstab.html
+++ b/src/raster/r.shalstab/r.shalstab.html
@@ -44,5 +44,5 @@ topographic control of shallow landsliding,Water Resour. Res., 30, 1153-1171, 19
 
 <h2>AUTHORS</h2>
 
-Andrea Filipello, University of Turin, Italy mail<br>
-Daniele Strigaro, University of Milan, Italy mail
+Andrea Filipello, University of Turin, Italy<br>
+Daniele Strigaro, University of Milan, Italy

--- a/src/raster/r.sim.terrain/r.sim.terrain.html
+++ b/src/raster/r.sim.terrain/r.sim.terrain.html
@@ -122,14 +122,9 @@ DOI: <a href="http://dx.doi.org/10.1016/B978-0-12-374739-6.00052-X">http://dx.do
 <a href="https://grass.osgeo.org/grass-stable/manuals/r.sim.sediment.html">r.sim.sediment</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 <p>
 Brendan A. Harmon<br>
 Louisiana State University<br>
 <i><a href="mailto:brendan.harmon@gmail.com">brendan.harmon@gmail.com</a></i>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.sim.water.mp/r.sim.water.mp.html
+++ b/src/raster/r.sim.water.mp/r.sim.water.mp.html
@@ -1,6 +1,6 @@
 <h2>DESCRIPTION</h2>
 
-<i>r.sim.water</i> is a landscape scale simulation model 
+<i>r.sim.water.mp</i> is a landscape scale simulation model
 of overland flow designed for spatially variable terrain, soil, cover 
 and rainfall excess conditions. A 2D shallow water flow is described by 
 the bivariate form of Saint Venant equations. The numerical solution is based
@@ -179,7 +179,7 @@ then a lower <em>nwalkers</em> parameter value has to be selected.
 <a href="https://grass.osgeo.org/grass-stable/manuals/r.sim.sediment.html">r.sim.sediment</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Helena Mitasova, Lubos Mitas<br>
 North Carolina State University<br>
@@ -236,8 +236,3 @@ April 2015
 <a href="http://www.grassbook.org">Open Source GIS: A GRASS GIS Approach. Third Edition.</a>
 The International Series in Engineering and Computer Science: Volume 773. Springer New York Inc, p. 406.
 </ul>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.skyview/r.skyview.html
+++ b/src/raster/r.skyview/r.skyview.html
@@ -48,11 +48,6 @@ r.skyview input=elevation output=elevation_skyview ndir=8
     <li>Yokoyama R, Shirasawa M, Pike J R. <em>Visualizing topography by Openness: A new application of image processing to digital elevation models.</em> Photogrammetric engineering and remote sensing 68.3 (2002): 257-266.</li>
 </ul>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Anna Petrasova, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.slope.direction/r.slope.direction.html
+++ b/src/raster/r.slope.direction/r.slope.direction.html
@@ -182,10 +182,6 @@ alt="Slope following street direction for 13 pixels" border="0">
 <a href="https://grass.osgeo.org/grass-stable/manuals/r.stream.slope.html">r.stream.slope</a>
 
 <h2>AUTHOR</h2>
+
 Stefan Blumentrath, Norwegian Institute for Nature Research, Oslo, Norway<br>
 Written for the INVAFISH project (RCN MILJ&Oslash;FORSK grant 243910)
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.smooth.seg/r.smooth.seg.html
+++ b/src/raster/r.smooth.seg/r.smooth.seg.html
@@ -164,8 +164,3 @@ Alfonso Vitti <br>
 &nbsp; Dept. Civil, Environmental and Mechanical Engineering <br> 
 &nbsp; University of Trento - Italy<br>
 &nbsp; alfonso.vitti [at] unitn.it
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.soillossbare/r.soillossbare.html
+++ b/src/raster/r.soillossbare/r.soillossbare.html
@@ -19,8 +19,3 @@ http://www4.ncsu.edu/~hmitaso/gmslab/erosion/usle.html
 <h2>AUTHOR</h2>
 
 Martin Zbinden
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.soils.texture/r.soils.texture.html
+++ b/src/raster/r.soils.texture/r.soils.texture.html
@@ -14,13 +14,6 @@ You can download *.dat files from the
 
 <em><a href="https://grass.osgeo.org/programming8/">GRASS 8 Programmer's Manual</a></em>
 
-
-<h2>AUTHOR</h2>
-Gianluca Massei (g_massa@libero.it) 
-
-<br>
-<br>
-
 <h2>REFERENCES</h2>
 
 <p>Bourke P., 1987 Determining if a point lies on the interior of a polygon. Downloaded printed</p>
@@ -33,7 +26,6 @@ scheme (guile), and tcl using a floating point numerical test - point inside
 polygon. Applied mathematics and computer technology center alcoa technical
 center. Distribution documents.</p>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+<h2>AUTHOR</h2>
+
+Gianluca Massei (g_massa@libero.it) 

--- a/src/raster/r.stream.basins/r.stream.basins.html
+++ b/src/raster/r.stream.basins/r.stream.basins.html
@@ -222,10 +222,6 @@ See also the tutorial: <a href="http://grass.OSGeo.org/wiki/R.stream.*">http://g
 </em>
 
 <h2>AUTHOR</h2>
+
 Jarek Jasiewicz, Adam Mickiewicz University, Geoecology and Geoinformation
 Institute.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.stream.channel/r.stream.channel.html
+++ b/src/raster/r.stream.channel/r.stream.channel.html
@@ -125,11 +125,7 @@ plot(sorted,stdist~stgrad,type="l")
 </em>
 
 <h2>AUTHOR</h2>
+
 Jarek Jasiewicz, Adam Mickiewicz University, Geoecology and Geoinformation
 Institute.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
 

--- a/src/raster/r.stream.distance/r.stream.distance.html
+++ b/src/raster/r.stream.distance/r.stream.distance.html
@@ -192,8 +192,3 @@ modules</a> wiki page.
 
 Jarek Jasiewicz, Adam Mickiewicz University, Geoecology and Geoinformation
 Institute.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.stream.order/r.stream.order.html
+++ b/src/raster/r.stream.order/r.stream.order.html
@@ -354,8 +354,3 @@ modules</a> wiki page.
 <h2>AUTHOR</h2>
 
 Jarek Jasiewicz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.stream.segment/r.stream.segment.html
+++ b/src/raster/r.stream.segment/r.stream.segment.html
@@ -227,10 +227,6 @@ also <a href="http://grasswiki.osgeo.org/wiki/R.stream.*_modules">r.streams.*
 modules</a> wiki page.
 
 <h2>AUTHOR</h2>
+
 Jarek Jasiewicz, Adam Mickiewicz University, Geoecology and Geoinformation
 Institute.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.stream.slope/r.stream.slope.html
+++ b/src/raster/r.stream.slope/r.stream.slope.html
@@ -76,8 +76,3 @@ modules</a> wiki page.
 
 Jarek Jasiewicz, Adam Mickiewicz University, Geoecology and Geoinformation
 Institute.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.stream.snap/r.stream.snap.html
+++ b/src/raster/r.stream.snap/r.stream.snap.html
@@ -125,10 +125,6 @@ also <a href="http://grasswiki.osgeo.org/wiki/R.stream.*_modules">r.streams.*
 modules</a> wiki page.
 
 <h2>AUTHOR</h2>
+
 Jarek Jasiewicz, Adam Mickiewicz University, Geoecology and Geoinformation
 Institute.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.stream.stats/r.stream.stats.html
+++ b/src/raster/r.stream.stats/r.stream.stats.html
@@ -212,9 +212,5 @@ also <a href="http://grasswiki.osgeo.org/wiki/R.stream.*_modules">r.streams.*
 modules</a> wiki page.
 
 <h2>AUTHOR</h2>
-Jarek Jasiewicz, Adam Mickiewicz University, Geoecology and Geoinformation Institute.
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Jarek Jasiewicz, Adam Mickiewicz University, Geoecology and Geoinformation Institute.

--- a/src/raster/r.stream.variables/r.stream.variables.html
+++ b/src/raster/r.stream.variables/r.stream.variables.html
@@ -1,5 +1,8 @@
 <h2>DESCRIPTION</h2>
 
+Calculation of contiguous stream-specific variables that account for
+the upstream environment (based on r.stream.watersheds).
+
 <h2>REFERENCES</h2>
 
 Sami Domisch, Giuseppe Amatulli, Walter Jetz (2015):
@@ -12,8 +15,3 @@ Scientific Data 2, 150073,
 
 Giuseppe Amatulli<br>
 Sami Domisch
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.stream.watersheds/r.stream.watersheds.html
+++ b/src/raster/r.stream.watersheds/r.stream.watersheds.html
@@ -1,5 +1,8 @@
 <h2>DESCRIPTION</h2>
 
+Delineate the upstream contributing area ('sub-watershed') and stream
+sections ('sub-stream') for each grid cell of a stream network.
+
 <h2>REFERENCES</h2>
 
 Sami Domisch, Giuseppe Amatulli, Walter Jetz (2015):
@@ -12,8 +15,3 @@ Scientific Data 2, 150073,
 
 Giuseppe Amatulli<br>
 Sami Domisch
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.subdayprecip.design/r.subdayprecip.design.html
+++ b/src/raster/r.subdayprecip.design/r.subdayprecip.design.html
@@ -87,15 +87,10 @@ Management&quot;.
   <a href="https://grass.osgeo.org/grass-stable/manuals/v.what.rast.html">v.what.rast</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Martin Landa, GeoForAll (OSGeoREL) Lab, Czech Technical University in Prague, Czech
 Republic<br>
 
 The module is inspired by Python script developed for Esri ArcGIS
 platform by M. Tomasu in 2013.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.suitability.regions/r.suitability.regions.html
+++ b/src/raster/r.suitability.regions/r.suitability.regions.html
@@ -193,8 +193,3 @@ See <a href="https://ecodiv.earth/TutorialsNotes/SuitabilityRegions/index.html">
 <h2>AUTHOR</h2>
 
 Paulo van Breugel, paulo at ecodiv.earth
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.sun.daily/r.sun.daily.html
+++ b/src/raster/r.sun.daily/r.sun.daily.html
@@ -45,8 +45,3 @@ r.info beam
 
 Vaclav Petras, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>,<br>
 Anna Petrasova, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.sun.hourly/r.sun.hourly.html
+++ b/src/raster/r.sun.hourly/r.sun.hourly.html
@@ -98,12 +98,7 @@ set one of the values (either shade or sunlight) as NULL.
 </em>
 
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Vaclav Petras, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>,<br>
 Anna Petrasova, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU OSGeoREL</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.sun.mp/r.sun.mp.html
+++ b/src/raster/r.sun.mp/r.sun.mp.html
@@ -379,8 +379,3 @@ Thomas Huld, JRC, Italy <br>
 <a href="MAILTO:hofierka@geomodel.sk">hofierka@geomodel.sk</a>
 <a href="MAILTO:suri@geomodel.sk">suri@geomodel.sk</a>
 </address>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
---> 

--- a/src/raster/r.surf.idw2/r.surf.idw2.html
+++ b/src/raster/r.surf.idw2/r.surf.idw2.html
@@ -50,23 +50,21 @@ compare this surface generation program with others available in GRASS.
 
 
 <h2>KNOWN ISSUES</h2>
+
 Module <em>r.surf.idw</em> works only for integer (CELL) raster maps.
 
 <h2>SEE ALSO</h2>
 
-<em><a href="https://grass.osgeo.org/grass-stable/manuals/r.surf.contour.html">r.surf.contour</a></em>,
-<em><a href="https://grass.osgeo.org/grass-stable/manuals/r.surf.idw.html">r.surf.idw</a></em>,
-<em><a href="https://grass.osgeo.org/grass-stable/manuals/r.surf.gauss.html">r.surf.gauss</a></em>,
-<em><a href="https://grass.osgeo.org/grass-stable/manuals/r.surf.fractal.html">r.surf.fractal</a></em>,
-<em><a href="https://grass.osgeo.org/grass-stable/manuals/r.surf.random.html">r.surf.random</a></em>,
-<em><a href="https://grass.osgeo.org/grass-stable/manuals/r.surf.idw2.html">r.surf.idw2</a></em>,
-<em><a href="https://grass.osgeo.org/grass-stable/manuals/v.surf.rst.html">v.surf.rst</a></em>
+<em>
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.surf.contour.html">r.surf.contour</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.surf.idw.html">r.surf.idw</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.surf.gauss.html">r.surf.gauss</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.surf.fractal.html">r.surf.fractal</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.surf.random.html">r.surf.random</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.surf.idw2.html">r.surf.idw2</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/v.surf.rst.html">v.surf.rst</a>
+</em>
 
 <h2>AUTHOR</h2>
 
 Michael Shapiro, U.S.Army Construction Engineering Research Laboratory
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.surf.nnbathy/r.surf.nnbathy.html
+++ b/src/raster/r.surf.nnbathy/r.surf.nnbathy.html
@@ -81,8 +81,3 @@ Adam Laza, OSGeoREL, Czech Technical University in Prague (mentor: Martin Landa)
 based on v.surf.nnbathy from GRASS 6 by<br>
 Hamish Bowman, Otago University, New Zealand<br>
 Based on <em>r.surf.nnbathy</em> by Maciej Sieczka<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.terrain.texture/r.terrain.texture.html
+++ b/src/raster/r.terrain.texture/r.terrain.texture.html
@@ -64,8 +64,3 @@ signature. Geomorphology 86, 409-440.
 <h2>AUTHOR</h2>
 
 Steven Pawley
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.texture.tiled/r.texture.tiled.html
+++ b/src/raster/r.texture.tiled/r.texture.tiled.html
@@ -44,8 +44,3 @@ r.texture.tiled ortho_2001_t792_1m output=ortho_texture method=idm \
 <h2>AUTHOR</h2> 
 
 Moritz Lennert
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.threshold/r.threshold.html
+++ b/src/raster/r.threshold/r.threshold.html
@@ -25,9 +25,5 @@ r.threshold acc=accumulation_map
 </em>
 
 <h2>AUTHOR</h2>
-<p>Margherita Di Leo (dileomargherita AT gmail DOT com)
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Margherita Di Leo (dileomargherita AT gmail DOT com)

--- a/src/raster/r.to.vect.lines/r.to.vect.lines.html
+++ b/src/raster/r.to.vect.lines/r.to.vect.lines.html
@@ -51,8 +51,3 @@ Hamish Bowman<br>
 Dept. of Geology<br>
 University of Otago<br>
 Dunedin, New Zealand</i>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.to.vect.tiled/r.to.vect.tiled.html
+++ b/src/raster/r.to.vect.tiled/r.to.vect.tiled.html
@@ -19,10 +19,6 @@ The tiles are optionally patched together with the <em>-p</em> flag.
 <a href="https://grass.osgeo.org/grass-stable/manuals/v.clean.html">v.clean</a>
 </em>
 
-<h2>AUTHORS</h2>
-Markus Metz
+<h2>AUTHOR</h2>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Markus Metz

--- a/src/raster/r.tpi/r.tpi.html
+++ b/src/raster/r.tpi/r.tpi.html
@@ -41,8 +41,3 @@ Guisan, A., S. B. Weiss, A. D. Weiss 1999. GLM versus CCA spatial modeling of pl
 <h2>AUTHOR</h2>
 
 Steven Pawley
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.traveltime/r.traveltime.html
+++ b/src/raster/r.traveltime/r.traveltime.html
@@ -75,10 +75,6 @@ GIS</em>, Journal of the American Water Resources Association, 8,
 </ul>
 
 <h2>AUTHOR</h2>
-Kristian Foerster
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Kristian Foerster
 

--- a/src/raster/r.tri/r.tri.html
+++ b/src/raster/r.tri/r.tri.html
@@ -65,8 +65,3 @@ Intermountain Journal of Sciences, vol. 5, No. 1-4, 1999.
 <h2>AUTHOR</h2>
 
 Steven Pawley
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.univar2/r.univar2.html
+++ b/src/raster/r.univar2/r.univar2.html
@@ -132,8 +132,3 @@ Hamish Bowman, Otago University, New Zealand<br>
 Extended statistics by Martin Landa<br>
 Multiple input map support by Ivan Shmakov<br>
 Zonal loop by Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.valley.bottom/r.valley.bottom.html
+++ b/src/raster/r.valley.bottom/r.valley.bottom.html
@@ -62,11 +62,6 @@ J.C. Gallant & T.I. Dowling 2003.
 A multiresolution index of valley bottom flatness for mapping depositional areas.
 Water Resources Research, Vol. 39, No. 12, 1347. doi:10.1029/2002WR001426
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Helmut Kudrnovsky & Steven Pawley
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.vect.stats/r.vect.stats.html
+++ b/src/raster/r.vect.stats/r.vect.stats.html
@@ -51,14 +51,8 @@ r.vect.stats input=schools_wake output=schools_capacity_sum column=CAPACITYTO me
 </em>
 
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Vaclav Petras, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU GeoForAll Lab</a><br>
 Column and method parameters added by Martin
-Landa, <a href="http://geomatics.fsv.cvut.cz/research/geoforall/">CTU
-GeoForAll Lab</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Landa, <a href="http://geomatics.fsv.cvut.cz/research/geoforall/">CTU GeoForAll Lab</a>

--- a/src/raster/r.vector.ruggedness/r.vector.ruggedness.html
+++ b/src/raster/r.vector.ruggedness/r.vector.ruggedness.html
@@ -55,8 +55,3 @@ A case Study Using Bighorn Sheep in the Mojave Desert. Journal of Wildlife Manag
 <h2>AUTHOR</h2>
 
 Steven Pawley
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.viewshed.cva/r.viewshed.cva.html
+++ b/src/raster/r.viewshed.cva/r.viewshed.cva.html
@@ -81,8 +81,3 @@ r.viewshed.cva input=elevation output=peaks_CVA_map \
 <h2>AUTHOR</h2>
 
 Isaac Ullah
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.vif/r.vif.html
+++ b/src/raster/r.vif/r.vif.html
@@ -218,8 +218,3 @@ Variance Inflation Factor Cutoff Values. Quality Engineering 14:
 <h2>AUTHOR</h2>
 
 Paulo van Breugel, paulo at ecodiv.earth
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.vol.dem/r.vol.dem.html
+++ b/src/raster/r.vol.dem/r.vol.dem.html
@@ -126,13 +126,8 @@ tbd
 <p>
 <a href="http://undine-lieberwirth.info/?page_id=8">Screenhot gallery</a>
 
-<h2> AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Software: Benjamin Ducke
 <p>
 Documentation: Undine Lieberwirth
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.vol.dem/r.vol.dem.html
+++ b/src/raster/r.vol.dem/r.vol.dem.html
@@ -129,5 +129,5 @@ tbd
 <h2>AUTHORS</h2>
 
 Software: Benjamin Ducke
-<p>
+<br>
 Documentation: Undine Lieberwirth

--- a/src/raster/r.wateroutlet.lessmem/r.wateroutlet.lessmem.html
+++ b/src/raster/r.wateroutlet.lessmem/r.wateroutlet.lessmem.html
@@ -21,8 +21,3 @@ to <em><a href="https://grass.osgeo.org/grass-stable/manuals/r.water.outlet.html
 <a href="mailto:grass4u@gmail com">Huidae Cho</a>
 <br>
 based on <a href="https://grass.osgeo.org/grass-stable/manuals/r.water.outlet.html">r.water.outlet</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.width.funct/r.width.funct.html
+++ b/src/raster/r.width.funct/r.width.funct.html
@@ -73,8 +73,3 @@ n. 9 (2010)</em>
 
 Margherita Di Leo (grass-dev AT lists DOT osgeo DOT org), Massimo Di 
 Stefano, Francesco Di Stefano
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster/r.zonal.classes/r.zonal.classes.html
+++ b/src/raster/r.zonal.classes/r.zonal.classes.html
@@ -155,8 +155,3 @@ Walloon region</a> as part of the WALOUS project.
 <h2>AUTHOR</h2>
 
 Tais GRIPPA - Universite Libre de Bruxelles. ANAGEO Lab.
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster3d/r3.count.categories/r3.count.categories.html
+++ b/src/raster3d/r3.count.categories/r3.count.categories.html
@@ -18,16 +18,11 @@ between 0 and 100. The values will be then preserved with precision 1
 
 <em>
 <a href="https://grass.osgeo.org/grass-stable/manuals/r3.to.rast.html">r3.to.rast</a>,
-<a href="r3.to.group.html">r3.to.group</a>,
+<a href="r3.to.group.html">r3.to.group</a> (addon),
 <a href="https://grass.osgeo.org/grass-stable/manuals/r3.what.html">r3.what</a>
 </em>
 
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Vaclav Petras, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU GeoForAll Lab</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster3d/r3.forestfrag/r3.forestfrag.html
+++ b/src/raster3d/r3.forestfrag/r3.forestfrag.html
@@ -81,14 +81,10 @@ Conservation Ecology 4(2): 3. [online] URL:
 
 
 <h2>AUTHORS</h2>
+
 Vaclav Petras,
 <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU GeoForAll Lab</a>
 <br>
 Paulo van Breugel,
 main author of the 2D version
 (<em><a href="r.forestfrag.html">r.forestfrag</a></em>)
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster3d/r3.profile/r3.profile.html
+++ b/src/raster3d/r3.profile/r3.profile.html
@@ -163,9 +163,5 @@ Approx. transect length: 995.014070 [meters]
 
 
 <h2>AUTHOR</h2>
-<a href="mailto:bcovill@tekmap.ns.ca">Bob Covill</a>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+<a href="mailto:bcovill@tekmap.ns.ca">Bob Covill</a>

--- a/src/raster3d/r3.to.group/r3.to.group.html
+++ b/src/raster3d/r3.to.group/r3.to.group.html
@@ -24,11 +24,6 @@ r3.to.rast
 </em>
 
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Vaclav Petras, <a href="http://geospatial.ncsu.edu/osgeorel/">NCSU GeoForAll Lab</a><br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/raster3d/r3.what/r3.what.html
+++ b/src/raster3d/r3.what/r3.what.html
@@ -52,10 +52,6 @@ r3.what input=new@user1 coordinates_3d=10,10,1,10,10,11
 <a href="https://grass.osgeo.org/grass-stable/manuals/g.region.html">g.region</a>
 </em>
 
-<h2>AUTHORS</h2>
-Anna Petrasova, NCSU GeoForAll Lab
+<h2>AUTHOR</h2>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Anna Petrasova, NCSU GeoForAll Lab

--- a/src/temporal/t.rast.null/t.rast.null.html
+++ b/src/temporal/t.rast.null/t.rast.null.html
@@ -22,6 +22,6 @@ Set specific values (0,-1 and -2) of a space time raster dataset to NULL:
 <a href="https://grass.osgeo.org/grass-stable/manuals/r.null.html">r.null</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Luca Delucchi, Fondazione Edmund Mach

--- a/src/temporal/t.rast.null/t.rast.null.html
+++ b/src/temporal/t.rast.null/t.rast.null.html
@@ -22,10 +22,6 @@ Set specific values (0,-1 and -2) of a space time raster dataset to NULL:
 <a href="https://grass.osgeo.org/grass-stable/manuals/r.null.html">r.null</a>
 </em>
 
-<h2>AUTHOR</h2>
-Luca Delucchi, Fondazione Edmund Mach
+<h2>AUTHORS</h2>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Luca Delucchi, Fondazione Edmund Mach

--- a/src/temporal/t.rast.patch/t.rast.patch.html
+++ b/src/temporal/t.rast.patch/t.rast.patch.html
@@ -37,10 +37,6 @@ r.info LST_Day_patched_2016
 <p>
 <a href="http://grasswiki.osgeo.org/wiki/Temporal_data_processing">Temporal data processing Wiki</a>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Anika Bettge, mundialis GmbH &amp; Co. KG
-
-<!--
-<p><i>Last changed: $Date$</i>
--->

--- a/src/temporal/t.rast.patch/t.rast.patch.html
+++ b/src/temporal/t.rast.patch/t.rast.patch.html
@@ -37,6 +37,6 @@ r.info LST_Day_patched_2016
 <p>
 <a href="http://grasswiki.osgeo.org/wiki/Temporal_data_processing">Temporal data processing Wiki</a>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Anika Bettge, mundialis GmbH &amp; Co. KG

--- a/src/temporal/t.rast.what.aggr/t.rast.what.aggr.html
+++ b/src/temporal/t.rast.what.aggr/t.rast.what.aggr.html
@@ -144,4 +144,5 @@ cat|station|name|long|lat|fechas|ndvi_mean|ndvi_max|ndvi_16_5600m_minimum|ndvi_1
 
 <h2>AUTHORS</h2>
 
-Luca Delucchi
+Luca Delucchi<br>
+Documentation by Veronica Andreo 

--- a/src/temporal/t.rast.what.aggr/t.rast.what.aggr.html
+++ b/src/temporal/t.rast.what.aggr/t.rast.what.aggr.html
@@ -142,11 +142,6 @@ cat|station|name|long|lat|fechas|ndvi_mean|ndvi_max|ndvi_16_5600m_minimum|ndvi_1
 <p>
 <a href="https://grasswiki.osgeo.org/wiki/Temporal_data_processing">GRASS GIS Wiki: temporal data processing</a>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Luca Delucchi
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/temporal/t.rast.whatcsv/t.rast.whatcsv.html
+++ b/src/temporal/t.rast.whatcsv/t.rast.whatcsv.html
@@ -126,11 +126,6 @@ x|y|1990-03-01 00:00:00;1990-04-01 00:00:00|1990-04-01 00:00:00;1990-05-01 00:00
 </em>
 
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 S&ouml;ren Gebbert, Th&uuml;nen Institute of Climate-Smart Agriculture
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/temporal/t.rast.whatcsv/t.rast.whatcsv.html
+++ b/src/temporal/t.rast.whatcsv/t.rast.whatcsv.html
@@ -126,6 +126,6 @@ x|y|1990-03-01 00:00:00;1990-04-01 00:00:00|1990-04-01 00:00:00;1990-05-01 00:00
 </em>
 
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 S&ouml;ren Gebbert, Th&uuml;nen Institute of Climate-Smart Agriculture

--- a/src/vector/v.area.weigh/v.area.weigh.html
+++ b/src/vector/v.area.weigh/v.area.weigh.html
@@ -46,8 +46,3 @@ v.area.weigh vector=... column=... weight=urban_ngbr5 out=...
 <h2>AUTHOR</h2>
 
 Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.build.pg/v.build.pg.html
+++ b/src/vector/v.build.pg/v.build.pg.html
@@ -107,8 +107,3 @@ SELECT topology.TopologySummary('topo_bridges')
 <h2>AUTHOR</h2>
 
 Martin Landa, Czech Technical University in Prague, Czech Republic
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.centerline/v.centerline.html
+++ b/src/vector/v.centerline/v.centerline.html
@@ -122,9 +122,5 @@ Similar addons:
 </em>
 
 <h2>AUTHOR</h2>
-Moritz Lennert
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Moritz Lennert

--- a/src/vector/v.centerpoint/v.centerpoint.html
+++ b/src/vector/v.centerpoint/v.centerpoint.html
@@ -76,8 +76,3 @@ v.centerpoint in=urbanarea out=urbanarea_median acenter=median
 <h2>AUTHOR</h2>
 
 Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.class.ml/v.class.ml.html
+++ b/src/vector/v.class.ml/v.class.ml.html
@@ -208,8 +208,3 @@ for vector classification which uses <em>mlpy</em>)
 <h2>AUTHOR</h2>
 
 Pietro Zambelli, University of Trento
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.class.mlR/v.class.mlR.html
+++ b/src/vector/v.class.mlR/v.class.mlR.html
@@ -198,10 +198,6 @@ v.class.mlR segments_file=segstats.csv training_file=training.csv train_class_co
 </em>
 
 <h2>AUTHOR</h2>
+
 Moritz Lennert, Université Libre de Bruxelles (ULB)
 based on an initial R-script by Ruben Van De Kerchove, also ULB at the time
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.class.mlpy/v.class.mlpy.html
+++ b/src/vector/v.class.mlpy/v.class.mlpy.html
@@ -110,8 +110,3 @@ D. Albanese, R. Visintainer, S. Merler, S. Riccadonna, G. Jurman, C. Furlanello.
 
 Vaclav Petras,
 <a href="http://www.cvut.cz">Czech Technical University in Prague</a>, Czech Republic
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.clean.ogr/v.clean.ogr.html
+++ b/src/vector/v.clean.ogr/v.clean.ogr.html
@@ -72,11 +72,6 @@ Two new Shapefile layers &quot;research_area_clean&quot; and
 <a href="https://grass.osgeo.org/grass-stable/manuals/v.out.ogr.html">v.out.ogr</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
-Markus Metz<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Markus Metz

--- a/src/vector/v.colors2/v.colors2.html
+++ b/src/vector/v.colors2/v.colors2.html
@@ -79,23 +79,17 @@ d.vect -a tin
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="https://grass.osgeo.org/grass-stable/manuals/d.vect.html">d.vect</a> -z<br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/r.colors.html">r.colors</a><br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/r.colors.stddev.html">r.colors.stddev</a><br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/r.what.color.html">r.what.color</a><br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/v.db.addcolumn">v.db.addcolumn</a><br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/v.db.select.html">v.db.select</a><br>
+<a href="https://grass.osgeo.org/grass-stable/manuals/d.vect.html">d.vect</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.colors.html">r.colors</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.colors.stddev.html">r.colors.stddev</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.what.color.html">r.what.color</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/v.db.addcolumn">v.db.addcolumn</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/v.db.select.html">v.db.select</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/db.execute.html">db.execute</a>
 </em>
-
 
 
 <h2>AUTHOR</h2>
 
 Hamish Bowman<br>
 <i>Dunedin, New Zealand</i>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.concave.hull/v.concave.hull.html
+++ b/src/vector/v.concave.hull/v.concave.hull.html
@@ -38,9 +38,5 @@ v.concave.hull in=schools_wake out=schools_wake_concave
 </em>
 
 <h2>AUTHOR</h2>
-Markus Metz
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Markus Metz

--- a/src/vector/v.convert.all/v.convert.all.html
+++ b/src/vector/v.convert.all/v.convert.all.html
@@ -39,8 +39,3 @@ v.convert.all
 <h2>AUTHOR</h2>
 
 Markus Neteler, ITC-Irst, Trento, Italy
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.convert/v.convert.html
+++ b/src/vector/v.convert/v.convert.html
@@ -33,8 +33,3 @@ v.convert in=vectormap_from_50 out=vectormap_60
 <h2>AUTHOR</h2>
 
 Radim Blazek, ITC-Irst, Trento, Italy
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.db.pyupdate/v.db.pyupdate.html
+++ b/src/vector/v.db.pyupdate/v.db.pyupdate.html
@@ -210,8 +210,3 @@ v.db.pyupdate map=buildings column="name" expression="f'Building num. {building_
 <h2>AUTHOR</h2>
 
 Vaclav Petras, <a href="http://geospatial.ncsu.edu/">NCSU Center for Geospatial Analytics</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.delaunay3d/v.delaunay3d.html
+++ b/src/vector/v.delaunay3d/v.delaunay3d.html
@@ -34,12 +34,6 @@ Number of triangles: 1019
 Number of tetrahedrons: 492
 </pre></div>
 
-<h2>SEE ALSO</h2>
-
-<em>
-<a href="https://grass.osgeo.org/grass-stable/manuals/v.delaunay.html">v.delaunay</a>
-</em>
-
 <h2>REFERENCES</h2>
 
 <ul>
@@ -47,11 +41,12 @@ Number of tetrahedrons: 492
   4.2 - 3D Triangulations</a>
 </ul>
 
+<h2>SEE ALSO</h2>
+
+<em>
+<a href="https://grass.osgeo.org/grass-stable/manuals/v.delaunay.html">v.delaunay</a>
+</em>
+
 <h2>AUTHOR</h2>
 
 Martin Landa, Czech Technical University in Prague, Czech Republic
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.ellipse/v.ellipse.html
+++ b/src/vector/v.ellipse/v.ellipse.html
@@ -40,8 +40,3 @@ v.ellipse input=points_of_interest output=ellipse step=1
 <h2>AUTHOR</h2>
 
 Tereza Fiedlerova, OSGeoREL, Czech Technical University in Prague, Czech Republic
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.external.all/v.external.all.html
+++ b/src/vector/v.external.all/v.external.all.html
@@ -60,8 +60,3 @@ v.external.all -l input=~/geodata/ncshape/
 <h2>AUTHOR</h2>
 
 Martin Landa, Czech Technical University in Prague
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.faultdirections/v.faultdirections.html
+++ b/src/vector/v.faultdirections/v.faultdirections.html
@@ -41,9 +41,5 @@ v.faultdirections faultmap column=azimuth step=10
 </em>
 
 <h2>AUTHOR</h2>
- Moritz Lennert
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Moritz Lennert

--- a/src/vector/v.feature.algebra/v.feature.algebra.html
+++ b/src/vector/v.feature.algebra/v.feature.algebra.html
@@ -263,8 +263,3 @@ equal sign. The very first expression, hence, will give an error:
 <h2>AUTHOR</h2>
 
 Christoph Simon &lt;ciccio at kiosknet com.br&gt;
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.fixed.segmentpoints/v.fixed.segmentpoints.html
+++ b/src/vector/v.fixed.segmentpoints/v.fixed.segmentpoints.html
@@ -1,6 +1,5 @@
 <h2>DESCRIPTION</h2>
 
-<p>
 <em>v.fixed.segmentpoints</em> creates segment points along a vector 
 line with fixed distances by using the <em>v.segment</em> module. A 
 category of one line has to be given. Start and end point of the line 
@@ -44,8 +43,3 @@ The <em>category (cat)</em> of the input line is stored in the column
 <h2>AUTHOR</h2>
 
 Helmut Kudrnovsky
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.flexure/v.flexure.html
+++ b/src/vector/v.flexure/v.flexure.html
@@ -17,7 +17,7 @@ The <a href="http://csdms.colorado.edu">Community Surface Dynamics Modeling Syst
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="v.flexure.html">v.flexure</a>
+<a href="v.flexure.html">v.flexure</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/v.surf.bspline.html">v.surf.bspline</a>
 </em>
 
@@ -30,11 +30,6 @@ Wickert, A. D., G. E. Tucker, E. W. H. Hutton, B. Yan, and S. D. Peckham (2011),
 <p>
 van Wees, J. D., and S. Cloetingh (1994), A Finite-Difference Technique to Incorporate Spatial Variations In Rigidity and Planar Faults Into 3-D Models For Lithospheric Flexure, <i>Geophysical Journal International</i>, <i>117</i>(1), 179&ndash;195, doi:10.1111/j.1365-246X.1994.tb03311.x.
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
-Andrew D. Wickert<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Andrew D. Wickert

--- a/src/vector/v.greedycolors/v.greedycolors.html
+++ b/src/vector/v.greedycolors/v.greedycolors.html
@@ -72,11 +72,6 @@ v.db.update map=my_boundary_county column=GRASSRGB value="255:255:153" where="gr
 <a href="v.category.html">v.category</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
-Markus Metz, mundialis<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Markus Metz, mundialis, Germany

--- a/src/vector/v.gsflow.export/v.gsflow.export.html
+++ b/src/vector/v.gsflow.export/v.gsflow.export.html
@@ -13,21 +13,16 @@ Ng, G.-H. C., A. D. Wickert, R. L. McLaughlin, J. La Frenierre, S. Liess, and L.
 <h2>SEE ALSO</h2>
 
 <em>
-  <a href="v.gsflow.gravres">v.gsflow.gravres</a><br>
-  <a href="v.gsflow.grid">v.gsflow.grid</a><br>
-  <a href="v.gsflow.hruparams">v.gsflow.hruparams</a><br>
-  <a href="v.gsflow.reaches">v.gsflow.reaches</a><br>
-  <a href="v.gsflow.segments">v.gsflow.segments</a><br>
-  <a href="v.gsflow.mapdata">v.gsflow.mapdata</a><br>
-  <a href="v.stream.inbasin">v.stream.inbasin</a><br>
-  <a href="v.stream.network">v.stream.network</a>
+  <a href="v.gsflow.gravres.html">v.gsflow.gravres</a>,
+  <a href="v.gsflow.grid.html">v.gsflow.grid</a>,
+  <a href="v.gsflow.hruparams.html">v.gsflow.hruparams</a>,
+  <a href="v.gsflow.reaches.html">v.gsflow.reaches</a>,
+  <a href="v.gsflow.segments.html">v.gsflow.segments</a>,
+  <a href="v.gsflow.mapdata.html">v.gsflow.mapdata</a>,
+  <a href="v.stream.inbasin.html">v.stream.inbasin</a>,
+  <a href="v.stream.network.html">v.stream.network</a>
 </em>
 
 <h2>AUTHOR</h2>
 
-Andrew D. Wickert<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Andrew D. Wickert

--- a/src/vector/v.gsflow.gravres/v.gsflow.gravres.html
+++ b/src/vector/v.gsflow.gravres/v.gsflow.gravres.html
@@ -10,20 +10,18 @@ glaciated watersheds to climate change, in AGU Fall Meeting Abstracts, H13L–15
 Francisco, CA.
 
 <h2>SEE ALSO</h2>
-<a href="v.gsflow.export">v.gsflow.export</a><br>
-<a href="v.gsflow.grid">v.gsflow.grid</a><br>
-<a href="v.gsflow.hruparams">v.gsflow.hruparams</a><br>
-<a href="v.gsflow.reaches">v.gsflow.reaches</a><br>
-<a href="v.gsflow.segments">v.gsflow.segments</a><br>
-<a href="v.gsflow.mapdata">v.gsflow.mapdata</a><br>
-<a href="v.stream.inbasin">v.stream.inbasin</a><br>
+
+<em>
+<a href="v.gsflow.export">v.gsflow.export</a>,
+<a href="v.gsflow.grid">v.gsflow.grid</a>,
+<a href="v.gsflow.hruparams">v.gsflow.hruparams</a>,
+<a href="v.gsflow.reaches">v.gsflow.reaches</a>,
+<a href="v.gsflow.segments">v.gsflow.segments</a>,
+<a href="v.gsflow.mapdata">v.gsflow.mapdata</a>,
+<a href="v.stream.inbasin">v.stream.inbasin</a>,
 <a href="v.stream.network">v.stream.network</a>
+</em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
-Andrew D. Wickert<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Andrew D. Wickert

--- a/src/vector/v.gsflow.grid/v.gsflow.grid.html
+++ b/src/vector/v.gsflow.grid/v.gsflow.grid.html
@@ -9,10 +9,6 @@ Modeling the role of groundwater and vegetation in the hydrological response of 
 glaciated watersheds to climate change, in AGU Fall Meeting Abstracts, H13L–1590, San
 Francisco, CA.
 
-<h2>AUTHORS</h2>
-
-Andrew D. Wickert<br>
-
 <h2>SEE ALSO</h2>
 <a href="v.gsflow.export">v.gsflow.export</a>,
 <a href="v.gsflow.gravres">v.gsflow.gravres</a>,
@@ -22,9 +18,8 @@ Andrew D. Wickert<br>
 <a href="v.gsflow.mapdata.html">v.gsflow.mapdata</a>,
 <a href="r.gsflow.hydrodem.html">r.gsflow.hydrodem</a>,
 <a href="v.stream.inbasin.html">v.stream.inbasin</a>,
-<a href="v.stream.network.html">v.stream.network</a>,
+<a href="v.stream.network.html">v.stream.network</a>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+<h2>AUTHOR</h2>
+
+Andrew D. Wickert

--- a/src/vector/v.gsflow.hruparams/v.gsflow.hruparams.html
+++ b/src/vector/v.gsflow.hruparams/v.gsflow.hruparams.html
@@ -10,20 +10,15 @@ glaciated watersheds to climate change, in AGU Fall Meeting Abstracts, H13L–15
 Francisco, CA.
 
 <h2>SEE ALSO</h2>
-<a href="v.gsflow.export">v.gsflow.export</a><br>
-<a href="v.gsflow.gravres">v.gsflow.gravres</a><br>
-<a href="v.gsflow.grid">v.gsflow.grid</a><br>
-<a href="v.gsflow.reaches">v.gsflow.reaches</a><br>
-<a href="v.gsflow.segments">v.gsflow.segments</a><br>
-<a href="v.gsflow.mapdata">v.gsflow.mapdata</a><br>
-<a href="v.stream.inbasin">v.stream.inbasin</a><br>
-<a href="v.stream.network">v.stream.network</a>
+<a href="v.gsflow.export.html">v.gsflow.export</a>,
+<a href="v.gsflow.gravres.html">v.gsflow.gravres</a>,
+<a href="v.gsflow.grid.html">v.gsflow.grid</a>,
+<a href="v.gsflow.reaches.html">v.gsflow.reaches</a>,
+<a href="v.gsflow.segments.html">v.gsflow.segments</a>,
+<a href="v.gsflow.mapdata.html">v.gsflow.mapdata</a>,
+<a href="v.stream.inbasin.html">v.stream.inbasin</a>,
+<a href="v.stream.network.html">v.stream.network</a>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
-Andrew D. Wickert<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Andrew D. Wickert

--- a/src/vector/v.gsflow.mapdata/v.gsflow.mapdata.html
+++ b/src/vector/v.gsflow.mapdata/v.gsflow.mapdata.html
@@ -10,11 +10,9 @@ An average (<a href="https://grass.osgeo.org/grass-stable/manuals/v.rast.stats.h
 Raster data<br>
 Vector area data with data in the column that is queried that is of "double precision" type<br>
 
-<h2>AUTHORS</h2>
-
-Andrew D. Wickert<br>
-
 <h2>SEE ALSO</h2>
+
+<em>
 <a href="v.gsflow.export">v.gsflow.export</a>,
 <a href="v.gsflow.gravres">v.gsflow.gravres</a>,
 <a href="v.gsflow.grid">v.gsflow.grid</a>,
@@ -24,8 +22,8 @@ Andrew D. Wickert<br>
 <a href="r.gsflow.hydrodem.html">r.gsflow.hydrodem</a>,
 <a href="v.stream.inbasin.html">v.stream.inbasin</a>,
 <a href="v.stream.network.html">v.stream.network</a>
+</em>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+<h2>AUTHOR</h2>
+
+Andrew D. Wickert

--- a/src/vector/v.gsflow.reaches/v.gsflow.reaches.html
+++ b/src/vector/v.gsflow.reaches/v.gsflow.reaches.html
@@ -1,6 +1,8 @@
 <h2>DESCRIPTION</h2>
 
-<em>v.gsflow.reaches</em> produces channel "reaches", which are the intersection between PRMS stream segments and MODFLOW grid cells, for the USGS combined groundwater and surface-water model GSFLOW.
+<em>v.gsflow.reaches</em> produces channel "reaches", which are the
+intersection between PRMS stream segments and MODFLOW grid cells, for
+the USGS combined groundwater and surface-water model GSFLOW.
 
 <h2>REFERENCES</h2>
 
@@ -10,20 +12,15 @@ glaciated watersheds to climate change, in AGU Fall Meeting Abstracts, H13L–15
 Francisco, CA.
 
 <h2>SEE ALSO</h2>
-<a href="v.gsflow.export">v.gsflow.export</a><br>
-<a href="v.gsflow.gravres">v.gsflow.gravres</a><br>
-<a href="v.gsflow.grid">v.gsflow.grid</a><br>
-<a href="v.gsflow.hruparams">v.gsflow.hruparams</a><br>
-<a href="v.gsflow.segments">v.gsflow.segments</a><br>
-<a href="v.gsflow.mapdata">v.gsflow.mapdata</a><br>
-<a href="v.stream.inbasin">v.stream.inbasin</a><br>
+<a href="v.gsflow.export">v.gsflow.export</a>,
+<a href="v.gsflow.gravres">v.gsflow.gravres</a>,
+<a href="v.gsflow.grid">v.gsflow.grid</a>,
+<a href="v.gsflow.hruparams">v.gsflow.hruparams</a>,
+<a href="v.gsflow.segments">v.gsflow.segments</a>,
+<a href="v.gsflow.mapdata">v.gsflow.mapdata</a>,
+<a href="v.stream.inbasin">v.stream.inbasin</a>,
 <a href="v.stream.network">v.stream.network</a>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
-Andrew D. Wickert<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Andrew D. Wickert

--- a/src/vector/v.gsflow.segments/v.gsflow.segments.html
+++ b/src/vector/v.gsflow.segments/v.gsflow.segments.html
@@ -1,6 +1,10 @@
 <h2>DESCRIPTION</h2>
 
-<em>v.gsflow.segments</em> produces channel segments that are each one link in the full drainage network. Each segment also corresponds to a hydrologic response unit (HRU) in this formulation. These are used for the USGS combined groundwater (MODFLOW) and surface-water (PRMS) model GSFLOW.
+<em>v.gsflow.segments</em> produces channel segments that are each one
+link in the full drainage network. Each segment also corresponds to a
+hydrologic response unit (HRU) in this formulation. These are used for
+the USGS combined groundwater (MODFLOW) and surface-water (PRMS) model
+GSFLOW.
 
 <h2>REFERENCES</h2>
 
@@ -10,20 +14,15 @@ glaciated watersheds to climate change, in AGU Fall Meeting Abstracts, H13L–15
 Francisco, CA.
 
 <h2>SEE ALSO</h2>
-<a href="v.gsflow.export">v.gsflow.export</a><br>
-<a href="v.gsflow.gravres">v.gsflow.gravres</a><br>
-<a href="v.gsflow.grid">v.gsflow.grid</a><br>
-<a href="v.gsflow.hruparams">v.gsflow.hruparams</a><br>
-<a href="v.gsflow.reaches">v.gsflow.reaches</a><br>
-<a href="v.gsflow.mapdata">v.gsflow.mapdata</a><br>
-<a href="v.stream.inbasin">v.stream.inbasin</a><br>
-<a href="v.stream.network">v.stream.network</a>
+<a href="v.gsflow.export.html">v.gsflow.export</a>,
+<a href="v.gsflow.gravres.html">v.gsflow.gravres</a>,
+<a href="v.gsflow.grid.html">v.gsflow.grid</a>,
+<a href="v.gsflow.hruparams.html">v.gsflow.hruparams</a>,
+<a href="v.gsflow.reaches.html">v.gsflow.reaches</a>,
+<a href="v.gsflow.mapdata.html">v.gsflow.mapdata</a>,
+<a href="v.stream.inbasin.html">v.stream.inbasin</a>,
+<a href="v.stream.network.html">v.stream.network</a>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
-Andrew D. Wickert<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Andrew D. Wickert

--- a/src/vector/v.habitat.dem/v.habitat.dem.html
+++ b/src/vector/v.habitat.dem/v.habitat.dem.html
@@ -241,8 +241,3 @@ Neteler, M. and Mitasova, H. 2008. <a href="https://grassbook.org/">Open Source 
 <h2>AUTHOR</h2>
 
 Helmut Kudrnovsky
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.in.csv/v.in.csv.html
+++ b/src/vector/v.in.csv/v.in.csv.html
@@ -8,7 +8,7 @@ pipe (<code>|</code>), or tabulator.
 
 <h2>NOTES</h2>
 
-The module requires on pyproj Python package to work.
+The module requires the "pyproj" Python package to work.
 
 <h2>EXAMPLES</h2>
 
@@ -38,8 +38,3 @@ v.in.csv input=latest_sites.csv output=sampling_sites latitude=Site_Lat longitud
 <h2>AUTHOR</h2>
 
 Vaclav Petras, <a href="http://geospatial.ncsu.edu/">NCSU Center for Geospatial Analytics</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.in.gbif/v.in.gbif.html
+++ b/src/vector/v.in.gbif/v.in.gbif.html
@@ -43,17 +43,12 @@ instead.
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="https://grass.osgeo.org/grass-stable/manuals/v.import.html">v.import</a>
-<a href="https://grass.osgeo.org/grass-stable/manuals/v.in.ascii.html">v.in.ascii</a>
-<a href="https://grass.osgeo.org/grass-stable/manuals/v.in.ogr.html">v.in.ogr</a>
+<a href="https://grass.osgeo.org/grass-stable/manuals/v.import.html">v.import</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/v.in.ascii.html">v.in.ascii</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/v.in.ogr.html">v.in.ogr</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/v.proj.html">v.proj</a>
 </em>
 
 <h2>AUTHOR</h2>
 
 Helmut Kudrnovsky
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.in.geopaparazzi/v.in.geopaparazzi.html
+++ b/src/vector/v.in.geopaparazzi/v.in.geopaparazzi.html
@@ -28,8 +28,3 @@ v.in.geopaparazzi -tz database=/path/to/geopaparazzi.db base=track3d
 <h2>AUTHOR</h2>
 
 Luca Delucchi
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.in.gns/v.in.gns.html
+++ b/src/vector/v.in.gns/v.in.gns.html
@@ -33,8 +33,3 @@ points map.
 <h2>AUTHOR</h2>
 
 Markus Neteler, MPBA Group, ITC-irst, Trento, Italy
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.in.gps/v.in.gps.html
+++ b/src/vector/v.in.gps/v.in.gps.html
@@ -27,6 +27,14 @@ flag, otherwise they will be imported as lines. You can run <em>v.in.gps</em>
 multiple times and merge the line and point vectors with the <em>v.patch</em>
 command if you want, but take care when merging dissimilar attribute tables.
 
+<!--
+When we tested the script with a Garmin GPS we noticed that importing waypoints
+the <i>time</i> field is not correctly set. The data reported is
+a default system time, while with a gpx text file this thing did not
+happen. We believe that is a <i>gpsbabel</i> trouble in translating
+from <i>garmin</i> to <i>xcsv</i> ...
+-->
+
 <h2>EXAMPLES</h2>
 
 <h3>GPS device connected via USB adapter</h3>
@@ -80,22 +88,9 @@ v.in.gps -r -p file=/dev/gps format=garmin output=routePoints
 cs2cs from <a href="https://proj.org/">PROJ</a>
 
 <h2>AUTHORS</h2>
+
 Claudio Porta and Lucio Davide Spano, students of Computer Science at
 University of Pisa (Italy).<br>
 Commission from Faunalia Pontedera (PI)<br><br>
 Based on <em>v.in.garmin</em> for GRASS 6.0 by Hamish Bowman<br>
 and <em>v.in.garmin.sh</em> for GRASS 5 by Andreas Lange
-<br>
-
-<!--
-When we tested the script with a Garmin GPS we noticed that importing waypoints 
-the <i>time</i> field is not correctly set. The data reported is 
-a default system time, while with a gpx text file this thing did not 
-happen. We believe that is a <i>gpsbabel</i> trouble in translating 
-from <i>garmin</i> to <i>xcsv</i> ... 
--->
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.in.natura2000/v.in.natura2000.html
+++ b/src/vector/v.in.natura2000/v.in.natura2000.html
@@ -87,16 +87,11 @@ output=pa_austria member_state=AT
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="https://grass.osgeo.org/grass-stable/manuals/v.import.html">v.import</a>
-<a href="https://grass.osgeo.org/grass-stable/manuals/v.in.ogr.html">v.in.ogr</a>
+<a href="https://grass.osgeo.org/grass-stable/manuals/v.import.html">v.import</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/v.in.ogr.html">v.in.ogr</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/v.proj.html">v.proj</a>
 </em>
 
 <h2>AUTHOR</h2>
 
 Helmut Kudrnovsky
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.in.ogc/v.in.ogc.features/v.in.ogc.features.html
+++ b/src/vector/v.in.ogc/v.in.ogc.features/v.in.ogc.features.html
@@ -20,7 +20,3 @@ More info about <a href="https://ogcapi.ogc.org/features/" target="blank">OGC AP
 <h2>AUTHOR</h2>
 
 Luca Delucchi, Fondazione Edmund Mach, during Joint OGC OSGeo ASF Code Sprint 2021.
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.in.ogc/v.in.ogc.html
+++ b/src/vector/v.in.ogc/v.in.ogc.html
@@ -38,10 +38,6 @@ g.extension v.in.ogc
 <a href="v.in.ogc.features.html">v.in.ogc.features</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Luca Delucchi, Fondazione Edmund Mach, during Joint OGC OSGeo ASF Code Sprint 2021.
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.in.osm/v.in.osm.html
+++ b/src/vector/v.in.osm/v.in.osm.html
@@ -28,11 +28,6 @@ PostgreSQL, PostGIS, <a href="http://wiki.openstreetmap.org/wiki/Osm2pgsql">osm2
 <a href="https://grass.osgeo.org/grass-stable/manuals/v.in.ogr.html">v.in.ogr</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Stepan Turek
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.in.ply/v.in.ply.html
+++ b/src/vector/v.in.ply/v.in.ply.html
@@ -26,11 +26,6 @@ v.in.ply input=myfile.ply output=myfile
 <br>
 <a href="http://www.cc.gatech.edu/projects/large_models/ply.html">http://www.cc.gatech.edu/projects/large_models/ply.html</a>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.in.redlist/v.in.redlist.html
+++ b/src/vector/v.in.redlist/v.in.redlist.html
@@ -40,8 +40,3 @@ One of the species mentioned by <i>-l</i> or <i>-s</i> flag has to be specified 
 <h2>AUTHOR</h2>
 
 Helmut Kudrnovsky
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.in.redwg/v.in.redwg.html
+++ b/src/vector/v.in.redwg/v.in.redwg.html
@@ -33,8 +33,3 @@ Not all entity types are supported (warning printed).
 
 Rodrigo Rodrigues da Silva (pitanga at members dot fsf dot org), São Paulo, Brazil
 <br>based on original code by Radim Blazek, ITC-Irst, Trento, Italy
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.in.survey/v.in.survey.html
+++ b/src/vector/v.in.survey/v.in.survey.html
@@ -265,13 +265,13 @@ Anything else cannot be accepted (in accordance to DXF settings). Default value:
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="https://grass.osgeo.org/grass-stable/manuals/v.in.ascii.html">v.in.ascii</a><br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/v.centroids.html">v.centroids</a><br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/g.remove.html">g.remove</a><br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/v.db.addtable">v.db.addtable</a><br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/v.db.update">v.db.update</a><br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/v.patch">v.patch</a><br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/v.clean">v.clean</a><br>
+<a href="https://grass.osgeo.org/grass-stable/manuals/v.in.ascii.html">v.in.ascii</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/v.centroids.html">v.centroids</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/g.remove.html">g.remove</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/v.db.addtable">v.db.addtable</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/v.db.update">v.db.update</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/v.patch">v.patch</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/v.clean">v.clean</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/v.out.dxf.html">v.out.dxf</a>
 </em>
 <br><br>
@@ -283,8 +283,3 @@ Engineering. ISSN 1802-2669. <a href="https://doi.org/10.14311/gi.15.2.2">DOI</a
 
 Eva Stopkova<br>
 functions for DXF conversion are taken from (or based on) the module <i>v.out.dxf</i> (Charles Ehlschlaeger and Radim Blazek)
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.in.wfs2/v.in.wfs2.html
+++ b/src/vector/v.in.wfs2/v.in.wfs2.html
@@ -22,4 +22,4 @@ v.in.wfs2 url=http://www2.dmsolutions.ca/cgi-bin/mswfs_gmap output=parks srs=423
 
 <h2>AUTHOR</h2>
 
-Štěpán Turek
+Stepan Turek

--- a/src/vector/v.in.wfs2/v.in.wfs2.html
+++ b/src/vector/v.in.wfs2/v.in.wfs2.html
@@ -20,11 +20,6 @@ v.in.wfs2 url=http://www2.dmsolutions.ca/cgi-bin/mswfs_gmap output=parks srs=423
 </em>
 
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Štěpán Turek
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.isochrones/v.isochrones.html
+++ b/src/vector/v.isochrones/v.isochrones.html
@@ -94,9 +94,5 @@ v.isochrones map=myroads cost_column=speed start_points=start isochrones=isochro
 </em>
 
 <h2>AUTHOR</h2>
-Moritz Lennert
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Moritz Lennert

--- a/src/vector/v.krige/v.krige.html
+++ b/src/vector/v.krige/v.krige.html
@@ -204,8 +204,3 @@ Isaaks and Srivastava, 1989: "An Introduction to Applied Geostatistics"
 <h2>AUTHOR</h2>
 
 Anne Ghisla, Google Summer of Code 2009
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.kriging/v.kriging.html
+++ b/src/vector/v.kriging/v.kriging.html
@@ -147,9 +147,4 @@ file=png out=lid792_500_linear crossval=lid792_500_xval_linear.txt -2 --o
 Eva Stopkova<br>
 functions taken from another modules are cited above the function or at
 the beginning of the file (e.g. <i>quantile.cpp</i> that uses slightly
-modified functions taken from the module <i>r.quantile</i> (Clemens, G.))
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+modified functions taken from the module <i>r.quantile</i> (Clements, G.))

--- a/src/vector/v.label.sa/v.label.sa.html
+++ b/src/vector/v.label.sa/v.label.sa.html
@@ -32,23 +32,21 @@ d.labels roads_labels
 
 
 <h2>REFERENCES</h2>
+
 Edmondson, Christensen, Marks and Shieber: A General Cartographic
 Labeling Algorithm, Cartographica, Vol. 33, No. 4, Winter 1996, pp. 13-23
 The algorithm works by the principle of Simulated Annealing.
 
 <h2>SEE ALSO</h2>
+
 <em>
 <a href="https://grass.osgeo.org/grass-stable/manuals/d.labels.html">d.labels</a>,
-<a href="https://grass.osgeo.org/grass-stable/manuals/v.label.html">v.label</a>
-<a href="https://grass.osgeo.org/grass-stable/manuals/ps.map.html">ps.map</a>
+<a href="https://grass.osgeo.org/grass-stable/manuals/v.label.html">v.label</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/ps.map.html">ps.map</a><br>
 <a href="http://en.wikipedia.org/wiki/Simulated_Annealing">Wikipedia article on simulated annealing</a>
 </em><br>
 
 <h2>AUTHOR</h2>
-Wolf Bergenheim
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Wolf Bergenheim
 

--- a/src/vector/v.lidar.mcc/v.lidar.mcc.html
+++ b/src/vector/v.lidar.mcc/v.lidar.mcc.html
@@ -90,17 +90,12 @@ optipng -o5 v_lidar_mcc.png
   <a href="https://grass.osgeo.org/grass-stable/manuals/v.lidar.edgedetection.html">v.lidar.edgedetection</a>
 </em>
 
-<h2>AUTHOR</h2>
-
-Stefan Blumentrath, Norwegian Institute for Nature Research (NINA), Oslo, Norway
-
 <h2>REFERENCES</h2>
 Evans, J. S. &amp; Hudak, A. T. 2007: A Multiscale Curvature Algorithm for Classifying Discrete Return LiDAR in Forested Environments. 
 IEEE TRANSACTIONS ON GEOSCIENCE AND REMOTE SENSING 45(4): 1029 - 1038. 
 <a href="http://www.fs.fed.us/rm/pubs_other/rmrs_2007_evans_j001.pdf">http://www.fs.fed.us/rm/pubs_other/rmrs_2007_evans_j001.pdf</a><br>
 <a href="http://sourceforge.net/p/mcclidar/wiki/Home/">http://sourceforge.net/p/mcclidar/wiki/Home/</a>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+<h2>AUTHOR</h2>
+
+Stefan Blumentrath, Norwegian Institute for Nature Research (NINA), Oslo, Norway

--- a/src/vector/v.mapcalc/v.mapcalc.html
+++ b/src/vector/v.mapcalc/v.mapcalc.html
@@ -122,9 +122,4 @@ sudo dnf install python-ply
 
 <h2>AUTHORS</h2>
 
-Thomas Leppelt, Soeren Gebbert, Thuenen Institut, Germany <br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Thomas Leppelt, Soeren Gebbert, Thuenen Institut, Germany

--- a/src/vector/v.maxent.swd/v.maxent.swd.html
+++ b/src/vector/v.maxent.swd/v.maxent.swd.html
@@ -54,8 +54,3 @@ and subsequently used in other models / functions.
 <h2>AUTHOR</h2>
 
 Paulo van Breugel, paulo at ecodiv.earth
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.mrmr/v.mrmr.html
+++ b/src/vector/v.mrmr/v.mrmr.html
@@ -55,8 +55,3 @@ Transactions on , vol.27, no.8, pp.1226-1238, Aug. 2005
 <h2>AUTHOR</h2>
 
 Steven Pawley
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.neighborhoodmatrix/v.neighborhoodmatrix.html
+++ b/src/vector/v.neighborhoodmatrix/v.neighborhoodmatrix.html
@@ -37,13 +37,9 @@ v.neighborhoodmatrix in=census_wake2000 idcolumn=STFID output=census_neighbors.c
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="https://grass.osgeo.org/grass-stable/manuals/v.to.db.html">v.to.db</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/v.to.db.html">v.to.db</a>
 </em>
 
 <h2>AUTHOR</h2>
- Moritz Lennert
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Moritz Lennert

--- a/src/vector/v.net.curvedarcs/v.net.curvedarcs.html
+++ b/src/vector/v.net.curvedarcs/v.net.curvedarcs.html
@@ -65,15 +65,10 @@ d.vect map=points display=shape,cat fill_color=red icon=basic/circle label_bcolo
 
 <em>
   <a href="https://grass.osgeo.org/grass-stable/manuals/v.net.html">v.net</a>,
-  <a href="https://grass.osgeo.org/grass-stable/manuals/v.segment.html">v.segment</a>,
+  <a href="https://grass.osgeo.org/grass-stable/manuals/v.segment.html">v.segment</a>
 </em>
 
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Moritz Lennert, DGES-ULB
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.net.salesman.opt/v.net.salesman.opt.html
+++ b/src/vector/v.net.salesman.opt/v.net.salesman.opt.html
@@ -84,13 +84,8 @@ v.net.salesman.opt in=streets_schools ccats=1-167 out=schools_tour_bs method=bs
 <em><a href="https://grass.osgeo.org/grass-stable/manuals/v.net.path.html">v.net.path</a></em>,
 <em><a href="https://grass.osgeo.org/grass-stable/manuals/v.net.steiner.html">v.net.steiner</a></em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Radim Blazek, ITC-Irst, Trento, Italy<br>
 Markus Metz<br>
 Documentation: Markus Neteler, Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.nnstat/v.nnstat.html
+++ b/src/vector/v.nnstat/v.nnstat.html
@@ -186,8 +186,3 @@ Eva Stopkova<br> functions for computation of Minimum Bounding Box
 volume (Minimum Bounding Rectangle area) are based on functions for
 computing convex hull from the module <i>v.hull</i> (Aime, A.,
 Neteler, M., Ducke, B., Landa, M.)
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.out.gps/v.out.gps.html
+++ b/src/vector/v.out.gps/v.out.gps.html
@@ -77,8 +77,9 @@ v.out.gps -r input=routes format=garmin output=/dev/ttyUSB0
 
 
 <h2>SEE ALSO</h2>
+
 <em>
-<a href="m.proj.html">m.proj</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/m.proj.html">m.proj</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/v.in.ascii.html">v.in.ascii</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/v.out.ascii.html">v.out.ascii</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/v.db.renamecolumn.html">v.db.renamecolumn</a>,
@@ -90,10 +91,6 @@ The <a href="http://www.gdal.org/ogr/drv_gpx.html">GDAL/OGR GPX format page</a><
 cs2cs from <a href="http://proj.osgeo.org">PROJ.4</a><br>
 
 
-<h2>AUTHOR</h2>
-Hamish Bowman, Dunedin New Zealand
+<h2>AUTHORS</h2>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Hamish Bowman, Dunedin, New Zealand

--- a/src/vector/v.out.gps/v.out.gps.html
+++ b/src/vector/v.out.gps/v.out.gps.html
@@ -91,6 +91,6 @@ The <a href="http://www.gdal.org/ogr/drv_gpx.html">GDAL/OGR GPX format page</a><
 cs2cs from <a href="http://proj.osgeo.org">PROJ.4</a><br>
 
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Hamish Bowman, Dunedin, New Zealand

--- a/src/vector/v.out.ply/v.out.ply.html
+++ b/src/vector/v.out.ply/v.out.ply.html
@@ -23,13 +23,8 @@ any <em>point</em> data within the vector map is sent to stdout.
 <a href="v.in.ply.html">v.in.ply</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Markus Metz
 <br>
 based on <a href="https://grass.osgeo.org/grass-stable/manuals/v.out.ascii.html">v.out.ascii</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.out.png/v.out.png.html
+++ b/src/vector/v.out.png/v.out.png.html
@@ -25,8 +25,3 @@ georeferencing support using the <b>-w</b> flag.
 
 Luca Delucchi<br>
 World file support by Anika Bettge and Markus Neteler
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.ply.rectify/v.ply.rectify.html
+++ b/src/vector/v.ply.rectify/v.ply.rectify.html
@@ -58,8 +58,3 @@ the georeferenced point cloud shifted to the coordinates' center, and
 <h2>AUTHOR</h2>
 
 Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.profile.points/v.profile.points.html
+++ b/src/vector/v.profile.points/v.profile.points.html
@@ -52,9 +52,5 @@ v.profile.points input_file=.../points.las output=points_profile width=5 \
 </pre></div>
 
 <h2>AUTHOR</h2>
-Vaclav Petras, <a href="https://geospatial.ncsu.edu/osgeorel/">NCSU GeoForAll Lab</a>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Vaclav Petras, <a href="https://geospatial.ncsu.edu/osgeorel/">NCSU GeoForAll Lab</a>

--- a/src/vector/v.rast.bufferstats/v.rast.bufferstats.html
+++ b/src/vector/v.rast.bufferstats/v.rast.bufferstats.html
@@ -50,16 +50,14 @@ Currently, the module uses GRASS native buffering through pygrass which should b
 https://trac.osgeo.org/grass/ticket/3628
 </p>
 
-
 <h2>SEE ALSO</h2>
+
+<em>
 <a href="https://grass.osgeo.org/grass-stable/manuals/r.univar.html">r.univar</a>
 <a href="https://grass.osgeo.org/grass-stable/manuals/r.stats.html">r.stats</a>
 <a href="https://grass.osgeo.org/grass-stable/manuals/v.rast.stats.html">v.rast.stats</a>
+</em>
 
 <h2>AUTHOR</h2>
-Stefan Blumentrath, Norwegian Institute for Nature Research, Oslo, Norway
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Stefan Blumentrath, Norwegian Institute for Nature Research, Oslo, Norway

--- a/src/vector/v.sort.points/v.sort.points.html
+++ b/src/vector/v.sort.points/v.sort.points.html
@@ -19,9 +19,5 @@ d.vect -r map=sorted_schools@user1 type=point,line,boundary,area,face width=1 ic
 </pre></div>
 
 <h2>AUTHOR</h2>
-Moritz Lennert
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Moritz Lennert

--- a/src/vector/v.stats/v.stats.html
+++ b/src/vector/v.stats/v.stats.html
@@ -4,9 +4,4 @@ The <em>v.stats</em> calculates vector statistics.
 
 <h2>AUTHOR</h2>
 
- Pietro Zambelli (University of Trento)
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Pietro Zambelli (University of Trento)

--- a/src/vector/v.strds.stats/v.strds.stats.html
+++ b/src/vector/v.strds.stats/v.strds.stats.html
@@ -22,8 +22,3 @@ v.strds.stats input=myvector strds=mystrds output=newvector
 <h2>AUTHOR</h2>
 
 Luca Delucchi, Fondazione Edmund Mach
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.stream.inbasin/v.stream.inbasin.html
+++ b/src/vector/v.stream.inbasin/v.stream.inbasin.html
@@ -10,15 +10,13 @@ glaciated watersheds to climate change, in AGU Fall Meeting Abstracts, H13L–15
 Francisco, CA.
 
 <h2>SEE ALSO</h2>
-<a href="v.gsflow.hruparams">v.gsflow.hruparams</a>
-<a href="v.gsflow.segments">v.gsflow.segments</a>
-<a href="v.stream.network">v.stream.network</a>
 
-<h2>AUTHORS</h2>
+<em>
+<a href="v.gsflow.hruparams.html">v.gsflow.hruparams</a>,
+<a href="v.gsflow.segments.html">v.gsflow.segments</a>,
+<a href="v.stream.network.html">v.stream.network</a>
+</em>
 
-Andrew D. Wickert<br>
+<h2>AUTHOR</h2>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Andrew D. Wickert

--- a/src/vector/v.stream.network/v.stream.network.html
+++ b/src/vector/v.stream.network/v.stream.network.html
@@ -31,22 +31,17 @@ print "Building drainage network"
 r.stream_extract(elevation=elevation, accumulation='drainageArea_m2', threshold=thresh, d8cut=0, mexp=0, stream_raster='streams', stream_vector='streams', direction='draindir', overwrite=True)
 </pre></div>
 
-<h2>SEE ALSO</h2>
-
-<em>
-<a href="https://grass.osgeo.org/grass-stable/manuals/r.stream.extract.html">r.stream.extract</a>
-<a href="v.stream.order">v.stream.order</a>
-</em>
-
 <h2>REFERENCES</h2>
 
 None (yet)
 
+<h2>SEE ALSO</h2>
+
+<em>
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.stream.extract.html">r.stream.extract</a>,
+<a href="v.stream.order.html">v.stream.order</a>
+</em>
+
 <h2>AUTHOR</h2>
 
-Andrew D. Wickert<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Andrew D. Wickert

--- a/src/vector/v.stream.order/v.stream.order.html
+++ b/src/vector/v.stream.order/v.stream.order.html
@@ -180,21 +180,20 @@ v.db.select stream_network_order | less
 </em>
 
 <h2>REFERENCES</h2>
+
+<em>
 <a href="https://grass.osgeo.org/grass-stable/manuals/r.stream.order.html">r.stream.order</a><br>
 <a href="https://en.wikipedia.org/wiki/Depth-first_search">Depth first search at Wikipedia</a><br>
 <a href="https://en.wikipedia.org/wiki/Strahler_number">Strahler number at Wikipedia</a><br>
+</em>
 
 <h2>AUTHOR</h2>
-<p>IGB-Berlin,Johannes Radinger; Implementation: Geoinformatikb&uuml;ro Dassau GmbH , Soeren Gebbert</p>
-<p>
-    This tool was developed as part of the BiodivERsA-net project 'FISHCON'
-    and has been funded by the German Federal Ministry for Education and
-    Research (grant number 01LC1205).
-</p>
-<p>Documentation of the implemented algorithms are in most parts copied from 
-   r.stream.order implemented by: Jarek  Jasiewicz and Markus Metz</p>
 
-<!--
+IGB-Berlin,Johannes Radinger; Implementation: Geoinformatikb&uuml;ro Dassau GmbH , Soeren Gebbert
 <p>
-<i>Last changed: $Date$</i>
--->
+This tool was developed as part of the BiodivERsA-net project 'FISHCON'
+and has been funded by the German Federal Ministry for Education and
+Research (grant number 01LC1205).
+<p>
+Documentation of the implemented algorithms are in most parts copied from
+r.stream.order implemented by: Jarek Jasiewicz and Markus Metz

--- a/src/vector/v.stream.order/v.stream.order.html
+++ b/src/vector/v.stream.order/v.stream.order.html
@@ -187,7 +187,7 @@ v.db.select stream_network_order | less
 <a href="https://en.wikipedia.org/wiki/Strahler_number">Strahler number at Wikipedia</a><br>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 IGB-Berlin,Johannes Radinger; Implementation: Geoinformatikb&uuml;ro Dassau GmbH , Soeren Gebbert
 <p>

--- a/src/vector/v.stream.profiler/v.stream.profiler.html
+++ b/src/vector/v.stream.profiler/v.stream.profiler.html
@@ -4,21 +4,16 @@
 
 It takes in the adjacency structure supplied by <a href="v.stream.network">v.stream.network</a>.
 
-<h2>SEE ALSO</h2>
-
-<em>
-<a href="v.stream.network">v.stream.network</a>
-</em>
-
 <h2>REFERENCES</h2>
 
 None (yet)
 
-<h2>AUTHORS</h2>
+<h2>SEE ALSO</h2>
 
-Andrew D. Wickert<br>
+<em>
+<a href="https://grass.osgeo.org/grass-stable/manuals/v.stream.network.html">v.stream.network</a>
+</em>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+<h2>AUTHOR</h2>
+
+Andrew D. Wickert

--- a/src/vector/v.surf.icw/v.surf.icw.html
+++ b/src/vector/v.surf.icw/v.surf.icw.html
@@ -122,12 +122,12 @@ Arch&auml;ologischer Anzeiger 2010/1, pp.239-261
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="https://grass.osgeo.org/grass-stable/manuals/v.surf.idw.html">v.surf.idw</a><br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/v.surf.rst.html">v.surf.rst</a><br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/v.surf.bspline.html">v.surf.bspline</a><br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/r.cost.html">r.cost</a><br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/r.surf.idw.html">r.surf.idw</a><br>
-<a href="https://grass.osgeo.org/grass-stable/manuals/r.surf.idw2.html">r.surf.idw2</a><br>
+<a href="https://grass.osgeo.org/grass-stable/manuals/v.surf.idw.html">v.surf.idw</a>.
+<a href="https://grass.osgeo.org/grass-stable/manuals/v.surf.rst.html">v.surf.rst</a>.
+<a href="https://grass.osgeo.org/grass-stable/manuals/v.surf.bspline.html">v.surf.bspline</a>.
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.cost.html">r.cost</a>.
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.surf.idw.html">r.surf.idw</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.surf.idw2.html">r.surf.idw2</a>
 </em>
 
 
@@ -136,8 +136,3 @@ Arch&auml;ologischer Anzeiger 2010/1, pp.239-261
 Hamish Bowman<br>
 <i>Department of Marine Science,<br>
 Dunedin, New Zealand</i>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.surf.mass/v.surf.mass.html
+++ b/src/vector/v.surf.mass/v.surf.mass.html
@@ -83,8 +83,3 @@ Regions. Journal of the American Statistical Association, 74 (367):
 <h2>AUTHOR</h2>
 
 Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.surf.nnbathy/v.surf.nnbathy.html
+++ b/src/vector/v.surf.nnbathy/v.surf.nnbathy.html
@@ -70,18 +70,12 @@ d.rast map=raster_map
   <a href="r.surf.nnbathy.html">r.surf.nnbathy</a>
 </em> 
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Adam Laza, OSGeoREL, Czech Technical University in Prague (mentor: Martin Landa)
 Corrected by Roberto Marzocchi, <a href="mailto:roberto.marzocchi@gter.it">roberto.marzocchi@gter.it</a>
 
-
 <p>
 Based on v.surf.nnbathy from GRASS 6 by:<br>
 Hamish Bowman, Otago University, New Zealand<br>
-Based on <em>r.surf.nnbathy</em> by Maciej Sieczka<br>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Based on <em>r.surf.nnbathy</em> by Maciej Sieczka

--- a/src/vector/v.surf.tps/v.surf.tps.html
+++ b/src/vector/v.surf.tps/v.surf.tps.html
@@ -133,11 +133,6 @@ optipng -o5 v_surf_tps.png
 <a href="https://grass.osgeo.org/grass-stable/manuals/v.surf.idw.html">v.surf.idw</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
 Markus Metz
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.tin.to.rast/v.tin.to.rast.html
+++ b/src/vector/v.tin.to.rast/v.tin.to.rast.html
@@ -1,16 +1,11 @@
 <h2>DESCRIPTION</h2>
+
 <em>v.tin.to.rast</em> converts (rasterizes) a TIN map into a raster map.
 
 <h2>SEE ALSO</h2>
 
 TBD
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Antonio Alliegro, Alexander Muriy
-
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.to.rast.multi/v.to.rast.multi.html
+++ b/src/vector/v.to.rast.multi/v.to.rast.multi.html
@@ -34,15 +34,12 @@ label_columns="ID,TRACTID" memory=3000 ndigits="0,4" separator=","
 
 
 <h2>SEE ALSO</h2>
+
 <em>
 <a href="https://grass.osgeo.org/grass-stable/manuals/v.to.rast.html">v.to.rast</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/v.what.strds.html">r.reclass</a>
 </em>
 
 <h2>AUTHOR</h2>
-Stefan Blumentrath, Norwegian Institute for Nature Research (NINA)
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Stefan Blumentrath, Norwegian Institute for Nature Research (NINA)

--- a/src/vector/v.transects/v.transects.html
+++ b/src/vector/v.transects/v.transects.html
@@ -104,10 +104,6 @@ v.db.select NH_2008_areas
 <a href="http://www4.ncsu.edu/~ejhardi2/vTransect.html">v.transects tutorial</a>
 
 
-<h2>AUTHOR</h2>
-Eric Hardin, Helena Mitasova, Updates by John Lloyd 
+<h2>AUTHORS</h2>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Eric Hardin, Helena Mitasova, Updates by John Lloyd

--- a/src/vector/v.vect.stats.multi/v.vect.stats.multi.html
+++ b/src/vector/v.vect.stats.multi/v.vect.stats.multi.html
@@ -159,8 +159,3 @@ v.vect.stats.multi points=firestations areas=zipcodes method=sum \
 <h2>AUTHOR</h2>
 
 Vaclav Petras, <a href="http://geospatial.ncsu.edu/">NCSU Center for Geospatial Analytics</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.vol.idw/v.vol.idw.html
+++ b/src/vector/v.vol.idw/v.vol.idw.html
@@ -38,11 +38,6 @@ University of Presov, Presov, Slovakia,
 
 <p>
     Modifications for raster3d library and vector format: <br>
-    Noortheen Raja J, Institute of Remote Sensing,College of Engineering, Guindy,    
+    Noortheen Raja J, Institute of Remote Sensing, College of Engineering, Guindy,
     Anna University, India.
     <a href="mailto:jnoortheen@gmail.com">jnoortheen@gmail.com</a>
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->

--- a/src/vector/v.vol.idw/v.vol.idw.html
+++ b/src/vector/v.vol.idw/v.vol.idw.html
@@ -37,7 +37,7 @@ University of Presov, Presov, Slovakia,
 <br>
 
 <p>
-    Modifications for raster3d library and vector format: <br>
-    Noortheen Raja J, Institute of Remote Sensing, College of Engineering, Guindy,
-    Anna University, India.
-    <a href="mailto:jnoortheen@gmail.com">jnoortheen@gmail.com</a>
+Modifications for raster3d library and vector format: <br>
+Noortheen Raja J, Institute of Remote Sensing, College of Engineering, Guindy,
+Anna University, India.
+<a href="mailto:jnoortheen@gmail.com">jnoortheen@gmail.com</a>

--- a/src/vector/v.what.rast.multi/v.what.rast.multi.html
+++ b/src/vector/v.what.rast.multi/v.what.rast.multi.html
@@ -49,14 +49,10 @@ v.db.select map=mygeodetic_pts columns=elevatin,slope,aspect separator=comma whe
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="https://grass.osgeo.org/grass-stable/manuals/v.what.rast.html">v.what.rast</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/v.what.rast.html">v.what.rast</a>
 </em>
 
 
-<h2>AUTHORS</h2>
-Pierre Roudier<br>
+<h2>AUTHOR</h2>
 
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Pierre Roudier<br>

--- a/src/vector/v.what.strds.timestamp/v.what.strds.timestamp.html
+++ b/src/vector/v.what.strds.timestamp/v.what.strds.timestamp.html
@@ -97,11 +97,7 @@ v.db.select sampling_points
 </em>
 
 <h2>AUTHOR</h2>
+
 Stefan Blumentrath, Norwegian Institute for Nature Research (NINA)<br>
 Written for the 2018 <a href="https://irsae.no">IRSAE</a> GRASS GIS course at 
 Studenterhytta, Oslo
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->


### PR DESCRIPTION
- remove already commented and unneeded SVN Date entries from all manual relate pages
- selectively update section order to follow https://trac.osgeo.org/grass/wiki/Submitting/Docs#HTMLPages

Note: This change brings in the disadvantage that *all* manual pages are touched in terms of editing date, which influences the recent PR https://github.com/OSGeo/grass/pull/2100 and the `g.citation` efforts ongoing in https://github.com/OSGeo/grass-addons/pull/677. On the other hand, it needs to be done one day...

See
- discussion in https://github.com/OSGeo/grass-addons/issues/684#issuecomment-1024918353
- in GRASS-core, see https://github.com/OSGeo/grass/pull/2143

Fixes #684 