### PR TITLE
cron_grass8_main_build_binaries.sh: no longer generate i18N .pot files

### DIFF
--- a/utils/cronjobs_osgeo_lxd/cron_grass8_main_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass8_main_build_binaries.sh
@@ -198,9 +198,8 @@ cd $GRASSBUILDDIR/
 ## bug in doxygen
 #(cd $TARGETPROGMAN/ ; ln -s index.html main.html)
 
-##### generate i18N POT files, needed for https://www.transifex.com/grass-gis/
+##### copy i18N POT files, needed for https://www.transifex.com/grass-gis/
 (cd locale ;
-$MYMAKE pot
 mkdir -p $TARGETDIR/transifex/
 cp templates/*.pot $TARGETDIR/transifex/
 )


### PR DESCRIPTION
After https://github.com/OSGeo/grass/pull/2316 now the i18N .pot files must not be generated any more in this cronjob, to avoid an git update error.

Currently only applies to G8.1 cronjob.