### PR TITLE
v.transects: Add categories of input lines to layer 2 of output

### DIFF
--- a/src/vector/v.transects/v.transects.html
+++ b/src/vector/v.transects/v.transects.html
@@ -40,6 +40,16 @@ to be in horizontal map units (e.g., degrees in the LatLong/WGS84 coordinate sys
 <p>
 <em><b>v.transects</b></em> may fail for a network of lines in Windows.
 
+<p>The categories of the input lines are stored in layer 2 of the output. To upload them
+  to the transects table, use v.to.db like this:
+  <br>
+  <div class=code><pre>
+v.transects input=lines output=transects transect_spacing=100
+v.db.addtable transects columns="line_cat"
+v.db.addtable transects layer=2
+v.to.db transects query_layer=2 query_column=cat option=query column=line_cat
+  </pre></div>
+
 <h2>EXAMPLES</h2>
 
 In these examples, the

--- a/src/vector/v.transects/v.transects.py
+++ b/src/vector/v.transects/v.transects.py
@@ -46,6 +46,7 @@
 # %end
 # %option G_OPT_V_TYPE
 # % multiple: no
+# % label: Output type
 # % options: point,line,area
 # % answer: line
 # %end
@@ -120,17 +121,21 @@ def loadVector(vector):
     while ":" in vectorAscii[l]:
         l += 1
     v = []
+    cats = []
     while l < len(vectorAscii):
         line = vectorAscii[l].split()
         if line[0] in ["L", "B", "A"]:
             skip = int(line[2])
+            ncat = int(line[2]) if len(line) > 2 else 0
             vertices = int(line[1])
             l += 1
             v.append([])
             for i in range(vertices):
                 v[-1].append(list(map(float, vectorAscii[l].split()[:2])))
                 l += 1
-            l += skip
+            if ncat > 0:
+                cats += [vectorAscii[l].split()[1]]
+            l += ncat
         elif line[0] in ["P", "C", "F", "K"]:
             skip = int(line[2])
             vertices = int(line[1])
@@ -142,7 +147,7 @@ def loadVector(vector):
             gs.fatal(_("Problem with line: <%s>") % vectorAscii[l])
     if len(v) < 1:
         gs.fatal(_("Zero lines found in vector map <%s>") % vector)
-    return v
+    return v, cats
 
 
 def get_transects_locs(vector, transect_spacing, dist_function, last_point):
@@ -184,9 +189,9 @@ def get_transect_ends(transect_locs, vectors, trend, dleft, dright):
     if not trend:
         for k, transect in enumerate(transect_locs):
             # if a line in input vec was shorter than transect_spacing
+            transect_ends.append([])
             if len(transect) < 2:
                 continue  # then don't put a transect on it
-            transect_ends.append([])
             transect = array(transect)
             v = NR(*vectors[k][0])  # vector pointing parallel to transect
             transect_ends[-1].append(
@@ -200,9 +205,9 @@ def get_transect_ends(transect_locs, vectors, trend, dleft, dright):
     else:
         for transect in transect_locs:
             # if a line in input vec was shorter than transect_spacing
+            transect_ends.append([])
             if len(transect) < 2:
                 continue  # then don't put a transect on it
-            transect_ends.append([])
             transect = array(transect)
             v = NR(transect[0], transect[1])  # vector pointing parallel to transect
             transect_ends[-1].append(
@@ -240,20 +245,30 @@ def NR(ip, fp):
     return array([-y / r, x / r])
 
 
-def writeTransects(transects, output):
+def writeTransects(transects, cats, output):
     """!Writes transects."""
     transects_str = ""
-    for transect in transects:
+    ncats = 2 if cats else 1
+    cat = 1
+    linecat = True if cats else ''
+    for i, transect in enumerate(transects):
+        if len(transect) == 0:
+            continue
+        # add line category in layer 2
+        if linecat:
+            linecat = "2 %s\n" % cats[i]
         transects_str += "\n".join(
             [
-                "L 2\n"
+                "L 2 %s\n" % ncats
                 + " ".join(map(str, end_points[0]))
                 + "\n"
                 + " ".join(map(str, end_points[1]))
                 + "\n"
-                for end_points in transect
+                + "1 %s \n%s" % (cat + ii, linecat)
+                for ii, end_points in enumerate(transect)
             ]
         )
+        cat += len(transect)
     # JL Rewrote Temporary File Logic for Windows
     _, temp_path = tempfile.mkstemp()
     a = open(temp_path, "w")
@@ -270,6 +285,8 @@ def writeQuads(transects, output):
     quad_str = ""
     cnt = 1
     for line in transects:
+        if len(line) == 0:
+            continue
         for tran in range(len(line) - 1):
             pt1 = " ".join(map(str, line[tran][0]))
             pt2 = " ".join(map(str, line[tran][1]))
@@ -378,7 +395,7 @@ def main():
         gs.fatal(_("vector <%s> does not contain lines") % vector)
 
     #################################
-    v = loadVector(vector)
+    v, cats = loadVector(vector)
     if options["metric"] == "straight":
         dist = dist_euclidean
     else:
@@ -391,7 +408,7 @@ def main():
     temp_map = tempmap()
     if shape == "line" or not shape:
         transect_ends = get_transect_ends(transect_locs, vectors, trend, dleft, dright)
-        writeTransects(transect_ends, temp_map)
+        writeTransects(transect_ends, cats, temp_map)
     elif shape == "area":
         transect_ends = get_transect_ends(transect_locs, vectors, trend, dleft, dright)
         writeQuads(transect_ends, temp_map)

--- a/src/vector/v.transects/v.transects.py
+++ b/src/vector/v.transects/v.transects.py
@@ -250,7 +250,7 @@ def writeTransects(transects, cats, output):
     transects_str = ""
     ncats = 2 if cats else 1
     cat = 1
-    linecat = True if cats else ''
+    linecat = True if cats else ""
     for i, transect in enumerate(transects):
         if len(transect) == 0:
             continue


### PR DESCRIPTION
This allows reference of the output transects to the original lines, which is essential in many applications of transects. The way to get the categories of the input lines into the transect table, also added to the docs:
```
v.transects input=lines output=transects transect_spacing=100
v.db.addtable transects columns="line_cat"
v.db.addtable transects layer=2
v.to.db transects query_layer=2 query_column=cat option=query column=line_cat
```
I have also updated the _type_ parameter description to say that it determines the output type rather than the input as it says now.