### PR TITLE
wx.metadata: fix launch csw browser window

### DIFF
--- a/src/gui/wxpython/wx.metadata/mdlib/cswlib.py
+++ b/src/gui/wxpython/wx.metadata/mdlib/cswlib.py
@@ -1435,9 +1435,7 @@ class CSWConnectionPanel(wx.Panel):
         self.panelRight.SetSizer(rightPanelSizer)
         self.panelLeft.SetSizer(self.configureSizer)
 
-        self.splitterConn.SplitVertically(
-            self.panelLeft, self.panelRight,
-        )
+        self.splitterConn.SplitVertically(self.panelLeft, self.panelRight)
         self.splitterConn.SetSashGravity(0.2)
         self.splitterConn.SetMinimumPaneSize(200)
         self.mainsizer.Add(self.splitterConn, 1, wx.EXPAND)

--- a/src/gui/wxpython/wx.metadata/mdlib/cswlib.py
+++ b/src/gui/wxpython/wx.metadata/mdlib/cswlib.py
@@ -1436,7 +1436,7 @@ class CSWConnectionPanel(wx.Panel):
         self.panelLeft.SetSizer(self.configureSizer)
 
         self.splitterConn.SplitVertically(
-            self.panelLeft, self.panelRight, sashPosition=0.8
+            self.panelLeft, self.panelRight,
         )
         self.splitterConn.SetSashGravity(0.2)
         self.splitterConn.SetMinimumPaneSize(200)


### PR DESCRIPTION
**Describe the bug**
Create/edit some raster/vector map metadata with g.gui.metadata module fail.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch g.gui.metadata module
2. Create/edit some metadata file for some raster/vector map (activate edit pen tool from the main toolbar)
3. Activate csw browser window by clicking on the csw tool on the main toolbar
4. See error

```
Traceback (most recent call last):
  File "/home/tomas/.grass8/addons/scripts/g.gui.metadata", line 547, in onExportCSW
    self.cswPanel = CswPublisher(self.cswDialog, self)
  File "/home/tomas/.grass8/addons/scripts/g.gui.metadata", line 1708, in __init__
    super(CswPublisher, self).__init__(parent, main, cswBrowser=False)
  File "/home/tomas/.grass8/addons/etc/wx.metadata/mdlib/cswlib.py", line 1130, in __init__
    self._layout()
  File "/home/tomas/.grass8/addons/etc/wx.metadata/mdlib/cswlib.py", line 1438, in _layout
    self.splitterConn.SplitVertically(
TypeError: SplitterWindow.SplitVertically(): argument 'sashPosition' has unexpected type 'float'
```

**Expected behavior**
Activate csw browser window by clicking on the csw tool on the main toolbar should work.

**System description:**

Python 3.10
wxPython 4.2.0