### PR TITLE
Replace np.float (numpy.float) by float

### DIFF
--- a/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
+++ b/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
@@ -849,11 +849,11 @@ class SentinelImporter(object):
                                                 [
                                                     np.array(
                                                         ssssn.text.split(" "),
-                                                        dtype=np.float,
+                                                        dtype=float,
                                                     )
                                                     for ssssn in list(sssn)
                                                 ],
-                                                dtype=np.float,
+                                                dtype=float,
                                             )
                                         )
                                         meta["MEAN_SUN_ZENITH_GRID_ANGLE"] = mean_zenith
@@ -865,11 +865,11 @@ class SentinelImporter(object):
                                                 [
                                                     np.array(
                                                         ssssn.text.split(" "),
-                                                        dtype=np.float,
+                                                        dtype=float,
                                                     )
                                                     for ssssn in list(sssn)
                                                 ],
-                                                dtype=np.float,
+                                                dtype=float,
                                             )
                                         )
                                         meta[

--- a/src/raster/r.mess/r.mess.py
+++ b/src/raster/r.mess/r.mess.py
@@ -440,7 +440,7 @@ def main(options, flags):
                 "GROUP BY {0} ORDER BY {0}"
             ).format(coln, tmpf0)
             volval = np.vstack(db.db_select(sql=sql3))
-            volval = volval.astype(np.float, copy=False)
+            volval = volval.astype(float, copy=False)
             a = np.cumsum(volval[:, 1], axis=0)
             b = np.sum(volval[:, 1], axis=0)
             c = a / b * 100

--- a/src/raster/r.object.activelearning/r.object.activelearning.py
+++ b/src/raster/r.object.activelearning/r.object.activelearning.py
@@ -129,7 +129,7 @@ def load_data(file_path, labeled=False, skip_header=1, scale=True):
     if skip_header != 0:
         header = data[0:skip_header, :]
     data = data[skip_header:, :]  # Remove header
-    data = data.astype(np.float)
+    data = data.astype(float)
 
     ID = data[:, 0]  # get only row 0s
     if labeled:

--- a/src/vector/v.class.ml/ml_functions.py
+++ b/src/vector/v.class.ml/ml_functions.py
@@ -401,7 +401,7 @@ def plot_extra(cls, labels, fmt="png", **kwargs):
             name=name,
             label=labels[cl],
         )
-    cnf = np.array(cls["confusion matrix"], dtype=np.float)
+    cnf = np.array(cls["confusion matrix"], dtype=float)
     sc = cnf.sum(axis=0)
     norm = sc / sc.sum(axis=1)[:, None]
     plot_confusion_matrix(


### PR DESCRIPTION
Replace np.float (numpy.float) by float (np.float is an alias for python float type), since it does not exist anymore in numpy (version 1.24.1).
Please see https://github.com/OSGeo/grass-addons/issues/856 for more details.