### PR TITLE
r.mapcalc.tiled: width and heigt as int

### DIFF
--- a/src/raster/r.mapcalc.tiled/r.mapcalc.tiled.py
+++ b/src/raster/r.mapcalc.tiled/r.mapcalc.tiled.py
@@ -152,18 +152,22 @@ def main():
     # v8.2 GridModule doesn't require tile size anymore
     # this is proxy for v8.2
     # can be removed in v9.0
+    if width:
+        width = int(width)
+    if height:
+        height = int(height)
     if not parallel_rpatch_available:
         warning = False
         if not width:
             width = 1000
             warning = True
-        else:
-            width = int(width)
+        # else:
+        #     width = int(width)
         if not height:
             height = 1000
             warning = True
-        else:
-            height = int(height)
+        # else:
+        #     height = int(height)
         if warning:
             # square tiles tend to be slower than horizontal slices
             gscript.warning(
@@ -171,11 +175,6 @@ def main():
                     "No tile width or height provided, default tile size set: {h} rows x {w} cols."
                 ).format(h=height, w=width)
             )
-    else:
-        if width:
-            width = int(width)
-        if height:
-            height = int(height)
     overlap = int(options["overlap"])
     processes = options["nprocs"]
     patch_backend = options["patch_backend"]

--- a/src/raster/r.mapcalc.tiled/r.mapcalc.tiled.py
+++ b/src/raster/r.mapcalc.tiled/r.mapcalc.tiled.py
@@ -171,6 +171,11 @@ def main():
                     "No tile width or height provided, default tile size set: {h} rows x {w} cols."
                 ).format(h=height, w=width)
             )
+    else:
+        if width:
+            width = int(width)
+        if height:
+            height = int(height)
     overlap = int(options["overlap"])
     processes = options["nprocs"]
     patch_backend = options["patch_backend"]

--- a/src/raster/r.mapcalc.tiled/r.mapcalc.tiled.py
+++ b/src/raster/r.mapcalc.tiled/r.mapcalc.tiled.py
@@ -161,13 +161,9 @@ def main():
         if not width:
             width = 1000
             warning = True
-        # else:
-        #     width = int(width)
         if not height:
             height = 1000
             warning = True
-        # else:
-        #     height = int(height)
         if warning:
             # square tiles tend to be slower than horizontal slices
             gscript.warning(


### PR DESCRIPTION
By calculating the example with GRASS 8.0 I get the following error:
```
r.mapcalc.tiled expression="bright_pixels = if(ortho_2001_t792_1m > 200, 1, 0)"    width=1000 height=1000 nprocs=4
Traceback (most recent call last):
  File "/home/aweinmann/.grass8/addons/scripts/r.mapcalc.tiled", line 227, in <module>
    main()
  File "/home/aweinmann/.grass8/addons/scripts/r.mapcalc.tiled", line 211, in main
    grd = MyGridModule(
  File "/home/aweinmann/repos/grass/grass/dist.x86_64-pc-linux-gnu/etc/python/grass/pygrass/modules/grid/grid.py", line 518, in __init__
    self.bboxes = split_region_tiles(
  File "/home/aweinmann/repos/grass/grass/dist.x86_64-pc-linux-gnu/etc/python/grass/pygrass/modules/grid/split.py", line 78, in split_region_tiles
    ncols = (reg.cols + width - 1) // width
TypeError: unsupported operand type(s) for +: 'int' and 'str'
```
This little change fixes that the `height` and `width` is given as integers to the `MyGridModule`.