### PR TITLE
r.series.boxplot / t.rast.boxplot: html manual fixes

### DIFF
--- a/src/raster/r.series.boxplot/r.series.boxplot.html
+++ b/src/raster/r.series.boxplot/r.series.boxplot.html
@@ -23,7 +23,7 @@ need to be the same as the number of input raster layers.
 
 <p>
 By default, the resulting plot is displayed on screen. However, the 
-user can also save the plot to file using the em>output</em> option. 
+user can also save the plot to file using the <em>output</em> option.
 The format is determined by the extension given by the user. So, if 
 output = outputfile.png, the plot will be saved as a *png* file. The 
 user can set the output size (in inches) and resolution (dpi) of the 

--- a/src/raster/r.series.boxplot/r.series.boxplot.html
+++ b/src/raster/r.series.boxplot/r.series.boxplot.html
@@ -108,12 +108,10 @@ University of Applied Sciences.
 <h2>SEE ALSO</h2> 
 
 <em>
-<ul>
-	<li><a href="https://grass.osgeo.org/grass-stable/manuals/addons/r.boxplot.html">r.boxplot.html</a></li>
-	<li><a href="https://grass.osgeo.org/grass-stable/manuals/addons/d.vect.colbp.html">d.vect.colbp</a></li> 
-	<li><a href="https://grass.osgeo.org/grass-stable/manuals/addons/r.scatterplot.html">r.scatterplot</a></li>
-	<li><a href="https://grass.osgeo.org/grass-stable/manuals/r.stats.zonal.html">r.stats.zonal</a></li>
-</ul>
+<a href="https://grass.osgeo.org/grass-stable/manuals/addons/r.boxplot.html">r.boxplot.html</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/addons/d.vect.colbp.html">d.vect.colbp</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/addons/r.scatterplot.html">r.scatterplot</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.stats.zonal.html">r.stats.zonal</a>
 </em> 
 
 <h2>AUTHOR</h2>

--- a/src/temporal/t.rast.boxplot/t.rast.boxplot.html
+++ b/src/temporal/t.rast.boxplot/t.rast.boxplot.html
@@ -183,14 +183,12 @@ University of Applied Sciences.
 <h2>SEE ALSO</h2> 
 
 <em>
-<ul>
-	<li><a href="https://grass.osgeo.org/grass-stable/manuals/addons/r.boxplot.html">r.boxplot.html</a></li>
-    <li><a href="https://grass.osgeo.org/grass-stable/manuals/addons/r.series.boxplot.html">r.series.boxplot.html</a></li>
-	<li><a href="https://grass.osgeo.org/grass-stable/manuals/addons/d.vect.colbp.html">d.vect.colbp</a></li> 
-	<li><a href="https://grass.osgeo.org/grass-stable/manuals/addons/r.scatterplot.html">r.scatterplot</a></li>
-	<li><a href="https://grass.osgeo.org/grass-stable/manuals/r.stats.zonal.html">r.stats.zonal</a></li>
-    <li><a href="https://grass.osgeo.org/grass-stable/manuals/t.rast.aggregate.html">t.rast.aggregate</a></li>
-</ul>
+<a href="https://grass.osgeo.org/grass-stable/manuals/addons/r.boxplot.html">r.boxplot.html</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/addons/r.series.boxplot.html">r.series.boxplot.html</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/addons/d.vect.colbp.html">d.vect.colbp</a>, 
+<a href="https://grass.osgeo.org/grass-stable/manuals/addons/r.scatterplot.html">r.scatterplot</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.stats.zonal.html">r.stats.zonal</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/t.rast.aggregate.html">t.rast.aggregate</a>
 </em> 
 
 <h2>AUTHOR</h2>


### PR DESCRIPTION
HTML manuals for currently fail to build, see:
https://grass.osgeo.org/addons/grass8/logs/

This PR attempts to addresses those issues and with the proposed changes HTML manuals build locally:
`python3 /opt/src/grass/dist.x86_64-pc-linux-gnu/utils/mkhtml.py t.rast.boxplot`