### PR TITLE
manual: g.bands has been renamed to i.band.library

### DIFF
--- a/src/imagery/i.landsat/i.landsat.import/i.landsat.import.html
+++ b/src/imagery/i.landsat/i.landsat.import/i.landsat.import.html
@@ -109,7 +109,7 @@ i.e., we only have one point in time. Hence, the output register file will
 contain the map name and start time separated by <tt>|</tt> when using GRASS
 GIS stable version.
 In the case of GRASS GIS development version which supports the band reference
-concept (see <em><a href="https://grass.osgeo.org/grass-devel/manuals/g.bands.html">g.bands</a></em> module for details),
+concept (see <em><a href="https://grass.osgeo.org/grass-devel/manuals/i.band.library.html">i.band.library</a></em> module for details),
 the output register file is extended by a third column containing the band
 reference information, see the examples below.
 

--- a/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.html
+++ b/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.html
@@ -269,7 +269,7 @@ t.register input=sentinel_ds file=t_register.txt
 A register file typically contains two columns: imported raster map
 name and timestamp separated by <tt>|</tt>. In the case of current
 development version of GRASS which supports band references concept
-(see <em><a href="https://grass.osgeo.org/grass-devel/manuals/g.bands.html">g.bands</a></em> module for details) a
+(see <em><a href="https://grass.osgeo.org/grass-devel/manuals/i.band.library.html">i.band.library</a></em> module for details) a
 register file is extended by a third column containg band reference
 information, see the examples below.
 


### PR DESCRIPTION
(minor fix; redirects are in place on grass.osgeo.org)