### PR TITLE
r.learn.ml2: change max_features=auto to sqrt

### DIFF
--- a/src/raster/r.learn.ml2/r.learn.train/r.learn.train.py
+++ b/src/raster/r.learn.ml2/r.learn.train/r.learn.train.py
@@ -424,7 +424,7 @@ def process_param_grid(hyperparams):
     if hyperparams["max_depth"] == 0:
         hyperparams["max_depth"] = None
     if hyperparams["max_features"] == 0:
-        hyperparams["max_features"] = "auto"
+        hyperparams["max_features"] = "sqrt"
     param_grid = {k: v for k, v in param_grid.items() if v is not None}
 
     return hyperparams, param_grid


### PR DESCRIPTION
From the [scikit docs](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html#sklearn.ensemble.RandomForestClassifier):

```
max_features{“sqrt”, “log2”, None}, int or float, default=”sqrt”
[...]
Changed in version 1.1: The default of max_features changed from "auto" to "sqrt".
```
The "auto" option is no longer existing and was an alias for "sqrt", this PR adapts `r.learn.train` accordingly without changing the behaviour and staying backwards compatible with older scikit versions.