### PR TITLE
i.landsat.download: do not log to landsatxplore.api if not necessary

### DIFF
--- a/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
+++ b/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
@@ -181,8 +181,6 @@ def main():
         except IOError as e:
             gs.fatal(_("Unable to open settings file: {}").format(e))
 
-    landsat_api = landsatxplore.api.API(user, password)
-
     if user is None or password is None:
         gs.fatal(_("No user or password given"))
 
@@ -229,6 +227,7 @@ def main():
         ee.logout()
 
     else:
+        landsat_api = landsatxplore.api.API(user, password)
 
         bb = get_bb(options["map"])
 


### PR DESCRIPTION
move the `landsatxplore.api` authentication to the corresponding (if-)else clause