### PR TITLE
m.tnm.download: Renamed from m.download.tnm to be consistent with other *.*.download

### DIFF
--- a/src/misc/m.download.tnm/Makefile
+++ b/src/misc/m.download.tnm/Makefile
@@ -1,6 +1,6 @@
 MODULE_TOPDIR = ../..
 
-PGM = m.download.tnm
+PGM = m.tnm.download
 
 include $(MODULE_TOPDIR)/include/Make/Script.make
 

--- a/src/misc/m.download.tnm/m.tnm.download.html
+++ b/src/misc/m.download.tnm/m.tnm.download.html
@@ -1,6 +1,6 @@
 <h2>DESCRIPTION</h2>
 
-<em>m.download.tnm</em> downloads data for specified polygon codes from <a href="https://apps.nationalmap.gov/downloader/">The National Map (TNM)</a>.
+<em>m.tnm.download</em> downloads data for specified polygon codes from <a href="https://apps.nationalmap.gov/downloader/">The National Map (TNM)</a>.
 
 
 <h2>NOTES</h2>
@@ -14,27 +14,27 @@ List supported datasets and exit:
 <div class="code"><pre>
 # use indices, IDs, or tags to select datasets, but indices can change between
 # sessions
-m.download.tnm -d
+m.tnm.download -d
 </pre></div>
 
 List supported states and exit:
 <div class="code"><pre>
 # use FIPS codes, USPS codes, or names to select states for type=state
-m.download.tnm -s
+m.tnm.download -s
 </pre></div>
 
 Download National Elevation Dataset (NED) 1-arcsecond files for Texas:
 <div class="code"><pre>
 # find the dataset ID
-m.download.tnm -d | grep "NED.* 1 arc-second"
-m.download.tnm dataset=one-arc-second-dem type=state code=TX
+m.tnm.download -d | grep "NED.* 1 arc-second"
+m.tnm.download dataset=one-arc-second-dem type=state code=TX
 </pre></div>
 
 Download National Watershed Boundary Dataset (WBD) files for HUC8 01010001:
 <div class="code"><pre>
 # find the dataset ID
-m.download.tnm -d | grep WBD
-m.download.tnm dataset=watershed-boundary-dataset type=huc8 code=01010001
+m.tnm.download -d | grep WBD
+m.tnm.download dataset=watershed-boundary-dataset type=huc8 code=01010001
 </pre></div>
 
 

--- a/src/misc/m.download.tnm/m.tnm.download.py
+++ b/src/misc/m.download.tnm/m.tnm.download.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 ############################################################################
 #
-# MODULE:       m.download.tnm
+# MODULE:       m.tnm.download
 # AUTHOR(S):    Huidae Cho <grass4u gmail.com>
 # PURPOSE:      Downloads data for specified polygon codes from The National
 #               Map (TNM).


### PR DESCRIPTION
`g.download.location` is the only exception, but it's not for a specific dataset or API...