### PR TITLE
r.learn.train: np.object to object

### DIFF
--- a/src/raster/r.learn.ml2/r.learn.train/r.learn.train.py
+++ b/src/raster/r.learn.ml2/r.learn.train/r.learn.train.py
@@ -596,7 +596,7 @@ def main():
             X, y, cat = stack.extract_points(training_points, field)
             y = y.flatten()
 
-            if y.dtype in (np.object_, np.object):
+            if y.dtype in (np.object_, object):
                 from sklearn.preprocessing import LabelEncoder
 
                 le = LabelEncoder()


### PR DESCRIPTION
Following up on bug report #872 - with numpy > 1.24.0 the numpy object is depricated. Changing `np.object` to `object` should solve the problem.