### PR TITLE
r.in.nasadem: catch http error

### DIFF
--- a/src/raster/r.in.nasadem/r.in.nasadem.py
+++ b/src/raster/r.in.nasadem/r.in.nasadem.py
@@ -301,9 +301,10 @@ def download_tile(tile, url, pid, version, username, password):
         time.sleep(0.5)
     except urllib.error.URLError as err:
         grass.fatal(
-            _("Download of tile {0} from URL {1} was not successful:\n{2}").format(
-                local_tile, remote_tile, err
-            )
+            _(
+                "Download of tile {local_tile} from URL {remote_tile} was not"
+                "successful:\n{err}"
+            ).format(local_tile=local_tile, remote_tile=remote_tile, err=err)
         )
 
     return goturl

--- a/src/raster/r.in.nasadem/r.in.nasadem.py
+++ b/src/raster/r.in.nasadem/r.in.nasadem.py
@@ -301,9 +301,8 @@ def download_tile(tile, url, pid, version, username, password):
         time.sleep(0.5)
     except urllib.error.URLError as err:
         grass.fatal(
-            _(
-                f"Download of tile {local_tile} from URL {remote_tile} was not "
-                f"successful:\n{err}"
+            _("Download of tile {0} from URL {1} was not successful:\n{2}").format(
+                local_tile, remote_tile, err
             )
         )
 

--- a/src/raster/r.in.nasadem/r.in.nasadem.py
+++ b/src/raster/r.in.nasadem/r.in.nasadem.py
@@ -300,8 +300,12 @@ def download_tile(tile, url, pid, version, username, password):
         fo.close
         time.sleep(0.5)
     except urllib.error.URLError as err:
-        grass.fatal(_(f"Download of tile {local_tile} from URL {remote_tile} was not "
-                      f"successful:\n{err}"))
+        grass.fatal(
+            _(
+                f"Download of tile {local_tile} from URL {remote_tile} was not "
+                f"successful:\n{err}"
+            )
+        )
 
     return goturl
 

--- a/src/raster/r.in.nasadem/r.in.nasadem.py
+++ b/src/raster/r.in.nasadem/r.in.nasadem.py
@@ -302,7 +302,7 @@ def download_tile(tile, url, pid, version, username, password):
     except urllib.error.URLError as err:
         grass.fatal(
             _(
-                "Download of tile {local_tile} from URL {remote_tile} was not"
+                "Download of tile {local_tile} from URL {remote_tile} was not "
                 "successful:\n{err}"
             ).format(local_tile=local_tile, remote_tile=remote_tile, err=err)
         )


### PR DESCRIPTION
This PR fixes #821:

- Any connection error for the download of nasadem tiles is now properly caught and reported using the generic [urllib.error.URLError](https://docs.python.org/3/library/urllib.error.html)
- A bug in the cleanup function is fixed: The region is saved in the original location/mapset, but at the beginning of the cleanup function, we may still be in the temp location. This resulted in errors of `g.remove type=region...`