### PR TITLE
utils/cronjobs_osgeo_lxd: fix MS Windows Addons compilation log files URL link

### DIFF
--- a/utils/cronjobs_osgeo_lxd/cron_grass7_relbranch_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass7_relbranch_build_binaries.sh
@@ -36,6 +36,7 @@ PATH=/home/neteler/binaries/bin:/usr/bin:/bin:/usr/X11R6/bin:/usr/local/bin
 
 GMAJOR=7
 GMINOR=8
+GPATCH=7 # required by grass-addons-index.sh
 DOTVERSION=$GMAJOR.$GMINOR
 VERSION=$GMAJOR$GMINOR
 GVERSION=$GMAJOR
@@ -264,7 +265,7 @@ for dir in `find ~/.grass$GMAJOR/addons -maxdepth 1 -type d`; do
         fi
     fi
 done
-sh ~/cronjobs/grass-addons-index.sh $GMAJOR $GMINOR $TARGETHTMLDIR/addons/
+sh ~/cronjobs/grass-addons-index.sh $GMAJOR $GMINOR $GPATCH $TARGETHTMLDIR/addons/
 chmod -R a+r,g+w $TARGETHTMLDIR 2> /dev/null
 # inject G8.x new version hint in a red box: into index.html and all addon manual pages
 (cd $TARGETHTMLDIR/addons/ ; sed -i -e "s: Addons Manual pages</h2>: Addons Manual pages</h2><p style=\"border\:3px; border-style\:solid; border-color\:#BC1818; padding\: 1em;\">Note\: This addon documentation is for an older version of GRASS GIS that will be discontinued soon. You should upgrade your GRASS GIS installation, and read the <a href=\"../../../grass-stable/manuals/addons/index.html\">current addon manual page</a>.</p>:g" index.html)

--- a/utils/cronjobs_osgeo_lxd/cron_grass8_main_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass8_main_build_binaries.sh
@@ -37,6 +37,7 @@ PATH=/home/neteler/binaries/bin:/usr/bin:/bin:/usr/X11R6/bin:/usr/local/bin
 
 GMAJOR=8
 GMINOR=3
+GPATCH="dev"
 DOTVERSION=$GMAJOR.$GMINOR
 VERSION=$GMAJOR$GMINOR
 GVERSION=$GMAJOR
@@ -298,7 +299,7 @@ for dir in `find ~/.grass$GMAJOR/addons -maxdepth 1 -type d`; do
         fi
     fi
 done
-sh ~/cronjobs/grass-addons-index.sh $GMAJOR $GMINOR $TARGETHTMLDIR/addons/
+sh ~/cronjobs/grass-addons-index.sh $GMAJOR $GMINOR $GPATCH $TARGETHTMLDIR/addons/
 cp $TARGETHTMLDIR/grass_logo.png $TARGETHTMLDIR/grassdocs.css $TARGETHTMLDIR/addons/
 chmod -R a+r,g+w $TARGETHTMLDIR 2> /dev/null
 

--- a/utils/cronjobs_osgeo_lxd/cron_grass8_relbranch_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass8_relbranch_build_binaries.sh
@@ -37,6 +37,7 @@ PATH=/home/neteler/binaries/bin:/usr/bin:/bin:/usr/X11R6/bin:/usr/local/bin
 
 GMAJOR=8
 GMINOR=2
+GPATCH=0
 DOTVERSION=$GMAJOR.$GMINOR
 VERSION=$GMAJOR$GMINOR
 GVERSION=$GMAJOR
@@ -293,7 +294,7 @@ for dir in `find ~/.grass$GMAJOR/addons -maxdepth 1 -type d`; do
         fi
     fi
 done
-sh ~/cronjobs/grass-addons-index.sh $GMAJOR $GMINOR $TARGETHTMLDIR/addons/
+sh ~/cronjobs/grass-addons-index.sh $GMAJOR $GMINOR $GPATCH $TARGETHTMLDIR/addons/
 cp $TARGETHTMLDIR/grass_logo.png $TARGETHTMLDIR/grassdocs.css $TARGETHTMLDIR/addons/
 chmod -R a+r,g+w $TARGETHTMLDIR 2> /dev/null
 

--- a/utils/cronjobs_osgeo_lxd/grass-addons-index.sh
+++ b/utils/cronjobs_osgeo_lxd/grass-addons-index.sh
@@ -19,17 +19,18 @@
 CRONJOBDIR=~/cronjobs/
 MAJOR=$1
 MINOR=$2
+PATCH=$3
 
 ##################
 # generated Addon HTML manual pages are expected to be in the directory
 # /var/www/code_and_data/grass${major}${minor}/manuals/addons/
 
-if [ $# -ne 3 ] ; then
+if [ $# -ne 4 ] ; then
   echo "ERROR: addon manpath required.
 
 Usage:
 
-$0 GMAJOR GMINOR manpath"
+$0 GMAJOR GMINOR GPATCH manpath"
   exit 1
 fi
 
@@ -88,7 +89,14 @@ generate () {
     # 7 8 manpath | 8 0 manpath
     major=$1
     minor=$2
-    manpath=$3
+    patch=$3
+    manpath=$4
+
+    if [ "$major" -eq 7 ]; then
+        win_log_url="https://wingrass.fsv.cvut.cz/grass${major}${minor}/x86_64/addons/grass-${major}.${minor}.${patch}/logs/"
+    else
+        win_log_url="https://wingrass.fsv.cvut.cz/grass${major}${minor}/addons/grass-${major}.${minor}.${patch}/logs/"
+    fi
 
     # DEBUG
     # mkdir -p /tmp/grass${major}${minor}/manuals/addons ; cd /tmp/grass${major}${minor}/manuals/addons
@@ -137,7 +145,7 @@ document as well as the <a href=\"https://trac.osgeo.org/grass/wiki/Submitting\"
 <p>
 See also log files of compilation:
 <a href=\"https://grass.osgeo.org/addons/grass${major}/logs\">Linux log files</a> |
-<a href=\"https://wingrass.fsv.cvut.cz/grass${major}${minor}/x86_64/addons/grass-${major}.${minor}.dev/logs/\">Windows log files</a>
+<a href=\"${win_log_url}\">Windows log files</a>
 
 </tr></table>
 <hr>
@@ -184,8 +192,8 @@ See also log files of compilation:
 }
 
 ## main
-# $3 is path to addons manual directory:
-generate $MAJOR $MINOR $3
+# $4 is path to addons manual directory:
+generate $MAJOR $MINOR $PATCH $4
 
 exit 0
 


### PR DESCRIPTION
**Describe the bug**
Wrong MS Windows Addons compilation log files URL link

**To Reproduce**
Steps to reproduce the behavior:

1. Open in web browser Addons manuals URL https://grass.osgeo.org/grass82/manuals/addons/
2. Click on the [Windows log files](https://wingrass.fsv.cvut.cz/grass82/x86_64/addons/grass-8.2.dev/logs/)
3. See error

**Expected behavior**
Correct MS Windows Addons compilation log files URL link