### PR TITLE
i.fusion.hpf: fix "Illegal filename <.hpf>" warning

### DIFF
--- a/src/imagery/i.fusion.hpf/i.fusion.hpf.py
+++ b/src/imagery/i.fusion.hpf/i.fusion.hpf.py
@@ -101,7 +101,7 @@
 # % label: Suffix for output image(s)
 # % description: Names of Pan-Sharpened image(s) will end with this suffix
 # % required: yes
-# % answer: .hpf
+# % answer: hpf
 # %end
 
 # %option
@@ -724,7 +724,7 @@ def main():
         run("r.support", map=tmp_msx_hpf, history="\n".join(cmd_history))
 
         # add suffix to basename & rename end product
-        msx_name = "{base}{suffix}"
+        msx_name = "{base}.{suffix}"
         msx_name = msx_name.format(base=msx.split("@")[0], suffix=outputsuffix)
         run("g.rename", raster=(tmp_msx_hpf, msx_name))
 


### PR DESCRIPTION
Fixes (when `suffix` is not used) confusing warning:

`WARNING: Illegal filename <.hpf>. Cannot start with '.' or be 'NULL'.`

(In the parser `answer` no trailing dot may be used).