### PR TITLE
i.sentinel.import: less obscure error message

### DIFF
--- a/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
+++ b/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
@@ -259,8 +259,8 @@ class SentinelImporter(object):
         if len(safes) < 1:
             gs.fatal(
                 _(
-                    "Nothing found to import. Please check input and pattern_file options."
-                )
+                    "No Sentinel files found to import in directory <{}>. Please check input and pattern_file options."
+                ).format(self.unzip_dir)
             )
 
         for safe in safes:


### PR DESCRIPTION
Better guide the user to the problem when specifying a SAFE file instead of the containing directory:

Before:
```
GRASS utm32N_32632/bonn:bonn_dgm1 > i.sentinel.import -p input=~/tmp/s2_data/S2A_MSIL2A_20211009T103941_N0301_R008_T32ULB_20211009T134536.SAFE.zip  --verbose
ERROR: Nothing found to import. Please check input and pattern_file
       options.
```

Now, with this PR:
```
GRASS utm32N_32632/bonn:bonn_dgm1 > i.sentinel.import -p input=~/tmp/s2_data/S2A_MSIL2A_20211009T103941_N0301_R008_T32ULB_20211009T134536.SAFE 
ERROR: No Sentinel files found to import in directory
       </home/mneteler/tmp/s2_data/S2A_MSIL2A_20211009T103941_N0301_R008_T32ULB_20211009T134536.SAFE>.
       Please check input and pattern_file options.
```
