### PR TITLE
markdown: fix lint errors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,6 +15,7 @@ A clear and concise description of what the bug of the addon is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Compute '....'
@@ -27,11 +28,13 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **System description (please complete the following information):**
+
 - Operating System: [e.g. Windows, Linux, ... incl. version]
 - GRASS GIS version [e.g. 7.8.1]
 <!---
 - details about further software components
-    - run `g.version -rge` in a GRASS GIS terminal session or check in the GUI menu "Help > About"
+    - run `g.version -rge` in a GRASS GIS terminal session or check in the
+      GUI menu "Help > About"
 --->
 
 **Additional context**

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ and finally open a [pull request](https://help.github.com/en/articles/about-pull
 If you aim at full write access, this must be formally requested, see here for details:
 <https://trac.osgeo.org/grass/wiki/HowToContribute#WriteaccesstotheGRASSaddonsrepository>
 
-In either case, please note the following submitting rules: To successfully submit your
-GRASS GIS AddOn module here, please check
+In either case, please note the following submitting rules: To successfully
+submit your GRASS GIS AddOn module here, please check
 
 <https://grass.osgeo.org/development/>
 

--- a/src/imagery/i.fusion.hpf/README.md
+++ b/src/imagery/i.fusion.hpf/README.md
@@ -26,28 +26,29 @@ Source: Gangkofner, 2008
 
 ## From the original paper
 
-> Step 1: HP Filtering of the High-resolution Image to Extract the Structural
-> Detail
->
-> Step 2: Adding the HP Filtered Image to Each Band of the Multispectral Image
-> Using a Standard Deviation-based Injection Model
->
-> Step 3: Linear Histogram Match to Adapt SD and Mean of the Merged Image Bands
-> to Those of the Original MS Image Bands
->
-> Figure 1:
+```text
+Step 1: HP Filtering of the High-resolution Image to Extract the Structural
+Detail
 
-     ____________________________________________________________________________
-    +                                                                            +
-    | Pan Img ->  High Pass Filter  ->  HP Img                                   |
-    |                                      |                                     |
-    |                                      v                                     |
-    | MSx Img ->  Weighting Factors ->  Weighted HP Img                          |
-    |       |                              |                                     |
-    |       |                              v                                     |
-    |       +------------------------>  Addition to MSx Img  =>  Fused MSx Image |
-    +____________________________________________________________________________+
+Step 2: Adding the HP Filtered Image to Each Band of the Multispectral Image
+Using a Standard Deviation-based Injection Model
 
+Step 3: Linear Histogram Match to Adapt SD and Mean of the Merged Image Bands
+to Those of the Original MS Image Bands
+
+Figure 1:
+
+ ____________________________________________________________________________
++                                                                            +
+| Pan Img ->  High Pass Filter  ->  HP Img                                   |
+|                                      |                                     |
+|                                      v                                     |
+| MSx Img ->  Weighting Factors ->  Weighted HP Img                          |
+|       |                              |                                     |
+|       |                              v                                     |
+|       +------------------------>  Addition to MSx Img  =>  Fused MSx Image |
++____________________________________________________________________________+
+```
 
 ## Installation
 
@@ -57,7 +58,8 @@ See [GRASS Addons SVN repository, README file, Installation - Code Compilation](
 
 ### Steps
 
-Making the script `i.fusion.hpf` available from within any GRASS-GIS ver. 7.x session, may be done via the following steps:
+Making the script `i.fusion.hpf` available from within any GRASS-GIS ver. 7.x
+session, may be done via the following steps:
 
 1. launch a GRASS-GIS’ ver. 7.x session
 2. navigate into the script’s source directory
@@ -65,24 +67,27 @@ Making the script `i.fusion.hpf` available from within any GRASS-GIS ver. 7.x se
 
 ## Usage
 
-After installation, from within a GRASS-GIS session, see help details via `i.fusion.hpf --help`
+After installation, from within a GRASS-GIS session, see help details via
+`i.fusion.hpf --help`
 
 ### Remarks
 
 * easy to use, i.e.:
   * for one band `i.fusion.hpf pan=Panchromatic msx=${Band}`
   * for multiple bands `i.fusion.hpf pan=Panchromatic msx=Red,Green,Blue,NIR`
-* easy to test various parameters that define the High-Pass filter’s *kernel size* and *center value*
+* easy to test various parameters that define the High-Pass filter’s
+  *kernel size* and *center value*
 * should work with **any** kind of imagery (think of bitness)
-* the "black border" effect, possibly caused due to a non-perfect match of the high vs. the low resolution
-  of the input images, can be trimmed out by using the `trim` option --a floating point "trimming factor"
-  with which to multiply the pixel size of the low resolution image-- and shrink the extent of the output image
+* the "black border" effect, possibly caused due to a non-perfect match of the
+  high vs. the low resolution of the input images, can be trimmed out by using
+  the `trim` option --a floating point "trimming factor" with which to multiply
+  the pixel size of the low resolution image-- and shrink the extent of the
+  output image
 
 ## Implementation notes
 
 * First commit on Sat Oct 25 12:26:54 2014 +0300
 * Working state reached on Tue Nov 4 09:28:25 2014 +0200
-
 
 ## To Do
 
@@ -109,8 +114,9 @@ After installation, from within a GRASS-GIS session, see help details via `i.fus
   PHOTOGRAMMETRIC ENGINEERING & REMOTE SENSING, 74(9):1107–1118.
 * “ERDAS IMAGINE.” Accessed March 19, 2015. <http://doc.hexagongeospatial.com/ERDAS%20IMAGINE/ERDAS_IMAGINE_Help/#ii_hpfmerge_mergedialog.htm>.
 
-
-- Aniruddha Ghosh & P.K. Joshi (2013) Assessment of pan-sharpened very high-resolution WorldView-2 images, International Journal of Remote Sensing, 34:23, 8336-8359
+* Aniruddha Ghosh & P.K. Joshi (2013) Assessment of pan-sharpened very
+  high-resolution WorldView-2 images, International Journal of Remote Sensing,
+  34:23, 8336-8359
 
 ## Ευχαριστώ
 

--- a/src/imagery/i.landsat8.swlst/README.md
+++ b/src/imagery/i.landsat8.swlst/README.md
@@ -4,7 +4,6 @@
 algorithm, estimating land surface temperature (LST), from the Thermal Infra-Red
 Sensor (TIRS) aboard Landsat 8 with an accuracy of better than 1.0 K.
 
-
 ## Quick examples
 
 After installation (see section *Installation* below), from within a GRASS-GIS
@@ -27,25 +26,26 @@ where:
 A faster call is to use existing maps for all in-between
 processing steps: at-satellite temperatures, cloud and emissivity maps.
 
-* At-satellite temperature maps (options `t10`, `t11`) may be derived via
+- At-satellite temperature maps (options `t10`, `t11`) may be derived via
   the `i.landsat.toar` module. Note that `i.landsat.toar` does not
   process single bands selectively.
 
-* The `clouds` option can be any user-defined map. Essentialy, it applies
+- The `clouds` option can be any user-defined map. Essentialy, it applies
   the given map as an inverted mask.
 
-* The emissivity maps, derived by the module itself, can be saved once
+- The emissivity maps, derived by the module itself, can be saved once
   via the `emissivity_out` and `delta_emissivity_out` options and used
   afterwards via the `emissivity` and `delta_emissivity` options. Expert
   users, however, may use emissivity maps from other sources directly.
   An example command may be:
 
 ```bash
-  i.landsat8.swlst t10=T10 t11=T11 clouds=Cloud_Map emissivity=Average_Emissivity_Map delta_emissivity=Delta_Emissivity_Map landcover=FROM_GLC -k -c
+  i.landsat8.swlst t10=T10 t11=T11 clouds=Cloud_Map \
+      emissivity=Average_Emissivity_Map delta_emissivity=Delta_Emissivity_Map \
+          landcover=FROM_GLC -k -c
 ```
 
 For details and more examples, read the manual.
-
 
 ## Description
 

--- a/src/raster/r.estimap.recreation/README.md
+++ b/src/raster/r.estimap.recreation/README.md
@@ -3,332 +3,225 @@
 ## Description
 
 *r.estimap.recreation*
-is an implementation of the ESTIMAP recreation algorithm
-to support mapping and modelling of ecosystem services
-(Zulian, 2014).
+is an implementation of the ESTIMAP recreation algorithm to support mapping
+and modelling of ecosystem services (Zulian, 2014).
 
 ## Examples
 
-For the sake of demonstrating
-the usage of the module,
-we use the following "component" maps
-to derive a recreation *potential* map:
+For the sake of demonstrating the usage of the module, we use the following
+"component" maps to derive a recreation *potential* map:
 
 * `input_area_of_interest`
 * `input_land_suitability`
 * `input_water_resources`
 * `input_protected_areas`
 
-<div>
-<p float="center">
-    <img alt="Area of interest" src="images/r_estimap_recreation_area_of_interest.png" width="190" />
-    <img alt="Land suitability" src="images/r_estimap_recreation_land_suitability.png" width="190" />
-    <img alt="Water resources"  src="images/r_estimap_recreation_water_resources.png"  width="190" />
-    <img alt="Protected areas"  src="images/r_estimap_recreation_protected_areas.png"  width="190" />
-</p>
-</div>
+<img alt="Area of interest" src="images/r_estimap_recreation_area_of_interest.png"
+    width="190" />
+<img alt="Land suitability" src="images/r_estimap_recreation_land_suitability.png"
+    width="190" />
+<img alt="Water resources"  src="images/r_estimap_recreation_water_resources.png"
+    width="190" />
+<img alt="Protected areas"  src="images/r_estimap_recreation_protected_areas.png"
+    width="190" />
 
-The maps shown above are available to download,
-among other sample maps, at:
+The maps shown above are available to download, among other sample maps, at:
 <https://gitlab.com/natcapes/r.estimap.recreation.data>.
 
-Note, the prefix
-`input_`
-in front of all maps
-is purposive in order to
-make the examples easier to understand.
-Similarly,
-all output maps and files
-will be prefixed with the string
-`output_`.
+Note, the prefix `input_` in front of all maps is purposive in order to make
+the examples easier to understand. Similarly, all output maps and files will
+be prefixed with the string `output_`.
 
+Before anything, we need to define the extent of interest by executing
 
-Before anything,
-we need to define the extent of interest
-by executing
-
-<div class="code">
-
-    g.region  raster=input_area_of_interest  -p
-
-</div>
+```bash
+g.region  raster=input_area_of_interest  -p
+```
 
 which returns
 
-<div class="code">
-
-    projection: 99 (ETRS89 / LAEA Europe)
-    zone:       0
-    datum:      etrs89
-    ellipsoid:  grs80
-    north:      2879700
-    south:      2748850
-    west:       4735600
-    east:       4854650
-    nsres:      50
-    ewres:      50
-    rows:       2617
-    cols:       2381
-    cells:      6231077
-
-</div>
+```text
+projection: 99 (ETRS89 / LAEA Europe)
+zone:       0
+datum:      etrs89
+ellipsoid:  grs80
+north:      2879700
+south:      2748850
+west:       4735600
+east:       4854650
+nsres:      50
+ewres:      50
+rows:       2617
+cols:       2381
+cells:      6231077
+```
 
 ### Using pre-processed maps
 
-The first four input options of the module,
-are designed to receive pre-processed input maps
-that classify as either
-`land`,
-`natural`,
-`water`,
-and `infrastructure` resources
-that add to the recreational value of the area.
-_Pro-processing_ means here
-to derive a map
-that scores the given resources,
-in the context of recreation and
-the ESTIMAP algorithm.
+The first four input options of the module, are designed to receive pre-processed
+input maps that classify as either `land`, `natural`, `water`, and
+`infrastructure` resources that add to the recreational value of the area.
+*Pro-processing* means here to derive a map that scores the given resources,
+in the context of recreation and the ESTIMAP algorithm.
 
 #### Potential
 
-To produce a recreation *potential* map,
-the simplest command
-requires the user
-to define the input map option `land`
-and name the output map
-via the option `potential`.
-Using a pre-processed map that depicts
-the suitability of different land types
-to support for recreation
-(here the map named `land_suitability`),
+To produce a recreation *potential* map, the simplest command requires the user
+to define the input map option `land` and name the output map via the option
+`potential`. Using a pre-processed map that depicts the suitability of different
+land types to support for recreation (here the map named `land_suitability`),
 the command to execute is:
 
-<div class="code">
-
-    r.estimap.recreation  land=input_land_suitability  potential=output_potential
-
-</div>
+```bash
+r.estimap.recreation  land=input_land_suitability  potential=output_potential
+```
 
 ![Example of a recreation potential output map](images/r_estimap_recreation_potential.png)
 
-Note,
-this will process the map
-`input_land_suitability`
-over the extent defined previously via `g.region`,
-which is the standard behaviour
-in GRASS GIS.
+Note, this will process the map `input_land_suitability` over the extent
+defined previously via `g.region`, which is the standard behaviour in GRASS GIS.
 
-To exclude certain areas from the computations,
-we may use a raster map as a mask
-and feed it to the input option `mask`:
+To exclude certain areas from the computations, we may use a raster map as a
+mask and feed it to the input option `mask`:
 
-<div class="code">
-
-    r.estimap.recreation  land=input_land_suitability  mask=input_area_of_interest  potential=output_potential_1
-
-</div>
+```bash
+r.estimap.recreation  land=input_land_suitability  mask=input_area_of_interest  potential=output_potential_1
+```
 
 ![Example of a recreation potential output map while using a
 MASK](images/r_estimap_recreation_potential_1.png)
 
-The use of a mask
-(in GRASS GIS' terminology known as **MASK**)
-will ignore areas of **No Data**
-(pixels in the `area_of_interest` map assigned the NULL value).
-Successively,
-these areas will be empty
-in the output map `output_potential_1`.
-Actually,
-the same effect can be achieved
-by using GRASS GIS' native mask creation module `r.mask`
-and feed it with a raster map of interest.
-The result will be a raster map named **MASK**
-whose presence acts as a filter.
-In the following examples,
-it becomes obvious that
-if a single input map
-features such **No Data** areas,
-they will be propagated in the output map.
+The use of a mask (in GRASS GIS' terminology known as **MASK**) will ignore
+areas of **No Data** (pixels in the `area_of_interest` map assigned the NULL
+value). Successively, these areas will be empty in the output map
+`output_potential_1`. Actually, the same effect can be achieved by using
+GRASS GIS' native mask creation module `r.mask` and feed it with a raster map
+of interest. The result will be a raster map named **MASK** whose presence acts
+as a filter. In the following examples, it becomes obvious that if a single
+input map features such **No Data** areas, they will be propagated in the
+output map.
 
-Nonetheless,
-it is good practice
-to use a `MASK`
-when one needs to ensure
-the exclusion of undesired areas
-from any computations.
-Note also the `--o` flag:
-it is required to overwrite
-the already existing map named `potential_1`.
+Nonetheless, it is good practice to use a `MASK` when one needs to ensure the
+exclusion of undesired areas from any computations. Note also the `--o` flag:
+it is required to overwrite the already existing map named `potential_1`.
 
-Next,
-we add in the water component
-a map named `water_resources`,
-we modify the output map name to `potential_2`
-and execute the new command
-without a mask:
+Next, we add in the water component a map named `water_resources`, we modify
+the output map name to `potential_2` and execute the new command without a mask:
 
-<div class="code">
-
-    r.estimap.recreation  land=input_land_suitability  water=input_water_resources  potential=output_potential_2
-
-</div>
+```bash
+r.estimap.recreation  land=input_land_suitability  water=input_water_resources \
+    potential=output_potential_2
+```
 
 ![Example of a recreation potential output map while using a MASK, a
 land suitability map and a water resources map](images/r_estimap_recreation_potential_2.png)
 
-At this point it becomes clear
-that all `NULL` cells
-present in the water map,
-are propagated in the output map
-`output_potential_2`.
+At this point it becomes clear that all `NULL` cells present in the water map,
+are propagated in the output map `output_potential_2`.
 
-Following,
-we provide a map of protected areas named `input_protected_areas`,
-we modify the output map name to `output_potential_3`
-and execute the updated command:
+Following, we provide a map of protected areas named `input_protected_areas`,
+we modify the output map name to `output_potential_3` and execute the updated
+command:
 
-<div class="code">
-
-    r.estimap.recreation  land=input_land_suitability  water=input_water_resources  natural=input_protected_areas  potential=output_potential_3
-
-</div>
+```bash
+r.estimap.recreation land=input_land_suitability  \
+    water=input_water_resources  natural=input_protected_areas \
+    potential=output_potential_3
+```
 
 ![Example of a recreation potential output map while using a MASK, a
 land suitability map, a water resources map and a natural resources
 map](images/r_estimap_recreation_potential_3.png)
 
-While the `land` option accepts only one map as an input,
-both the `water`
-and the `natural` options
-accept multiple maps as inputs.
-For example,
-we add a second map named `input_bathing_water_quality`
-to the *water* component
-and modify the output map name to
-`output_potential_4`:
+While the `land` option accepts only one map as an input, both the `water`
+and the `natural` options accept multiple maps as inputs. For example, we
+add a second map named `input_bathing_water_quality` to the *water* component
+and modify the output map name to `output_potential_4`:
 
-<div class="code">
+```bash
+r.estimap.recreation  land=input_land_suitability \
+     water=input_water_resources,input_bathing_water_quality \
+     natural=input_protected_areas  potential=output_potential_4
+```
 
-    r.estimap.recreation  land=input_land_suitability  water=input_water_resources,input_bathing_water_quality  natural=input_protected_areas  potential=output_potential_4
-
-</div>
-
-In general,
-arbitrary number of maps,
-separated by comma,
-may be added to options
-that accept multiple inputs.
+In general, arbitrary number of maps, separated by comma, may be added to
+options that accept multiple inputs.
 
 ![Example of a recreation potential output map while using a MASK, a
 land suitability map, two water resources maps and a natural resources
 map](images/r_estimap_recreation_potential_4.png)
 
-This example,
-features also a title and a legend,
-so as to make sense of the map
-(however,
-we will skip for now important cartographic elements).
+This example, features also a title and a legend, so as to make sense of the
+map (however, we will skip for now important cartographic elements).
 
-<div class="code">
+```bash
+d.rast  output_potential_4
+d.legend  -c  -b  output_potential_4  at=0,15,0,1  border_color=white
+d.text  text="Potential"  bgcolor=white
+```
 
-    d.rast  output_potential_4
-    d.legend  -c  -b  output_potential_4  at=0,15,0,1  border_color=white
-    d.text  text="Potential"  bgcolor=white
-
-</div>
-
-The different output map names
-are purposefully selected
-so as to enable a visual comparison
-of the differences among the differenct examples.
-The output maps `output_potential_1`,
-`output_potential_2`,
-`output_potential_3`
-and `output_potential_4`,
-range within \[0,3\].
-Yet, they differ in the distribution
+The different output map names are purposefully selected so as to enable a
+visual comparison of the differences among the differenct examples. The output
+maps `output_potential_1`, `output_potential_2`, `output_potential_3` and
+`output_potential_4`, range within \[0,3\]. Yet, they differ in the distribution
 of values due to the different set of input maps.
 
-<mark>
-All of the above examples
-base upon pre-processed maps
-that score the access to
-and quality of
-land, water and natural resources.
-For using *raw*,
-unprocessed maps,
-read section **Using unprocessed maps**.
-</mark>
+:exclamation:
+All of the above examples base upon pre-processed maps that score the access to
+and quality of land, water and natural resources. For using *raw*, unprocessed
+maps, read section **Using unprocessed maps**.
 
+We can remove all of the *potential* maps via
 
-We can remove
-all of the *potential* maps
-via
-
-<div class="code">
-
-    g.remove raster pattern=output_potential* -f
-
-</div>
+```bash
+g.remove raster pattern=output_potential* -f
+```
 
 #### Spectrum
 
-To derive
-a map with the recreation (opportunity) `spectrum`,
-we need in addition an `infrastructure` component.
-In this example
-a map that scores
-distance to infrastructure
-(such as the road network)
-named `input_distance_to_infrastructure`,
-is defined as an additional input:
+To derive a map with the recreation (opportunity) `spectrum`, we need in
+addition an `infrastructure` component. In this example a map that scores
+distance to infrastructure (such as the road network) named
+`input_distance_to_infrastructure`, is defined as an additional input:
 
 ![Example of an input map showing distances to
 infrastructure](images/r_estimap_recreation_distance_to_infrastructure.png)
 
-Naturally,
-we need to
-define the output map option `spectrum`
-too:
+Naturally, we need to define the output map option `spectrum` too:
 
-<div class="code">
-
-    r.estimap.recreation  \
-      land=input_land_suitability \
-      water=input_water_resources,input_bathing_water_quality \
-      natural=input_protected_areas \
-      infrastructure=input_distance_to_infrastructure \
-      spectrum=output_spectrum
-
-</div>
+```bash
+r.estimap.recreation  \
+    land=input_land_suitability \
+    water=input_water_resources,input_bathing_water_quality \
+    natural=input_protected_areas \
+    infrastructure=input_distance_to_infrastructure \
+    spectrum=output_spectrum
+```
 
 or, the same command in a copy-paste friendly way for systems that won't
 understand the special  `\` character:
 
-<div class="code">
-
-    r.estimap.recreation  land=input_land_suitability  water=input_water_resources,input_bathing_water_quality  natural=input_protected_areas  infrastructure=input_distance_to_infrastructure  spectrum=output_spectrum
-
-</div>
+<!-- markdownlint-disable line-length -->
+```bash
+r.estimap.recreation  land=input_land_suitability  water=input_water_resources,input_bathing_water_quality  natural=input_protected_areas  infrastructure=input_distance_to_infrastructure  spectrum=output_spectrum
+```
+<!-- markdownlint-enable line-length -->
 
 ![Example of a recreation spectrum output map while using a MASK, a land
 suitability map, a water resources map and a natural resources
 map](images/r_estimap_recreation_spectrum.png)
 
-Missing to define an `infrastructure` map,
-while asking for the `spectrum` output,
-the command will abort and inform about.
+Missing to define an `infrastructure` map, while asking for the `spectrum`
+output, the command will abort and inform about.
 
-The image of the *spectrum* map
-was produced via the following native GRASS GIS commands
+The image of the *spectrum* map was produced via the following native
+GRASS GIS commands
 
-<div class="code">
-
-    d.rast  output_spectrum
-    d.legend  -c  -b  output_spectrum  at=0,30,0,1  border_color=white
-    d.text  text="Spectrum"  bgcolor=white
-
-</div>
+```bash
+d.rast  output_spectrum
+d.legend  -c  -b  output_spectrum  at=0,30,0,1  border_color=white
+d.text  text="Spectrum"  bgcolor=white
+```
 
 ##### Opportunity
 
@@ -339,117 +232,85 @@ requires to also request for the output option `spectrum`. Be aware that this
 design choice is applied in the case of the `unmet` output map option too.
 Building upon the previous command, we add the `opportunity` output option:
 
-<div class="code">
-
-    r.estimap.recreation --o \
-      mask=input_area_of_interest \
-      land=input_land_suitability \
-      water=input_water_resources,input_bathing_water_quality \
-      natural=input_protected_areas \
-      infrastructure=input_distance_to_infrastructure \
-      opportunity=output_opportunity \
-      spectrum=output_spectrum
-
-</div>
+```bash
+r.estimap.recreation --o \
+    mask=input_area_of_interest \
+    land=input_land_suitability \
+    water=input_water_resources,input_bathing_water_quality \
+    natural=input_protected_areas \
+    infrastructure=input_distance_to_infrastructure \
+    opportunity=output_opportunity \
+    spectrum=output_spectrum
+```
 
 or, the same command in a copy-paste friendly way:
 
-<div class="code">
+<!-- markdownlint-disable line-length -->
+```bash
+r.estimap.recreation  --o mask=input_area_of_interest  land=input_land_suitability  water=input_water_resources,input_bathing_water_quality  natural=input_protected_areas  infrastructure=input_distance_to_infrastructure  opportunity=output_opportunity  spectrum=output_spectrum
+```
+<!-- markdownlint-enable line-length -->
 
-    r.estimap.recreation  --o mask=input_area_of_interest  land=input_land_suitability  water=input_water_resources,input_bathing_water_quality  natural=input_protected_areas  infrastructure=input_distance_to_infrastructure  opportunity=output_opportunity  spectrum=output_spectrum
-
-</div>
-
-We also add the `--o` overwrite flag,
-because existing `output_spectrum` map
+We also add the `--o` overwrite flag, because existing `output_spectrum` map
 will cause the module to abort.
 
 ![Example of a recreation spectrum output map while using a MASK, a land
 suitability map, a water resources map and a natural resources
 map](images/r_estimap_recreation_opportunity.png)
 
-The image of
-the *opportunity* map
-was produced via
-the following native GRASS GIS commands
+The image of the *opportunity* map was produced via the following native
+GRASS GIS commands
 
-<div class="code">
-
-    d.rast  output_opportunity
-    d.legend  -c  -b  output_opportunity  at=0,20,0,1  border_color=white
-    d.text  text="Opportunity"  bgcolor=white
-
-</div>
+```bash
+d.rast  output_opportunity
+d.legend  -c  -b  output_opportunity  at=0,20,0,1  border_color=white
+d.text  text="Opportunity"  bgcolor=white
+```
 
 #### More input maps
 
-To derive the outputs
-met `demand` distribution,
-`unmet` demand distribution
-and the actual `flow`,
-additional requirements are
-a `population` map
-and one of boundaries,
-as an input to the option `base`
-within which
-to quantify the distribution of the population.
-Using a map of administrative boundaries
-for the latter option,
-serves for deriving comparable figures
-across these boundaries.
-The algorithm sets internally
-the spatial resolution of all related output maps
-(`demand`,
-`unmet`
-and `flow`)
-to the spatial resolution
-of the `population` input map.
+To derive the outputs met `demand` distribution, `unmet` demand distribution
+and the actual `flow`, additional requirements are a `population` map and one
+of boundaries, as an input to the option `base` within which to quantify the
+distribution of the population. Using a map of administrative boundaries for
+the latter option, serves for deriving comparable figures across these
+boundaries. The algorithm sets internally the spatial resolution of all related
+output maps (`demand`, `unmet` and `flow`) to the spatial resolution of
+the `population` input map.
 
 ##### Population
 
 ![Fragment of a population map (GHSL, 2015)](images/r_estimap_recreation_population_2015.png)
 
-In this example,
-the population map named `population_2015`
-is of 1000m\^2.
+In this example, the population map named `population_2015` is of 1000m\^2.
 
 ##### Local administrative units
 
 ![Fragment of a local administrative units input
 map](images/r_estimap_recreation_local_administrative_units.png)
 
-The map named `local_administrative_units`
-serves in the following example
-as the base map
-for the zonal statistics
-to obtain the demand map.
+The map named `local_administrative_units` serves in the following example
+as the base map for the zonal statistics to obtain the demand map.
 
 #### Demand
 
-In this example command,
-we remove the previously added `opportunity`
-and `spectrum` output options,
-and logically add the `demand` output option:
+In this example command, we remove the previously added `opportunity` and
+`spectrum` output options, and logically add the `demand` output option:
 
-<div class="code">
+```bash
+r.estimap.recreation --o \
+    mask=input_area_of_interest \
+    land=input_land_suitability \
+    water=input_water_resources,input_bathing_water_quality \
+    natural=input_protected_areas \
+    infrastructure=input_distance_to_infrastructure \
+    population=input_population_2015 \
+    base=input_local_administrative_units \
+    demand=output_demand
+```
 
-    r.estimap.recreation --o \
-      mask=input_area_of_interest \
-      land=input_land_suitability \
-      water=input_water_resources,input_bathing_water_quality \
-      natural=input_protected_areas \
-      infrastructure=input_distance_to_infrastructure \
-      population=input_population_2015 \
-      base=input_local_administrative_units \
-      demand=output_demand
-
-</div>
-
-Of course,
-the maps `output_opportunity`
-and `output_spectrum`
-still exist in our data base,
-unless explicitly removed.
+Of course, the maps `output_opportunity` and `output_spectrum` still exist
+in our data base, unless explicitly removed.
 
 ![Example of a demand distribution output map while using a MASK and
 inputs for land suitability, water resources, natural resources,
@@ -457,463 +318,366 @@ infrastructure, population and base](images/r_estimap_recreation_demand.png)
 
 #### Unmet Demand
 
-In the following example,
-we add `unmet` output map option.
-In this case
-of the *unmet* distribution map too,
-by design
-the module requires the user
+In the following example, we add `unmet` output map option. In this case of
+the *unmet* distribution map too, by design the module requires the user
 to define the `demand` output map option.
 
-<div class="code">
-
-    r.estimap.recreation --o \
-      mask=input_area_of_interest \
-      land=input_land_suitability \
-      water=input_water_resources,input_bathing_water_quality \
-      natural=input_protected_areas \
-      infrastructure=input_distance_to_infrastructure \
-      population=input_population_2015 \
-      base=input_local_administrative_units \
-      demand=output_demand \
-      unmet=output_unmet_demand
-
-</div>
+```bash
+r.estimap.recreation --o \
+    mask=input_area_of_interest \
+    land=input_land_suitability \
+    water=input_water_resources,input_bathing_water_quality \
+    natural=input_protected_areas \
+    infrastructure=input_distance_to_infrastructure \
+    population=input_population_2015 \
+    base=input_local_administrative_units \
+    demand=output_demand \
+    unmet=output_unmet_demand
+```
 
 ![Example of an 'unmet demand' output map while using a MASK and inputs
 for land suitability, water resources, natural resources,
 infrastructure, population and base](images/r_estimap_recreation_unmet_demand.png)
 
-It is left
-as an exercise to the user
-to create screenshots of
-the *met*,
-the *unmet* demand distribution
-and the *flow* output maps.
-For example,
-is may be similar
-to the command examples
-that demonstrate the use of the commands
-`d.rast`,
-`d.legend`
-and `d.text`,
-that draw
-the *potential*,
-the *spectrum*
+It is left as an exercise to the user to create screenshots of the *met*, the
+*unmet* demand distribution and the *flow* output maps. For example, is may be
+similar to the command examples that demonstrate the use of the commands
+`d.rast`, `d.legend` and `d.text`, that draw the *potential*, the *spectrum*
 and the *opportunity* maps.
 
 #### Flow
 
-The *flow*
-bases upon the same function
-used to quantify
-the attractiveness of locations
-for their recreational value.
-It includes an extra *score* term.
+The *flow* bases upon the same function used to quantify the attractiveness
+of locations for their recreational value. It includes an extra *score* term.
 
-The computation involves a *distance* map,
-reclassified in 5 categories
-as shown in the following table.
-For each distance category,
-a unique pair of coefficient values
-is assigned to the basic equation.
+The computation involves a *distance* map, reclassified in 5 categories as
+shown in the following table. For each distance category, a unique pair of
+coefficient values is assigned to the basic equation.
 
-<div class="tg-wrap">
+```text
+Distance   Kappa     Alpha
+---------- --------- ---------
+0 to 1     0.02350   0.00102
+1 to 2     0.02651   0.00109
+2 to 3     0.05120   0.00098
+3 to 4     0.10700   0.00067
+>4         0.06930   0.00057
+```
 
-  Distance   Kappa     Alpha
-  ---------- --------- ---------
-  0 to 1     0.02350   0.00102
-  1 to 2     0.02651   0.00109
-  2 to 3     0.05120   0.00098
-  3 to 4     0.10700   0.00067
-  &gt;4      0.06930   0.00057
+Note, the last distance category is not considered in deriving the final
+"map of visits". The output is essentially a raster map with the distribution of
+the demand per distance category and within predefined geometric boundaries
 
-</div>
-
-Note,
-the last distance category
-is not considered
-in deriving the final "map of visits".
-The output is essentially a raster map
-with the distribution of
-the demand per distance category and
-within predefined geometric boundaries
-
-<div class="code">
-
-    r.estimap.recreation --o \
-      mask=input_area_of_interest \
-      land=input_land_suitability \
-      water=input_water_resources,input_bathing_water_quality \
-      natural=input_protected_areas \
-      infrastructure=input_distance_to_infrastructure \
-      population=input_population_2015 \
-      base=input_local_administrative_units \
-      flow=output_flow
-
-</div>
+```bash
+r.estimap.recreation --o \
+    mask=input_area_of_interest \
+    land=input_land_suitability \
+    water=input_water_resources,input_bathing_water_quality \
+    natural=input_protected_areas \
+    infrastructure=input_distance_to_infrastructure \
+    population=input_population_2015 \
+    base=input_local_administrative_units \
+    flow=output_flow
+```
 
 ![Example of a flow output map while using a MASK and inputs for
 land suitability, water resources, natural resources, infrastructure,
 population and base](images/r_estimap_recreation_mobility.png)
 
-If we check the output values
-for the `output_flow` map,
-they are rounded by the module automatically to integers!
-Here the first few lines
-reporting areal statistics on the `output_flow` map:
+If we check the output values for the `output_flow` map, they are rounded by
+the module automatically to integers! Here the first few lines reporting areal
+statistics on the `output_flow` map:
 
-<div class="code">
-
-    r.stats output_flow -acpln --q |head
-
-</div>
+```bash
+r.stats output_flow -acpln --q |head
+```
 
 returns
 
-<div class="code">
+```text
+52  125000000.000000 50000 1.72%
+53  191000000.000000 76400 2.63%
+54  303000000.000000 121200 4.17%
+55  392000000.000000 156800 5.39%
+56  196000000.000000 78400 2.69%
+57  178000000.000000 71200 2.45%
+58  286000000.000000 114400 3.93%
+59  185000000.000000 74000 2.54%
+60  207000000.000000 82800 2.85%
+61  176000000.000000 70400 2.42%
+```
 
-    52  125000000.000000 50000 1.72%
-    53  191000000.000000 76400 2.63%
-    54  303000000.000000 121200 4.17%
-    55  392000000.000000 156800 5.39%
-    56  196000000.000000 78400 2.69%
-    57  178000000.000000 71200 2.45%
-    58  286000000.000000 114400 3.93%
-    59  185000000.000000 74000 2.54%
-    60  207000000.000000 82800 2.85%
-    61  176000000.000000 70400 2.42%
-
-</div>
-
-If the user wants the real numbers,
-that derive from the mobility function,
+If the user wants the real numbers, that derive from the mobility function,
 the `-r` flag comes in handy:
 
-<div class="code">
-
-    r.estimap.recreation --o -r \
-      mask=input_area_of_interest \
-      land=input_land_suitability \
-      water=input_water_resources,input_bathing_water_quality \
-      natural=input_protected_areas \
-      infrastructure=input_distance_to_infrastructure \
-      population=input_population_2015 \
-      base=input_local_administrative_units \
-      flow=output_flow
-
-</div>
+```bash
+r.estimap.recreation --o -r \
+    mask=input_area_of_interest \
+    land=input_land_suitability \
+    water=input_water_resources,input_bathing_water_quality \
+    natural=input_protected_areas \
+    infrastructure=input_distance_to_infrastructure \
+    population=input_population_2015 \
+    base=input_local_administrative_units \
+    flow=output_flow
+```
 
 Querying again areal statistics via
 
-<div class="code">
-
-    r.stats output_flow -acpln --q |head
-
-</div>
+```bash
+r.stats output_flow -acpln --q | head
+```
 
 returns
 
-<div class="code">
-
-    52-52.139117 from  to  50000000.000000 20000 0.69%
-    52.139117-52.278233 from  to  11000000.000000 4400 0.15%
-    52.278233-52.41735 from  to  39000000.000000 15600 0.54%
-    52.41735-52.556467 from  to  32000000.000000 12800 0.44%
-    52.556467-52.695583 from  to  7000000.000000 2800 0.10%
-    52.695583-52.8347 from  to  9000000.000000 3600 0.12%
-    52.8347-52.973817 from  to  25000000.000000 10000 0.34%
-    52.973817-53.112933 from  to  13000000.000000 5200 0.18%
-    53.112933-53.25205 from  to  28000000.000000 11200 0.38%
-    53.25205-53.391167 from  to  92000000.000000 36800 1.26%
-
-</div>
-
+```text
+52-52.139117 from  to  50000000.000000 20000 0.69%
+52.139117-52.278233 from  to  11000000.000000 4400 0.15%
+52.278233-52.41735 from  to  39000000.000000 15600 0.54%
+52.41735-52.556467 from  to  32000000.000000 12800 0.44%
+52.556467-52.695583 from  to  7000000.000000 2800 0.10%
+52.695583-52.8347 from  to  9000000.000000 3600 0.12%
+52.8347-52.973817 from  to  25000000.000000 10000 0.34%
+52.973817-53.112933 from  to  13000000.000000 5200 0.18%
+53.112933-53.25205 from  to  28000000.000000 11200 0.38%
+53.25205-53.391167 from  to  92000000.000000 36800 1.26%
+```
 
 #### Supply and Use
 
-The module outputs by request
-the *supply*
-and *use* tables
-in form of CSV files.
+The module outputs by request the *supply* and *use* tables in form of CSV files.
 Here is how:
 
-<div class="code">
+```bash
+r.estimap.recreation --o -r \
+    mask=input_area_of_interest \
+    land=input_land_suitability \
+    water=input_water_resources,input_bathing_water_quality \
+    natural=input_protected_areas \
+    infrastructure=input_distance_to_infrastructure \
+    population=input_population_2015 \
+    base=input_local_administrative_units \
+    supply=output_supply \
+    use=output_use
+```
 
-    r.estimap.recreation --o -r \
-      mask=input_area_of_interest \
-      land=input_land_suitability \
-      water=input_water_resources,input_bathing_water_quality \
-      natural=input_protected_areas \
-      infrastructure=input_distance_to_infrastructure \
-      population=input_population_2015 \
-      base=input_local_administrative_units \
-      supply=output_supply \
-      use=output_use
+:exclamation:
+Not surprisingly, the above command fails!
 
-</div>
-
-<mark>
-Not surprisingly,
-the above command fails!
-</mark>
-It however informs
-that a <strong>land cover map</strong>
-and corresponding <strong>reclassification rules</strong>,
-for the classes of the <code>landcover</code> map,
-are required.
-Specifically,
-the algorithm's designers
-developed a MAES land classes scheme.
-The "translation" of the CORINE land classes (left)
-into this scheme (classes after the `=` sign)
+It however informs that a **land cover map** and corresponding
+**reclassification rules**, for the classes of the `landcover`
+map, are required. Specifically, the algorithm's designers developed
+a MAES land classes scheme. The "translation" of the CORINE land
+classes (left) into this scheme (classes after the `=` sign)
 are for example:
 
-<div class="code">
+```text
+1 = 1 Urban
+2 = 1 Urban
+3 = 1 Urban
+4 = 1 Urban
+5 = 1 Urban
+6 = 1 Urban
+7 = 1 Urban
+8 = 1 Urban
+9 = 1 Urban
+10 = 1 Urban
+11 = 1 Urban
+12 = 2 Cropland
+13 = 2 Cropland
+14 = 2 Cropland
+15 = 2 Cropland
+16 = 2 Cropland
+17 = 2 Cropland
+18 = 4 Grassland
+19 = 2 Cropland
+20 = 2 Cropland
+21 = 2 Cropland
+22 = 2 Cropland
+23 = 3 Woodland and forest
+24 = 3 Woodland and forest
+25 = 3 Woodland and forest
+26 = 4 Grassland
+27 = 5 Heathland and shrub
+28 = 5 Heathland and shrub
+29 = 3 Woodland and forest
+30 = 6 Sparsely vegetated land
+31 = 6 Sparsely vegetated land
+32 = 6 Sparsely vegetated land
+33 = 6 Sparsely vegetated land
+34 = 6 Sparsely vegetated land
+35 = 7 Wetland
+36 = 7 Wetland
+37 = 8 Marine
+38 = 8 Marine
+39 = 8 Marine
+```
 
-    1 = 1 Urban
-    2 = 1 Urban
-    3 = 1 Urban
-    4 = 1 Urban
-    5 = 1 Urban
-    6 = 1 Urban
-    7 = 1 Urban
-    8 = 1 Urban
-    9 = 1 Urban
-    10 = 1 Urban
-    11 = 1 Urban
-    12 = 2 Cropland
-    13 = 2 Cropland
-    14 = 2 Cropland
-    15 = 2 Cropland
-    16 = 2 Cropland
-    17 = 2 Cropland
-    18 = 4 Grassland
-    19 = 2 Cropland
-    20 = 2 Cropland
-    21 = 2 Cropland
-    22 = 2 Cropland
-    23 = 3 Woodland and forest
-    24 = 3 Woodland and forest
-    25 = 3 Woodland and forest
-    26 = 4 Grassland
-    27 = 5 Heathland and shrub
-    28 = 5 Heathland and shrub
-    29 = 3 Woodland and forest
-    30 = 6 Sparsely vegetated land
-    31 = 6 Sparsely vegetated land
-    32 = 6 Sparsely vegetated land
-    33 = 6 Sparsely vegetated land
-    34 = 6 Sparsely vegetated land
-    35 = 7 Wetland
-    36 = 7 Wetland
-    37 = 8 Marine
-    38 = 8 Marine
-    39 = 8 Marine
+We save this into a file named `corine_to_maes_land_classes.rules` and
+feed it to the `land_classes` option, then re-execute the command:
 
-</div>
-
-We save this into a file named
-`corine_to_maes_land_classes.rules` and
-feed it to the `land_classes` option,
-then re-execute the command:
-
-<div class="code">
-
-    r.estimap.recreation --o -r \
-      mask=input_area_of_interest \
-      land=input_land_suitability \
-      water=input_water_resources,input_bathing_water_quality \
-      natural=input_protected_areas \
-      infrastructure=input_distance_to_infrastructure \
-      population=input_population_2015 \
-      base=input_local_administrative_units \
-      landcover=input_corine_land_cover_2006 \
-      land_classes=corine_to_maes_land_classes.rules \
-      supply=output_supply \
-      use=output_use
-
-</div>
+```bash
+r.estimap.recreation --o -r \
+    mask=input_area_of_interest \
+    land=input_land_suitability \
+    water=input_water_resources,input_bathing_water_quality \
+    natural=input_protected_areas \
+    infrastructure=input_distance_to_infrastructure \
+    population=input_population_2015 \
+    base=input_local_administrative_units \
+    landcover=input_corine_land_cover_2006 \
+    land_classes=corine_to_maes_land_classes.rules \
+    supply=output_supply \
+    use=output_use
+```
 
 This time it works.
 Here the first few lines
 from the output CSV files:
 
-<div class="code">
-
-    head -5 output_*.csv
-
-</div>
+```bash
+head -5 output_*.csv
+```
 
 returns
 
-<div class="code">
+```text
+==> output_supply.csv <==
+base,base_label,cover,cover_label,area,count,percents
+3,,1,723.555560,9000000.000000,9,7.76%
+3,,3,246142.186250,64000000.000000,64,55.17%
+3,,2,21710.289271,47000000.000000,47,40.52%
+1,,1,1235.207129,11000000.000000,11,7.97%
 
-    ==> output_supply.csv <==
-    base,base_label,cover,cover_label,area,count,percents
-    3,,1,723.555560,9000000.000000,9,7.76%
-    3,,3,246142.186250,64000000.000000,64,55.17%
-    3,,2,21710.289271,47000000.000000,47,40.52%
-    1,,1,1235.207129,11000000.000000,11,7.97%
+==> output_use.csv <==
+category,label,value
+3,,268576.031081
+4,,394828.563827
+5,,173353.69508600002
+1,,144486.484126
+```
 
-    ==> output_use.csv <==
-    category,label,value
-    3,,268576.031081
-    4,,394828.563827
-    5,,173353.69508600002
-    1,,144486.484126
-
-</div>
-
-Using other land cover maps as input,
-would obviously require a similar set of
+Using other land cover maps as input, would obviously require a similar set of
 land classes translation rules.
 
 #### All in one call
 
-Of course it is possible
-to derive all output maps
-with one call:
+Of course it is possible to derive all output maps with one call:
 
-<div class="code">
+```bash
+r.estimap.recreation --o \
+    land=input_land_suitability \
+    natural=input_protected_areas,input_urban_green  \
+    water=input_water_resources,input_bathing_water_quality \
+    infrastructure=input_distance_to_infrastructure \
+    landcover=input_corine_land_cover_2006 \
+    land_classes=corine_to_maes_land_classes.rules \
+    mask=input_area_of_interest \
+    potential=output_potential \
+    opportunity=output_opportunity \
+    spectrum=output_spectrum \
+    base=input_local_administrative_units \
+    aggregation=input_regions \
+    population=input_population_2015 \
+    demand=output_demand \
+    unmet=output_unmet_demand \
+    flow=output_flow \
+    supply=output_supply \
+    use=output_use \
+    timestamp='2015'
+```
 
-    r.estimap.recreation --o \
-      land=input_land_suitability \
-      natural=input_protected_areas,input_urban_green  \
-      water=input_water_resources,input_bathing_water_quality \
-      infrastructure=input_distance_to_infrastructure \
-      landcover=input_corine_land_cover_2006 \
-      land_classes=corine_to_maes_land_classes.rules \
-      mask=input_area_of_interest \
-      potential=output_potential \
-      opportunity=output_opportunity \
-      spectrum=output_spectrum \
-      base=input_local_administrative_units \
-      aggregation=input_regions \
-      population=input_population_2015 \
-      demand=output_demand \
-      unmet=output_unmet_demand \
-      flow=output_flow \
-      supply=output_supply \
-      use=output_use \
-      timestamp='2015'
-
-</div>
-
-Note the use of the `timestamp` parameter!
-This concerns the `spectrum` map.
-If plans include working with GRASS GIS' temporal framework
-on time-series,
+Note the use of the `timestamp` parameter! This concerns the `spectrum` map.
+If plans include working with GRASS GIS' temporal framework on time-series,
 maybe this will be useful.
 
 #### Vector map
 
-A vector input map with the role of the *base* map,
-can be used too.
-
-<div>
+A vector input map with the role of the *base* map, can be used too.
 
 ![Example of a vector map showing local administrative units](images/r_estimap_recreation_input_vector_local_administrative_units.png)
 
-</div>
-
-<div class="code">
-
-    r.estimap.recreation --o -r \
-      mask=input_area_of_interest \
-      land=input_land_suitability \
-      water=input_water_resources,input_bathing_water_quality \
-      natural=input_protected_areas \
-      infrastructure=input_distance_to_infrastructure \
-      population=input_population_2015 \
-      base=input_local_administrative_units \
-      base_vector=input_vector_local_administrative_units \
-      landcover=input_corine_land_cover_2006 \
-      land_classes=corine_to_maes_land_classes.rules \
-      supply=output_supply \
-      use=output_use
-
-</div>
+```bash
+r.estimap.recreation --o -r \
+    mask=input_area_of_interest \
+    land=input_land_suitability \
+    water=input_water_resources,input_bathing_water_quality \
+    natural=input_protected_areas \
+    infrastructure=input_distance_to_infrastructure \
+    population=input_population_2015 \
+    base=input_local_administrative_units \
+    base_vector=input_vector_local_administrative_units \
+    landcover=input_corine_land_cover_2006 \
+    land_classes=corine_to_maes_land_classes.rules \
+    supply=output_supply \
+    use=output_use
+```
 
 This command will also:
 
-* export results of the mobility function
-  in the files `output_supply.csv`
+* export results of the mobility function in the files `output_supply.csv`
   and `output_use.csv`
 * add the following columns in the attribute table linked to the
   `input_vector_local_administrative_units` vector map:
 
-<div class="code">
-    spectrum_sum
-    demand_sum
-    unmet_sum
-    flow_sum
-    flow_1_sum
-    flow_2_sum
-    flow_3_sum
-    flow_4_sum
-    flow_5_sum
-    flow_6_sum
-</div>
+  ```text
+  spectrum_sum
+  demand_sum
+  unmet_sum
+  flow_sum
+  flow_1_sum
+  flow_2_sum
+  flow_3_sum
+  flow_4_sum
+  flow_5_sum
+  flow_6_sum
+  ```
 
 all of which are of double precision.
 
 For example, the
 
-<div class="code">
-
-    v.db.select input_vector_local_administrative_units columns=lau2_no_name,spectrum_sum,demand_sum,unmet_sum,flow_sum where="flow_sum IS NOT NULL" |head
-
-</div>
+```bash
+v.db.select input_vector_local_administrative_units \
+    columns=lau2_no_name,spectrum_sum,demand_sum,unmet_sum,flow_sum \
+    where="flow_sum IS NOT NULL" | head
+ ```
 
 following the analysis, returns
 
-<div class="code">
+```text
+lau2_no_name|spectrum_sum|demand_sum|unmet_sum|flow_sum
+801 Bad Erlach|22096|2810||700
+841 Leopoldsdorf|8014|1800||426
+630 Rabensburg|23358|8474||1546
+468 Maissau|73168|6650||2580
+10 Müllendorf|19419|1902||718
+544 Straß im Straßertale|57314|4368||1471
+67 Forchtenstein|53009|272||848
+460 Guntersdorf|27408|12183||1955
+103 Sankt Andrä am Zicksee|45130|3833||1926
+```
 
-    lau2_no_name|spectrum_sum|demand_sum|unmet_sum|flow_sum
-    801 Bad Erlach|22096|2810||700
-    841 Leopoldsdorf|8014|1800||426
-    630 Rabensburg|23358|8474||1546
-    468 Maissau|73168|6650||2580
-    10 Müllendorf|19419|1902||718
-    544 Straß im Straßertale|57314|4368||1471
-    67 Forchtenstein|53009|272||848
-    460 Guntersdorf|27408|12183||1955
-    103 Sankt Andrä am Zicksee|45130|3833||1926
-
-</div>
-
-Here the vector map used for administrative boundaries with the sum of flow for each unit:
-
-<div>
+Here the vector map used for administrative boundaries with the sum of
+flow for each unit:
 
 ![Example of a vector map showing the flow per unit](images/r_estimap_recreation_sum_of_flow_per_local_administrative_unit.png)
 
-</div>
-
 and the corresponding unmet demand, based on the analysis
-
-<div>
 
 ![Example of a vector map showing the unmet demand in concerned units](images/r_estimap_recreation_sum_of_unmet_demand_in_concerned_local_administrative_unit.png)
 
-</div>
-
-In the latter screenshot,
-the units bearing the unmet demand results,
-are not the same as the raster map previously shown.
-The different results are due to the `-r` flag
-used in this last analysis.
-The `-r` flag will round up floating point values during computations,
-thus the results with or without it will differ.
-The reason to use, in this last example the `-r` flag,
-was to have short integer numbers
-to print as labels inside the units (in the vector map).
+In the latter screenshot, the units bearing the unmet demand results, are not
+the same as the raster map previously shown. The different results are due to
+the `-r` flag used in this last analysis. The `-r` flag will round up floating
+point values during computations, thus the results with or without it will
+differ. The reason to use, in this last example the `-r` flag, was to have
+short integer numbers to print as labels inside the units (in the vector map).
 
 ### Using unprocessed input maps
 
-The module offers a pre-processing functionality for all of the
-following input components:
+The module offers a pre-processing functionality for all of the following
+input components:
 
 * landuse
 * suitability\_scores
@@ -960,112 +724,88 @@ following input components:
 * roads\_distances
 * 0:500:1,500.000001:1000:2,1000.000001:5000:3,5000.000001:10000:4,10000.00001:\*:5
 
-A first look on how this works,
-is to experiment with
-the `landuse`
-and `suitability_scores`
-input options.
+A first look on how this works, is to experiment with the `landuse` and
+`suitability_scores` input options.
 
-Let's return to the first example,
-and use a fragment from the unprocessed CORINE land data set,
-instead of the `land_suitability` map.
-This requires a set of "score" rules,
-that correspond to the CORINE nomenclature,
-to translate the land cover types into recreation potential.
-
-<div>
+Let's return to the first example, and use a fragment from the unprocessed
+CORINE land data set, instead of the `land_suitability` map. This requires
+a set of "score" rules, that correspond to the CORINE nomenclature, to
+translate the land cover types into recreation potential.
 
 ![Fragment from the CORINE land data base ](images/r_estimap_recreation_corine_land_cover_2006.png)
 ![Legend for the CORINE land data base](images/r_estimap_recreation_corine_land_cover_legend.png)
 
-</div>
+In this case, the rules are a simple ASCII file (for example named
+`corine_suitability.scores`) that contains the following:
 
-In this case,
-the rules are a simple ASCII file
-(for example named `corine_suitability.scores`)
-that contains the following:
-
-<div class="code">
-
-    1:1:0:0
-    2:2:0.1:0.1
-    3:9:0:0
-    10:10:1:1
-    11:11:0.1:0.1
-    12:13:0.3:0.3
-    14:14:0.4:0.4
-    15:17:0.5:0.5
-    18:18:0.6:0.6
-    19:20:0.3:0.3
-    21:22:0.6:0.6
-    23:23:1:1
-    24:24:0.8:0.8
-    25:25:1:1
-    26:29:0.8:0.8
-    30:30:1:1
-    31:31:0.8:0.8
-    32:32:0.7:0.7
-    33:33:0:0
-    34:34:0.8:0.8
-    35:35:1:1
-    36:36:0.8:0.8
-    37:37:1:1
-    38:38:0.8:0.8
-    39:39:1:1
-    40:42:1:1
-    43:43:0.8:0.8
-    44:44:1:1
-    45:45:0.3:0.3
-
-</div>
+```text
+1:1:0:0
+2:2:0.1:0.1
+3:9:0:0
+10:10:1:1
+11:11:0.1:0.1
+12:13:0.3:0.3
+14:14:0.4:0.4
+15:17:0.5:0.5
+18:18:0.6:0.6
+19:20:0.3:0.3
+21:22:0.6:0.6
+23:23:1:1
+24:24:0.8:0.8
+25:25:1:1
+26:29:0.8:0.8
+30:30:1:1
+31:31:0.8:0.8
+32:32:0.7:0.7
+33:33:0:0
+34:34:0.8:0.8
+35:35:1:1
+36:36:0.8:0.8
+37:37:1:1
+38:38:0.8:0.8
+39:39:1:1
+40:42:1:1
+43:43:0.8:0.8
+44:44:1:1
+45:45:0.3:0.3
+```
 
 This file is provided in the `suitability_scores` option:
 
-<div class="code">
-
-    r.estimap.recreation  landuse=input_corine_land_cover_2006  suitability_scores=corine_suitability.scores  potential=output_potential_corine
-
-</div>
+```bash
+r.estimap.recreation  landuse=input_corine_land_cover_2006 \
+    suitability_scores=corine_suitability.scores \
+    potential=output_potential_corine
+```
 
 ![Example of a recreation spectrum output map while using a MASK, based
 on a fragment from the CORINE land data base](images/r_estimap_recreation_potential_corine.png)
 
-The same
-can be achieved
-with a long one-line string too:
+The same can be achieved with a long one-line string too:
 
-<div class="code">
+<!-- markdownlint-disable line-length -->
+```bash
+r.estimap.recreation \
+    landuse=input_corine_land_cover_2006 \
+    suitability_scores="1:1:0:0,2:2:0.1:0.1,3:9:0:0,10:10:1:1,11:11:0.1:0.1,12:13:0.3:0.3,14:14:0.4:0.4,15:17:0.5:0.5,18:18:0.6:0.6,19:20:0.3:0.3,21:22:0.6:0.6,23:23:1:1,24:24:0.8:0.8,25:25:1:1,26:29:0.8:0.8,30:30:1:1,31:31:0.8:0.8,32:32:0.7:0.7,33:33:0:0,34:34:0.8:0.8,35:35:1:1,36:36:0.8:0.8,37:37:1:1,38:38:0.8:0.8,39:39:1:1,40:42:1:1,43:43:0.8:0.8,44:44:1:1,45:45:0.3:0.3" \
+    potential=potential_1
+```
+<!-- markdownlint-enable line-length -->
 
-    r.estimap.recreation \
-      landuse=input_corine_land_cover_2006 \
-      suitability_scores="1:1:0:0,2:2:0.1:0.1,3:9:0:0,10:10:1:1,11:11:0.1:0.1,12:13:0.3:0.3,14:14:0.4:0.4,15:17:0.5:0.5,18:18:0.6:0.6,19:20:0.3:0.3,21:22:0.6:0.6,23:23:1:1,24:24:0.8:0.8,25:25:1:1,26:29:0.8:0.8,30:30:1:1,31:31:0.8:0.8,32:32:0.7:0.7,33:33:0:0,34:34:0.8:0.8,35:35:1:1,36:36:0.8:0.8,37:37:1:1,38:38:0.8:0.8,39:39:1:1,40:42:1:1,43:43:0.8:0.8,44:44:1:1,45:45:0.3:0.3" \
-      potential=potential_1
+In fact, this very scoring scheme, for CORINE land data sets, is integrated in
+the module, so we obtain the same output even by discarding the
+`suitability_scores` option:
 
-</div>
-
-In fact,
-this very scoring scheme,
-for CORINE land data sets,
-is integrated in the module,
-so we obtain the same output
-even by discarding the `suitability_scores` option:
-
-<div class="code">
-
-    r.estimap.recreation \
+```bash
+r.estimap.recreation \
     landuse=input_corine_land_cover_2006  \
     suitability_scores=suitability_of_corine_land_cover.scores \
     potential=output_potential_1 --o
+```
 
-</div>
-
-This is so
-because CORINE is a standard choice
-among existing land data bases
-that cover european territories.
-In case of a user requirement
-to provide an alternative scoring scheme,
-all what is required is either of
+This is so because CORINE is a standard choice among existing land data bases
+that cover european territories. In case of a user requirement to provide an
+alternative scoring scheme, all what is required is either of
 
 * provide a new "rules" file with the desired set of scoring rules
 * provide a string to the `suitability_scores` option
@@ -1078,19 +818,17 @@ Nikos Alexandris
 
 Copyright 2018 European Union
 
-Licensed under the EUPL, Version 1.2 or – as soon they will be
-approved by the European Commission – subsequent versions of the
-EUPL (the "Licence");
+Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+the European Commission – subsequent versions of the EUPL (the "Licence");
 
-You may not use this work except in compliance with the Licence.
-You may obtain a copy of the Licence at:
+You may not use this work except in compliance with the Licence. You may
+obtain a copy of the Licence at:
 
 <https://joinup.ec.europa.eu/collection/eupl/eupl-text-11-12>
 
-Unless required by applicable law or agreed to in writing,
-software distributed under the Licence is distributed on an
-"AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-either express or implied. See the Licence for the specific
-language governing permissions and limitations under the Licence.
+Unless required by applicable law or agreed to in writing, software distributed
+under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the Licence for the
+specific language governing permissions and limitations under the Licence.
 
 Consult the LICENCE file for details.

--- a/src/raster/r.findtheriver/README.md
+++ b/src/raster/r.findtheriver/README.md
@@ -7,11 +7,9 @@
 This program is free software under the GNU General Public License
 (>=v2). Read the file COPYING that comes with GRASS for details.
 
-
 ## AUTHOR
 
 Brian Miles - brian_miles@unc.edu
-
 
 ## DESCRIPTION
 
@@ -61,7 +59,6 @@ sudo make GRASS_HOME=./ GRASS_APP=/Applications/GRASS-6.4.app deploy
 Assuming you have unpacked r.findtheriver into your local copy of
 modbuild/module (see ReadMe-OSX.rtf) and the current directory is
 r.findtheriver.
-
 
 Linux/Unix
 

--- a/src/raster/r.landscape.evol/r.landscape.evol.md
+++ b/src/raster/r.landscape.evol/r.landscape.evol.md
@@ -2,11 +2,11 @@
 
 ## DESCRIPTION
 
-_r.landscape.evol_ takes as input a raster digital
-elevation model (DEM) of surface topography and an input raster DEM
-of bedrock elevations, as well as several environmental variables,
-and computes the net change in elevation due to erosion and
-deposition Stream Power equation, the Shear Stress equation, or the USPED equation.
+_r.landscape.evol_ takes as input a raster digital elevation model (DEM) of
+surface topography and an input raster DEM of bedrock elevations, as well
+as several environmental variables, and computes the net change in elevation
+due to erosion and deposition Stream Power equation, the Shear Stress
+equation, or the USPED equation.
 
 ## NOTES
 
@@ -38,7 +38,8 @@ a) GIS Implementation:
 b) Variables:
 
 * Tc = Transport Capacity [kg/meters.second]
-* K\*C\*P ~ Kt = mitigating effects of soil type, vegetation cover, and land-use practices. [unitless]
+* K\*C\*P ~ Kt = mitigating effects of soil type, vegetation cover, and
+  land-use practices. [unitless]
 * gw = Hydrostatic pressure of water 9810 [kg/m2.second]
 * N = Manning's coefficient (0.3-0.6 for different types of stream channels) [unitless]
 * i = rainfall intensity [m/rainfall event]
@@ -61,7 +62,8 @@ d) NOTES:
 * This is likely the best of the three equations for simulating erosion at the
   scale of small watersheds, including overland flow on hillslopes and
   channelized flow in gullies and streams.
-* It is likely not appropriate for simulating erosion and deposition processes in larger rivers, especially meandering  flood plains.
+* It is likely not appropriate for simulating erosion and deposition processes
+  in larger rivers, especially meandering  flood plains.
 * `K*C*P` should equal an appropriate value of `Kt`: 0.001 for a soft
   substrate, 0.0001 for a normal substrate, 0.00001 for a hard substrate,
   0.000001 for a very hard substrate. See note below about methods for scaling
@@ -86,7 +88,8 @@ a) GIS Implmentation:
 b) Variables:
 
 * Tc = Transport Capacity [kg/meters.second]
-* K\*C\*P ~ Kt = mitigating effects of soil type, vegetation cover, and land-use practices. [unitless]
+* K\*C\*P ~ Kt = mitigating effects of soil type, vegetation cover, and land-use
+  practices. [unitless]
 * gw = Hydrostatic pressure of water 9810 [kg/m2.second]
 * N = Manning's coefficient ~0.3-0.6 for different types of stream channels [unitless]
 * i = rainfall intensity [m/rainfall event]
@@ -98,13 +101,14 @@ b) Variables:
 
 c) Converted to Map Algebra:
 
-         ${K}*${C}*${P} * exp(9810.*(((${rain}/1000)*${flowacc})/(0.595*\
-         ${stormtimet}))*tan(${slope}), graph(${flowacc}, ${exp_n1a},${exp_n1b},\
-          ${exp_n2a},${exp_n2b}))
+    ${K}*${C}*${P} * exp(9810.*(((${rain}/1000)*${flowacc})/(0.595*\
+    ${stormtimet}))*tan(${slope}), graph(${flowacc}, ${exp_n1a},${exp_n1b},\
+     ${exp_n2a},${exp_n2b}))
 
 d) NOTES:
 
-* This implementation of the Shear Stress equation assumes the critical shear stress is 0.
+* This implementation of the Shear Stress equation assumes the critical shear
+  stress is 0.
 * This means the equation is likely to over predict erosion in situations where
   shear stress is less than the actual critical shear stress, such as on
   vegetated hillslopes.
@@ -131,7 +135,8 @@ b) Variables:
 
 * Tc = Transport Capacity [kg/meters.second]
 * R = Rainfall intensity factor [MJ.mm/ha.h.yr]
-* K\*C\*P ~ Kt = mitigating effects of soil type, vegetation cover, and land-use practices. [unitless]
+* K\*C\*P ~ Kt = mitigating effects of soil type, vegetation cover, and
+  land-use practices. [unitless]
 * A = upslope accumulated area per contour (cell) width [m2/m] = [m]
 * S = topographic slope [degrees]
 * m = transport coefficient for upslope area [unitless]
@@ -139,13 +144,14 @@ b) Variables:
 
 c) Converted to Map Algebra:
 
-        (${R}*${K}*${C}*${P}*exp((${flowacc}*${res}),graph(${flowacc}, ${exp_m1a},\
-        ${exp_m1b}, ${exp_m2a},${exp_m2b}))*exp(sin(${slope}), graph(${slope}, \
-        ${exp_n1a},${exp_n1b}, ${exp_n2a},${exp_n2b})))
+    (${R}*${K}*${C}*${P}*exp((${flowacc}*${res}),graph(${flowacc}, ${exp_m1a},\
+    ${exp_m1b}, ${exp_m2a},${exp_m2b}))*exp(sin(${slope}), graph(${slope}, \
+    ${exp_n1a},${exp_n1b}, ${exp_n2a},${exp_n2b})))
 
 d) NOTES:
 
-* The USPED equation is best suited for modeling erosion and deposition on hillslopes and small gullies.
+* The USPED equation is best suited for modeling erosion and deposition on
+  hillslopes and small gullies.
 * It will vastly over predict erosion/deposition in channels and streams.
 
 ### Scalar m and n exponents to simulate changing process across landscapes
@@ -228,8 +234,8 @@ possible to use constants in their place, but it will be much better to create
 maps using some theoretical concepts. The simplest way is to scale `C` to a
 wetness index using the principle that the more water accumulation, the denser
 the vegetation. From a DEM, it is possible to calculate the TCI topographic
-wetness index using *r.watershed* with output parameter **tci**. Here is an
-example set of *r.recode* rules to create a `C` map from TCI to enter in input
+wetness index using _r.watershed_ with output parameter **tci**. Here is an
+example set of _r.recode_ rules to create a `C` map from TCI to enter in input
 variable **c**:
 
     0:3:0.1:0.01
@@ -240,7 +246,7 @@ variable **c**:
 Here, low values of TCI will be coded as shrubs or open woodlands. Moderate
 values of TCI will become wooded, and high values of TCI will coded as dense
 riparian vegetation. It's important to note that this should be done with a TCI
-map created with *r.watershed* on the same DEM that will be used as the initial
+map created with _r.watershed_ on the same DEM that will be used as the initial
 DEM for the simulation.
 
 From here, it is possible to map rainfall excess to values of `C`. The
@@ -257,7 +263,7 @@ excess water escaping from the cell. The resulting map should be entered into
 input variable **flowcontrib**.
 
 Finally, Manning's `N` can be scaled to flow accumulation (i.e., computed with
-*r.watershed*) using the following recode rules to create an input map for
+_r.watershed_) using the following recode rules to create an input map for
 variable **manningn**:
 
     0:10:0.03:0.04
@@ -271,9 +277,9 @@ is at the level of small watershed feeding into a small trunk stream, not a
 large free-flowing river. If some empirical data about channel conditions are
 known, then the values used in the recode statement should be adjusted to
 reflect this. Again, it's important to note that this should be done with a
-flow accumulation map created with *r.watershed* on the same DEM that will be
+flow accumulation map created with _r.watershed_ on the same DEM that will be
 used as the initial DEM for the simulation. Further, the -a flag in
-*r.watershed* should be checked so that the output flow accumulation will
+_r.watershed_ should be checked so that the output flow accumulation will
 contain only positive numbers.
 
 ### Creating a hydrologically-appropriate base DEM
@@ -286,68 +292,68 @@ resolutions. As a general rule of thumb, cell resolution should be <= 10m. This
 can be achieved through resampling/interpolation from coarser data sets (e.g.,
 a 30m SRTM DEM). If interpolation is used, it is best to use an interpolation
 procedure that will result in relatively smooth interpolated DEM with minimal
-depressions. Generally, *v.surf.bspline* achieves good results when the spline
+depressions. Generally, _v.surf.bspline_ achieves good results when the spline
 step is double to triple the cell resolution of the coarser input map, and the
 smoothing parameter is set to provide some additional smoothing (e.g., ~0.1).
 This results in an interpolated DEM with a smooth surface and minimal localized
 depressions caused by over-fitting to localized surface trends. Although
-*v.surf.rst* can also be used, it often produces rectilinear artifacts from
+_v.surf.rst_ can also be used, it often produces rectilinear artifacts from
 it's segmentation procedure that can adversely affect simulation of water flow
 on the interpolated DEM.
 
 The DEM should be clipped to a contiguous watershed boundary (e.g., extracted
-with *r.watershed* or *r.water.outlet*). Rectilinear input maps will produce
+with _r.watershed_ or _r.water.outlet_). Rectilinear input maps will produce
 erroneous results outside of internally contiguous watersheds leading to faulty
 statistics, so it is more useful to clip to the watershed of interest (e.g.,
-using *r.mapcalc*).
+using _r.mapcalc_).
 
 Finally, in order to assure that water will flow naturally across the DEM, it
 is important to ensure that the DEM is depressionless. This _could_ be achieved
-with *r.fill.dir* to fill any interior basins to an elevation level with their
+with _r.fill.dir_ to fill any interior basins to an elevation level with their
 spill point, but doing so creates many flat areas where otherwise channelized
 flow will diverge (and thus deposit). This can be partially addressed by
 adjusting **convergence** to a low value, which forces the flow accumulation
-routine in *r.watershed* to send a higher proportion of the flow to the most
+routine in _r.watershed_ to send a higher proportion of the flow to the most
 downstream cell.
 
 However, a much better, if more complicated approach is to create a
 depressionless DEM by _carving_ the main streams through any blockages. The
-module *r.carve* can do this relatively simply, but you are only able to use a
+module _r.carve_ can do this relatively simply, but you are only able to use a
 uniform stream width and depth. Ideally, the width and depth of the carved
 channels should decrease in width and depth from the basin outlet to the stream
 sources. To do this requires several steps. First extract an
-appropriately-scaled stream network using *r.watershed* and/or
-*r.stream.extract* and an appropriate interior basin threshold parameter to
+appropriately-scaled stream network using _r.watershed_ and/or
+_r.stream.extract__ and an appropriate interior basin threshold parameter to
 isolate main trunk streams with some smaller tributary branches. Use this
-output raster streams map as the input to the addon module *r.stream.order*
+output raster streams map as the input to the addon module _r.stream.order_
 with the output option for the Shreve stream order. This will create a raster
 streams map where trunk streams are coded with a large number, and tributaries
-with smaller numbers. Use *r.univar* to determine the maximum Shreve value, and
-then use *r.mapcalc* to standardize the values between 0 and 1 by dividing the
+with smaller numbers. Use _r.univar_ to determine the maximum Shreve value, and
+then use _r.mapcalc__ to standardize the values between 0 and 1 by dividing the
 Shreve-scaled streams map by the maximum Shreve order value (ensure that you
 use a decimal point behind the maximum value number so that a floating point
 map will be made). The standardized Shreve order streams raster map is then
-converted to a line vector map with *r.to.vect* with option **column** set in
+converted to a line vector map with _r.to.vect_ with option **column** set in
 order to write the scaled Shreve order into the table. This vector map is then
-input into *v.buffer* with option **column** set to the column where the scaled
+input into _v.buffer_ with option **column** set to the column where the scaled
 Shreve order values were saved and flag **t** is selected so that the attribute
 table will transfer to the new file. Also set option **scale** to the maximum
 channel width (in meters) of the largest trunk stream in the streams map, which
 will create a vector areas map with streams scaled to the appropriate widths.
 This vector areas map should then be converted back to a raster map with
-*v.to.rast*, making sure that the option **use** is set to "attr" and the
+_v.to.rast_, making sure that the option **use** is set to "attr" and the
 option **attribute_column** is set so that the scaled Shreve order values will
-be saved as the raster values. Finally, use *r.mapcalc* to scale the Sherve
+be saved as the raster values. Finally, use _r.mapcalc_ to scale the Sherve
 order values into the depth of the carved streams by multiplying the converted
 buffer raster map by the maximum desired depth of the largest trunk stream.
 This final output raster map will now be scaled to both width and depth
-throughout the stream network. Use *r.mapcalc* to "carve" into the DEM by
+throughout the stream network. Use _r.mapcalc_ to "carve" into the DEM by
 subtracting this scaled width/depth map from the DEM. As a final measure to
-ensure that there is no stream blockage, you can use the module **r.carve* with
+ensure that there is no stream blockage, you can use the module _r.carve_ with
 the streams vector map and the "precarved" DEM, which will ensure that no high
 areas exist in the channel bottoms. Finally, you may wish to re-interpolate the
 carved DEM so that harsh angles on the edges of the carved banks are removed.
-Using a bicubic interpolation in *v.surf.bspline* with relatively long spline
+Using a bicubic interpolation in _v.surf.bspline_ with relatively long spline
 step and high smoothing should accomplish this.
 
 ### Estimating soil depth
@@ -357,8 +363,8 @@ on the amount of erosion that can occur at any particular cell (see below). The
 depth of soil available to erode is the difference between the current surface
 elevations (DEM) and the bedrock elevation map **initbdrk**. The simplest way
 to estimate the bedrock elevation map is to subtract a constant from the
-starting DEM map used for **elev** using *r.mapcalc*. A more complex bedrock
-topography can be estimated using the addon module *r.soildepth*. In either
+starting DEM map used for **elev** using _r.mapcalc_. A more complex bedrock
+topography can be estimated using the addon module _r.soildepth_. In either
 case, it is important to use the same DEM to derive the bedrock elevations as
 you will use for the initial starting topography in the simulation.
 
@@ -444,7 +450,9 @@ This approach is more flexible than using R factor to encapsulate rainfall
 intensivity, as with USPED, as often R factor can only be estimated from
 rainfall totals at the timescale of the year or decade.
 
+<!-- markdownlint-disable line-length -->
 ### Conversion of output of divergence to calculated erosion and deposition in vertical meters of elevation change
+<!-- markdownlint-enable line-length -->
 
 In order to convert the changes in transport capacity into the amount of
 elevation gained or lost by deposition or erosion, first the divergence in
@@ -478,7 +486,7 @@ To prevent null cells at the edges of maps, (the edge cells have no upstream
 cell, so get turned null), the initial DEM is patched underneath. Thus, the
 perimeter cells will never change in elevation throughout the simulation. Users
 are therefore strongly suggested to use a watershed boundary for their input
-maps (e.g., extracted from *r.watershed*, and then clipped with the map
+maps (e.g., extracted from _r.watershed_, and then clipped with the map
 calculator), as cells at the watershed boundary should not change in elevation
 much in real world scenarios over the time spans of landscape evolution
 intended to be modeled with this module (100's to 1000's of years).
@@ -505,91 +513,186 @@ be considered stable and ready for production use.
 
 ## SEE ALSO
 
-The <a href="http://medland.asu.edu/">MEDLAND</a> project at Arizona State University
+The [MEDLAND](http://medland.asu.edu) project at Arizona State University
 
-<a href="r.watershed.html">r.watershed</a>, <a href="r.terraflow.html">r.terraflow</a>, <a href="r.mapcalc.html">r.mapcalc</a>
+[r.watershed](https://grass.osgeo.org/grass-stable/manuals/r.watershed.html),
+[r.terraflow](https://grass.osgeo.org/grass-stable/manuals/r.terraflow.html),
+[r.mapcalc](https://grass.osgeo.org/grass-stable/manuals/r.mapcalc.html)
 
-Mitasova, H., C. M. Barton, I. I. Ullah, J. Hofierka, and R. S. Harmon 2013 GIS-based soil erosion modeling. In Remote Sensing and GIScience in Geomorphology, edited by J. Shroder and M. P. Bishop. 3:228-258. San Diego: Academic Press.
+Mitasova, H., C. M. Barton, I. I. Ullah, J. Hofierka, and R. S. Harmon 2013
+GIS-based soil erosion modeling. In Remote Sensing and GIScience in
+Geomorphology, edited by J. Shroder and M. P. Bishop. 3:228-258.
+San Diego: Academic Press.
 
 ## REFERENCES
 
-Aiello, A., Adamo, M., Canora, F., 2015. Remote sensing and GIS to assess soil erosion with RUSLE3D and USPED at river basin scale in southern Italy. CATENA 131, 174–185. <https://doi.org/10.1016/j.catena.2015.04.003>
+Aiello, A., Adamo, M., Canora, F., 2015. Remote sensing and GIS to assess soil
+erosion with RUSLE3D and USPED at river basin scale in southern Italy.
+CATENA 131, 174–185. <https://doi.org/10.1016/j.catena.2015.04.003>
 
-Aksoy, H., Kavvas, M.L., 2005. A review of hillslope and watershed scale erosion and sediment transport models. CATENA 64, 247–271. <https://doi.org/10.1016/j.catena.2005.08.008>
+Aksoy, H., Kavvas, M.L., 2005. A review of hillslope and watershed scale
+erosion and sediment transport models. CATENA 64, 247–271.
+<https://doi.org/10.1016/j.catena.2005.08.008>
 
-Ayala, G., French, C., 2005. Erosion modeling of past land-use practices in the Fiume di Sotto di Troina river valley, north-central Sicily. Geoarchaeology 20, 149–167.
+Ayala, G., French, C., 2005. Erosion modeling of past land-use practices in the
+Fiume di Sotto di Troina river valley, north-central Sicily. Geoarchaeology 20,
+149–167.
 
-Benavidez, R., Jackson, B., Maxwell, D., Norton, K., 2018. A review of the (Revised) Universal Soil Loss Equation (R/USLE): with a view to increasing its global applicability and improving soil loss estimates. Hydrology and Earth System Sciences Discussions 1–34. <https://doi.org/10.5194/hess-2018-68>
+Benavidez, R., Jackson, B., Maxwell, D., Norton, K., 2018. A review of the
+(Revised) Universal Soil Loss Equation (R/USLE): with a view to increasing its
+global applicability and improving soil loss estimates. Hydrology and Earth
+System Sciences Discussions 1–34. <https://doi.org/10.5194/hess-2018-68>
 
-Bosco, C., de Rigo, D., Dewitte, O., Poesen, J., Panagos, P., 2015. Modelling soil erosion at European scale: towards harmonization and reproducibility. Natural Hazards and Earth System Science 15, 225–245. <https://doi.org/10.5194/nhess-15-225-2015>
+Bosco, C., de Rigo, D., Dewitte, O., Poesen, J., Panagos, P., 2015. Modelling
+soil erosion at European scale: towards harmonization and reproducibility.
+Natural Hazards and Earth System Science 15, 225–245.
+<https://doi.org/10.5194/nhess-15-225-2015>
 
-Davy, P., Crave, A., 2000. Upscaling local-scale transport processes in large-scale relief dynamics. Physics and Chemistry of the Earth, Part A: Solid Earth and Geodesy 25, 533–541. <https://doi.org/10.1016/S1464-1895(00)00082-X>
+Davy, P., Crave, A., 2000. Upscaling local-scale transport processes in
+large-scale relief dynamics. Physics and Chemistry of the Earth, Part A: Solid
+Earth and Geodesy 25, 533–541. <https://doi.org/10.1016/S1464-1895(00)00082-X>
 
-Dietrich, W.E., Bellugi, D.G., Sklar, L.S., Stock, J.D., Heimsath, A.M., Roering, J.J., 2003. Geomorphic Transport Laws for Predicting Landscape form and Dynamics, in: Wilcock, P.R., Iverson, R.M. (Eds.), Prediction in Geomorphology, Geophysical Monograph. American Geophysical Union, pp. 103–132.
+Dietrich, W.E., Bellugi, D.G., Sklar, L.S., Stock, J.D., Heimsath, A.M.,
+Roering, J.J., 2003. Geomorphic Transport Laws for Predicting Landscape form
+and Dynamics, in: Wilcock, P.R., Iverson, R.M. (Eds.), Prediction in
+Geomorphology, Geophysical Monograph. American Geophysical Union, pp. 103–132.
 
-Diodato, N., 2006. Predicting RUSLE (Revised Universal Soil Loss Equation) Monthly Erosivity Index from Readily Available Rainfall Data in Mediterranean Area. The Environmentalist 26, 63–70. <https://doi.org/10.1007/s10669-006-5359-x>
+Diodato, N., 2006. Predicting RUSLE (Revised Universal Soil Loss Equation)
+Monthly Erosivity Index from Readily Available Rainfall Data in Mediterranean
+Area. The Environmentalist 26, 63–70.
+<https://doi.org/10.1007/s10669-006-5359-x>
 
-Hammad, A.A., Lundekvam, H., Børresen, T., 2004. Adaptation of RUSLE in the Eastern Part of the Mediterranean Region. Environmental Management 34, 829–841.
+Hammad, A.A., Lundekvam, H., Børresen, T., 2004. Adaptation of RUSLE in the
+Eastern Part of the Mediterranean Region. Environmental Management 34, 829–841.
 
-Hancock, G.R., 2004. Modelling soil erosion on the catchment and landscape scale using landscape evolution models – a probabilistic approach using digital elevation model error, in: Super Soil 2004:3rd Australian New Zealand Soils Conference. University of Sydney, Australia.
+Hancock, G.R., 2004. Modelling soil erosion on the catchment and landscape
+scale using landscape evolution models – a probabilistic approach using digital
+elevation model error, in: Super Soil 2004:3rd Australian New Zealand Soils
+Conference. University of Sydney, Australia.
 
-Kelley, A.D., Malin, M.C., Nielson, G.M., 1988. Terrain simulation using a model of stream erosion. ACM SIGGRAPH Computer Graphics 22, 263–268.
+Kelley, A.D., Malin, M.C., Nielson, G.M., 1988. Terrain simulation using a
+model of stream erosion. ACM SIGGRAPH Computer Graphics 22, 263–268.
 
-Koko, Š., 2011. Simulation of gully erosion using the SIMWE model and GIS. Landform Analysis 17, 81–86.
+Koko, Š., 2011. Simulation of gully erosion using the SIMWE model and GIS.
+Landform Analysis 17, 81–86.
 
-Kwang, J.S., Parker, G., 2017. Landscape evolution models using the stream power incision model show unrealistic behavior when &lt;i&gt;m&lt;/i&gt; ∕ &lt;i&gt;n&lt;/i&gt; equals 0.5. Earth Surface Dynamics 5, 807–820. <https://doi.org/10.5194/esurf-5-807-2017>
+Kwang, J.S., Parker, G., 2017. Landscape evolution models using the stream
+power incision model show unrealistic behavior when _m/n_ equals 0.5. Earth
+Surface Dynamics 5, 807–820. <https://doi.org/10.5194/esurf-5-807-2017>
 
-Martínez-Casasnovas, J.A., Sánchez-Bosch, I., 2000. Impact assessment of changes in land use/conservation practices on soil erosion in the Penedès-Anoia vineyard region (NE Spain). Soil and Tillage Research 57, 101–106.
+Martínez-Casasnovas, J.A., Sánchez-Bosch, I., 2000. Impact assessment of changes
+in land use/conservation practices on soil erosion in the Penedès-Anoia vineyard
+region (NE Spain). Soil and Tillage Research 57, 101–106.
 
-Mathier, L., Roy, A.G., Paré, J.P., 1989. The effect of slope gradient and length on the parameters of a sediment transport equation for sheetwash. CATENA 16, 545–558. <https://doi.org/10.1016/0341-8162(89)90041-6>
+Mathier, L., Roy, A.G., Paré, J.P., 1989. The effect of slope gradient and
+length on the parameters of a sediment transport equation for sheetwash.
+CATENA 16, 545–558. <https://doi.org/10.1016/0341-8162(89)90041-6>
 
-Mitasova, H., Barton, C.M., Ullah, I.I., Hofierka, J., Harmon, R.S., 2013. GIS-based soil erosion modeling, in: Shroder, J., Bishop, M.P. (Eds.), Remote Sensing and GIScience in Geomorphology, Treatise in Geomorphology. Academic Press, San Diego, pp. 228–258.
+Mitasova, H., Barton, C.M., Ullah, I.I., Hofierka, J., Harmon, R.S., 2013.
+GIS-based soil erosion modeling, in: Shroder, J., Bishop, M.P. (Eds.), Remote
+Sensing and GIScience in Geomorphology, Treatise in Geomorphology. Academic Press,
+San Diego, pp. 228–258.
 
-Mitasova, H., Brown, W.M., Johnston, D., 2002. Terrain Modeling and Soil Erosion Simulation Final Report. Geographic Modeling Systems Lab, University of Illinois at Urbana-Champaign.
+Mitasova, H., Brown, W.M., Johnston, D., 2002. Terrain Modeling and Soil Erosion
+Simulation Final Report. Geographic Modeling Systems Lab, University of Illinois
+at Urbana-Champaign.
 
-Mitasova, H., Hofierka, J., Zlocha, M., Iverson, L.R., 1996a. Modelling topographic potential for erosion and deposition using GIS. International journal of geographical information systems 10, 629–641. <https://doi.org/10.1080/02693799608902101>
+Mitasova, H., Hofierka, J., Zlocha, M., Iverson, L.R., 1996a. Modelling
+topographic potential for erosion and deposition using GIS. International journal
+of geographical information systems 10, 629–641.
+<https://doi.org/10.1080/02693799608902101>
 
-Mitasova, H., Mitas, L., Brown, W.M., 2001. Multiscale Simulation of Land Use Impact on Soil Erosion and Deposition Patterns, in: Stott, D.E., Mohtar, R.H., Steinhardt, G.C. (Eds.), Sustaining the Global Farm: 10th International Soil Conservation Organization Meeting Held May 24-29, 1999. Purdue University and the USDA-ARS National Soil Erosion Research Laboratory, pp. 1163–1169.
+Mitasova, H., Mitas, L., Brown, W.M., 2001. Multiscale Simulation of Land Use
+Impact on Soil Erosion and Deposition Patterns, in: Stott, D.E., Mohtar, R.H.,
+Steinhardt, G.C. (Eds.), Sustaining the Global Farm: 10th International Soil
+Conservation Organization Meeting Held May 24-29, 1999. Purdue University and
+the USDA-ARS National Soil Erosion Research Laboratory, pp. 1163–1169.
 
-Mitasova, H., Mitas, L., Brown, W.M., Johnston, D., 1996b. Multidimensional Soil Erosion/Deposition Modeling Part III: Process based erosion simulation. Geographic Modeling and Systems Laboratory, University of Illinois at Urban-Champaign.
+Mitasova, H., Mitas, L., Brown, W.M., Johnston, D., 1996b. Multidimensional Soil
+Erosion/Deposition Modeling Part III: Process based erosion simulation.
+Geographic Modeling and Systems Laboratory, University of Illinois at
+Urban-Champaign.
 
-Mitasova, H., Mitas, L., Brown, W.M., Johnston, D.M., 1999. Terrain modeling and Soil Erosion Simulations for Fort Hood and Fort Polk test areas. Geographic Modeling and Systems Laboratory, University of Illinois at Urbana-Champaign.
+Mitasova, H., Mitas, L., Brown, W.M., Johnston, D.M., 1999. Terrain modeling and
+Soil Erosion Simulations for Fort Hood and Fort Polk test areas. Geographic
+Modeling and Systems Laboratory, University of Illinois at Urbana-Champaign.
 
-Onori, F., De Bonis, P., Grauso, S., 2006. Soil erosion prediction at the basin scale using the revised universal soil loss equation (RUSLE) in a catchment of Sicily (southern Italy). Environmental Geology 50, 1129–1140.
+Onori, F., De Bonis, P., Grauso, S., 2006. Soil erosion prediction at the basin
+scale using the revised universal soil loss equation (RUSLE) in a catchment of
+Sicily (southern Italy). Environmental Geology 50, 1129–1140.
 
-Panagos, P., Ballabio, C., Borrelli, P., Meusburger, K., Klik, A., Rousseva, S., Tadić, M.P., Michaelides, S., Hrabalíková, M., Olsen, P., Aalto, J., Lakatos, M., Rymszewicz, A., Dumitrescu, A., Beguería, S., Alewell, C., 2015a. Rainfall erosivity in Europe. Science of The Total Environment 511, 801–814. <https://doi.org/10.1016/j.scitotenv.2015.01.008>
+Panagos, P., Ballabio, C., Borrelli, P., Meusburger, K., Klik, A., Rousseva, S.,
+Tadić, M.P., Michaelides, S., Hrabalíková, M., Olsen, P., Aalto, J., Lakatos, M.,
+Rymszewicz, A., Dumitrescu, A., Beguería, S., Alewell, C., 2015a. Rainfall
+erosivity in Europe. Science of The Total Environment 511, 801–814.
+<https://doi.org/10.1016/j.scitotenv.2015.01.008>
 
-Panagos, P., Borrelli, P., Meusburger, K., Alewell, C., Lugato, E., Montanarella, L., 2015b. Estimating the soil erosion cover-management factor at the European scale. Land Use Policy 48, 38–50. <https://doi.org/10.1016/j.landusepol.2015.05.021>
+Panagos, P., Borrelli, P., Meusburger, K., Alewell, C., Lugato, E.,
+Montanarella, L., 2015b. Estimating the soil erosion cover-management factor at
+the European scale. Land Use Policy 48, 38–50.
+<https://doi.org/10.1016/j.landusepol.2015.05.021>
 
-Panagos, P., Borrelli, P., Meusburger, K., van der Zanden, E.H., Poesen, J., Alewell, C., 2015c. Modelling the effect of support practices (P-factor) on the reduction of soil erosion by water at European scale. Environmental Science & Policy 51, 23–34. <https://doi.org/10.1016/j.envsci.2015.03.012>
+Panagos, P., Borrelli, P., Meusburger, K., van der Zanden, E.H., Poesen, J.,
+Alewell, C., 2015c. Modelling the effect of support practices (P-factor) on the
+reduction of soil erosion by water at European scale. Environmental
+Science & Policy 51, 23–34. <https://doi.org/10.1016/j.envsci.2015.03.012>
 
-Panagos, P., Meusburger, K., Ballabio, C., Borrelli, P., Alewell, C., 2014. Soil erodibility in Europe: A high-resolution dataset based on LUCAS. Science of The Total Environment 479–480, 189–200. <https://doi.org/10.1016/j.scitotenv.2014.02.010>
+Panagos, P., Meusburger, K., Ballabio, C., Borrelli, P., Alewell, C., 2014.
+Soil erodibility in Europe: A high-resolution dataset based on LUCAS. Science of
+The Total Environment 479–480, 189–200.
+<https://doi.org/10.1016/j.scitotenv.2014.02.010>
 
-Peckham, S.D., 2003. Fluvial landscape models and catchment-scale sediment transport. Global and Planetary Change 39, 31–51. <https://doi.org/10.1016/S0921-8181(03)00014-6>
+Peckham, S.D., 2003. Fluvial landscape models and catchment-scale sediment
+transport. Global and Planetary Change 39, 31–51.
+<https://doi.org/10.1016/S0921-8181(03)00014-6>
 
-Peeters, I., Rommens, T., Verstraeten, G., Govers, G., Van Rompaey, A., Poesen, J., Van Oost, K., 2006. Reconstructing ancient topography through erosion modelling. Geomorphology 78, 250–264.
-Pistocchi, A., Cassani, G., Zani, O., n.d. Use of the USPED model for mapping soil erosion and managing best land conservation practices 7.
+Peeters, I., Rommens, T., Verstraeten, G., Govers, G., Van Rompaey, A.,
+Poesen, J., Van Oost, K., 2006. Reconstructing ancient topography through erosion
+modelling. Geomorphology 78, 250–264.
 
-Renard, K.G., Foster, G.R., Weesies, G.A., McCool, D.K., Yoder, D.C., 1997. Predicting soil erosion by water: a guide to conservation planning with the Revised Universal Soil Loss Equation (RUSLE), in: Agriculture Handbook. US Department of Agriculture, Washington, DC, pp. 1–251.
+Pistocchi, A., Cassani, G., Zani, O., n.d. Use of the USPED model for mapping
+soil erosion and managing best land conservation practices 7.
 
-Renard, K.G., Foster, G.R., Weesies, G.A., Porter, J.P., 1991. RUSLE: Revised Universal Soil Loss Equation. Journal of Soil and Water Conservation 46, 30–33.
+Renard, K.G., Foster, G.R., Weesies, G.A., McCool, D.K., Yoder, D.C., 1997.
+Predicting soil erosion by water: a guide to conservation planning with the
+Revised Universal Soil Loss Equation (RUSLE), in: Agriculture Handbook.
+US Department of Agriculture, Washington, DC, pp. 1–251.
 
-Renard, K.G., Freimund, J.R., 1994. Using monthly precipitation data to estimate the R-factor in the revised USLE. Journal of Hydrology 157, 287–306.
+Renard, K.G., Foster, G.R., Weesies, G.A., Porter, J.P., 1991. RUSLE: Revised
+Universal Soil Loss Equation. Journal of Soil and Water Conservation 46, 30–33.
 
+Renard, K.G., Freimund, J.R., 1994. Using monthly precipitation data to estimate
+the R-factor in the revised USLE. Journal of Hydrology 157, 287–306.
 
-Sklar, L.S., Riebe, C.S., Marshall, J.A., Genetti, J., Leclere, S., Lukens, C.L., Merces, V., 2017. The problem of predicting the size distribution of sediment supplied by hillslopes to rivers. Geomorphology 277, 31–49. <https://doi.org/10.1016/j.geomorph.2016.05.005>
+Sklar, L.S., Riebe, C.S., Marshall, J.A., Genetti, J., Leclere, S., Lukens, C.L.,
+Merces, V., 2017. The problem of predicting the size distribution of sediment
+supplied by hillslopes to rivers. Geomorphology 277, 31–49.
+<https://doi.org/10.1016/j.geomorph.2016.05.005>
 
-Terranova, O., Antronico, L., Coscarelli, R., Iaquinta, P., 2009. Soil erosion risk scenarios in the Mediterranean environment using RUSLE and GIS: An application model for Calabria (southern Italy). Geomorphology 112, 228–245. <https://doi.org/10.1016/j.geomorph.2009.06.009>
+Terranova, O., Antronico, L., Coscarelli, R., Iaquinta, P., 2009. Soil erosion
+risk scenarios in the Mediterranean environment using RUSLE and GIS: An
+application model for Calabria (southern Italy). Geomorphology 112, 228–245.
+<https://doi.org/10.1016/j.geomorph.2009.06.009>
 
-Tucker, G.E., Whipple, K.X., 2002. Topographic outcomes predicted by stream erosion models: Sensitivity analysis and intermodel comparison. J. Geophys. Res 107, 1–1.
+Tucker, G.E., Whipple, K.X., 2002. Topographic outcomes predicted by stream
+erosion models: Sensitivity analysis and intermodel comparison.
+J. Geophys. Res 107, 1–1.
 
-Warren, S.D., Mitasova, H., Hohmann, M.G., Landsberger, S., Skander, F.Y., Ruzycki, T.S., Senseman, G.M., 2005. Validation of a 3-D enhancement of the Universal Soil Loss Equation for preediction of soil erosion and sediment deposition. Catena 64, 281–296.
+Warren, S.D., Mitasova, H., Hohmann, M.G., Landsberger, S., Skander, F.Y.,
+Ruzycki, T.S., Senseman, G.M., 2005. Validation of a 3-D enhancement of the
+Universal Soil Loss Equation for preediction of soil erosion and sediment
+deposition. Catena 64, 281–296.
 
-Whipple, K.X., Tucker, G.E., 2002. Implications of sediment-flux-dependent river incision models for landscape evolution. Journal of Geophysical Research 107.
+Whipple, K.X., Tucker, G.E., 2002. Implications of sediment-flux-dependent river
+incision models for landscape evolution. Journal of Geophysical Research 107.
 
-Whipple, K.X., Tucker, G.E., 1999. Dynamics of the stream-power river incision model; implications for height limits of mountain ranges, landscape response timescales, and research needs. Journal of Geophysical Research 104, 17,661-17,674.
+Whipple, K.X., Tucker, G.E., 1999. Dynamics of the stream-power river incision
+model; implications for height limits of mountain ranges, landscape response
+timescales, and research needs. Journal of Geophysical Research 104, 17,661-17,674.
 
-Willgoose, G., 2005. Mathematical Modeling of Whole Landscape Evolution. Annual Review of Earth and Planetary Sciences 33, 443–459.
+Willgoose, G., 2005. Mathematical Modeling of Whole Landscape Evolution. Annual
+Review of Earth and Planetary Sciences 33, 443–459.
 
-<h2>AUTHORS</h2>
+## AUTHORS
+
 Isaac I. Ullah, C. Michael Barton, and Helena Mitasova

--- a/src/raster/r.mapcalc.tiled/tests/README.md
+++ b/src/raster/r.mapcalc.tiled/tests/README.md
@@ -1,6 +1,5 @@
 # Test r.mapcalc.tiled with different parameters vs. r.mapcalc
 
-
 `test.py` is a script for testing `r.mapcalc.tiled` vs `r.mapcalc`. In the
 `config.ini` you can set some general parameters like the map on which
 the region has to be set, the `r.mapcalc` expression and the number of
@@ -15,8 +14,8 @@ dataset) with:
 
 `python3 test.py config.ini`
 
-`visualization.py` is a script to visualize the result of the `test.py` output CSV file.
-It can be executed with
+`visualization.py` is a script to visualize the result of the `test.py` output
+CSV file. It can be executed with
 
 `python3 visualization.py rmapcalctiled_test.csv images`
 

--- a/src/raster/r.mblend/README.md
+++ b/src/raster/r.mblend/README.md
@@ -1,6 +1,7 @@
 # r.mblend
 
-Draft implementation of the [Mblend algorithm](http://www.sciencedirect.com/science/article/pii/S0098300416300012) as an add-on for [GRASS GIS](https://grass.osgeo.org/).
+Draft implementation of the [Mblend algorithm](http://www.sciencedirect.com/science/article/pii/S0098300416300012)
+as an add-on for [GRASS GIS](https://grass.osgeo.org/).
 
 Manual and detailed description is available at the [GRASS manual pages](https://grass.osgeo.org/grass8/manuals/addons/r.mblend.html).
 
@@ -8,14 +9,15 @@ Manual and detailed description is available at the [GRASS manual pages](https:/
 
 To cite or reference r.mblend please use the following article:
 
-L. M. de Sousa, J. P. Leitão. [Improvements to DEM merging with `r.mblend`](http://www.scitepress.org/DigitalLibrary/Link.aspx?doi=10.5220/0006672500420049). *Proceedings of the Fourth International Conference on Geographical Information Systems Theory, Applications and Management: GISTAM*, 1, 2018.
+L. M. de Sousa, J. P. Leitão. [Improvements to DEM merging with `r.mblend`](http://www.scitepress.org/DigitalLibrary/Link.aspx?doi=10.5220/0006672500420049).
+*Proceedings of the Fourth International Conference on Geographical Information
+Systems Theory, Applications and Management: GISTAM*, 1, 2018.
 
 ## Copyright
 
 Copyright 2017 Luís Moreira de Sousa. All rights reserved.
 Any use of these documents constitutes full acceptance of all terms of the
 documents licence.
-
 
 ## Licence
 

--- a/src/raster/r.pops.spread/README.md
+++ b/src/raster/r.pops.spread/README.md
@@ -55,9 +55,9 @@ you are using for example:
 
 ### Download and install
 
-The latest release of the *r.pops.spread* module is available in GRASS GIS Addons repository
-and can be installed directly in GRASS GIS through graphical user
-interface or using the following command:
+The latest release of the *r.pops.spread* module is available in GRASS GIS
+Addons repository and can be installed directly in GRASS GIS through graphical
+user interface or using the following command:
 
 ```bash
 g.extension r.pops.spread
@@ -87,8 +87,8 @@ so downloading as ZIP is not useful for this repo.
 
 ## Contributing
 
-Please see the [pops-core](https://github.com/ncsu-landscape-dynamics/pops-core#readme) repository
-for contributing best practices and release policies.
+Please see the [pops-core](https://github.com/ncsu-landscape-dynamics/pops-core#readme)
+repository for contributing best practices and release policies.
 Other than that, just open pull requests against this repo.
 
 ### Updating submodule to latest version
@@ -166,7 +166,7 @@ grass .../modeling/scenario1 --exec r.pops.spread ...
 
 ### Authors
 
-_(alphabetical order)_
+*(alphabetical order)*:
 
 * Chris Jones
 * Margaret Lawrimore
@@ -175,7 +175,7 @@ _(alphabetical order)_
 
 ### Previous contributors
 
-_(alphabetical order)_
+*(alphabetical order)*:
 
 * Zexi Chen
 * Devon Gaydos

--- a/src/raster/r.pops.spread/pops-core/CHANGELOG.md
+++ b/src/raster/r.pops.spread/pops-core/CHANGELOG.md
@@ -39,7 +39,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## 2020-01-04 - Movement Module
 
 * Added
-  * movement modeule to the simulation class to move hosts from one location to another. (Chris Jones)
+  * movement modeule to the simulation class to move hosts from one location
+    to another. (Chris Jones)
 
 ## 2019-12-18 - More date functionality
 
@@ -125,7 +126,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
   * Added ability to set number of days for the timestep instead of
     day, week, or month. This is useful if the pest has multiple generations
     in a year. (Chris Jones)
-* Changed  
+* Changed
   * Made extension of the 52 week to be 8 or 9 (leap years) days instead of
     7 to ensure that the next year starts on Jan 1st. This makes forecasting
     into the future more streamlined. (Chris Jones)

--- a/src/raster/r.pops.spread/pops-core/README.md
+++ b/src/raster/r.pops.spread/pops-core/README.md
@@ -54,13 +54,21 @@ you are using for example:
 
 ## Contributing
 
-This section is designed to clarify the branch structure and versioning of this repository (and interface repositories) and general naming of new features and bug fix branches, especially those that are take longer to develop.
+This section is designed to clarify the branch structure and versioning of
+this repository (and interface repositories) and general naming of new
+features and bug fix branches, especially those that are take longer to
+develop.
 
 ### Branch Structure
 
-1. **master** is the stable version of the model that is used for official releases.
-2. **fix-issuenumber** or **fix-bugdescription** are branched off of master then merged back via a pull request once bug is fixed.
-3. **new_feature** is where new features are developed before they are merged into Master via a pull request. For example, infect and vector are currently being developed and will be merged together prior to being merged to master for an official major version release.
+1. **master** is the stable version of the model that is used for official
+   releases.
+2. **fix-issuenumber** or **fix-bugdescription** are branched off of master
+   then merged back via a pull request once bug is fixed.
+3. **new_feature** is where new features are developed before they are merged
+   into Master via a pull request. For example, infect and vector are currently
+   being developed and will be merged together prior to being merged to master
+   for an official major version release.
 
 ### Bug Fixes
 
@@ -92,8 +100,9 @@ version 1.1 to version 2.0 and the R package and Grass module are updated
 to 2.0.0). When you are creating branches in your fork, we still recommend
 choosing informative names such as the one suggested above.
 
-If you are interested in contributing to PoPS and are not a core developer on the model, please take a look at following
-documents to make the process as seamless as possible.
+If you are interested in contributing to PoPS and are not a core developer
+on the model, please take a look at following documents to make the process
+as seamless as possible.
 
 1. [Contributor Code of Conduct](contributing_docs/CODE_OF_CONDUCT.md)
 1. [PoPS Core Style Guide](contributing_docs/STYLE_GUIDE.md)
@@ -120,15 +129,23 @@ repo or elsewhere and discuss planned changes with you.
 If you are interested in reviewing the code, you may want to focus at
 the following core functions rather than the API.
 
-simulation.remove : removes the pest or pathogen from the infested hosts based on some environmental threshold (currently only temperature is accounted for).
+simulation.remove : removes the pest or pathogen from the infested hosts
+based on some environmental threshold (currently only temperature is
+accounted for).
 
-simulation.generate : generates dispersing indivduls from all infested cells based as a function of local infected hosts and weather.
+simulation.generate : generates dispersing indivduls from all infested
+cells based as a function of local infected hosts and weather.
 
-simulation.disperse : creates dispersal locations for the dispersing individuals from the generate function.
+simulation.disperse : creates dispersal locations for the dispersing
+individuals from the generate function.
 
-simulation.mortality : causes mortality in infested/infected hosts based on mortality rate
+simulation.mortality : causes mortality in infested/infected hosts based
+on mortality rate
 
-The custom date class is used to easily manage different time steps within the model and account for differences in the way frequently used weather data sets treat leap years (DAYMET drops December 31st from leap years, PRISM keeps all days even for leap years)
+The custom date class is used to easily manage different time steps within
+the model and account for differences in the way frequently used weather
+data sets treat leap years (DAYMET drops December 31st from leap years,
+PRISM keeps all days even for leap years)
 
 ## Using the model
 
@@ -234,7 +251,7 @@ Note that not all tests are not fully automatic, so in couple cases
 this only testing if the code is running and not crashing
 (you will need to examine the source code to see the details).
 
-Additionally, create documentation using the following (_Doxygen_ required):
+Additionally, create documentation using the following (*Doxygen* required):
 
 ```bash
 cmake --build build --target docs
@@ -268,7 +285,7 @@ target_link_libraries(your_target PRIVATE pops-core)
 
 ### Authors
 
-_(alphabetical order)_
+*(alphabetical order)*:
 
 * Chris Jones
 * Margaret Lawrimore
@@ -277,7 +294,7 @@ _(alphabetical order)_
 
 ### Previous contributors
 
-_(alphabetical order)_
+*(alphabetical order)*:
 
 * Zexi Chen
 * Devon Gaydos

--- a/src/raster/r.pops.spread/pops-core/TECHNICALDEBT.md
+++ b/src/raster/r.pops.spread/pops-core/TECHNICALDEBT.md
@@ -24,7 +24,6 @@ optionally linked in an entry.
     use it as it creates complexity. Will need to return to add this in
     the future.
 
-
 ## 2019-10-29 - More raster generalizations
 
 * Add
@@ -57,7 +56,8 @@ optionally linked in an entry.
 ## 2019-07-09
 
 * Add
-  * Tests need to be written for weekly, daily, and multi-day timesteps for Date functionality.
+  * Tests need to be written for weekly, daily, and multi-day timesteps
+    for Date functionality.
 
 ## 2019-06-14
 
@@ -67,8 +67,10 @@ optionally linked in an entry.
 ## 2018-09-14 - SEID and multiple host handling
 
 * Add
-  * Exposed and Diseased classes should be added (need to think about how to handle in disperse).
-  * 3-D array for Susceptible, Exposed, Infected, Diseased classes to handle multiple species up to N.
+  * Exposed and Diseased classes should be added (need to think about how to
+    handle in disperse).
+  * 3-D array for Susceptible, Exposed, Infected, Diseased classes to handle
+    multiple species up to N.
   * Host-compentency score for handling multiple hosts.
 
 ## 2018-08-02 - PoPS Model Separation

--- a/src/raster/r.pops.spread/pops-core/contributing_docs/CODE_OF_CONDUCT.md
+++ b/src/raster/r.pops.spread/pops-core/contributing_docs/CODE_OF_CONDUCT.md
@@ -1,24 +1,27 @@
 # Contributor Code of Conduct
 
-As contributors and maintainers of this project, we pledge to respect all people who
-contribute through reporting issues, posting feature requests, updating documentation,
-submitting pull requests or patches, and other activities.
+As contributors and maintainers of this project, we pledge to respect all
+people who contribute through reporting issues, posting feature requests,
+updating documentation, submitting pull requests or patches, and other
+activities.
 
-We are committed to making participation in this project a harassment-free experience for
-everyone, regardless of level of experience, gender, gender identity and expression,
-sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender,
+gender identity and expression, sexual orientation, disability, personal
+appearance, body size, race, ethnicity, age, or religion.
 
-Examples of unacceptable behavior by participants include the use of sexual language or
-imagery, derogatory comments or personal attacks, trolling, public or private harassment,
-insults, or other unprofessional conduct.
+Examples of unacceptable behavior by participants include the use of sexual
+language or imagery, derogatory comments or personal attacks, trolling,
+public or private harassment, insults, or other unprofessional conduct.
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments,
-commits, code, wiki edits, issues, and other contributions that are not aligned to this
-Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed
-from the project team.
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct. Project maintainers who do not
+follow the Code of Conduct may be removed from the project team.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by
-opening an issue, emailing the project lead (<cmjone25@ncsu.edu>), or one of the core developers.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by opening an issue, emailing the project lead (<cmjone25@ncsu.edu>),
+or one of the core developers.
 
 This Code of Conduct is adapted from the Contributor Covenant
 (<http://contributor-covenant.org>), version 1.0.0, available at

--- a/src/raster/r.pops.spread/pops-core/contributing_docs/CONTRIBUTING.md
+++ b/src/raster/r.pops.spread/pops-core/contributing_docs/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing to PoPS Core from outside of core development team
 
-The goal of this guide is to help you get up and contributing to PoPS Core and/or rPoPS as quickly as possible. The guide is divided into two main pieces:
+The goal of this guide is to help you get up and contributing to PoPS Core
+and/or rPoPS as quickly as possible. The guide is divided into two main pieces:
 
 1. Filing a bug report or feature request in an issue.
 1. Suggesting a change via a pull request.
@@ -14,11 +15,12 @@ When filing an issue, the most important thing is to include a minimal
 reproducible example so that we can quickly verify the problem, and then figure
 out how to fix it. There are three things you need to include to make your
 example reproducible: required packages, data, code.
-  
-1. The easiest way to include **data** is to include a link to a google drive folder containing your rasters and
+
+1. The easiest way to include **data** is to include a link to a google drive
+   folder containing your rasters and
 1. Spend a little bit of time ensuring that your **code** is easy for others to
    read:
-  
+
     * make sure you've used spaces and your variable names are concise, but
       informative
     * use comments to indicate where your problem lies
@@ -30,7 +32,8 @@ example reproducible: required packages, data, code.
 To contribute a change to PoPS Core or rPoPS, follow these steps:
 
 1. Create a branch in git and make your changes.
-1. Push branch to github and issue pull request (PR) if new feature add to a feature/new_feature branch.
+1. Push branch to github and issue pull request (PR) if new feature add to a
+   feature/new_feature branch.
 1. Discuss the pull request.
 1. Iterate until either we accept the PR or decide that it's not
    a good fit for this project.
@@ -49,13 +52,12 @@ overwhelming the first time you get set up, but it gets easier with practice.
 
 Pull requests will be evaluated against a seven-point checklist:
 
-1. __Motivation__. Your pull request should clearly and concisely motivate the
+1. **Motivation**. Your pull request should clearly and concisely motivate the
    need for change. Unfortunately neither Winston nor I have much time to
    work on ggplot2 these days, so you need to describe the problem and show
    how your pull request solves it as concisely as possible.
 
-
-1. __Only related changes__. Before you submit your pull request, please
+1. **Only related changes**. Before you submit your pull request, please
    check to make sure that you haven't accidentally included any unrelated
    changes. These make it harder to see exactly what's changed, and to
    evaluate any unexpected side effects.
@@ -65,20 +67,19 @@ Pull requests will be evaluated against a seven-point checklist:
    multiple changes that depend on each other, start with the first one
    and don't submit any others until the first one has been processed.
 
-1. __Use PoPS Core coding style__. Please follow the
+1. **Use PoPS Core coding style**. Please follow the
    [PoPS Core style guide](contributing/STYLE_GUIDE.md). Maintaining
    a consistent style across the whole code base makes it much easier to
    jump into the code. If you're modifying existing code that
    doesn't follow the style guide, a separate pull request to fix the
    style would be greatly appreciated.
 
-1. If you're adding new parameters or a new function to the R package, you'll also need
-   to document them with [roxygen](https://github.com/klutometis/roxygen).
+1. If you're adding new parameters or a new function to the R package, you'll
+   also need to document them with [roxygen](https://github.com/klutometis/roxygen).
    Make sure to re-run `devtools::document()` on the code before submitting.
 
 1. If fixing a bug or adding a new feature to the R package,
    please add a [testthat](https://github.com/r-lib/testthat) unit test.
-
 
 This seems like a lot of work but don't worry if your pull request isn't perfect.
 It's a learning process and members of the PoPS team will be on hand to help you

--- a/src/raster/r.pops.spread/pops-core/contributing_docs/STYLE_GUIDE.md
+++ b/src/raster/r.pops.spread/pops-core/contributing_docs/STYLE_GUIDE.md
@@ -36,9 +36,11 @@ docker build -t doozyx/clang-format-lint-action "github.com/DoozyX/clang-format-
 
 Then run the formatting using a Docker container in the top directory:
 
+<!-- markdownlint-disable line-length -->
 ```sh
 docker run --rm --workdir /src -v $(pwd):/src --entrypoint /clang-format/clang-format10 doozyx/clang-format-lint-action -i include/*/*.hpp tests/*.cpp
 ```
+<!-- markdownlint-enable line-length -->
 
 #### Functions and methods
 

--- a/utils/cronjobs_osgeo_lxd/README.md
+++ b/utils/cronjobs_osgeo_lxd/README.md
@@ -9,7 +9,8 @@ programmer's manual.
 
 * cronjob schedule:
   * `cron_job_list_grass`
-  * IMPORTANT: to activate any cronjob change, run the following on `grasslxd` container (as user `neteler`):
+  * IMPORTANT: to activate any cronjob change, run the following on `grasslxd`
+    container (as user `neteler`):
     * `crontab $HOME/cronjobs/cron_job_list_grass && crontab -l`
 * generate and deploy the GRASS GIS Web pages at <https://grass.osgeo.org/>:
   * `hugo_clean_and_update_job.sh`
@@ -67,14 +68,16 @@ page is generated.
 Important: there are two web related directories on the server:
 
 * `/var/www/code_and_data/`: contains source code, sample data, etc.
-* `/var/www/html/`: contains the hugo generated files. The relevant subdirectories of `/var/www/code_and_data/` are linked here.
+* `/var/www/html/`: contains the hugo generated files. The relevant
+  subdirectories of `/var/www/code_and_data/` are linked here.
 
 ## Infrastructure
 
 The server is hosted as LXD container on `osgeo7`, see:
 <https://wiki.osgeo.org/wiki/SAC_Service_Status#GRASS_GIS_server>
 
-The container is only accessible via the related OSGeo ssh jumphost and registered ssh pubkey.
+The container is only accessible via the related OSGeo ssh jumphost and
+registered ssh pubkey.
 
 ## Cronjob execution
 


### PR DESCRIPTION
All markdown files are formatted and now passes [markdownlint](https://github.com/igorshubovych/markdownlint-cli).