### PR TITLE
i.pr: Replace drand48() with G_drand48(), Add lib version to -lgrass_pr for Windows

### DIFF
--- a/src/imagery/i.pr/PRLIB/bootstrap.c
+++ b/src/imagery/i.pr/PRLIB/bootstrap.c
@@ -35,7 +35,7 @@ void Bootsamples(int n, double *prob, int *random_labels)
     cumprob = (double *)G_calloc(n, sizeof(double));
 
     for (i = 0; i < n; ++i) {
-	random[i] = (double)drand48();
+	random[i] = G_drand48();
 	random_labels[i] = n - 1;
 	random_labels_flag[i] = 0;
     }

--- a/src/imagery/i.pr/PRLIB/svm.c
+++ b/src/imagery/i.pr/PRLIB/svm.c
@@ -328,7 +328,7 @@ static int examineExample(int i1, SupportVectorMachine * SVM)
 	{
 	    int k0, k, i2;
 
-	    for (k0 = (int)(drand48() * SVM->end_support_i), k = k0;
+	    for (k0 = (int)(G_drand48() * SVM->end_support_i), k = k0;
 		 k < SVM->end_support_i + k0; k++) {
 		i2 = k % SVM->end_support_i;
 		if (SVM->alph[i2] > 0 && SVM->alph[i2] < SVM->Cw[i2]) {
@@ -340,7 +340,7 @@ static int examineExample(int i1, SupportVectorMachine * SVM)
 	{
 	    int k0, k, i2;
 
-	    for (k0 = (int)(drand48() * SVM->end_support_i), k = k0;
+	    for (k0 = (int)(G_drand48() * SVM->end_support_i), k = k0;
 		 k < SVM->end_support_i + k0; k++) {
 		i2 = k % SVM->end_support_i;
 		if (takeStep(i1, i2, SVM))
@@ -880,7 +880,7 @@ void estimate_cv_error(SupportVectorMachine * SVM)
 
 		if (n_span > SVM->d)
 		    for (i = 0; i < n_span; i++)
-			M[i][i] += drand48() * M[i][i] / 100.;
+			M[i][i] += G_drand48() * M[i][i] / 100.;
 
 		indx1 = 0;
 		for (i = 0; i < SVM->N; i++)

--- a/src/imagery/i.pr/i.pr_blob/Makefile
+++ b/src/imagery/i.pr/i.pr_blob/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PRINCLUDE = ../include/
 EXTRA_CFLAGS = -I$(PRINCLUDE)
-PRLIB = -lgrass_pr
+PRLIB = -lgrass_pr.$(GRASS_LIB_VERSION_NUMBER)
 
 PGM = i.pr.blob
 

--- a/src/imagery/i.pr/i.pr_classify/Makefile
+++ b/src/imagery/i.pr/i.pr_classify/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PRINCLUDE = ../include/
 EXTRA_CFLAGS = -I$(PRINCLUDE)
-PRLIB = -lgrass_pr
+PRLIB = -lgrass_pr.$(GRASS_LIB_VERSION_NUMBER)
 
 PGM = i.pr.classify
 

--- a/src/imagery/i.pr/i.pr_features/Makefile
+++ b/src/imagery/i.pr/i.pr_features/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PRINCLUDE = ../include/
 EXTRA_CFLAGS = -I$(PRINCLUDE)
-PRLIB = -lgrass_pr
+PRLIB = -lgrass_pr.$(GRASS_LIB_VERSION_NUMBER)
 
 PGM = i.pr.features
 

--- a/src/imagery/i.pr/i.pr_features_additional/Makefile
+++ b/src/imagery/i.pr/i.pr_features_additional/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PRINCLUDE = ../include/
 EXTRA_CFLAGS = -I$(PRINCLUDE)
-PRLIB = -lgrass_pr
+PRLIB = -lgrass_pr.$(GRASS_LIB_VERSION_NUMBER)
 
 PGM = i.pr.features_additional
 

--- a/src/imagery/i.pr/i.pr_features_extract/Makefile
+++ b/src/imagery/i.pr/i.pr_features_extract/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PRINCLUDE = ../include/
 EXTRA_CFLAGS = -I$(PRINCLUDE)
-PRLIB = -lgrass_pr
+PRLIB = -lgrass_pr.$(GRASS_LIB_VERSION_NUMBER)
 
 PGM = i.pr.features_extract
 

--- a/src/imagery/i.pr/i.pr_features_selection/Makefile
+++ b/src/imagery/i.pr/i.pr_features_selection/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PRINCLUDE = ../include/
 EXTRA_CFLAGS = -I$(PRINCLUDE)
-PRLIB = -lgrass_pr
+PRLIB = -lgrass_pr.$(GRASS_LIB_VERSION_NUMBER)
 
 PGM = i.pr.features_selection
 

--- a/src/imagery/i.pr/i.pr_model/Makefile
+++ b/src/imagery/i.pr/i.pr_model/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PRINCLUDE = ../include/
 EXTRA_CFLAGS = -I$(PRINCLUDE)
-PRLIB = -lgrass_pr
+PRLIB = -lgrass_pr.$(GRASS_LIB_VERSION_NUMBER)
 
 PGM = i.pr.model
 

--- a/src/imagery/i.pr/i.pr_sites_aggregate/Makefile
+++ b/src/imagery/i.pr/i.pr_sites_aggregate/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PRINCLUDE = ../include/
 EXTRA_CFLAGS = $(VECT_CFLAGS) -I$(PRINCLUDE)
-PRLIB = -lgrass_pr
+PRLIB = -lgrass_pr.$(GRASS_LIB_VERSION_NUMBER)
 
 PGM = i.pr.sites_aggregate
 

--- a/src/imagery/i.pr/i.pr_statistics/Makefile
+++ b/src/imagery/i.pr/i.pr_statistics/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PRINCLUDE = ../include/
 EXTRA_CFLAGS = -I$(PRINCLUDE)
-PRLIB = -lgrass_pr
+PRLIB = -lgrass_pr.$(GRASS_LIB_VERSION_NUMBER)
 
 PGM = i.pr.statistics
 

--- a/src/imagery/i.pr/i.pr_subsets/Makefile
+++ b/src/imagery/i.pr/i.pr_subsets/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PRINCLUDE = ../include/
 EXTRA_CFLAGS = -I$(PRINCLUDE)
-PRLIB = -lgrass_pr
+PRLIB = -lgrass_pr.$(GRASS_LIB_VERSION_NUMBER)
 
 PGM = i.pr.subsets
 

--- a/src/imagery/i.pr/i.pr_training/Makefile
+++ b/src/imagery/i.pr/i.pr_training/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PRINCLUDE = ../include/
 EXTRA_CFLAGS = -I$(PRINCLUDE)
-PRLIB = -lgrass_pr
+PRLIB = -lgrass_pr.$(GRASS_LIB_VERSION_NUMBER)
 
 PGM = i.pr.training
 

--- a/src/imagery/i.pr/i.pr_uxb/Makefile
+++ b/src/imagery/i.pr/i.pr_uxb/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../../..
 
 PRINCLUDE = ../include/
 EXTRA_CFLAGS = -I$(PRINCLUDE)
-PRLIB = -lgrass_pr
+PRLIB = -lgrass_pr.$(GRASS_LIB_VERSION_NUMBER)
 
 PGM = i.pr.uxb
 


### PR DESCRIPTION
This PR enables compilation of i.pr modules for Windows (except some modules that use old header files).