### PR TITLE
CI: upgrade to latest R to fix test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
     - name: Set up R
       uses: r-lib/actions/setup-r@v1
       with:
-        r-version: "4.0.4"
+        r-version: "4.2.1"
 
     - name: Get R dependencies
       run: |


### PR DESCRIPTION
r.futures.potential uses MuMIn R package which requires >= 4.2.0. Upgrading from 4.0.4 to latest 4.2.1 should fix that.