### PR TITLE
v.db.pyupdate: fix to use latest v.db.select format=json option

### DIFF
--- a/src/vector/v.db.pyupdate/testsuite/test_v_db_pyupdate.py
+++ b/src/vector/v.db.pyupdate/testsuite/test_v_db_pyupdate.py
@@ -38,8 +38,8 @@ class TestVDbPyUpdate(TestCase):
             expression="f'Phone num. {phone}'",
         )
         table = json.loads(
-            gs.read_command("v.db.select", map=self.vector_name, flags="j")
-        )
+            gs.read_command("v.db.select", map=self.vector_name, format="json")
+        )["records"]
         for row in table:
             self.assertTrue(
                 row["display_phone"].startswith("Phone num. "),
@@ -62,18 +62,19 @@ class TestVDbPyUpdate(TestCase):
             where="phone is not null",
         )
         table = json.loads(
-            gs.read_command("v.db.select", map=self.vector_name, flags="j")
-        )
+            gs.read_command("v.db.select", map=self.vector_name, format="json")
+        )["records"]
         for row in table:
-            if row["PHONE"].startswith("(919)"):
-                self.assertTrue(
-                    row["display_phone"].startswith("Phone num. (919)"),
-                    msg="Column does not contain the expected prefix: {row}".format(
-                        **locals()
-                    ),
-                )
-            else:
-                self.assertFalse(row["display_phone"].startswith("Phone num."))
+            if row["PHONE"]:
+                if row["PHONE"].startswith("(919)"):
+                    self.assertTrue(
+                        row["display_phone"].startswith("Phone num. (919)"),
+                        msg="Column does not contain the expected prefix: {row}".format(
+                            **locals()
+                        ),
+                    )
+                else:
+                    self.assertTrue(row["display_phone"] is None)
 
 
 if __name__ == "__main__":

--- a/src/vector/v.db.pyupdate/v.db.pyupdate.py
+++ b/src/vector/v.db.pyupdate/v.db.pyupdate.py
@@ -311,7 +311,6 @@ def main():
         )
         table_contents = csv_loads(csv_text, delimeter=sep, null=null)
     else:
-        # TODO: XXX is a workaround for a bug in v.db.select -j
         json_text = gs.read_command(
             "v.db.select", map=vector, layer=layer, format="json", where=where
         )

--- a/src/vector/v.db.pyupdate/v.db.pyupdate.py
+++ b/src/vector/v.db.pyupdate/v.db.pyupdate.py
@@ -313,9 +313,9 @@ def main():
     else:
         # TODO: XXX is a workaround for a bug in v.db.select -j
         json_text = gs.read_command(
-            "v.db.select", map=vector, layer=layer, flags="j", null="XXX", where=where
+            "v.db.select", map=vector, layer=layer, format="json", where=where
         )
-        table_contents = json.loads(json_text)
+        table_contents = json.loads(json_text)["records"]
 
     cmd = python_to_transaction(
         table=table,


### PR DESCRIPTION
At one point during development v.db.select used -j flag for json output, but it was changed to format=json before release. v.db.pyupdate was using the old syntax. Tests are also updated, so they should run now.