### PR TITLE
r.learn.ml2: fix r.category call in r.learn.predict

### DIFF
--- a/src/raster/r.learn.ml2/r.learn.predict/r.learn.predict.py
+++ b/src/raster/r.learn.ml2/r.learn.predict/r.learn.predict.py
@@ -155,11 +155,11 @@ def main():
         rules = []
 
         for val, lab in class_labels.items():
-            rules.append(",".join([str(val), str(lab)]))
+            rules.append("|".join([str(val), str(lab)]))
 
         rules = "\n".join(rules)
         rules_file = string_to_rules(rules)
-        r.category(map=output, rules=rules_file, separator="comma")
+        r.category(map=output, rules=rules_file, separator="pipe")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Avoid crash when category labels contain a comma as e.g. in US NLCD Land cover product

![image](https://user-images.githubusercontent.com/1295172/184543132-9c5b3ae3-19a9-4f00-a4ee-95492ac2d35e.png)

... by changing the separator from comma to pipe character.

(see https://grasswiki.osgeo.org/wiki/NLCD_Land_Cover#Legend)

