### PR TITLE
utils/cronjobs_osgeo_lxd: allow register all addons keywords in main Keywords Index

### DIFF
--- a/utils/cronjobs_osgeo_lxd/cron_grass7_relbranch_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass7_relbranch_build_binaries.sh
@@ -280,6 +280,14 @@ cp -p ~/.grass$GMAJOR/addons/logs/* $TARGETMAIN/addons/grass$GMAJOR/logs/
 ~/src/$BRANCH/bin.$ARCH/grass$VERSION --tmp-location EPSG:4326 --exec ~/cronjobs/build-xml.py --build ~/.grass$GMAJOR/addons
 cp ~/.grass$GMAJOR/addons/modules.xml $TARGETMAIN/addons/grass$GMAJOR/modules.xml
 
+# regenerate keywords.html file with addons modules keywords
+export ARCH
+export ARCH_DISTDIR=$GRASSBUILDDIR/dist.$ARCH
+export GISBASE=$ARCH_DISTDIR
+export VERSION_NUMBER=$DOTVERSION
+python3 $GRASSBUILDDIR/man/build_keywords.py $TARGETMAIN/grass$GMAJOR$GMINOR/manuals/ $TARGETMAIN/grass$GMAJOR$GMINOR/manuals/addons/
+unset ARCH ARCH_DISTDIR GISBASE VERSION_NUMBER
+
 ############################################
 # create sitemaps to expand the hugo sitemap
 

--- a/utils/cronjobs_osgeo_lxd/cron_grass8_relbranch_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass8_relbranch_build_binaries.sh
@@ -306,6 +306,14 @@ cp -p ~/.grass$GMAJOR/addons/logs/* $TARGETMAIN/addons/grass$GMAJOR/logs/
 ~/src/$BRANCH/bin.$ARCH/grass --tmp-location EPSG:4326 --exec ~/cronjobs/build-xml.py --build ~/.grass$GMAJOR/addons
 cp ~/.grass$GMAJOR/addons/modules.xml $TARGETMAIN/addons/grass$GMAJOR/modules.xml
 
+# regenerate keywords.html file with addons modules keywords
+export ARCH
+export ARCH_DISTDIR=$GRASSBUILDDIR/dist.$ARCH
+export GISBASE=$ARCH_DISTDIR
+export VERSION_NUMBER=$DOTVERSION
+python3 $GRASSBUILDDIR/man/build_keywords.py $TARGETMAIN/grass$GMAJOR$GMINOR/manuals/ $TARGETMAIN/grass$GMAJOR$GMINOR/manuals/addons/
+unset ARCH ARCH_DISTDIR GISBASE VERSION_NUMBER
+
 ############################################
 # create sitemaps to expand the hugo sitemap
 


### PR DESCRIPTION
For main dev branch injecting addons keywords into main keywords HTML page  works as expected https://grass.osgeo.org/grass83/manuals/keywords.html.

We can do it for release branch for GRASS GIS version 7 and 8, too and this PR solve it.