### PR TITLE
wx.metadata: fix launch g.gui.cswbrowser module

### DIFF
--- a/src/gui/wxpython/wx.metadata/mdlib/cswlib.py
+++ b/src/gui/wxpython/wx.metadata/mdlib/cswlib.py
@@ -967,7 +967,7 @@ class CSWBrowserPanel(wx.Panel):
         upSearchSizer.Add(self.qtypeCb, 1, wx.EXPAND)
 
         self.leftSearchSizer.Add(upSearchSizer, 1, wx.EXPAND)
-        self.rightSearchSizer.Add(wx.StaticText(self), 0)
+        self.rightSearchSizer.Add(wx.StaticText(self.pnlLeft), 0)
         mainSearchSizer.Add(self.leftSearchSizer, wx.EXPAND)
         mainSearchSizer.Add(self.rightSearchSizer)
 


### PR DESCRIPTION
**Describe the bug**
Launching g.gui.cswbrowser module fail.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch g.gui.cswbrowser module
2. See error

```
Traceback (most recent call last):
  File "/home/tomas/.grass8/addons/scripts/g.gui.cswbrowser", line 65, in <module>
    main()
  File "/home/tomas/.grass8/addons/scripts/g.gui.cswbrowser", line 58, in main
    a = CswBrowserMainDialog(giface)
  File "/home/tomas/.grass8/addons/scripts/g.gui.cswbrowser", line 40, in __init__
    self.BrowserPanel = CSWBrowserPanel(self.mainNotebook, self, giface)
  File "/home/tomas/.grass8/addons/etc/wx.metadata/mdlib/cswlib.py", line 263, in __init__
    self._layout()
  File "/home/tomas/.grass8/addons/etc/wx.metadata/mdlib/cswlib.py", line 1049, in _layout
    self.pnlLeft.SetSizer(leftPanelSizer)
wx._core.wxAssertionError: C++ assertion "CheckExpectedParentIs(w, m_containingWindow)" failed at /var/tmp/portage/x11-libs/wxGTK-3.2.2.1-r1/work/wxWidgets-3.2.2.1/src/common/sizer.cpp(887) in SetContainingWindow(): Windows managed by the sizer associated with the given window must have this window as parent, otherwise they will not be repositioned correctly.

Please use the window wxPanel@0x555823759580 ("panel") with which this sizer is associated, as the parent when creating the window wxStaticText@0x555824054000 ("staticText") managed by it
```

**Expected behavior**
Launching g.gui.cswbrowser module should work.

**System description:**

Python 3.10
wxPython 4.2.0