### PR TITLE
.github/workflows: remove build old stable GRASS GIS 8.0 version from the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
             python-version: "3.8"
           - grass-version: releasebranch_8_2
             python-version: "3.8"
-          - grass-version: releasebranch_8_0
-            python-version: "3.7"
       fail-fast: false
 
     steps:


### PR DESCRIPTION
See https://github.com/OSGeo/grass-addons/pull/819#issuecomment-1287415722.