### PR TITLE
wx.metadata: lazy import owslib so pre-compiling for MS Windows succeeds

### DIFF
--- a/src/gui/wxpython/wx.metadata/mdlib/mdeditorfactory.py
+++ b/src/gui/wxpython/wx.metadata/mdlib/mdeditorfactory.py
@@ -41,7 +41,6 @@ import wx
 import wx.lib.scrolledpanel as scrolled
 
 from . import globalvar
-from . import mdutil
 from .mdjinjaparser import JinjaTemplateParser
 
 # =========================================================================
@@ -57,12 +56,14 @@ class MdFileWork:
     def __init__(self, pathToXml=None):
 
         try:
-            global Environment, FileSystemLoader, etree, GError, GMessage
+            global Environment, FileSystemLoader, etree, GError, GMessage, mdutil
 
             from jinja2 import Environment, FileSystemLoader
             from lxml import etree
 
             from core.gcmd import GError, GMessage
+
+            from . import mdutil
         except ModuleNotFoundError as e:
             msg = e.msg
             sys.exit(
@@ -81,7 +82,7 @@ class MdFileWork:
         @return: initialized md object by input xml
         """
         if path is None:
-            self.md = mdutil.MD_MetadataMOD(md=None)
+            self.md = mdutil.get_md_metadatamod_inst(md=None)
             return self.md
         else:
             io = open(path, "r")
@@ -96,7 +97,7 @@ class MdFileWork:
             try:
                 tree = etree.parse(path)
                 root = tree.getroot()
-                self.md = mdutil.MD_MetadataMOD(root)
+                self.md = mdutil.get_md_metadatamod_inst(root)
 
                 return self.md
 

--- a/src/gui/wxpython/wx.metadata/mdlib/mdgrass.py
+++ b/src/gui/wxpython/wx.metadata/mdlib/mdgrass.py
@@ -82,7 +82,7 @@ class GrassMD:
         context = mdutil.StaticContext()
         self.dirpath = os.path.join(context.lib_path, "profiles")
         # metadata object from OWSLIB ( for define md values)
-        self.md = mdutil.MD_MetadataMOD(md=None)
+        self.md = mdutil.get_md_metadatamod_inst(md=None)
         self.profilePath = None  # path to file with xml templates
 
         if self.type == "raster":
@@ -245,7 +245,7 @@ class GrassMD:
         self.profileName = "TEMPORAL"
 
         # OWSLib md object
-        self.md.identification = mdutil.MD_DataIdentification_MOD()
+        self.md.identification = mdutil.get_md_dataidentification_mod_inst()
         self.md.dataquality = DQ_DataQuality()
         self.md.distribution = MD_Distribution()
         self.md.identification.extent = EX_Extent()
@@ -341,7 +341,7 @@ class GrassMD:
             self.profilePath = profile
 
         # OWSLib md object
-        self.md.identification = mdutil.MD_DataIdentification_MOD()
+        self.md.identification = mdutil.get_md_dataidentification_mod_inst()
         self.md.dataquality = DQ_DataQuality()
         self.md.distribution = MD_Distribution()
         self.md.identification.extent = EX_Extent()
@@ -529,7 +529,7 @@ class GrassMD:
 
     def readXML(self, xml_file):
         """create instance of metadata(owslib) from xml file"""
-        self.md = mdutil.MD_MetadataMOD(etree.parse(xml_file))
+        self.md = mdutil.get_md_metadatamod_inst(etree.parse(xml_file))
 
     def getMapInfo(self):
         xml_out_name = (

--- a/src/gui/wxpython/wx.metadata/mdlib/mdjinjaparser.py
+++ b/src/gui/wxpython/wx.metadata/mdlib/mdjinjaparser.py
@@ -19,7 +19,6 @@ This program is free software under the GNU General Public License
 import sys
 
 from . import globalvar
-from .mdutil import findBetween
 
 
 class MdDescription:
@@ -133,9 +132,11 @@ class JinjaTemplateParser:
         """
 
         try:
-            global GError
+            global GError, mdutil
 
             from core.gcmd import GError
+
+            from . import mdutil
         except ModuleNotFoundError as e:
             msg = e.msg
             sys.exit(
@@ -163,11 +164,11 @@ class JinjaTemplateParser:
 
                     # if found start of comments
                     if str(line).find("{{") != -1:
-                        obj = findBetween(line, "{{", "}}")
+                        obj = mdutil.findBetween(line, "{{", "}}")
                         self.mdOWSTag.append(obj)
 
                     if str(line).find("{%") != -1:
-                        obj = findBetween(line, "{%", "-%}")
+                        obj = mdutil.findBetween(line, "{%", "-%}")
                         self.mdOWSTag.append(obj)
 
         except:
@@ -183,9 +184,9 @@ class JinjaTemplateParser:
                 for line in f:
                     # if found start of comments
                     if str(line).find("{#") != -1:
-                        values = findBetween(line, "{#", "#}")
-                        values1 = findBetween(line, "{%", "#}")
-                        values2 = findBetween(line, "{{", "#}")
+                        values = mdutil.findBetween(line, "{#", "#}")
+                        values1 = mdutil.findBetween(line, "{%", "#}")
+                        values2 = mdutil.findBetween(line, "{{", "#}")
                         if values1 != "":
                             values += ",selfInfoString='''{%" + values1 + "#}'''"
                         else:

--- a/src/gui/wxpython/wx.metadata/mdlib/mdutil.py
+++ b/src/gui/wxpython/wx.metadata/mdlib/mdutil.py
@@ -657,14 +657,18 @@ def get_md_metadatamod_inst(*args, **kwargs):
                 )
 
                 if val is not None:
-                    self.identification = get_md_dataidentification_mod_inst(val, "dataset")
+                    self.identification = get_md_dataidentification_mod_inst(
+                        val, "dataset"
+                    )
                     self.serviceidentification = None
                 elif val2 is not None:
                     self.identification = get_md_dataidentification_mod_inst(
                         val2,
                         "service",
                     )
-                    self.serviceidentification = owslib_iso.SV_ServiceIdentification(val2)
+                    self.serviceidentification = owslib_iso.SV_ServiceIdentification(
+                        val2
+                    )
                 else:
                     self.identification = None
                     self.serviceidentification = None
@@ -697,4 +701,5 @@ def get_md_metadatamod_inst(*args, **kwargs):
                         owslib_iso.namespaces,
                     ),
                 )
+
     return MD_MetadataMOD(*args, **kwargs)

--- a/src/gui/wxpython/wx.metadata/mdlib/mdutil.py
+++ b/src/gui/wxpython/wx.metadata/mdlib/mdutil.py
@@ -33,12 +33,7 @@ from grass.script import core as grass
 
 import wx
 
-
-class Owslib:
-    """Lazy import of 'owslib.iso' module"""
-
-    iso = importlib.import_module("owslib.iso", "owslib")
-    util = importlib.import_module("owslib.util", "owslib")
+from . import globalvar
 
 
 class StaticContext(object):
@@ -530,149 +525,176 @@ def isnpireValidator(md):
     return result
 
 
-class MD_DataIdentification_MOD(Owslib.iso.MD_DataIdentification):
-    def __init__(self, md=None, identtype=None):
-        Owslib.iso.MD_DataIdentification.__init__(
-            self,
-            md,
-            identtype,
+def get_md_dataidentification_mod_inst(*args, **kwargs):
+    try:
+        import owslib.iso as owslib_iso
+        import owslib.util as owslib_util
+    except ModuleNotFoundError as e:
+        msg = e.msg
+        sys.exit(
+            globalvar.MODULE_NOT_FOUND.format(
+                lib=msg.split("'")[-2], url=globalvar.MODULE_URL
+            )
         )
-        if md is None:
-            self.timeUnit = None
-            self.temporalType = None
-            self.timeUnit = None
-            self.factor = None
-            self.radixT = None
-        else:
-            val2 = None
-            val1 = None
-            val3 = None
-            val4 = None
-            extents = md.findall(
-                Owslib.util.nspath_eval("gmd:extent", Owslib.iso.namespaces),
+
+    class MD_DataIdentification_MOD(owslib_iso.MD_DataIdentification):
+        def __init__(self, md=None, identtype=None):
+            owslib_iso.MD_DataIdentification.__init__(
+                self,
+                md,
+                identtype,
             )
-            extents.extend(
-                md.findall(
-                    Owslib.util.nspath_eval("srv:extent", Owslib.iso.namespaces),
-                ),
-            )
-            for extent in extents:
-                if val2 is None:
-                    duration = (
-                        "gmd:EX_Extent/gmd:temporalElement/"
-                        "gmd:EX_TemporalExtent/gmd:extent/"
-                        "gml:TM_PeriodDuration/gml:duration"
-                    )
-                    val2 = extent.find(
-                        Owslib.util.nspath_eval(
-                            duration,
-                            Owslib.iso.namespaces,
-                        ),
-                    )  # TODO
-                self.temporalType = Owslib.util.testXMLValue(val2)
-
-                if val1 is None:
-                    time_unit_type = (
-                        "gmd:EX_Extent/gmd:temporalElement/"
-                        "gmd:EX_TemporalExtent/gmd:extent/"
-                        "gml:timeLength/gml:timeInterval/"
-                        "gml:unit/gml:TimeUnitType"
-                    )
-                    val1 = extent.find(
-                        Owslib.util.nspath_eval(
-                            time_unit_type,
-                            Owslib.iso.namespaces,
-                        ),
-                    )
-                self.timeUnit = Owslib.util.testXMLValue(val1)
-                if val3 is None:
-                    positive_int = (
-                        "gmd:EX_Extent/gmd:temporalElement/"
-                        "gmd:EX_TemporalExtent/gmd:extent/"
-                        "gml:timeLength/gml:timeInterval/"
-                        "gml:radix/gco:positiveInteger"
-                    )
-                    val3 = extent.find(
-                        Owslib.util.nspath_eval(
-                            positive_int,
-                            Owslib.iso.namespaces,
-                        ),
-                    )
-                self.radixT = Owslib.util.testXMLValue(val3)
-
-                if val4 is None:
-                    integer = (
-                        "gmd:EX_Extent/gmd:temporalElement/"
-                        "gmd:EX_TemporalExtent/gmd:extent/"
-                        "gml:timeLength/gml:timeInterval/"
-                        "gml:factor/gco:Integer"
-                    )
-                    val4 = extent.find(
-                        Owslib.util.nspath_eval(
-                            integer,
-                            Owslib.iso.namespaces,
-                        ),
-                    )
-                self.factor = Owslib.util.testXMLValue(val4)
-
-
-class MD_MetadataMOD(Owslib.iso.MD_Metadata):
-    """Process gmd:MD_Metadata"""
-
-    def __init__(self, md=None):
-        Owslib.iso.MD_Metadata.__init__(self, md)
-        if md is not None:
-            val = md.find(
-                Owslib.util.nspath_eval(
-                    "gmd:identificationInfo/gmd:MD_DataIdentification",
-                    Owslib.iso.namespaces,
-                ),
-            )
-            val2 = md.find(
-                Owslib.util.nspath_eval(
-                    "gmd:identificationInfo/srv:SV_ServiceIdentification",
-                    Owslib.iso.namespaces,
-                ),
-            )
-
-            if val is not None:
-                self.identification = MD_DataIdentification_MOD(val, "dataset")
-                self.serviceidentification = None
-            elif val2 is not None:
-                self.identification = MD_DataIdentification_MOD(
-                    val2,
-                    "service",
-                )
-                self.serviceidentification = Owslib.iso.SV_ServiceIdentification(val2)
+            if md is None:
+                self.timeUnit = None
+                self.temporalType = None
+                self.timeUnit = None
+                self.factor = None
+                self.radixT = None
             else:
-                self.identification = None
-                self.serviceidentification = None
+                val2 = None
+                val1 = None
+                val3 = None
+                val4 = None
+                extents = md.findall(
+                    owslib_util.nspath_eval("gmd:extent", owslib_iso.namespaces),
+                )
+                extents.extend(
+                    md.findall(
+                        owslib_util.nspath_eval("srv:extent", owslib_iso.namespaces),
+                    ),
+                )
+                for extent in extents:
+                    if val2 is None:
+                        duration = (
+                            "gmd:EX_Extent/gmd:temporalElement/"
+                            "gmd:EX_TemporalExtent/gmd:extent/"
+                            "gml:TM_PeriodDuration/gml:duration"
+                        )
+                        val2 = extent.find(
+                            owslib_util.nspath_eval(
+                                duration,
+                                owslib_iso.namespaces,
+                            ),
+                        )  # TODO
+                    self.temporalType = owslib_util.testXMLValue(val2)
 
-            self.identificationinfo = []
-            for idinfo in md.findall(
-                Owslib.util.nspath_eval(
-                    "gmd:identificationInfo",
-                    Owslib.iso.namespaces,
-                ),
-            ):
-                val = list(idinfo)[0]
-                tagval = Owslib.util.xmltag_split(val.tag)
-                if tagval == "MD_DataIdentification":
-                    self.identificationinfo.append(
-                        MD_DataIdentification_MOD(val, "dataset"),
-                    )
-                elif tagval == "MD_ServiceIdentification":
-                    self.identificationinfo.append(
-                        MD_DataIdentification_MOD(val, "service"),
-                    )
-                elif tagval == "SV_ServiceIdentification":
-                    self.identificationinfo.append(
-                        Owslib.iso.SV_ServiceIdentification(val),
-                    )
+                    if val1 is None:
+                        time_unit_type = (
+                            "gmd:EX_Extent/gmd:temporalElement/"
+                            "gmd:EX_TemporalExtent/gmd:extent/"
+                            "gml:timeLength/gml:timeInterval/"
+                            "gml:unit/gml:TimeUnitType"
+                        )
+                        val1 = extent.find(
+                            owslib_util.nspath_eval(
+                                time_unit_type,
+                                owslib_iso.namespaces,
+                            ),
+                        )
+                    self.timeUnit = owslib_util.testXMLValue(val1)
+                    if val3 is None:
+                        positive_int = (
+                            "gmd:EX_Extent/gmd:temporalElement/"
+                            "gmd:EX_TemporalExtent/gmd:extent/"
+                            "gml:timeLength/gml:timeInterval/"
+                            "gml:radix/gco:positiveInteger"
+                        )
+                        val3 = extent.find(
+                            owslib_util.nspath_eval(
+                                positive_int,
+                                owslib_iso.namespaces,
+                            ),
+                        )
+                    self.radixT = owslib_util.testXMLValue(val3)
 
-            val = md.find(
-                Owslib.util.nspath_eval(
-                    "gmd:distributionInfo/gmd:MD_Distribution",
-                    Owslib.iso.namespaces,
-                ),
+                    if val4 is None:
+                        integer = (
+                            "gmd:EX_Extent/gmd:temporalElement/"
+                            "gmd:EX_TemporalExtent/gmd:extent/"
+                            "gml:timeLength/gml:timeInterval/"
+                            "gml:factor/gco:Integer"
+                        )
+                        val4 = extent.find(
+                            owslib_util.nspath_eval(
+                                integer,
+                                owslib_iso.namespaces,
+                            ),
+                        )
+                    self.factor = owslib_util.testXMLValue(val4)
+
+    return MD_DataIdentification_MOD(*args, **kwargs)
+
+
+def get_md_metadatamod_inst(*args, **kwargs):
+    try:
+        import owslib.iso as owslib_iso
+        import owslib.util as owslib_util
+    except ModuleNotFoundError as e:
+        msg = e.msg
+        sys.exit(
+            globalvar.MODULE_NOT_FOUND.format(
+                lib=msg.split("'")[-2], url=globalvar.MODULE_URL
             )
+        )
+
+    class MD_MetadataMOD(owslib_iso.MD_Metadata):
+        """Process gmd:MD_Metadata"""
+
+        def __init__(self, md=None):
+            owslib_iso.MD_Metadata.__init__(self, md)
+            if md is not None:
+                val = md.find(
+                    owslib_util.nspath_eval(
+                        "gmd:identificationInfo/gmd:MD_DataIdentification",
+                        owslib_iso.namespaces,
+                    ),
+                )
+                val2 = md.find(
+                    owslib_util.nspath_eval(
+                        "gmd:identificationInfo/srv:SV_ServiceIdentification",
+                        owslib_iso.namespaces,
+                    ),
+                )
+
+                if val is not None:
+                    self.identification = get_md_dataidentification_mod_inst(val, "dataset")
+                    self.serviceidentification = None
+                elif val2 is not None:
+                    self.identification = get_md_dataidentification_mod_inst(
+                        val2,
+                        "service",
+                    )
+                    self.serviceidentification = owslib_iso.SV_ServiceIdentification(val2)
+                else:
+                    self.identification = None
+                    self.serviceidentification = None
+
+                self.identificationinfo = []
+                for idinfo in md.findall(
+                    owslib_util.nspath_eval(
+                        "gmd:identificationInfo",
+                        owslib_iso.namespaces,
+                    ),
+                ):
+                    val = list(idinfo)[0]
+                    tagval = owslib_util.xmltag_split(val.tag)
+                    if tagval == "MD_DataIdentification":
+                        self.identificationinfo.append(
+                            get_md_dataidentification_mod_inst(val, "dataset"),
+                        )
+                    elif tagval == "MD_ServiceIdentification":
+                        self.identificationinfo.append(
+                            get_md_dataidentification_mod_inst(val, "service"),
+                        )
+                    elif tagval == "SV_ServiceIdentification":
+                        self.identificationinfo.append(
+                            owslib_iso.SV_ServiceIdentification(val),
+                        )
+
+                val = md.find(
+                    owslib_util.nspath_eval(
+                        "gmd:distributionInfo/gmd:MD_Distribution",
+                        owslib_iso.namespaces,
+                    ),
+                )
+    return MD_MetadataMOD(*args, **kwargs)

--- a/src/gui/wxpython/wx.metadata/mdlib/mdutil.py
+++ b/src/gui/wxpython/wx.metadata/mdlib/mdutil.py
@@ -31,8 +31,6 @@ from grass.pygrass.modules import Module
 from grass.pygrass.utils import get_lib_path
 from grass.script import core as grass
 
-from owslib import util
-
 import wx
 
 
@@ -40,6 +38,7 @@ class Owslib:
     """Lazy import of 'owslib.iso' module"""
 
     iso = importlib.import_module("owslib.iso", "owslib")
+    util = importlib.import_module("owslib.util", "owslib")
 
 
 class StaticContext(object):
@@ -230,7 +229,6 @@ def grassProfileValidator(md):
             md.identification.temporalextent_start is (None or "")
             or md.identification.temporalextent_end is (None or "")
         ):
-
             result["errors"].append(
                 "Both gmd:EX_TemporalExtent and gmd:CI_Date are missing"
             )
@@ -304,7 +302,6 @@ def isnpireValidator(md):
         errors += 20
     else:
         if md.identification.contact is None or len(md.identification.contact) < 1:
-
             result["errors"].append(
                 "gmd:CI_ResponsibleParty: Organization name is missing"
             )
@@ -372,7 +369,6 @@ def isnpireValidator(md):
                 errors += 1
 
         if md.identification.keywords is None or len(md.identification.keywords) < 1:
-
             result["errors"].append("gmd:MD_Keywords: Keywords are missing")
             result["errors"].append("gmd:thesaurusName: Thesaurus title is missing")
             result["errors"].append("gmd:thesaurusName: Thesaurus date is missing")
@@ -385,7 +381,6 @@ def isnpireValidator(md):
                 or len(md.identification.keywords[0]["keywords"]) < 1
                 or str(md.identification.keywords[0]["keywords"]) == "[u'']"
             ):
-
                 result["errors"].append("gmd:MD_Keywords: Keywords are missing")
                 errors += 1
             if md.identification.keywords[0]["thesaurus"] is None:
@@ -484,7 +479,6 @@ def isnpireValidator(md):
         result["errors"].append("gmd:DQ_ConformanceResult: Title is missing")
         errors += 4
     else:
-
         if md.dataquality.lineage is (None or ""):
             result["errors"].append("gmd:LI_Lineage is missing")
             errors += 1
@@ -517,7 +511,6 @@ def isnpireValidator(md):
         result["errors"].append("gmd:role: Role is missing")
         errors += 3
     else:
-
         if md.contact[0].organization is (None or ""):
             result["errors"].append("gmd:contact: Organization name is missing")
             errors += 1
@@ -556,11 +549,11 @@ class MD_DataIdentification_MOD(Owslib.iso.MD_DataIdentification):
             val3 = None
             val4 = None
             extents = md.findall(
-                util.nspath_eval("gmd:extent", Owslib.iso.namespaces),
+                Owslib.util.nspath_eval("gmd:extent", Owslib.iso.namespaces),
             )
             extents.extend(
                 md.findall(
-                    util.nspath_eval("srv:extent", Owslib.iso.namespaces),
+                    Owslib.util.nspath_eval("srv:extent", Owslib.iso.namespaces),
                 ),
             )
             for extent in extents:
@@ -571,12 +564,12 @@ class MD_DataIdentification_MOD(Owslib.iso.MD_DataIdentification):
                         "gml:TM_PeriodDuration/gml:duration"
                     )
                     val2 = extent.find(
-                        util.nspath_eval(
+                        Owslib.util.nspath_eval(
                             duration,
                             Owslib.iso.namespaces,
                         ),
                     )  # TODO
-                self.temporalType = util.testXMLValue(val2)
+                self.temporalType = Owslib.util.testXMLValue(val2)
 
                 if val1 is None:
                     time_unit_type = (
@@ -586,12 +579,12 @@ class MD_DataIdentification_MOD(Owslib.iso.MD_DataIdentification):
                         "gml:unit/gml:TimeUnitType"
                     )
                     val1 = extent.find(
-                        util.nspath_eval(
+                        Owslib.util.nspath_eval(
                             time_unit_type,
                             Owslib.iso.namespaces,
                         ),
                     )
-                self.timeUnit = util.testXMLValue(val1)
+                self.timeUnit = Owslib.util.testXMLValue(val1)
                 if val3 is None:
                     positive_int = (
                         "gmd:EX_Extent/gmd:temporalElement/"
@@ -600,12 +593,12 @@ class MD_DataIdentification_MOD(Owslib.iso.MD_DataIdentification):
                         "gml:radix/gco:positiveInteger"
                     )
                     val3 = extent.find(
-                        util.nspath_eval(
+                        Owslib.util.nspath_eval(
                             positive_int,
                             Owslib.iso.namespaces,
                         ),
                     )
-                self.radixT = util.testXMLValue(val3)
+                self.radixT = Owslib.util.testXMLValue(val3)
 
                 if val4 is None:
                     integer = (
@@ -615,12 +608,12 @@ class MD_DataIdentification_MOD(Owslib.iso.MD_DataIdentification):
                         "gml:factor/gco:Integer"
                     )
                     val4 = extent.find(
-                        util.nspath_eval(
+                        Owslib.util.nspath_eval(
                             integer,
                             Owslib.iso.namespaces,
                         ),
                     )
-                self.factor = util.testXMLValue(val4)
+                self.factor = Owslib.util.testXMLValue(val4)
 
 
 class MD_MetadataMOD(Owslib.iso.MD_Metadata):
@@ -630,13 +623,13 @@ class MD_MetadataMOD(Owslib.iso.MD_Metadata):
         Owslib.iso.MD_Metadata.__init__(self, md)
         if md is not None:
             val = md.find(
-                util.nspath_eval(
+                Owslib.util.nspath_eval(
                     "gmd:identificationInfo/gmd:MD_DataIdentification",
                     Owslib.iso.namespaces,
                 ),
             )
             val2 = md.find(
-                util.nspath_eval(
+                Owslib.util.nspath_eval(
                     "gmd:identificationInfo/srv:SV_ServiceIdentification",
                     Owslib.iso.namespaces,
                 ),
@@ -657,13 +650,13 @@ class MD_MetadataMOD(Owslib.iso.MD_Metadata):
 
             self.identificationinfo = []
             for idinfo in md.findall(
-                util.nspath_eval(
+                Owslib.util.nspath_eval(
                     "gmd:identificationInfo",
                     Owslib.iso.namespaces,
                 ),
             ):
                 val = list(idinfo)[0]
-                tagval = util.xmltag_split(val.tag)
+                tagval = Owslib.util.xmltag_split(val.tag)
                 if tagval == "MD_DataIdentification":
                     self.identificationinfo.append(
                         MD_DataIdentification_MOD(val, "dataset"),
@@ -678,7 +671,7 @@ class MD_MetadataMOD(Owslib.iso.MD_Metadata):
                     )
 
             val = md.find(
-                util.nspath_eval(
+                Owslib.util.nspath_eval(
                     "gmd:distributionInfo/gmd:MD_Distribution",
                     Owslib.iso.namespaces,
                 ),


### PR DESCRIPTION
Pre-compilation of ` wx.metadata` for MS Windows fails because `owslib` is not consequently lazy-imported.

See:
https://github.com/OSGeo/grass/issues/2517