### PR TITLE
v.stream.inbasin: Modernize interface, fix for v8

### DIFF
--- a/src/vector/v.stream.inbasin/testsuite/test_v_stream_inbasin.py
+++ b/src/vector/v.stream.inbasin/testsuite/test_v_stream_inbasin.py
@@ -1,0 +1,153 @@
+##############################################################################
+# AUTHOR(S): Vaclav Petras <wenzeslaus gmail com>
+#
+# COPYRIGHT: (C) 2023 Vaclav Petras and the GRASS Development Team
+#
+#            This program is free software under the GNU General Public
+#            License (>=v2). Read the file COPYING that comes with GRASS
+#            for details.
+##############################################################################
+
+"""Test v.stream.inbasin tool using grass.gunittest with NC SPM dataset"""
+
+import json
+
+import grass.script as gs
+from grass.gunittest.case import TestCase
+from grass.gunittest.main import test
+
+
+class FunctionalityVStreamNetwork(TestCase):
+    """Test case for v.stream.inbasin focused on functionality
+
+    The test needs v.stream.network to run.
+    """
+
+    original = "streams@PERMANENT"
+    ours = "functionality_streams"
+    input_as_raster = "input_as_raster"
+    output_as_raster = "output_as_raster"
+    bad_difference = "bad_difference"
+    subset_output = "selected_subset"
+    point_output = "pour_point"
+    coordinates = (639089, 223304)
+
+    @classmethod
+    def setUpClass(cls):
+        cls.runModule("g.copy", vector=(cls.original, cls.ours))
+        cls.runModule("v.stream.network", map=cls.ours)
+        cls.runModule("g.region", vector=cls.ours, res=5)
+        cls.runModule(
+            "v.to.rast", input=cls.ours, output=cls.input_as_raster, use="val", value=1
+        )
+        cls.runModule(
+            "v.stream.inbasin",
+            input_streams=cls.ours,
+            coordinates=cls.coordinates,
+            output_streams=cls.subset_output,
+            output_pour_point=cls.point_output,
+            flags="s",
+        )
+        cls.runModule(
+            "v.to.rast",
+            input=cls.subset_output,
+            output=cls.output_as_raster,
+            use="val",
+            value=1,
+        )
+        cls.runModule(
+            "r.mapcalc",
+            expression=f"{cls.bad_difference} = if(isnull({cls.input_as_raster}) && not(isnull({cls.input_as_raster})), 1, 0)",
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.runModule(
+            "g.remove",
+            type="vector",
+            name=[cls.ours, cls.subset_output, cls.point_output],
+            flags="f",
+        )
+        cls.runModule(
+            "g.remove",
+            type="raster",
+            name=[cls.input_as_raster, cls.output_as_raster, cls.bad_difference],
+            flags="f",
+        )
+
+    def test_geometry_is_subset(self):
+        """Check that geometry is subset of the input by comparing raster versions"""
+        self.assertRasterFitsInfo(self.bad_difference, {"max": 0, "min": 0})
+
+    def test_geometry_statistics(self):
+        """Check against values determined by running the tool"""
+        info = gs.vector_info(self.subset_output)
+        self.assertEqual(info["level"], 2)
+        self.assertEqual(info["lines"], 918)
+        self.assertEqual(info["nodes"], 915)
+        self.assertEqual(info["primitives"], 918)
+
+    def test_attribute_info(self):
+        """Check attribute info against expected values"""
+        info = gs.vector_info(self.subset_output)
+        self.assertEqual(info["num_dblinks"], 1)
+        self.assertEqual(info["attribute_layer_number"], "1")
+        self.assertEqual(info["attribute_table"], self.subset_output)
+        self.assertEqual(info["attribute_primary_key"], "cat")
+
+    def compare_columns(self, old_vector, new_vector):
+        original_columns = gs.vector_columns(old_vector)
+        our_columns = gs.vector_columns(new_vector)
+        for original_column in original_columns:
+            self.assertIn(original_column, our_columns)
+        for name, original_column in original_columns.items():
+            for key, value in original_column.items():
+                self.assertEqual(value, our_columns[name][key])
+
+    def test_columns_preserved_from_original_streams(self):
+        """Check that columns are preserved from original unchanged input"""
+        self.compare_columns(self.original, self.ours)
+
+    def test_columns_preserved_from_input(self):
+        """Check that columns are preserved from input"""
+        self.compare_columns(self.ours, self.subset_output)
+
+    def test_point_geometry_statistics(self):
+        """Check against values determined by running the tool"""
+        self.assertVectorExists(self.point_output)
+        info = gs.vector_info(self.point_output)
+        self.assertEqual(info["level"], 2)
+        self.assertEqual(info["points"], 1)
+        self.assertEqual(info["nodes"], 0)
+        self.assertEqual(info["primitives"], 1)
+
+    def test_point_attribute_info(self):
+        """Check attribute info against expected values"""
+        self.assertVectorExists(self.point_output)
+        info = gs.vector_info(self.point_output)
+        self.assertEqual(info["num_dblinks"], 1)
+        self.assertEqual(info["attribute_layer_number"], "1")
+        self.assertEqual(info["attribute_table"], self.point_output)
+        self.assertEqual(info["attribute_primary_key"], "cat")
+
+    def test_pour_point_geometry(self):
+        """Check pour point against coordinates determined by running the tool"""
+        data = (
+            gs.read_command("v.out.ascii", input=self.point_output).strip().split("|")
+        )
+        self.assertEqual(len(data), 3)
+        self.assertAlmostEqual(float(data[0]), 639258.424, places=3)
+        self.assertAlmostEqual(float(data[1]), 223266.931, places=3)
+
+    def test_pour_point_attributes(self):
+        """Check pour point against coordinates determined by running the tool"""
+        records = json.loads(
+            gs.read_command("v.db.select", map=self.point_output, format="json")
+        )["records"]
+        self.assertEqual(len(records), 1)
+        self.assertAlmostEqual(records[0]["x"], 639258.424, places=3)
+        self.assertAlmostEqual(records[0]["y"], 223266.931, places=3)
+
+
+if __name__ == "__main__":
+    test()

--- a/src/vector/v.stream.inbasin/v.stream.inbasin.html
+++ b/src/vector/v.stream.inbasin/v.stream.inbasin.html
@@ -1,13 +1,36 @@
 <h2>DESCRIPTION</h2>
 
-<em>v.stream.inbasin</em> uses the output of v.stream.network to select only those streams (and sub-basins) that are upstream of (and inclusive of) a selected link in the network. It is used as a step to develop GSFLOW model inputs for a watershed, but need not be exclusively used for that purpose.
+<em>v.stream.inbasin</em> uses the output of <em>v.stream.network</em> to
+select only those streams (and sub-basins) that are upstream of (and inclusive
+of) a selected link in the network. It is used as a step to develop GSFLOW
+model inputs for a watershed, but need not be exclusively used for that
+purpose.
+
+<em>v.stream.inbasin</em> expects the stream network attributes created by
+<em>v.stream.network</em> and named using the names <em>v.stream.network</em>
+uses by default. In other words, <em>v.stream.inbasin</em> will work on the
+output <em>v.stream.network</em> with default attribute names.
 
 <h2>REFERENCES</h2>
 
-Ng, G.-H. C., A. D. Wickert, R. L. McLaughlin, J. La Frenierre, S. Liess, and L. Sabeeri (2016),
-Modeling the role of groundwater and vegetation in the hydrological response of tropical
-glaciated watersheds to climate change, in AGU Fall Meeting Abstracts, H13L–1590, San
-Francisco, CA.
+<ul>
+    <li>
+        Ng, G.-H. C., A. D. Wickert, R. L. McLaughlin, J. La Frenierre,
+        S. Liess, and L. Sabeeri (2016),
+        Modeling the role of groundwater and vegetation in the hydrological
+        response of tropical glaciated watersheds to climate change,
+        in AGU Fall Meeting Abstracts, H13L–1590, San Francisco, CA.
+    </li>
+    <li>
+        Ng, G-H. Crystal, Andrew D. Wickert, Lauren D. Somers, Leila Saberi,
+        Collin Cronkite-Ratcliff, Richard G. Niswonger,
+        and Jeffrey M. McKenzie.
+        "GSFLOW–GRASS v1. 0.0: GIS-enabled hydrologic modeling of coupled
+        groundwater–surface-water systems."
+        <em>Geoscientific Model Development</em> 11 (2018): 4755-4777.
+        <a href="https://doi.org/10.5194/gmd-11-4755-2018">DOI 10.5194/gmd-11-4755-2018</a>
+    </li>
+</ul>
 
 <h2>SEE ALSO</h2>
 


### PR DESCRIPTION
- Changes x_outlet and y_outlet to single coordinates standard option which is recognized by GUI and user can click to get coordinates there. Call in Python has less parameters and same readability (x,y).
- Makes coordinates optional which seems to be the original intention.
- Uses rules to decide about valid options instead of custom if statements.
- Updates interfacing with numpy to Python 3.
- Adds more recent reference.
- Describes stream input more.
- Adds tests.
