### PR TITLE
GitHub actions: update to current versions

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -15,17 +15,17 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             python-version: "3.10"
             black-version: "22.3.0"
 
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     name: ${{ matrix.grass-version }} (Python ${{ matrix.python-version }})
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -21,22 +21,22 @@ jobs:
         # only.
         include:
           - grass-version: main
-            python-version: "3.8"
+            python-version: "3.10"
           - grass-version: releasebranch_8_2
-            python-version: "3.8"
+            python-version: "3.10"
       fail-fast: false
 
     steps:
 
     - name: Checkout core
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: OSGeo/grass
         ref: ${{ matrix.grass-version }}
         path: grass
 
     - name: Checkout addons
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: grass-addons
 
@@ -48,7 +48,7 @@ jobs:
             sudo apt-get install -y --no-install-recommends --no-install-suggests
 
     - name: Set up Python ${{ matrix.python-version }} as default Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -94,7 +94,7 @@ jobs:
         pip install -r grass-addons/.github/workflows/extra_requirements.txt
 
     - name: Set up R
-      uses: r-lib/actions/setup-r@v1
+      uses: r-lib/actions/setup-r@v2
       with:
         r-version: "4.2.1"
 

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -6,15 +6,15 @@ on:
 
 jobs:
   flake8:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.10
 
       - name: Install
         run: |

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Install
         run: |

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -16,18 +16,18 @@ jobs:
         uses: github/super-linter@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Listed but disabled linters would be nice to have.
+          # Listed but commented out linters would be nice to have.
+          # (see https://github.com/github/super-linter#environment-variables)
+          #
           # Python (supported using Pylint) and C/C++ (not supported) are
           # handled separately due to the complexity of the settings.
-          # (The rest is simply disabled automatically as of v2.)
-          # VALIDATE_BASH: false
-          # VALIDATE_CSS: false
-          # VALIDATE_DOCKER: false
+          # VALIDATE_BASH: true
+          # VALIDATE_CSS: true
+          # VALIDATE_DOCKER: true
           VALIDATE_JAVASCRIPT_ES: true
-          # VALIDATE_JAVASCRIPT_STANDARD: false
+          # VALIDATE_JAVASCRIPT_STANDARD: true
           VALIDATE_JSON: true
           VALIDATE_MARKDOWN: true
-          # VALIDATE_PERL: false
           VALIDATE_POWERSHELL: true
-          # VALIDATE_XML: false
+          # VALIDATE_XML: true
           VALIDATE_YAML: true

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Lint code base
-        uses: docker://github/super-linter:v2.2.2
+        uses: docker://github/super-linter:v4
         env:
           # Listed but disabled linters would be nice to have.
           # Python (supported using Pylint) and C/C++ (not supported) are

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -26,7 +26,7 @@ jobs:
           VALIDATE_JAVASCRIPT_ES: true
           # VALIDATE_JAVASCRIPT_STANDARD: false
           VALIDATE_JSON: true
-          VALIDATE_MD: true
+          VALIDATE_MARKDOWN: true
           # VALIDATE_PERL: false
           VALIDATE_POWERSHELL: true
           # VALIDATE_XML: false

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -20,14 +20,14 @@ jobs:
           # Python (supported using Pylint) and C/C++ (not supported) are
           # handled separately due to the complexity of the settings.
           # (The rest is simply disabled automatically as of v2.)
-          VALIDATE_BASH: false
-          VALIDATE_CSS: false
-          VALIDATE_DOCKER: false
+          # VALIDATE_BASH: false
+          # VALIDATE_CSS: false
+          # VALIDATE_DOCKER: false
           VALIDATE_JAVASCRIPT_ES: true
-          VALIDATE_JAVASCRIPT_STANDARD: false
+          # VALIDATE_JAVASCRIPT_STANDARD: false
           VALIDATE_JSON: true
           VALIDATE_MD: true
-          VALIDATE_PERL: false
+          # VALIDATE_PERL: false
           VALIDATE_POWERSHELL: true
-          VALIDATE_XML: false
+          # VALIDATE_XML: false
           VALIDATE_YAML: true

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Lint code base
-        uses: docker://github/super-linter:v4
+        uses: github/super-linter@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Listed but disabled linters would be nice to have.

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Lint code base
         uses: docker://github/super-linter:v4
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Listed but disabled linters would be nice to have.
           # Python (supported using Pylint) and C/C++ (not supported) are
           # handled separately due to the complexity of the settings.


### PR DESCRIPTION
The GHA `ci.yml` and others show the warning

_Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-python@v2, r-lib/actions/setup-r@v1, actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/._

Additionally:
- update the various actions
- updates ubuntu-20.04 to ubuntu-22.04 (see also https://github.com/OSGeo/grass/pull/2730)
- sync Python to v3.10
- updates to super-linter:v4
- super-linter: enable markdown linting
- use the real super-linter action instead of a container
- super-linter.yml: do not mix VALIDATE=true and VALIDATE=false