### PR TITLE
i.sentinel.import: fix unit test (capital letter)

### DIFF
--- a/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
+++ b/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
@@ -204,7 +204,7 @@ class SentinelImporter(object):
 
     def _check_location_projection_meters(self):
         units = gs.parse_command("g.proj", flags="g")["units"]
-        if units != "meters":
+        if units != "meters" and units != "Meters":
             return False
         else:
             return True


### PR DESCRIPTION
If - like in the NC sample dataset - the unit in the `PROJ_UNITS` file is written with a capital letter the resolution detection fails.

```
GRASS nc_spm_08_grass7/sentinel2:foss4g_grass4rs > g.proj -p
-PROJ_INFO-------------------------------------------------
name       : Lambert Conformal Conic
proj       : lcc
...
-PROJ_SRID-------------------------------------------------
SRID       : EPSG:3358
-PROJ_UNITS------------------------------------------------
unit       : Meter
units      : Meters
meters     : 1
```

Completes PR #769.