### PR TITLE
i.sentinel.import fails on Windows with Invalid format string

### DIFF
--- a/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
+++ b/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
@@ -891,7 +891,7 @@ class SentinelImporter(object):
                     continue
 
                 timestamp = meta["timestamp"]
-                timestamp_str = timestamp.strftime("%-d %b %Y %H:%M:%S.%f")
+                timestamp_str = timestamp.strftime("%d %b %Y %H:%M:%S.%f")
                 descr_list = []
                 for dkey in meta.keys():
                     if dkey != "timestamp":


### PR DESCRIPTION
Timestamp format string `%-d %b %Y %H:%M:%S.%f` works on Linux (Python 3.9.10) but fails on Windows (Python 3.9.5) with

```
ValueError: Invalid format string
```