### PR TITLE
r.bioclim: End with success when precipitation is missing

### DIFF
--- a/src/raster/r.bioclim/r.bioclim.py
+++ b/src/raster/r.bioclim/r.bioclim.py
@@ -412,7 +412,7 @@ def main():
         grass.run_command(
             "g.remove", flags="f", type="raster", pattern=tmp_pattern, quiet=True
         )
-        sys.exit(1)
+        return
 
     precl = prec.split(",")
 

--- a/src/raster/r.bioclim/r.bioclim.py
+++ b/src/raster/r.bioclim/r.bioclim.py
@@ -78,7 +78,6 @@
 # % description: Number of parallel processes to launch
 # %End
 
-import sys
 import os
 import string
 import grass.script as grass


### PR DESCRIPTION
The precipitation parameter is optional, so the process return code should be 0, not 1, as no error occured.

A return statement is more appropriate here than a direct exit call because this is a main function. Using return is consistent with the other branch which ends with the end of the function (an implicit return).
