### PR TITLE
checks: Fix syntax in Flake8 config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,27 +1,49 @@
 [flake8]
 ignore =
-    E203,  # whitespace before ':' (Black)
-    W503,  # line break before binary operator (Black)
-    E265, # block comment should start with '# '
-    E266, # too many leading '#' for block comment
-    E402, # module level import not at top of file
-    E501, # line too long (161 > 150 characters)
-    E712, # comparison to False should be 'if cond is False:' or 'if not cond:'
-    E722, # do not use bare 'except'
-    E741, # ambiguous variable name 'l'
-    F401, # 'grass.script.core.gisenv' imported but unused
-    F402, # import 'ant' from line 15 shadowed by loop variable
-    F403, # 'from ... import *' used; unable to detect undefined names
-    F405, # '_' may be undefined, or defined from star imports: datetime
-    F507, # '...' % ... has 5 placeholder(s) but 7 substitution(s)
-    F509, # '...' % ... has unsupported format character '='
-    F521, # '...'.format(...) has invalid format string: Single '}' encountered in format string
-    F522, # '...'.format(...) has unused named argument(s): overwrite
-    F523, # '...'.format(...) has unused arguments at position(s): 0
-    F632, # use ==/!= to compare constant literals (str, bytes, int, float, tuple)
-    F811, # redefinition of unused 'GMessage' from line 35
-    F821, # undefined name '_'
-    F841, # local variable 'center' is assigned to but never used
+    # whitespace before ':' (Black)
+    E203,
+    # line break before binary operator (Black)
+    W503,
+    # block comment should start with '# '
+    E265,
+    # too many leading '#' for block comment
+    E266,
+    # module level import not at top of file
+    E402,
+    # line too long (161 > 150 characters)
+    E501,
+    # comparison to False should be 'if cond is False:' or 'if not cond:'
+    E712,
+    # do not use bare 'except'
+    E722,
+    # ambiguous variable name 'l'
+    E741,
+    # 'grass.script.core.gisenv' imported but unused
+    F401,
+    # import 'ant' from line 15 shadowed by loop variable
+    F402,
+    # 'from ... import *' used; unable to detect undefined names
+    F403,
+    # '_' may be undefined, or defined from star imports: datetime
+    F405,
+    # '...' % ... has 5 placeholder(s) but 7 substitution(s)
+    F507,
+    # '...' % ... has unsupported format character '='
+    F509,
+    # '...'.format(...) has invalid format string: Single '}' encountered in format string
+    F521,
+    # '...'.format(...) has unused named argument(s): overwrite
+    F522,
+    # '...'.format(...) has unused arguments at position(s): 0
+    F523,
+    # use ==/!= to compare constant literals (str, bytes, int, float, tuple)
+    F632,
+    # redefinition of unused 'GMessage' from line 35
+    F811,
+    # undefined name '_'
+    F821,
+    # local variable 'center' is assigned to but never used
+    F841,
 
 # W605 invalid escape sequence
 # F823 local variable '_' defined as a builtin referenced before assignment


### PR DESCRIPTION
Flake8 config file does not allow inline comments. Previous versions did not enforce that (which lead to silent errors), but the new versions (v6) do.

Source: https://github.com/PyCQA/flake8/issues/1760

In core repo: https://github.com/OSGeo/grass/pull/2976
