### PR TITLE
r.vif.py: add error message

### DIFF
--- a/src/raster/r.vif/r.vif.py
+++ b/src/raster/r.vif/r.vif.py
@@ -123,10 +123,12 @@ import grass.script as gs
 
 
 # Functions
-def prRed(skk): print("\033[91m {}\033[00m" .format(skk))
+def prRed(skk):
+    print("\033[91m {}\033[00m".format(skk))
 
 
-def prGreen(skk): print("\033[92m {}\033[00m" .format(skk))
+def prGreen(skk):
+    print("\033[92m {}\033[00m".format(skk))
 
 
 CLEAN_RAST = []
@@ -358,8 +360,9 @@ def main(options, flags):
                         y = p[:, k]
                     except IndexError as e:
                         prRed(f"An error occurred: {str(e)}")
-                        prGreen("Tip: check if all input rasters have values"
-                              " within the computation region.")
+                        prGreen(
+                            "Tip: check if all input rasters have values within the computation region."
+                        )
                     x = np.delete(p, k, axis=1)
                     vifstat = compute_vif(x, y)
 

--- a/src/raster/r.vif/r.vif.py
+++ b/src/raster/r.vif/r.vif.py
@@ -123,6 +123,12 @@ import grass.script as gs
 
 
 # Functions
+def prRed(skk): print("\033[91m {}\033[00m" .format(skk))
+
+
+def prGreen(skk): print("\033[92m {}\033[00m" .format(skk))
+
+
 CLEAN_RAST = []
 
 
@@ -348,7 +354,12 @@ def main(options, flags):
                     vifstat = compute_vif2(x, y)
                 else:
                     # Compute vif using sample
-                    y = p[:, k]
+                    try:
+                        y = p[:, k]
+                    except IndexError as e:
+                        prRed(f"An error occurred: {str(e)}")
+                        prGreen("Tip: check if all input rasters have values"
+                              " within the computation region.")
                     x = np.delete(p, k, axis=1)
                     vifstat = compute_vif(x, y)
 


### PR DESCRIPTION
The error message given when one of the input layers has no values (within the computational region) does not help to understand the problem. Added an error message to suggest the possible cause of the error. On the command line, the error message is written in red.