### PR TITLE
i.sentinel.import: os.linesep -> \n

### DIFF
--- a/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
+++ b/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
@@ -979,7 +979,7 @@ class SentinelImporter(object):
                             sep=sep, semantic_label=semantic_label
                         )
                     )
-                fd.write(os.linesep)
+                fd.write("\n")
 
 
 def main():


### PR DESCRIPTION
`i.sentinel.import` creates on Windows register output file with empty lines:

```
T32UPB_20190407T102021_B04_10m|2019-04-07 10:26:45.035007|S2_4

T32UPB_20190407T102021_B08_10m|2019-04-07 10:26:45.035007|S2_8
```
which leads to problem with registering maps into space-time dataset:

```
t.create output=sentinel title="Sentinel L2A 2019" desc="Jena region"
t.register input=sentinel file=z:\timestamps.txt
t.info input=sentinel
...
| Number of registered maps:.. 1
```

This PR replaces `os.linesep` with `\n`. From Python docs:

```
Do not use os.linesep as a line terminator when writing files opened in text mode (the default); use a single '\n' instead, on all platforms.
```