### PR TITLE
r.confusionmatrix: fix tests

### DIFF
--- a/src/raster/r.confusionmatrix/r.confusionmatrix.html
+++ b/src/raster/r.confusionmatrix/r.confusionmatrix.html
@@ -7,7 +7,7 @@ of classification result using <em>r.kappa</em>.
 <h2>NOTES</h2>
 
 The reference can be a raster map <b>raster_reference</b> or a vector map
-<b>vector_reference</b> with a <b>column</b> containing the class labels as 
+<b>vector_reference</b> with a <b>column</b> containing the class labels as
 integer numbers.
 <p>
 In case of vector reference, this map is rasterized according to the extent and
@@ -30,4 +30,4 @@ r.confusionmatrix classification=classified raster_reference=trainingmap csvfile
 
 <h2>AUTHOR</h2>
 
-Anika Bettge, mundialis GmbH &amp; Co. KG
+Anika Weinmann, mundialis GmbH &amp; Co. KG

--- a/src/raster/r.confusionmatrix/r.confusionmatrix.html
+++ b/src/raster/r.confusionmatrix/r.confusionmatrix.html
@@ -30,4 +30,4 @@ r.confusionmatrix classification=classified raster_reference=trainingmap csvfile
 
 <h2>AUTHOR</h2>
 
-Anika Weinmann, mundialis GmbH &amp; Co. KG
+Anika Weinmann, <a href="https://www.mundialis.de/">mundialis GmbH &amp; Co. KG</a>

--- a/src/raster/r.confusionmatrix/r.confusionmatrix.py
+++ b/src/raster/r.confusionmatrix/r.confusionmatrix.py
@@ -2,13 +2,13 @@
 
 ############################################################################
 #
-# MODULE:	r.confusionmatrix
+# MODULE:	 r.confusionmatrix
 #
-# AUTHOR(S):    Anika Bettge <bettge at mundialis.de>
+# AUTHOR(S): Anika Weinmann <weinmann at mundialis.de>
 #
-# PURPOSE:      Calculates a confusion matrix and accuracies for a given classification using r.kappa.
+# PURPOSE:   Calculates a confusion matrix and accuracies for a given classification using r.kappa.
 #
-# COPYRIGHT:	(C) 2020 by mundialis and the GRASS Development Team
+# COPYRIGHT: (C) 2020 by mundialis and the GRASS Development Team
 #
 # 		This program is free software under the GNU General Public
 # 		License (>=v2). Read the file COPYING that comes with GRASS

--- a/src/raster/r.confusionmatrix/r.confusionmatrix.py
+++ b/src/raster/r.confusionmatrix/r.confusionmatrix.py
@@ -8,7 +8,7 @@
 #
 # PURPOSE:   Calculates a confusion matrix and accuracies for a given classification using r.kappa.
 #
-# COPYRIGHT: (C) 2020 by mundialis and the GRASS Development Team
+# COPYRIGHT: (C) 2020-2023 by mundialis and the GRASS Development Team
 #
 # 		This program is free software under the GNU General Public
 # 		License (>=v2). Read the file COPYING that comes with GRASS

--- a/src/raster/r.confusionmatrix/testsuite/data/confusionmatrix_raster_matrix.csv
+++ b/src/raster/r.confusionmatrix/testsuite/data/confusionmatrix_raster_matrix.csv
@@ -1,5 +1,5 @@
 ,,Reference Map,landclass96
-,,developed,agriculture,herbaceous,shrubland,forest,water,sediment,Class_7,Class_8,Class_9,Class_10,Class_11,Class_12,Class_13,Class_14,User Accuracy,Commission Error
+,,developed,agriculture,herbaceous,shrubland,forest,water,sediment,8,9,10,11,15,18,20,21,User Accuracy,Commission Error
 Classified Map,High Intensity Developed,34931,0,0,0,0,0,0,0,0,0,0,0,0,0,0,100.0,0.0
 landuse96_28m,Low Intensity Developed,38146,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0.0,100.0
 ,Cultivated,0,2137,0,0,0,0,0,0,0,0,0,0,0,0,0,0.0,100.0

--- a/src/raster/r.confusionmatrix/testsuite/data/confusionmatrix_raster_matrix_oneclass.csv
+++ b/src/raster/r.confusionmatrix/testsuite/data/confusionmatrix_raster_matrix_oneclass.csv
@@ -1,6 +1,6 @@
 ,,Reference Map,landclass96_class1only
-,,Class_0,User Accuracy,Commission Error
-Classified Map,Class_0,73077,100.0,0.0
+,,1,User Accuracy,Commission Error
+Classified Map,1,73077,100.0,0.0
 landuse96_28m_class1only,,,,
 ,Producer Accuracy,100.0,Overall Accuracy,100.0
 ,Omission Error,0.0,Kappa coefficient,nan

--- a/src/raster/r.confusionmatrix/testsuite/test_r_confusionmatrix.py
+++ b/src/raster/r.confusionmatrix/testsuite/test_r_confusionmatrix.py
@@ -2,8 +2,8 @@
 Name:       r.confusionmatrix test
 Purpose:    Tests r.confusionmatrix input parsing.
             Uses NC full sample data set.
-Author:     Anika Bettge
-Copyright:  (C) 2020 Anika Bettge, mundialis, and the GRASS Development Team
+Author:     Anika Weinmann
+Copyright:  (C) 2020-2023 Anika Weinmann, mundialis, and the GRASS Development Team
 Licence:    This program is free software under the GNU General Public
             License (>=v2). Read the file COPYING that comes with GRASS
             for details.
@@ -67,7 +67,6 @@ class Testconfusionmatrix(TestCase):
         # check to see if output file exists
         self.assertFileExists(self.output_csv, msg="Output file does not exist")
         # check if the output file is equal to the reference file
-
         self.assertFilesEqualMd5(
             self.output_csv,
             "data/confusionmatrix_raster_matrix.csv",


### PR DESCRIPTION
Fix tests by adjust result data after `r.kappa` change.
Solves [831](https://github.com/OSGeo/grass-addons/issues/831)