### PR TITLE
v.surf.nnbathy: Fix exception type for Python 3

### DIFF
--- a/src/vector/v.surf.nnbathy/nnbathy.py
+++ b/src/vector/v.surf.nnbathy/nnbathy.py
@@ -207,7 +207,7 @@ class Nnbathy_vector(Nnbathy):
                         # fout.write(parts[0]+' '+parts[1]+' '+parts[4])
                         fout.write("{} {} {}".format(parts[0], parts[1], parts[4]))
                     pnt.close()
-            except (StandardError, OSError) as e:
+            except (Exception, OSError) as e:
                 grass.fatal_error("Invalid input: %s" % e)
             fin.close()
             fout.close()


### PR DESCRIPTION
Fixes both v.surf.nnbathy and r.surf.nnbathy because r.surf.nnbathy imports the Python module installed with v.surf.nnbathy.

Fixes Pylint error E0602: Undefined variable 'StandardError' (undefined-variable), but introduces warning W0718: Catching too general exception Exception (broad-exception-caught).

This is aiming at making the tool run with Python 3 and GRASS GIS 8. Proper fix would separate try-except blocks to the relevant parts. Now two string splits, all vector handling and file writing are all in one try-except which catches everything including IndexError and AttributeError. This basic fix is just applying The Conservative Python 3 Porting Guide without further changes.
