### PR TITLE
Update r.bioclim.html

### DIFF
--- a/src/raster/r.bioclim/r.bioclim.html
+++ b/src/raster/r.bioclim/r.bioclim.html
@@ -42,10 +42,10 @@ option should be used when long-term averages are used as input.
 
 <h4>Precipitation data</h4>
 Check the unit of measure of precipitation data. To calculate the bio18 and bio19
-r.bioclim rounds the value of the raster to the closest integer. If the unit
-of measure of your data is, for example, kg m-2 m-1 (eg fluxes per second) as in
-CHELSA data <a href="<a href="https://chelsa-climate.org/">CHELSA</a>"></a>
-you will have a raster of 0s for the bio18 and bio19, because the precipitation values
+<b>r.bioclim</b> rounds the value of the raster to the closest integer value. If the unit
+of measure of your data is, for example, kg m-2 m-1 (i.e., fluxes per second) as in
+<a href="https://chelsa-climate.org/">CHELSA</a> data you will gain a raster map with
+zero values for the bio18 and bio19, because the precipitation values
 are very close to 0. 
 
 <h4>List of bioclimatic indices</h4>

--- a/src/raster/r.bioclim/r.bioclim.html
+++ b/src/raster/r.bioclim/r.bioclim.html
@@ -42,7 +42,7 @@ option should be used when long-term averages are used as input.
 
 <h4>Precipitation data</h4>
 Check the unit of measure of precipitation data. To calculate the bio18 and bio19
-r.bioclim rounds the value of the raster to the closest integer. If your the unit
+r.bioclim rounds the value of the raster to the closest integer. If the unit
 of measure of your data is, for example, kg m-2 m-1 (eg fluxes per second) as in
 CHELSA data <a href="<a href="https://chelsa-climate.org/">CHELSA</a>"></a>
 you will have a raster of 0s for the bio18 and bio19, because the precipitation values

--- a/src/raster/r.bioclim/r.bioclim.html
+++ b/src/raster/r.bioclim/r.bioclim.html
@@ -44,11 +44,9 @@ option should be used when long-term averages are used as input.
 Check the unit of measure of precipitation data. To calculate the bio18 and bio19
 r.bioclim rounds the value of the raster to the closest integer. If your the unit
 of measure of your data is, for example, kg m-2 m-1 (eg fluxes per second) as in
-CHELSA data <a href="<a href="http://gis.cri.fmach.it/eurolst-bioclim/">CHELSA</a>"></a>
+CHELSA data <a href="<a href="https://chelsa-climate.org/">CHELSA</a>"></a>
 you will have a raster of 0s for the bio18 and bio19, because the precipitation values
 are very close to 0. 
-
-
 
 <h4>List of bioclimatic indices</h4>
 

--- a/src/raster/r.bioclim/r.bioclim.html
+++ b/src/raster/r.bioclim/r.bioclim.html
@@ -40,6 +40,16 @@ and how the bioclimatic variables provided by <a
 href="http://worldclim.org/bioclim">Worldclim</a> were computed. This 
 option should be used when long-term averages are used as input.
 
+<h4>Precipitation data</h4>
+Check the unit of measure of precipitation data. To calculate the bio18 and bio19
+r.bioclim rounds the value of the raster to the closest integer. If your the unit
+of measure of your data is, for example, kg m-2 m-1 (eg fluxes per second) as in
+CHELSA data <a href="<a href="http://gis.cri.fmach.it/eurolst-bioclim/">CHELSA</a>"></a>
+you will have a raster of 0s for the bio18 and bio19, because the precipitation values
+are very close to 0. 
+
+
+
 <h4>List of bioclimatic indices</h4>
 
 <p><b>BIO 01</b> Annual mean temperature as the mean of the monthly temperatures (&deg;C)


### PR DESCRIPTION
I added a couple of lines highliting that the bio18 and the bio19 are calculated rounding the precipitation values to the closest integer. I think is helpful to suggest to check the unit of measure of the precipitation rasters  for people that are not used to work with climatic data. I had this problem with the CHELSA database that provides pricipitation in kg m-2 s-1, with values very close to 0 that lead to a raster of 0s for bio18 and bio19.