### PR TITLE
wx.metadata: fix create/edit map metadata with g.gui.metadata module

### DIFF
--- a/src/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
+++ b/src/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
@@ -1121,7 +1121,7 @@ class MdMainFrame(wx.Frame):
 
             self.ntbRight = NotebookRight(self.splitter, self.xmlPath)
 
-            self.splitter.SplitVertically(self.editor, self.ntbRight, sashPosition=0.65)
+            self.splitter.SplitVertically(self.editor, self.ntbRight)
             self.splitter.SetSashGravity(0.65)
             self.leftPanel.Hide()
             self.Hsizer.Add(self.splitter, proportion=1, flag=wx.EXPAND)

--- a/src/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
+++ b/src/gui/wxpython/wx.metadata/g.gui.metadata/g.gui.metadata.py
@@ -1658,7 +1658,7 @@ class MdValidator(wx.Panel):
     def __init__(self, parent):
         wx.Panel.__init__(self, parent=parent, id=wx.ID_ANY)
         self.text = wx.TextCtrl(
-            parent,
+            self,
             id=wx.ID_ANY,
             size=(0, 55),
             style=wx.VSCROLL


### PR DESCRIPTION
**Describe the bug**
Create/edit some raster/vector map metadata with g.gui.metadata module fail.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch g.gui.metadata module
2. Create/edit some metadata file for some raster/vector map (activate edit pen tool from the main toolbar)
3. See error

```
Traceback (most recent call last):
  File "/home/tomas/.grass8/addons/scripts/g.gui.metadata", line 611, in onEdit
    ok = self.editMapMetadata()
  File "/home/tomas/.grass8/addons/scripts/g.gui.metadata", line 979, in editMapMetadata
    self.initEditor()
  File "/home/tomas/.grass8/addons/scripts/g.gui.metadata", line 1122, in initEditor
    self.ntbRight = NotebookRight(self.splitter, self.xmlPath)
  File "/home/tomas/.grass8/addons/scripts/g.gui.metadata", line 1469, in __init__
    self.validator = MdValidator(self.notebookValidator)
  File "/home/tomas/.grass8/addons/scripts/g.gui.metadata", line 1672, in __init__
    self._layout()
  File "/home/tomas/.grass8/addons/scripts/g.gui.metadata", line 1677, in _layout
    self.mainSizer.Add(self.text, proportion=1, flag=wx.EXPAND)
wx._core.wxAssertionError: C++ assertion "CheckExpectedParentIs(w, m_containingWindow)" failed at /var/tmp/portage/x11-libs/wxGTK-3.2.2.1-r1/work/wxWidgets-3.2.2.1/src/common/sizer.cpp(850) in DoInsert(): Windows managed by the sizer associated with the given window must have this window as parent, otherwise they will not be repositioned correctly.
```

```
Traceback (most recent call last):
  File "/home/tomas/.grass8/addons/scripts/g.gui.metadata", line 611, in onEdit
    ok = self.editMapMetadata()
  File "/home/tomas/.grass8/addons/scripts/g.gui.metadata", line 979, in editMapMetadata
    self.initEditor()
  File "/home/tomas/.grass8/addons/scripts/g.gui.metadata", line 1124, in initEditor
    self.splitter.SplitVertically(self.editor, self.ntbRight, sashPosition=0.65)
TypeError: SplitterWindow.SplitVertically(): argument 'sashPosition' has unexpected type 'float
```

**Expected behavior**
Create/edit some raster/vector map metadata wit g.gui.metadata module should work.


**System description:**

Python 3.10
wxPython 4.2.0