### PR TITLE
r.pi: Add GRASS_LIB_VERSION_NUMBER to LIB_NAME for Windows

### DIFF
--- a/src/raster/r.pi/r.pi.corearea/Makefile
+++ b/src/raster/r.pi/r.pi.corearea/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PGM = r.pi.corearea
 
-LIB_NAME = grass_rpi
+LIB_NAME = grass_rpi.$(GRASS_LIB_VERSION_NUMBER)
 RPI_LIB  = -l$(LIB_NAME)
 
 LIBES = $(STATSLIB) $(RASTERLIB) $(GISLIB) $(RPI_LIB)

--- a/src/raster/r.pi/r.pi.csr.mw/Makefile
+++ b/src/raster/r.pi/r.pi.csr.mw/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PGM = r.pi.csr.mw
 
-LIB_NAME = grass_rpi
+LIB_NAME = grass_rpi.$(GRASS_LIB_VERSION_NUMBER)
 RPI_LIB  = -l$(LIB_NAME)
 
 LIBES = $(STATSLIB) $(RASTERLIB) $(GISLIB) $(RPI_LIB)

--- a/src/raster/r.pi/r.pi.energy.pr/Makefile
+++ b/src/raster/r.pi/r.pi.energy.pr/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PGM = r.pi.energy.pr
 
-LIB_NAME = grass_rpi
+LIB_NAME = grass_rpi.$(GRASS_LIB_VERSION_NUMBER)
 RPI_LIB  = -l$(LIB_NAME)
 
 LIBES = $(STATSLIB) $(RASTERLIB) $(GISLIB) $(RPI_LIB)

--- a/src/raster/r.pi/r.pi.energy/Makefile
+++ b/src/raster/r.pi/r.pi.energy/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PGM = r.pi.energy
 
-LIB_NAME = grass_rpi
+LIB_NAME = grass_rpi.$(GRASS_LIB_VERSION_NUMBER)
 RPI_LIB  = -l$(LIB_NAME)
 
 LIBES = $(STATSLIB) $(RASTERLIB) $(GISLIB) $(RPI_LIB)

--- a/src/raster/r.pi/r.pi.enn.pr/Makefile
+++ b/src/raster/r.pi/r.pi.enn.pr/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PGM = r.pi.enn.pr
 
-LIB_NAME = grass_rpi
+LIB_NAME = grass_rpi.$(GRASS_LIB_VERSION_NUMBER)
 RPI_LIB  = -l$(LIB_NAME)
 
 LIBES = $(STATSLIB) $(RASTERLIB) $(GISLIB) $(RPI_LIB)

--- a/src/raster/r.pi/r.pi.enn/Makefile
+++ b/src/raster/r.pi/r.pi.enn/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PGM = r.pi.enn
 
-LIB_NAME = grass_rpi
+LIB_NAME = grass_rpi.$(GRASS_LIB_VERSION_NUMBER)
 RPI_LIB  = -l$(LIB_NAME)
 
 LIBES = $(STATSLIB) $(RASTERLIB) $(GISLIB) $(RPI_LIB)

--- a/src/raster/r.pi/r.pi.export/Makefile
+++ b/src/raster/r.pi/r.pi.export/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PGM = r.pi.export
 
-LIB_NAME = grass_rpi
+LIB_NAME = grass_rpi.$(GRASS_LIB_VERSION_NUMBER)
 RPI_LIB  = -l$(LIB_NAME)
 
 LIBES = $(STATSLIB) $(RASTERLIB) $(GISLIB) $(RPI_LIB)

--- a/src/raster/r.pi/r.pi.fnn/Makefile
+++ b/src/raster/r.pi/r.pi.fnn/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PGM = r.pi.fnn
 
-LIB_NAME = grass_rpi
+LIB_NAME = grass_rpi.$(GRASS_LIB_VERSION_NUMBER)
 RPI_LIB  = -l$(LIB_NAME)
 
 LIBES = $(STATSLIB) $(RASTERLIB) $(GISLIB) $(RPI_LIB)

--- a/src/raster/r.pi/r.pi.graph.dec/Makefile
+++ b/src/raster/r.pi/r.pi.graph.dec/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PGM = r.pi.graph.dec
 
-LIB_NAME = grass_rpi
+LIB_NAME = grass_rpi.$(GRASS_LIB_VERSION_NUMBER)
 RPI_LIB  = -l$(LIB_NAME)
 
 LIBES = $(STATSLIB) $(RASTERLIB) $(GISLIB) $(RPI_LIB)

--- a/src/raster/r.pi/r.pi.graph.pr/Makefile
+++ b/src/raster/r.pi/r.pi.graph.pr/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PGM = r.pi.graph.pr
 
-LIB_NAME = grass_rpi
+LIB_NAME = grass_rpi.$(GRASS_LIB_VERSION_NUMBER)
 RPI_LIB  = -l$(LIB_NAME)
 
 LIBES = $(STATSLIB) $(RASTERLIB) $(GISLIB) $(RPI_LIB)

--- a/src/raster/r.pi/r.pi.graph.red/Makefile
+++ b/src/raster/r.pi/r.pi.graph.red/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PGM = r.pi.graph.red
 
-LIB_NAME = grass_rpi
+LIB_NAME = grass_rpi.$(GRASS_LIB_VERSION_NUMBER)
 RPI_LIB  = -l$(LIB_NAME)
 
 LIBES = $(STATSLIB) $(RASTERLIB) $(GISLIB) $(RPI_LIB)

--- a/src/raster/r.pi/r.pi.graph/Makefile
+++ b/src/raster/r.pi/r.pi.graph/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PGM = r.pi.graph
 
-LIB_NAME = grass_rpi
+LIB_NAME = grass_rpi.$(GRASS_LIB_VERSION_NUMBER)
 RPI_LIB  = -l$(LIB_NAME)
 
 LIBES = $(STATSLIB) $(RASTERLIB) $(GISLIB) $(RPI_LIB)

--- a/src/raster/r.pi/r.pi.import/Makefile
+++ b/src/raster/r.pi/r.pi.import/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PGM = r.pi.import
 
-LIB_NAME = grass_rpi
+LIB_NAME = grass_rpi.$(GRASS_LIB_VERSION_NUMBER)
 RPI_LIB  = -l$(LIB_NAME)
 
 LIBES = $(STATSLIB) $(RASTERLIB) $(GISLIB) $(RPI_LIB)

--- a/src/raster/r.pi/r.pi.index/Makefile
+++ b/src/raster/r.pi/r.pi.index/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PGM = r.pi.index
 
-LIB_NAME = grass_rpi
+LIB_NAME = grass_rpi.$(GRASS_LIB_VERSION_NUMBER)
 RPI_LIB  = -l$(LIB_NAME)
 
 LIBES = $(STATSLIB) $(RASTERLIB) $(GISLIB) $(RPI_LIB)

--- a/src/raster/r.pi/r.pi.neigh/Makefile
+++ b/src/raster/r.pi/r.pi.neigh/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PGM = r.pi.neigh
 
-LIB_NAME = grass_rpi
+LIB_NAME = grass_rpi.$(GRASS_LIB_VERSION_NUMBER)
 RPI_LIB  = -l$(LIB_NAME)
 
 LIBES = $(STATSLIB) $(RASTERLIB) $(GISLIB) $(RPI_LIB)

--- a/src/raster/r.pi/r.pi.nlm.circ/Makefile
+++ b/src/raster/r.pi/r.pi.nlm.circ/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PGM = r.pi.nlm.circ
 
-LIB_NAME = grass_rpi
+LIB_NAME = grass_rpi.$(GRASS_LIB_VERSION_NUMBER)
 RPI_LIB  = -l$(LIB_NAME)
 
 LIBES = $(STATSLIB) $(RASTERLIB) $(GISLIB) $(RPI_LIB)

--- a/src/raster/r.pi/r.pi.nlm.stats/Makefile
+++ b/src/raster/r.pi/r.pi.nlm.stats/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PGM = r.pi.nlm.stats
 
-LIB_NAME = grass_rpi
+LIB_NAME = grass_rpi.$(GRASS_LIB_VERSION_NUMBER)
 RPI_LIB  = -l$(LIB_NAME)
 
 LIBES = $(STATSLIB) $(RASTERLIB) $(GISLIB) $(RPI_LIB)

--- a/src/raster/r.pi/r.pi.nlm/Makefile
+++ b/src/raster/r.pi/r.pi.nlm/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PGM = r.pi.nlm
 
-LIB_NAME = grass_rpi
+LIB_NAME = grass_rpi.$(GRASS_LIB_VERSION_NUMBER)
 RPI_LIB  = -l$(LIB_NAME)
 
 LIBES = $(STATSLIB) $(RASTERLIB) $(GISLIB) $(RPI_LIB)

--- a/src/raster/r.pi/r.pi.odc/Makefile
+++ b/src/raster/r.pi/r.pi.odc/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PGM = r.pi.odc
 
-LIB_NAME = grass_rpi
+LIB_NAME = grass_rpi.$(GRASS_LIB_VERSION_NUMBER)
 RPI_LIB  = -l$(LIB_NAME)
 
 LIBES = $(STATSLIB) $(RASTERLIB) $(GISLIB) $(RPI_LIB)

--- a/src/raster/r.pi/r.pi.prob.mw/Makefile
+++ b/src/raster/r.pi/r.pi.prob.mw/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PGM = r.pi.prob.mw
 
-LIB_NAME = grass_rpi
+LIB_NAME = grass_rpi.$(GRASS_LIB_VERSION_NUMBER)
 RPI_LIB  = -l$(LIB_NAME)
 
 LIBES = $(STATSLIB) $(RASTERLIB) $(GISLIB) $(RPI_LIB)

--- a/src/raster/r.pi/r.pi.prox/Makefile
+++ b/src/raster/r.pi/r.pi.prox/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PGM = r.pi.prox
 
-LIB_NAME = grass_rpi
+LIB_NAME = grass_rpi.$(GRASS_LIB_VERSION_NUMBER)
 RPI_LIB  = -l$(LIB_NAME)
 
 LIBES = $(STATSLIB) $(RASTERLIB) $(GISLIB) $(RPI_LIB)

--- a/src/raster/r.pi/r.pi.searchtime.mw/Makefile
+++ b/src/raster/r.pi/r.pi.searchtime.mw/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PGM = r.pi.searchtime.mw
 
-LIB_NAME = grass_rpi
+LIB_NAME = grass_rpi.$(GRASS_LIB_VERSION_NUMBER)
 RPI_LIB  = -l$(LIB_NAME)
 
 LIBES = $(STATSLIB) $(RASTERLIB) $(GISLIB) $(RPI_LIB)

--- a/src/raster/r.pi/r.pi.searchtime.pr/Makefile
+++ b/src/raster/r.pi/r.pi.searchtime.pr/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PGM = r.pi.searchtime.pr
 
-LIB_NAME = grass_rpi
+LIB_NAME = grass_rpi.$(GRASS_LIB_VERSION_NUMBER)
 RPI_LIB  = -l$(LIB_NAME)
 
 LIBES = $(STATSLIB) $(RASTERLIB) $(GISLIB) $(RPI_LIB)

--- a/src/raster/r.pi/r.pi.searchtime/Makefile
+++ b/src/raster/r.pi/r.pi.searchtime/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PGM = r.pi.searchtime
 
-LIB_NAME = grass_rpi
+LIB_NAME = grass_rpi.$(GRASS_LIB_VERSION_NUMBER)
 RPI_LIB  = -l$(LIB_NAME)
 
 LIBES = $(STATSLIB) $(RASTERLIB) $(GISLIB) $(RPI_LIB)


### PR DESCRIPTION
This PR adds the version number to `-lgrass_rpi` to support MinGW compilation on Windows.