### PR TITLE
wx.metadata: use osmsm map static OpenStreetMap image generator

### DIFF
--- a/src/gui/wxpython/wx.metadata/mdlib/dependency.py
+++ b/src/gui/wxpython/wx.metadata/mdlib/dependency.py
@@ -19,6 +19,7 @@
 #############################################################################
 
 import importlib
+import subprocess
 import sys
 
 
@@ -120,10 +121,29 @@ def check_dependencies(module_name, check_version=False):
         sys.stderr.write(message)
 
 
+def check_osmsm_lib():
+    """Check if osmsm JavaScript static map image OpenStreetMap generator
+    is installed
+
+    https://github.com/jperelli/osm-static-maps
+    """
+    lib = "osmsm"
+    try:
+        subprocess.call([lib], stdout=subprocess.PIPE)
+    except OSError:
+        message = "{name} JavaScript {text} <{url}>.\n".format(
+            name=lib,
+            text="library is missing. Check requirements on the manual page",
+            url=URL,
+        )
+        sys.stderr.write(message)
+
+
 def main():
     for module in MODULES:
         if check_dependencies(module_name=module):
             print("{name} is installed.".format(name=module))
+    check_osmsm_lib()
 
 
 if __name__ == "__main__":

--- a/src/gui/wxpython/wx.metadata/mdlib/mdpdffactory.py
+++ b/src/gui/wxpython/wx.metadata/mdlib/mdpdffactory.py
@@ -52,7 +52,6 @@ class MyTheme(DefaultTheme):
 
 class PdfCreator(object):
     def __init__(self, MD_metadata, pdf_file, map, type, filename, profile):
-
         """@:param MD_metadata- instance of metadata(owslib)
         @:param pdf_file- path and name of generated report
         """
@@ -345,7 +344,6 @@ class PdfCreator(object):
         return text
 
     def _parseMDOWS(self, md=None):
-
         if md is None:
             md = self.md
         metadata = {}
@@ -827,9 +825,7 @@ class MapBBFactory:
             pic, error = pic.communicate(0)
             if error:
                 GError(
-                    _(
-                        "Failed get static map image with osmsm. {}"
-                    ).format(
+                    _("Failed get static map image with osmsm. {}").format(
                         grass.decode(error),
                     )
                 )


### PR DESCRIPTION
**Describe the bug**
Export vector/raster map metadata to PDF file fail.

**To Reproduce**
Steps to reproduce the behavior:

1.  Launch `g.gui.metadata` module
2. Create metadata for some vector/raster map
3. Validate metadata
4.  Try export map metadata to PDF file
5. An error message will appear because remote service for generation map static images is not working https://osm-static-maps.herokuapp.com/

Check if this URL exists:

```
test@test:~$ URL=https://osm-static-maps.herokuapp.com/; if curl --output /dev/null --silent --head --fail "$URL"; then echo "URL exists: $URL"; else echo "URL does not exist: $URL"; fi
URL does not exist: https://osm-static-maps.herokuapp.com/
```

**Expected behavior**
Export vector/raster map metadata to PDF file should work and exported PDF metadata document file should contain two map static images. 

**Screenshots**


![raster_map_static_imgs](https://user-images.githubusercontent.com/50632337/235499350-d7ad53ca-055c-49f7-ade5-222b0db82085.png)

