### PR TITLE
i.modis.import: remove grass version check

### DIFF
--- a/src/imagery/i.modis/i.modis.import/i.modis.import.py
+++ b/src/imagery/i.modis/i.modis.import/i.modis.import.py
@@ -613,12 +613,6 @@ def main():
     elif options["input"] != "" and options["files"] != "":
         grass.fatal(_('It is not possible set "input" and "files"' " options together"))
         return 0
-    # check the version
-    version = grass.core.version()
-    # this is would be set automatically
-    if version["version"].find("7.") == -1:
-        grass.fatal(_("GRASS GIS version 7 required"))
-        return 0
     # check if remove the files or not
     if flags["t"]:
         remove = False


### PR DESCRIPTION
`i.modis.import` fails in GRASS 8 by

```
ERORR: GRASS GIS version 7 required
```

This PR removes version check completely since in `grass8` branch we are expecting code compatible with GRASS 8.