### PR TITLE
t.rast.boxplot correction manual page

### DIFF
--- a/src/temporal/t.rast.boxplot/t.rast.boxplot.html
+++ b/src/temporal/t.rast.boxplot/t.rast.boxplot.html
@@ -82,7 +82,6 @@ plot_dimensions=12,8 dpi=200
 </pre></div>
 
 <p>
-<p><img src="r_series_boxplot_1.png">
 <div align="center" style="margin: 10px">
 <img src="t_rast_boxplot_01.png">
 </div>
@@ -116,7 +115,6 @@ href="https://matplotlib.org/stable/tutorials/colors/colors.html">here</a>
 for the different formats in which colors can be specified.
 
 <p>
-<p><img src="r_series_boxplot_1.png">
 <div align="center" style="margin: 10px">
 <img src="t_rast_boxplot_02.png">
 </div>
@@ -138,7 +136,6 @@ font_size=9
 </pre></div>
 
 <p>
-<p><img src="r_series_boxplot_1.png">
 <div align="center" style="margin: 10px">
 <img src="t_rast_boxplot_03.png">
 </div>
@@ -170,7 +167,6 @@ As you can see below, the plot plots the boxplots using the 3-month
 granularity of the input strds.
 
 <p>
-<p><img src="r_series_boxplot_1.png">
 <div align="center" style="margin: 10px">
 <img src="t_rast_boxplot_04.png">
 </div>


### PR DESCRIPTION
Removing reference to wrong image in examples