### PR TITLE
r.flowaccumulation: Remove a global variable

### DIFF
--- a/src/raster/r.flowaccumulation/global.h
+++ b/src/raster/r.flowaccumulation/global.h
@@ -32,12 +32,4 @@ long long timeval_diff(struct timeval *, struct timeval *, struct timeval *);
 /* accumulate.c */
 void accumulate(struct raster_map *, struct raster_map *);
 
-#ifdef _MAIN_C_
-#define GLOBAL
-#else
-#define GLOBAL extern
-#endif
-
-GLOBAL CELL cell_null;
-
 #endif

--- a/src/raster/r.flowaccumulation/main.c
+++ b/src/raster/r.flowaccumulation/main.c
@@ -177,8 +177,6 @@ int main(int argc, char *argv[])
     nrows = Rast_window_rows();
     ncols = Rast_window_cols();
 
-    Rast_set_c_null_value(&cell_null, 1);
-
     dir_map = G_malloc(sizeof *dir_map);
     dir_map->nrows = nrows;
     dir_map->ncols = ncols;
@@ -188,17 +186,17 @@ int main(int argc, char *argv[])
         Rast_get_c_row(dir_fd, dir_map->cells + ncols * row, row);
         if (dir_format == DIR_DEG) {
             for (col = 0; col < ncols; col++)
-                if (DIR(row, col) != cell_null)
+                if (!Rast_is_c_null_value(&DIR(row, col)))
                     DIR(row, col) = pow(2, abs(DIR(row, col) / 45.));
         }
         else if (dir_format == DIR_DEG45) {
             for (col = 0; col < ncols; col++)
-                if (DIR(row, col) != cell_null)
+                if (!Rast_is_c_null_value(&DIR(row, col)))
                     DIR(row, col) = pow(2, 8 - abs(DIR(row, col)));
         }
         else {
             for (col = 0; col < ncols; col++)
-                if (DIR(row, col) != cell_null)
+                if (!Rast_is_c_null_value(&DIR(row, col)))
                     DIR(row, col) = abs(DIR(row, col));
         }
     }


### PR DESCRIPTION
This PR removes a global variable and uses `Rast_is_c_null_value()` instead. There wasn't much performance difference between inline and function calls.