### PR TITLE
.github/workflows: fix `MODULE_TOPDIR` ENV var path value

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
     - name: Build addons
       run: |
         cd grass-addons/src
-        GRASS_INSTALL=$HOME/install/grass*
+        GRASS_INSTALL=$($HOME/install/bin/grass --config | sed -n '4{p;q}')
         make MODULE_TOPDIR=$GRASS_INSTALL
 
     - name: Get extra Python dependencies


### PR DESCRIPTION
Python code doesn't interpret wildcard `*` inside path. Fixes #803. 