### PR TITLE
Add parallel keyword for multiprocessing and OpenMP

### DIFF
--- a/src/imagery/i.segment.hierarchical/i.segment.hierarchical.py
+++ b/src/imagery/i.segment.hierarchical/i.segment.hierarchical.py
@@ -19,6 +19,7 @@
 # % description: Hierarchical segmentation
 # % keyword: imagery
 # % keyword: segment
+# % keyword: parallel
 # % overwrite: yes
 # %End
 # %option G_OPT_I_GROUP
@@ -36,7 +37,7 @@
 # %end
 # %option G_OPT_R_OUTPUT
 # % key: output
-# % description: Name of output sement raster map
+# % description: Name of output segment raster map
 # % required: yes
 # %end
 # %option

--- a/src/imagery/i.segment.stats/i.segment.stats.py
+++ b/src/imagery/i.segment.stats/i.segment.stats.py
@@ -18,6 +18,7 @@
 # % keyword: imagery
 # % keyword: segmentation
 # % keyword: statistics
+# % keyword: parallel
 # %end
 # %option G_OPT_R_MAP
 # % label: Name for input raster map with areas

--- a/src/imagery/i.segment.uspo/i.segment.uspo.py
+++ b/src/imagery/i.segment.uspo/i.segment.uspo.py
@@ -35,6 +35,7 @@
 # % keyword: variance
 # % keyword: segmentation
 # % keyword: threshold
+# % keyword: parallel
 # %end
 #
 # %option G_OPT_I_GROUP

--- a/src/imagery/i.spec.sam/main.c
+++ b/src/imagery/i.spec.sam/main.c
@@ -87,6 +87,7 @@ int main(int argc,char * argv[])
     module = G_define_module();
     G_add_keyword(_("imagery"));
     G_add_keyword(_("spectral angle mapping"));
+    G_add_keyword(_("parallel"));
     module->description =
         _("Performs Spectral angle mapping on satellite/aerial images");
 

--- a/src/raster/r.gdd/main.c
+++ b/src/raster/r.gdd/main.c
@@ -70,6 +70,7 @@ int main(int argc, char *argv[])
     module = G_define_module();
     G_add_keyword(_("raster"));
     G_add_keyword(_("series"));
+    G_add_keyword(_("parallel"));
     module->description =
 	_("Makes each output cell value a "
 	  "function of the values assigned to the corresponding cells "

--- a/src/raster/r.gdd/main.c
+++ b/src/raster/r.gdd/main.c
@@ -69,6 +69,7 @@ int main(int argc, char *argv[])
 
     module = G_define_module();
     G_add_keyword(_("raster"));
+    G_add_keyword(_("aggregation"));
     G_add_keyword(_("series"));
     G_add_keyword(_("parallel"));
     module->description =

--- a/src/raster/r.in.usgs/r.in.usgs.py
+++ b/src/raster/r.in.usgs/r.in.usgs.py
@@ -26,6 +26,7 @@
 # % keyword: USGS
 # % keyword: NED
 # % keyword: NAIP
+# % keyword: parallel
 # %end
 
 # %flag

--- a/src/raster/r.learn.ml/r.learn.ml.py
+++ b/src/raster/r.learn.ml/r.learn.ml.py
@@ -23,6 +23,7 @@
 # % keyword: regression
 # % keyword: machine learning
 # % keyword: scikit-learn
+# % keyword: parallel
 # %end
 
 # %option G_OPT_I_GROUP

--- a/src/raster/r.learn.ml2/r.learn.train/r.learn.train.py
+++ b/src/raster/r.learn.ml2/r.learn.train/r.learn.train.py
@@ -23,6 +23,7 @@
 # % keyword: machine learning
 # % keyword: scikit-learn
 # % keyword: training
+# % keyword: parallel
 # %end
 
 # %option G_OPT_I_GROUP

--- a/src/raster/r.massmov/main.c
+++ b/src/raster/r.massmov/main.c
@@ -157,6 +157,7 @@ int main(int argc, char *argv[])
     G_add_keyword(_("raster"));
     G_add_keyword(_("landslide"));
     G_add_keyword(_("model"));
+    G_add_keyword(_("parallel"));
     module->description =
 	_("Estimates run-out and deposition of landslide phenomena over a complex topography.");
 

--- a/src/raster/r.maxent.lambdas/r.maxent.lambdas.py
+++ b/src/raster/r.maxent.lambdas/r.maxent.lambdas.py
@@ -58,6 +58,7 @@ COPYRIGHT:    (C) 2019-2022 by the Norwegian Institute for Nature Research
 # % keyword: maxent
 # % keyword: ecology
 # % keyword: niche
+# % keyword: parallel
 # %End
 
 # %flag

--- a/src/raster/r.shaded.pca/r.shaded.pca.py
+++ b/src/raster/r.shaded.pca/r.shaded.pca.py
@@ -20,6 +20,7 @@
 # % keyword: elevation
 # % keyword: terrain
 # % keyword: visualization
+# % keyword: parallel
 # %end
 # %option
 # % type: string

--- a/src/raster/r.sim.terrain/r.sim.terrain.py
+++ b/src/raster/r.sim.terrain/r.sim.terrain.py
@@ -20,6 +20,7 @@ COPYRIGHT: (C) 2016 Brendan Harmon and the GRASS Development Team
 # % keyword: terrain
 # % keyword: landscape
 # % keyword: evolution
+# % keyword: parallel
 # %end
 
 # %option G_OPT_R_ELEV

--- a/src/raster/r.sun.daily/r.sun.daily.py
+++ b/src/raster/r.sun.daily/r.sun.daily.py
@@ -20,6 +20,7 @@
 # % keyword: raster
 # % keyword: solar
 # % keyword: sun energy
+# % keyword: parallel
 # %end
 
 # %option G_OPT_R_ELEV

--- a/src/raster/r.sun.hourly/r.sun.hourly.py
+++ b/src/raster/r.sun.hourly/r.sun.hourly.py
@@ -18,6 +18,7 @@
 # % keyword: raster
 # % keyword: solar
 # % keyword: sun energy
+# % keyword: parallel
 # % overwrite: yes
 # %end
 # %option

--- a/src/raster/r.survey/r.survey.py
+++ b/src/raster/r.survey/r.survey.py
@@ -34,9 +34,10 @@
 
 # %Module
 # % description: Returns maps of visibility indexes from multiple survey points
-# % keywords: raster
-# % keywords: visibility
-# % keywords: survey
+# % keyword: raster
+# % keyword: visibility
+# % keyword: survey
+# % keyword: parallel
 # %end
 # %option G_OPT_V_INPUT
 # % key: points
@@ -1579,7 +1580,7 @@ def main():
                 ),
                 quiet=True,
             )
-        gscript.message(" Succesful run ")
+        gscript.message(" Successful run ")
     # in case of CTRL-C
     except KeyboardInterrupt as error:
         gscript.fatal(f"Program interruption: {error}")

--- a/src/raster/r.tpi/r.tpi.py
+++ b/src/raster/r.tpi/r.tpi.py
@@ -50,9 +50,6 @@
 # %end
 
 import atexit
-import multiprocessing as mp
-import random
-import string
 import sys
 from subprocess import PIPE
 

--- a/src/raster/r.tpi/r.tpi.py
+++ b/src/raster/r.tpi/r.tpi.py
@@ -3,6 +3,9 @@
 # %module
 # % description: Calculates the multiscale topographic position index
 # % keyword: raster
+# % keyword: surface
+# % keyword: terrain
+# % keyword: topography
 # %end
 
 # %option G_OPT_R_INPUT

--- a/src/raster/r.tri/r.tri.py
+++ b/src/raster/r.tri/r.tri.py
@@ -15,6 +15,11 @@
 
 # %module
 # % description: Computes the Terrain Ruggedness Index.
+# % keyword: raster
+# % keyword: surface
+# % keyword: terrain
+# % keyword: ruggedness
+# % keyword: parallel
 # %end
 
 # %option G_OPT_R_INPUT

--- a/src/raster/r.vector.ruggedness/r.vector.ruggedness.py
+++ b/src/raster/r.vector.ruggedness/r.vector.ruggedness.py
@@ -22,6 +22,11 @@
 
 # %module
 # % description: Vector Ruggedness Measure
+# % keyword: raster
+# % keyword: surface
+# % keyword: terrain
+# % keyword: ruggedness
+# % keyword: parallel
 # %end
 
 # %option G_OPT_R_INPUTS

--- a/src/raster/r.viewshed.exposure/r.viewshed.exposure.py
+++ b/src/raster/r.viewshed.exposure/r.viewshed.exposure.py
@@ -6,7 +6,7 @@ MODULE:       r.viewshed.exposure
 AUTHOR(S):    Zofie Cimburova, Stefan Blumentrath
 
 PURPOSE:      Computes visual exposure to defined exposure source using
-              weighted parametrised cummulative viewshed analysis
+              weighted parametrised cumulative viewshed analysis
 
 COPYRIGHT:    (C) 2022 by Zofie Cimburova, Stefan Blumentrath, and the GRASS
               GIS Development Team
@@ -23,12 +23,13 @@ for details.
 
 # %module
 # % label: Visual exposure to defined exposure source.
-# % description: Computes visual exposure to defined exposure source using weighted parametrised cummulative viewshed analysis.
+# % description: Computes visual exposure to defined exposure source using weighted parametrised cumulative viewshed analysis.
 # % keyword: raster
 # % keyword: viewshed
 # % keyword: line of sight
 # % keyword: LOS
 # % keyword: visual exposure
+# % keyword: parallel
 # %end
 
 # %option G_OPT_R_INPUT
@@ -289,7 +290,7 @@ def do_it_all(global_vars, target_pts_np):
     the previous partial viewsheds
     :param target_pts_np: Array of target points in global coordinate system
     :type target_pts_np: ndarray
-    :return: 2D array of weighted parametrised cummulative viewshed
+    :return: 2D array of weighted parametrised cumulative viewshed
     :rtype: ndarray
     """
     # Set counter
@@ -428,13 +429,13 @@ def do_it_all(global_vars, target_pts_np):
         # 5. Cummulate viewsheds
         # ======================================================================
         # Determine position of local parametrised viewshed within
-        # global cummulative viewshed
+        # global cumulative viewshed
         o_2 = [
             int(round((reg.north - loc_reg_n) / reg.nsres)),  # NS (rows)
             int(round((loc_reg_w - reg.west) / reg.ewres)),  # EW (cols)
         ]
 
-        # Add local parametrised viewshed to global cummulative viewshed
+        # Add local parametrised viewshed to global cumulative viewshed
         # replace nans with 0 in processed regions, keep nan where both are nan
         all_nan = np.all(
             np.isnan(
@@ -1109,7 +1110,7 @@ def main():
     if pfunction == "Fuzzy_viewshed" and range_inp == -1:
         grass.fatal(
             "Exposure range cannot be \
-            infinity for fuzzy viewshed approch."
+            infinity for fuzzy viewshed approach."
         )
 
     if pfunction == "Fuzzy_viewshed" and b_1 > range_inp:
@@ -1319,7 +1320,7 @@ def main():
     grass.debug("target_pts_np: {}".format(target_pts_np))
 
     # ==========================================================================
-    # Calculate weighted parametrised cummulative viewshed
+    # Calculate weighted parametrised cumulative viewshed
     # by iterating over target points T
     # ==========================================================================
     grass.verbose("Calculating partial viewsheds...")
@@ -1362,7 +1363,7 @@ def main():
     # Combine each chunk with dictionary
     combo = list(zip(itertools.repeat(global_vars), target_pnts))
 
-    # Calculate partial cummulative viewshed
+    # Calculate partial cumulative viewshed
     with Pool(cores) as pool:
         np_sum = pool.starmap(do_it_all, combo)
         pool.close()
@@ -1380,7 +1381,7 @@ def main():
     reg.set_current()
     reg.set_raster_region()
 
-    # Convert numpy array of cummulative viewshed to raster
+    # Convert numpy array of cumulative viewshed to raster
     numpy2raster(np_sum, mtype="FCELL", rastname=r_output, overwrite=True)
 
     # Remove temporary files and reset mask if needed

--- a/src/temporal/t.rast.null/t.rast.null.py
+++ b/src/temporal/t.rast.null/t.rast.null.py
@@ -20,6 +20,7 @@
 # % keyword: temporal
 # % keyword: raster
 # % keyword: null data
+# % keyword: parallel
 # %end
 
 # %option G_OPT_STRDS_INPUT

--- a/src/temporal/t.rast.what.aggr/t.rast.what.aggr.py
+++ b/src/temporal/t.rast.what.aggr/t.rast.what.aggr.py
@@ -23,6 +23,7 @@
 # % keyword: sampling
 # % keyword: raster
 # % keyword: time
+# % keyword: parallel
 # %end
 
 # %option G_OPT_V_INPUT


### PR DESCRIPTION
* Adds parallel keyword to modules which use multiprocessing for parallel runs.
* Adds parallel keyword to modules which use OpenMP in C.
* No new keyword for r.futures, i.ann.maskrcnn, r.pops.spread, r.sun.mp, r.sim.water.mp.
* Remove unused multiprocessing and other unused imports from r.tpi.
* Adds or fixes keywords when missing or using keywords instead of keywords.
* Add aggregation as topic keyword for r.gdd (based on r.series topic keyword).
* Fixes obvious typos in non-code in modified files.