### PR TITLE
hugo_clean_and_update_job.sh: update path to hugo

### DIFF
--- a/utils/cronjobs_osgeo_lxd/hugo_clean_and_update_job.sh
+++ b/utils/cronjobs_osgeo_lxd/hugo_clean_and_update_job.sh
@@ -23,7 +23,7 @@
 cd /home/neteler/grass-website/ && \
    git pull origin master && \
    rm -rf /home/neteler/grass-website/public/* && \
-   nice /usr/local/bin/hugo && \
+   nice hugo && \
    mkdir /var/www/html_new && \
    \cp -rp /home/neteler/grass-website/public/* /var/www/html_new/ && \
    rm -fr /var/www/html/* && \


### PR DESCRIPTION
After updating grass.osgeo.org to Debian 11 (bullseye; see https://trac.osgeo.org/osgeo/ticket/2894) the previously manually installed `hugo` binary now comes with Debian 11. This PR simply updates the path to the `hugo` binary.

Note: the Debian update implies a `hugo` update from v0.69 to v0.80:

```
neteler@grasslxd:~$ dpkg -l | grep hugo
ii  hugo                                   0.80.0-6+b5
```

(Un)related: issue [#312](https://github.com/OSGeo/grass-website/issues/312)