### PR TITLE
hugo_clean_and_update_job.sh: remove superfluous sitemap link

### DIFF
--- a/utils/cronjobs_osgeo_lxd/hugo_clean_and_update_job.sh
+++ b/utils/cronjobs_osgeo_lxd/hugo_clean_and_update_job.sh
@@ -30,5 +30,4 @@ cd /home/neteler/grass-website/ && \
    \mv /var/www/html_new/* /var/www/html/ && \
    ln -s /var/www/code_and_data/* /var/www/html/ && \
    rmdir /var/www/html_new && \
-   ln -s /var/www/html/files/sitemap.xml /var/www/html/ && \
    (cd /var/www/html/ ; /home/neteler/bin/fix_link_timestamp.sh .)


### PR DESCRIPTION
Local file linking of sitemap.xml no longer needed after https://github.com/OSGeo/grass-website/pull/318