### PR TITLE
G78 addon cronjob: add "new version G8" box into addon man pages

### DIFF
--- a/utils/cronjobs_osgeo_lxd/cron_grass7_relbranch_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass7_relbranch_build_binaries.sh
@@ -266,6 +266,9 @@ for dir in `find ~/.grass$GMAJOR/addons -maxdepth 1 -type d`; do
 done
 sh ~/cronjobs/grass-addons-index.sh $GMAJOR $GMINOR $TARGETHTMLDIR/addons/
 chmod -R a+r,g+w $TARGETHTMLDIR 2> /dev/null
+# inject G8.x new version hint in a red box:
+(cd $TARGETHTMLDIR/addons/ ; for myfile in `ls *.html` ; do sed -i -e "s:<hr class=\"header\">:<hr class=\"header\"><p style=\"border\:3px; border-style\:solid; border-color\:#BC1818; padding\: 1em;\">Note\: This addon document is for an old version of GRASS GIS that is no longer supported. You should upgrade your GRASS GIS installation, and read the <a href=\"../../../grass-stable/manuals/addons/$myfile\">current addon manual page</a>.</p>:g" $myfile ; done)
+
 
 # cp logs from ~/.grass$GMAJOR/addons/logs/
 mkdir -p $TARGETMAIN/addons/grass$GMAJOR/logs/


### PR DESCRIPTION
This PR injects a red box into the G78 addon manual pages, pointing to the respective G80 addon manual page.

It completes #718.

Random example:

![image](https://user-images.githubusercontent.com/1295172/164222217-309cc0bf-398b-4202-9190-a0988d68b33d.png)
