### PR TITLE
G78 cronjobs: add "new version G8" box into man pages

### DIFF
--- a/utils/cronjobs_osgeo_lxd/cron_grass7_relbranch_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass7_relbranch_build_binaries.sh
@@ -168,9 +168,9 @@ echo "Injecting DuckDuckGo search field into manual main page..."
 cp -p AUTHORS CHANGES CITING COPYING GPL.TXT INSTALL REQUIREMENTS.html $TARGETDIR/
 
 # inject G8.x new version hint in a red box:
-(cd $TARGETHTMLDIR/ ; for myfile in `ls *.html` ; do sed -i -e "s:<hr class=\"header\">:<hr class=\"header\"><p style=\"border\:3px; border-style\:solid; border-color\:#BC1818; padding\: 1em;\">Note\: The new GRASS GIS 8 stable version has been released, available <a href=\"https\://grass.osgeo.org/download/\">here</a>\.<br> Updated manual page at\: <a href=\"../../grass-stable/manuals/$myfile\">here</a></p>:g" $myfile ; done)
+(cd $TARGETHTMLDIR/ ; for myfile in `ls *.html` ; do sed -i -e "s:<hr class=\"header\">:<hr class=\"header\"><p style=\"border\:3px; border-style\:solid; border-color\:#BC1818; padding\: 1em;\">Note\: This document is for an old version of GRASS GIS that is no longer supported. You should upgrade, and read the <a href=\"../../grass-stable/manuals/$myfile\">current manual page</a>.</p>:g" $myfile ; done)
 # also for Python
-(cd $TARGETHTMLDIR/libpython/ ; for myfile in `ls *.html` ; do sed -i -e "s:<hr class=\"header\">:<hr class=\"header\"><p style=\"border\:3px; border-style\:solid; border-color\:#FF2121; padding\: 1em;\">Note\: The new GRASS GIS 8 stable version has been released, available <a href=\"https\://grass.osgeo.org/download/\">here</a>\.<br>. Go directly to the new Python manual page <a href=\"../../../grass-stable/manuals/libpython/$myfile\">here</a></p>:g" $myfile ; done)
+(cd $TARGETHTMLDIR/libpython/ ; for myfile in `ls *.html` ; do sed -i -e "s:<hr class=\"header\">:<hr class=\"header\"><p style=\"border\:3px; border-style\:solid; border-color\:#FF2121; padding\: 1em;\">Note\: This document is for an old version of GRASS GIS that is no longer supported. You should upgrade, and read the <a href=\"../../../grass-stable/manuals/libpython/$myfile\">current Python manual page</a>.</p>:g" $myfile ; done)
 
 
 # clean wxGUI sphinx manual etc

--- a/utils/cronjobs_osgeo_lxd/cron_grass7_relbranch_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass7_relbranch_build_binaries.sh
@@ -22,6 +22,7 @@
 # - generates the pyGRASS 7 HTML manual
 # - generates the user 7 HTML manuals
 # - injects DuckDuckGo search field
+# - injects G8 new version box
 
 # Preparations:
 #  - Install PROJ: http://trac.osgeo.org/proj/ incl Datum shift grids
@@ -165,6 +166,12 @@ echo "Injecting DuckDuckGo search field into manual main page..."
 (cd $TARGETHTMLDIR/ ; sed -i -e "s+</table>+</table><\!\-\- injected in cron_grass7_relbranch_build_binaries.sh \-\-> <center><iframe src=\"https://duckduckgo.com/search.html?site=grass.osgeo.org\&prefill=Search manual pages at DuckDuckGo\" style=\"overflow:hidden;margin:0;padding:0;width:410px;height:40px;\" frameborder=\"0\"></iframe></center>+g" index.html)
 
 cp -p AUTHORS CHANGES CITING COPYING GPL.TXT INSTALL REQUIREMENTS.html $TARGETDIR/
+
+# inject G8.x new version hint in a red box:
+(cd $TARGETHTMLDIR/ ; for myfile in `ls *.html` ; do sed -i -e "s:<hr class=\"header\">:<hr class=\"header\"><p style=\"border\:3px; border-style\:solid; border-color\:#BC1818; padding\: 1em;\">Note\: The new GRASS GIS 8 stable version has been released, available <a href=\"https\://grass.osgeo.org/download/\">here</a>\.<br> Updated manual page at\: <a href=\"../../grass-stable/manuals/$myfile\">here</a></p>:g" $myfile ; done)
+# also for Python
+(cd $TARGETHTMLDIR/libpython/ ; for myfile in `ls *.html` ; do sed -i -e "s:<hr class=\"header\">:<hr class=\"header\"><p style=\"border\:3px; border-style\:solid; border-color\:#FF2121; padding\: 1em;\">Note\: The new GRASS GIS 8 stable version has been released, available <a href=\"https\://grass.osgeo.org/download/\">here</a>\.<br>. Go directly to the new Python manual page <a href=\"../../../grass-stable/manuals/libpython/$myfile\">here</a></p>:g" $myfile ; done)
+
 
 # clean wxGUI sphinx manual etc
 (cd $GRASSBUILDDIR/ ; $MYMAKE cleansphinx)

--- a/utils/cronjobs_osgeo_lxd/grass-addons-index.sh
+++ b/utils/cronjobs_osgeo_lxd/grass-addons-index.sh
@@ -104,13 +104,13 @@ generate () {
     echo "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0 Transitional//EN\">
 <html>
 <head>
- <title>GRASS GIS ${major} Addons Manual pages</title>
+ <title>GRASS GIS ${major}.${minor} Addons Manual pages</title>
  <meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">
  <meta name=\"Author\" content=\"GRASS Development Team\">
  <link rel=\"stylesheet\" href=\"../grassdocs.css\" type=\"text/css\">
 </head>
 <body bgcolor=\"#FFFFFF\">
-<h2>GRASS GIS ${major} Addons Manual pages</h2>
+<h2>GRASS GIS ${major}.${minor} Addons Manual pages</h2>
 
 <!-- Generated from: grasslxd (on osgeo7): ~/cronjobs/grass-addons-index.sh -->
 <!--       See also: https://github.com/OSGeo/grass-addons/tree/grass8/utils/cronjobs_osgeo_lxd/README.md -->


### PR DESCRIPTION
This PR injects a red box into the [G78 manual pages](https://grass.osgeo.org/grass78/manuals/), pointing to the respective G80 manual page.

![image](https://user-images.githubusercontent.com/1295172/158805613-12ad5b33-b3a8-473e-b68c-a9dfe8026364.png)

This is added to all G78 manual pages.

In addition, it adds minor version number to addon manual landing page title to reduce confusion.