### PR TITLE
CI: Test with v8.3, Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
           - grass-version: main
             python-version: '3.10'
           - grass-version: releasebranch_8_2
+            python-version: '3.7'
+          - grass-version: releasebranch_8_3
             python-version: '3.10'
       fail-fast: false
 


### PR DESCRIPTION
Run compilation and tests with 8.3 branch. Test 8.2 branch with Python 3.7.
