### PR TITLE
SEO GRASS GIS 7 manual: properly inject canonical

### DIFF
--- a/utils/cronjobs_osgeo_lxd/cron_job_list_grass
+++ b/utils/cronjobs_osgeo_lxd/cron_job_list_grass
@@ -30,11 +30,11 @@
 
 # daily Linux binary snapshots, also creates main manuals, addon manuals, and prog-manual (target dir: /var/www/code_and_data/)
 # old stable: G78
-05 05 * * * nice sh /home/neteler/cronjobs/cron_grass7_relbranch_build_binaries.sh > /var/www/code_and_data/grass78/binary/linux/snapshot/build.log.txt 2>&1
+00 05 * * * nice sh /home/neteler/cronjobs/cron_grass7_relbranch_build_binaries.sh > /var/www/code_and_data/grass78/binary/linux/snapshot/build.log.txt 2>&1
 # stable: G82
-15 05 * * * nice sh /home/neteler/cronjobs/cron_grass8_relbranch_build_binaries.sh > /var/www/code_and_data/grass82/binary/linux/snapshot/build.log.txt 2>&1
+35 05 * * * nice sh /home/neteler/cronjobs/cron_grass8_relbranch_build_binaries.sh > /var/www/code_and_data/grass82/binary/linux/snapshot/build.log.txt 2>&1
 # dev: G83
-25 05 * * * nice sh /home/neteler/cronjobs/cron_grass8_main_build_binaries.sh > /var/www/code_and_data/grass83/binary/linux/snapshot/build.log.txt 2>&1
+10 06 * * * nice sh /home/neteler/cronjobs/cron_grass8_main_build_binaries.sh > /var/www/code_and_data/grass83/binary/linux/snapshot/build.log.txt 2>&1
 
 
 # generate osgeo_mailman_stats/ + email


### PR DESCRIPTION
- Since the canonical was overwritten during addon compilation, a second (modified) injection in the cronjob
- shift timings of cronjobs to avoid overlaps