### PR TITLE
i.sentinel.download: add S3OL1 product types

### DIFF
--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.html
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.html
@@ -28,11 +28,18 @@ for download from the <b>Copernicus Open Access Hub</b>:
     <li>S2MSI1C: Top-Of-Atmosphere reflectances in cartographic geometry (Level-1C)</li>
   </ul>
   </li>
-  <li>Sentinel-3 (OLCI and SLSTR instrument data products at level 2; available from April 2018 to present day)
-  (optical) <a href="https://sentinel.esa.int/web/sentinel/missions/sentinel-3/data-products">products</a>:
+  <li>Sentinel-3 (OLCI and SLSTR instrument data products at level 2, for OLCI sensor also Level 1;
+  available from April 2018 to present day) (optical)
+  <a href="https://sentinel.esa.int/web/sentinel/missions/sentinel-3/data-products">products</a>:
   <ul>
-    <li>S3OL2LFR: Land and atmosphere geophysical parameters</li>
-    <li>S3OL2LRR: Land and atmosphere geophysical parameters at reduced resolution</li>
+    <li>S3OL1EFR: Land colour and atmosphere TOA radiances at full resolution</li>
+    <li>S3OL1ERR: Land colour and atmosphere TOA radiances at reduced resolution</li>
+    <li>S3OL1RAC: Dark offset and gain coefficients from radiometric calibration</li>
+    <li>S3OL1SAC: Wavelength characterisation from spectral calibration</li>
+    <li>S3OL2WFR: Ocean colour, water and atmosphere geophysical parameters</li>
+    <li>S3OL2WRR: Ocean colour, water and atmosphere geophysical parameters at reduced resolution</li>
+    <li>S3OL2LFR: Land colour and atmosphere geophysical parameters</li>
+    <li>S3OL2LRR: Land colour and atmosphere geophysical parameters at reduced resolution</li>
     <li>S3SL2LST: Land Surface Temperature</li>
     <li>S3SL2FRP: Fire Radiative Power</li>
     <li>S3SR2LAN: Land Surface Height</li>

--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -69,7 +69,7 @@
 # % description: Sentinel product type to filter
 # % label: USGS Earth Explorer only supports S2MSI1C
 # % required: no
-# % options: SLC,GRD,OCN,S2MSI1C,S2MSI2A,S2MSI2Ap,S3OL2LFR,S3OL2LRR,S3SL2LST,S3SL2FRP,S3SY2SYN,S3SY2VGP,S3SY2VG1,S3SY2V10,S3SY2AOD,S3SR2LAN
+# % options: SLC,GRD,OCN,S2MSI1C,S2MSI2A,S2MSI2Ap,S3OL1EFR,S3OL1ERR,S3OL1SPC,S3OL1RAC,S3OL2WFR,S3OL2WRR,S3OL2LFR,S3OL2LRR,S3SL2LST,S3SL2FRP,S3SY2SYN,S3SY2VGP,S3SY2VG1,S3SY2V10,S3SY2AOD,S3SR2LAN
 # % answer: S2MSI2A
 # % guisection: Filter
 # %end
@@ -170,6 +170,7 @@
 import fnmatch
 import hashlib
 import os
+import re
 import xml.etree.ElementTree as ET
 import shutil
 import sys
@@ -319,8 +320,6 @@ def get_bbox_from_S2_UTMtile(tile):
 
 def check_s2l1c_identifier(identifier, source="esa"):
     # checks beginning of identifier string for correct pattern
-    import re
-
     if source == "esa":
         expression = "^(S2[A-B]_MSIL1C_20[0-9][0-9][0-9][0-9])"
         test = re.match(expression, identifier)
@@ -736,7 +735,7 @@ class SentinelDownloader(object):
             return
         # Check for previously downloaded scenes
         existing_files = [
-            f for f in os.listdir(output) if re.search(r".zip$|.safe$|.ZIP$|.SAFE$", f)
+            os.path.join(output, f) for f in os.listdir(output) if re.search(r".zip$|.safe$|.ZIP$|.SAFE$", f)
         ]
         if len(existing_files) <= 1:
             return

--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -735,7 +735,9 @@ class SentinelDownloader(object):
             return
         # Check for previously downloaded scenes
         existing_files = [
-            os.path.join(output, f) for f in os.listdir(output) if re.search(r".zip$|.safe$|.ZIP$|.SAFE$", f)
+            os.path.join(output, f)
+            for f in os.listdir(output)
+            if re.search(r".zip$|.safe$|.ZIP$|.SAFE$", f)
         ]
         if len(existing_files) <= 1:
             return


### PR DESCRIPTION
This PR adds support for Sentinel-3 OLCI level 1 producttypes.
It also fixes two bugs related to the `-s` flag:
 1) using the `-s` flag caused an import error for `re`
 2) existing files were not found if `output` was set to a different directory than ./, because os.listdir only returns filenames and not full paths (unlike glob from pathlib would do).