### PR TITLE
i.landsat.import: update suffix after latest USGS change

### DIFF
--- a/src/imagery/i.landsat/i.landsat.import/i.landsat.import.html
+++ b/src/imagery/i.landsat/i.landsat.import/i.landsat.import.html
@@ -162,6 +162,13 @@ i.landsat.import input=data pattern_file='229083_2019' pattern='B(4|5)'
 </pre></div>
 
 <p>
+Limit import to optical, NIR, and QA_PIXEL using a regular rexpression (Landsat-8):
+
+<div class="code"><pre>
+i.landsat.import input=data pattern='(B(2|3|4|5|6|7|8|10|11)|QA_PIXEL)'
+</pre></div>
+
+<p>
 Limit import to bands 4 and 5 for path 229 and row 083 in 2019 and get a
 txt file to use in <em>t.register</em>
 

--- a/src/imagery/i.landsat/i.landsat.import/i.landsat.import.html
+++ b/src/imagery/i.landsat/i.landsat.import/i.landsat.import.html
@@ -162,7 +162,8 @@ i.landsat.import input=data pattern_file='229083_2019' pattern='B(4|5)'
 </pre></div>
 
 <p>
-Limit import to optical, NIR, and QA_PIXEL using a regular rexpression (Landsat-8):
+Limit import to optical, NIR, thermal and QA_PIXEL using a regular
+expression (Landsat-8):
 
 <div class="code"><pre>
 i.landsat.import input=data pattern='(B(2|3|4|5|6|7|8|10|11)|QA_PIXEL)'

--- a/src/imagery/i.landsat/i.landsat.import/i.landsat.import.py
+++ b/src/imagery/i.landsat/i.landsat.import/i.landsat.import.py
@@ -148,9 +148,9 @@ def _untar(inputdir, untardir):
             gs.fatal(_("Directory <{}> is not writable.").format(untardir))
 
     if options["pattern_file"]:
-        filter_f = "*" + options["pattern_file"] + "*.tar.gz"
+        filter_f = "*" + options["pattern_file"] + "*.tar*"
     else:
-        filter_f = "*.tar.gz"
+        filter_f = "*.tar*"
 
     scenes_to_untar = glob.glob(os.path.join(inputdir, filter_f))
 

--- a/src/imagery/i.landsat/i.landsat.import/i.landsat.import.py
+++ b/src/imagery/i.landsat/i.landsat.import/i.landsat.import.py
@@ -148,11 +148,14 @@ def _untar(inputdir, untardir):
             gs.fatal(_("Directory <{}> is not writable.").format(untardir))
 
     if options["pattern_file"]:
-        filter_f = "*" + options["pattern_file"] + "*.tar*"
+        filter_f = "*" + options["pattern_file"] + "*"
     else:
-        filter_f = "*.tar*"
+        filter_f = "*"
 
-    scenes_to_untar = glob.glob(os.path.join(inputdir, filter_f))
+    # find .tar archives (new archiving standard for Landsat as of 2023) and
+    # .tar.gz (downloads of older date)
+    scenes_to_untar = glob.glob(os.path.join(inputdir, f"{filter_f}.tar"))
+    scenes_to_untar.extend(glob.glob(os.path.join(inputdir, f"{filter_f}.tar.gz")))
 
     for scene in scenes_to_untar:
         with tarfile.open(name=scene, mode="r") as tar:

--- a/src/imagery/i.landsat/i.landsat.import/i.landsat.import.py
+++ b/src/imagery/i.landsat/i.landsat.import/i.landsat.import.py
@@ -259,7 +259,7 @@ def write_register_file(filenames, register_output):
             if has_band_ref:
                 try:
                     band_ref = re.match(
-                        r".*_(B([1-9]+)|QA_PIXEL|QA_RADSAT|QA_AEROSOL).*", map_name
+                        r".*_(B([1-9]+)|QA_(RADSAT|PIXEL|AEROSOL)).*", map_name
                     ).groups()
                     band_ref = band_ref[0] if band_ref[0] else band_ref[1]
                 except AttributeError:

--- a/src/imagery/i.landsat/i.landsat.import/i.landsat.import.py
+++ b/src/imagery/i.landsat/i.landsat.import/i.landsat.import.py
@@ -258,7 +258,9 @@ def write_register_file(filenames, register_output):
             fd.write("{img}{sep}{ts}".format(img=map_name, sep=sep, ts=timestamp))
             if has_band_ref:
                 try:
-                    band_ref = re.match(r".*_B([1-9]+).*", map_name).groups()
+                    band_ref = re.match(
+                        r".*_(B([1-9]+)|QA_PIXEL|QA_RADSAT|QA_AEROSOL).*", map_name
+                    ).groups()
                     band_ref = band_ref[0] if band_ref[0] else band_ref[1]
                 except AttributeError:
                     gs.warning(


### PR DESCRIPTION
This PR adapts `i.landsat.import` to the latest archive format (no longer `.tar.gz` but simply `.tar`.

In addition, a small regex example added to the manual page.