### PR TITLE
i.landsat.download: remove a call of non-existent function raw_input()

### DIFF
--- a/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
+++ b/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
@@ -164,7 +164,7 @@ def main():
         # stdin
         import getpass
 
-        user = raw_input(_("Insert username: "))
+        user = input(_("Insert username: "))
         password = getpass.getpass(_("Insert password: "))
 
     else:


### PR DESCRIPTION
in Python3, it was replaced by input()