### PR TITLE
Dynamic subdirs in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+
+MODULE_TOPDIR = ..
+
+SUBDIRS = src
+
+include $(MODULE_TOPDIR)/include/Make/Dir.make
+
+default: parsubdirs

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,8 +1,7 @@
 
 MODULE_TOPDIR = ..
 
-# display gui misc
-SUBDIRS := $(shell find ./ -maxdepth 2 -mindepth 2 -name "Makefile" -exec dirname {} \; | xargs -I {} basename {} )
+SUBDIRS := ${sort ${dir ${wildcard */Makefile}}}
 
 include $(MODULE_TOPDIR)/include/Make/Dir.make
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,15 +2,7 @@
 MODULE_TOPDIR = ..
 
 # display gui misc
-SUBDIRS = \
-	db \
-	display \
-	general \
-	imagery \
-	raster \
-	raster3d \
-	vector \
-	temporal
+SUBDIRS := $(shell find ./ -maxdepth 2 -mindepth 2 -name "Makefile" -exec dirname {} \; | xargs -I {} basename {} )
 
 include $(MODULE_TOPDIR)/include/Make/Dir.make
 

--- a/src/gui/Makefile
+++ b/src/gui/Makefile
@@ -1,0 +1,9 @@
+MODULE_TOPDIR = ..
+
+ALL_SUBDIRS := ${sort ${dir ${wildcard */.}}}
+DEPRECATED_SUBDIRS := ${sort ${dir ${wildcard */DEPRECATED}}}
+SUBDIRS := $(filter-out $(DEPRECATED_SUBDIRS), $(ALL_SUBDIRS))
+
+include $(MODULE_TOPDIR)/include/Make/Dir.make
+
+default: subdirs

--- a/src/gui/wxpython/Makefile
+++ b/src/gui/wxpython/Makefile
@@ -1,0 +1,9 @@
+MODULE_TOPDIR = ..
+
+ALL_SUBDIRS := ${sort ${dir ${wildcard */.}}}
+DEPRECATED_SUBDIRS := ${sort ${dir ${wildcard */DEPRECATED}}}
+SUBDIRS := $(filter-out $(DEPRECATED_SUBDIRS), $(ALL_SUBDIRS))
+
+include $(MODULE_TOPDIR)/include/Make/Dir.make
+
+default: subdirs

--- a/src/hadoop/Makefile
+++ b/src/hadoop/Makefile
@@ -1,0 +1,9 @@
+MODULE_TOPDIR = ..
+
+ALL_SUBDIRS := ${sort ${dir ${wildcard */.}}}
+DEPRECATED_SUBDIRS := ${sort ${dir ${wildcard */DEPRECATED}}}
+SUBDIRS := $(filter-out $(DEPRECATED_SUBDIRS), $(ALL_SUBDIRS))
+
+include $(MODULE_TOPDIR)/include/Make/Dir.make
+
+default: subdirs


### PR DESCRIPTION
With sparse checkout of addons in `g.extension` implemented in https://github.com/OSGeo/grass/pull/2895, not all subdirs of the repository exist at all time.

Runing make in a directory below module level is thus likely to fail. This PR should make sure that _make_ is run in all subdirs that contain a _Makefile_. And instead of hardcoded directory names, relevant subdirs are identified with the `find` command line tool.

When `g.extension` is improved to support also the installation of multiple AddOns (which now should be relatively straight forward on UNIX like systems) then _make_ should be run at the root of the addon repository to install all downloaded addons.

Are find, basename, dirname and xargs available on all relevant UNIX like platforms*?
It seems Mac OS has those (but I have only Fedora and Ubuntu to test).

*On MS Windows addons are not compiled anyway.