### PR TITLE
i.gabor: fix lazy import py packages

### DIFF
--- a/src/imagery/i.gabor/i.gabor.py
+++ b/src/imagery/i.gabor/i.gabor.py
@@ -194,11 +194,10 @@ def main():
 
 
 if __name__ == "__main__":
+    options, flags = grass.parser()
     # Lazy import for scipy.signal.fftconvolve
     try:
         from scipy.signal import fftconvolve
     except ImportError:
         grass.fatal(_("Cannot import fftconvolve from scipy"))
-
-    options, flags = grass.parser()
     sys.exit(main())


### PR DESCRIPTION
Lazy import py packages must be called after call `grass.parser()` function.

**Error message:**

`scipy` py package is not available.

```
GRASS nc_spm_08_grass7/landsat:~ > g.extension i.gabor
Fetching <i.gabor> from GRASS GIS Addons repository (be patient)...
Compiling...
ERROR: Cannot import fftconvolve from scipy
make: *** [/usr/lib64/grass83/include/Make/Html.make:14: i.gabor.tmp.html] Error 1
ERROR: Compilation failed, sorry. Please check above error messages.
```

**Expected behavior:**

The addon installation should work even if the scipy py package is not available.