### PR TITLE
CI: do not configure with PDAL

### DIFF
--- a/.github/workflows/build_grass.sh
+++ b/.github/workflows/build_grass.sh
@@ -36,6 +36,7 @@ export INSTALL_PREFIX=$1
     --with-geos \
     --with-sqlite \
     --with-fftw \
+    --without-pdal \
     --with-netcdf
 
 make


### PR DESCRIPTION
New settings on GRASS main with pkg-config means `--with-pdal` is default.
This sets grass-addons CI to the previous state, with explicit `--without-pdal`.