### PR TITLE
cronjobs: build programmer's manual for "preview" version

### DIFF
--- a/utils/cronjobs_osgeo_lxd/cron_grass_legacy_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_legacy_build_binaries.sh
@@ -22,12 +22,12 @@
 # - generates the pyGRASS 7 HTML manual
 # - generates the user 7 HTML manuals
 # - injects DuckDuckGo search field
-# - injects G8 new version box
+# - injects G8 is the new version box
 # - injects canonical URL
 
 # Preparations:
 #  - Install PROJ
-#  - Install GDAL: http://trac.osgeo.org/gdal/wiki/DownloadSource
+#  - Install GDAL
 #  - Install apt-get install texlive-latex-extra python3-sphinxcontrib.apidoc
 #  - Clone source from github
 #################################
@@ -59,7 +59,8 @@ GRASSBUILDDIR=$SOURCE/$BRANCH
 TARGETMAIN=/var/www/code_and_data
 TARGETDIR=$TARGETMAIN/grass${VERSION}/binary/linux/snapshot
 TARGETHTMLDIR=$TARGETMAIN/grass${VERSION}/manuals/
-# programmer's manual is only built from the relbranch_8_0
+# progman not built for older dev versions or old stable, only for preview
+#TARGETPROGMAN=$TARGETMAIN/programming${GVERSION}
 
 MYBIN=$MAINDIR/binaries
 
@@ -82,6 +83,11 @@ configure_grass()
 # which package?
 #   --with-mysql --with-mysql-includes=/usr/include/mysql --with-mysql-libs=/usr/lib/mysql \
 
+# cleanup
+rm -f config_$GMAJOR.$GMINOR.git_log.txt
+
+# reset i18N POT files to git, just to be sure
+git checkout locale/templates/*.pot
 
 CFLAGS=$CFLAGSSTRING LDFLAGS=$LDFLAGSSTRING ./configure \
   --with-cxx \
@@ -187,12 +193,7 @@ cp -p AUTHORS CHANGES CITING COPYING GPL.TXT INSTALL REQUIREMENTS.html $TARGETDI
 # clean wxGUI sphinx manual etc
 (cd $GRASSBUILDDIR/ ; $MYMAKE cleansphinx)
 
-##### generate i18N POT files, needed for https://www.transifex.com/grass-gis/
-(cd locale ;
-$MYMAKE pot
-mkdir -p $TARGETDIR/transifex/
-cp templates/*.pot $TARGETDIR/transifex/
-)
+# note: the gettext POT files are managed in git and OSGeo Weblate
 
 ##### generate i18N stats for HTML page path (WebSVN):
 ## Structure:  grasslibs_ar.po 144 translated messages 326 fuzzy translations 463 untranslated messages.
@@ -298,9 +299,9 @@ export VERSION_NUMBER=$DOTVERSION
 python3 $GRASSBUILDDIR/man/build_keywords.py $TARGETHTMLDIR/ $TARGETHTMLDIR/addons/
 unset ARCH ARCH_DISTDIR GISBASE VERSION_NUMBER
 
-# canonical: once again after addon manual (re)creation, only where missing
 # SEO: inject canonical link in all (old) manual pages to point to latest stable (avoid duplicate content SEO punishment)
 # see https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls
+# canonical: once again after addon manual (re)creation, only where missing
 (cd $TARGETHTMLDIR/ ; for myfile in `grep -L 'link rel="canonical"' *.html` ; do sed -i -e "s:</head>:<link rel=\"canonical\" href=\"https\://grass.osgeo.org/grass82/manuals/$myfile\">\n</head>:g" $myfile ; done)
 (cd $TARGETHTMLDIR/addons/ ; for myfile in `grep -L 'link rel="canonical"' *.html` ; do sed -i -e "s:</head>:<link rel=\"canonical\" href=\"https\://grass.osgeo.org/grass82/manuals/addons/$myfile\">\n</head>:g" $myfile ; done)
 (cd $TARGETHTMLDIR/libpython/ ; for myfile in `grep -L 'link rel="canonical"' *.html` ; do sed -i -e "s:</head>:<link rel=\"canonical\" href=\"https\://grass.osgeo.org/grass82/manuals/libpython/$myfile\">\n</head>:g" $myfile ; done)
@@ -316,6 +317,7 @@ python3 $HOME/src/grass$GMAJOR-addons/utils/create_manuals_sitemap.py --dir=/var
 # cleanup
 cd $GRASSBUILDDIR
 $MYMAKE distclean  > /dev/null || (echo "$0: an error occurred" ; exit 1)
+rm -rf lib/html/ lib/latex/
 
 echo "Finished GRASS $VERSION $ARCH compilation."
 echo "Written to: $TARGETDIR"

--- a/utils/cronjobs_osgeo_lxd/cron_grass_new_current_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_new_current_build_binaries.sh
@@ -12,14 +12,13 @@
 # - configures, compiles
 # - packages the binaries
 # - generated the install scripts
-# - generates the programmer's 8 HTML manual
 # - generates the pyGRASS 8 HTML manual
 # - generates the user 8 HTML manuals
 # - injects DuckDuckGo search field
 
 # Preparations, on server:
 #  - Install PROJ incl Datum shift grids
-#  - Install GDAL:
+#  - Install GDAL
 #  - Install apt-get install texlive-latex-extra python3-sphinxcontrib.apidoc
 #  - Clone source from github:
 #    mkdir -p ~/src ; cd ~/src
@@ -62,8 +61,8 @@ TARGETMAIN=/var/www/code_and_data
 TARGETDIR=$TARGETMAIN/grass${VERSION}/binary/linux/snapshot
 TARGETHTMLDIR=$TARGETMAIN/grass${VERSION}/manuals/
 
-# only built for new stable (not built for dev version or old stable)
-TARGETPROGMAN=$TARGETMAIN/programming${GVERSION}
+# progman not built for older dev versions or old stable, only for preview
+#TARGETPROGMAN=$TARGETMAIN/programming${GVERSION}
 
 MYBIN=$MAINDIR/binaries
 
@@ -193,6 +192,7 @@ $MYMAKE htmldocs-single || (echo "$0 htmldocs-single: an error occurred" ; exit 
 
 cd $GRASSBUILDDIR/
 
+#### unused, only done in "preview" script
 ## clean old TARGETPROGMAN stuff from last run
 #if  [ -z "$TARGETPROGMAN" ] ; then
 # echo "\$TARGETPROGMAN undefined, error!"
@@ -211,13 +211,9 @@ cd $GRASSBUILDDIR/
 #chmod -R a+r,g+w $TARGETPROGMAN/*
 ## bug in doxygen
 #(cd $TARGETPROGMAN/ ; ln -s index.html main.html)
+#### end unused
 
-##### copy i18N POT files, originally needed for https://www.transifex.com/grass-gis/
-### note: from G82+ onwards the gettext POT files are managed in git and OSGeo Weblate
-#(cd locale ;
-#mkdir -p $TARGETDIR/transifex/
-#cp templates/*.pot $TARGETDIR/transifex/
-#)
+# note: from G82+ onwards the gettext POT files are managed in git and OSGeo Weblate
 
 ##### generate i18N stats for HTML page path (WebSVN):
 ## Structure:  grasslibs_ar.po 144 translated messages 326 fuzzy translations 463 untranslated messages.
@@ -342,7 +338,7 @@ echo "Finished GRASS $VERSION $ARCH compilation."
 echo "Written to: $TARGETDIR"
 echo "Copied HTML ${GVERSION} manual to https://grass.osgeo.org/grass${VERSION}/manuals/"
 echo "Copied pygrass progman ${GVERSION} to https://grass.osgeo.org/grass${VERSION}/manuals/libpython/"
-echo "Copied HTML ${GVERSION} progman to https://grass.osgeo.org/programming${GVERSION}"
+## echo "Copied HTML ${GVERSION} progman to https://grass.osgeo.org/programming${GVERSION}"
 echo "Copied Addons ${GVERSION} to https://grass.osgeo.org/grass${VERSION}/manuals/addons/"
 
 exit 0

--- a/utils/cronjobs_osgeo_lxd/cron_grass_old_current_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_old_current_build_binaries.sh
@@ -12,16 +12,15 @@
 # - configures, compiles
 # - packages the binaries
 # - generated the install scripts
-# - generates the programmer's 8 HTML manual
 # - generates the pyGRASS 8 HTML manual
 # - generates the user 8 HTML manuals
 # - injects DuckDuckGo search field
-# - injects G8 new version box
+# - injects G8 is the new version box
 # - injects canonical URL
 
 # Preparations, on server:
 #  - Install PROJ incl Datum shift grids
-#  - Install GDAL:
+#  - Install GDAL
 #  - Install apt-get install texlive-latex-extra python3-sphinxcontrib.apidoc
 #  - Clone source from github:
 #    mkdir -p ~/src ; cd ~/src
@@ -34,7 +33,7 @@
 #    cd /var/www/html/
 #    ln -s /var/www/code_and_data/grass82 .
 #
-##########################################
+#################################
 PATH=/home/neteler/binaries/bin:/usr/bin:/bin:/usr/X11R6/bin:/usr/local/bin
 
 GMAJOR=8
@@ -63,8 +62,9 @@ GRASSBUILDDIR=$SOURCE/$BRANCH
 TARGETMAIN=/var/www/code_and_data
 TARGETDIR=$TARGETMAIN/grass${VERSION}/binary/linux/snapshot
 TARGETHTMLDIR=$TARGETMAIN/grass${VERSION}/manuals/
-# not built for dev version or old stable
-## TARGETPROGMAN=$TARGETMAIN/programming${GVERSION}
+
+# progman not built for older dev versions or old stable, only for preview
+#TARGETPROGMAN=$TARGETMAIN/programming${GVERSION}
 
 MYBIN=$MAINDIR/binaries
 
@@ -205,6 +205,7 @@ $MYMAKE htmldocs-single || (echo "$0 htmldocs-single: an error occurred" ; exit 
 
 cd $GRASSBUILDDIR/
 
+#### unused, only done in "preview" script
 ## clean old TARGETPROGMAN stuff from last run
 #if  [ -z "$TARGETPROGMAN" ] ; then
 # echo "\$TARGETPROGMAN undefined, error!"
@@ -223,7 +224,7 @@ cd $GRASSBUILDDIR/
 #chmod -R a+r,g+w $TARGETPROGMAN/*
 ## bug in doxygen
 #(cd $TARGETPROGMAN/ ; ln -s index.html main.html)
-
+#### end unused
 
 # note: from G82+ onwards the gettext POT files are managed in git and OSGeo Weblate
 
@@ -350,7 +351,7 @@ echo "Finished GRASS $VERSION $ARCH compilation."
 echo "Written to: $TARGETDIR"
 echo "Copied HTML ${GVERSION} manual to https://grass.osgeo.org/grass${VERSION}/manuals/"
 echo "Copied pygrass progman ${GVERSION} to https://grass.osgeo.org/grass${VERSION}/manuals/libpython/"
-#echo "Copied HTML ${GVERSION} progman to https://grass.osgeo.org/programming${GVERSION}"
+## echo "Copied HTML ${GVERSION} progman to https://grass.osgeo.org/programming${GVERSION}"
 echo "Copied Addons ${GVERSION} to https://grass.osgeo.org/grass${VERSION}/manuals/addons/"
 
 exit 0

--- a/utils/cronjobs_osgeo_lxd/cron_grass_preview_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_preview_build_binaries.sh
@@ -19,7 +19,7 @@
 
 # Preparations, on server:
 #  - Install PROJ incl Datum shift grids
-#  - Install GDAL:
+#  - Install GDAL
 #  - Install apt-get install texlive-latex-extra python3-sphinxcontrib.apidoc
 #  - Clone source from github:
 #    mkdir -p ~/src ; cd ~/src
@@ -30,7 +30,7 @@
 #    cd /var/www/html/
 #    ln -s /var/www/code_and_data/grass84 .
 #
-##########################################
+#################################
 PATH=/home/neteler/binaries/bin:/usr/bin:/bin:/usr/X11R6/bin:/usr/local/bin
 
 GMAJOR=8
@@ -60,8 +60,9 @@ TARGETMAIN=/var/www/code_and_data
 TARGETDIR=$TARGETMAIN/grass${VERSION}/binary/linux/snapshot
 TARGETHTMLDIR=$TARGETMAIN/grass${VERSION}/manuals/
 
-# not built for dev version or old stable
-## TARGETPROGMAN=$TARGETMAIN/programming${GVERSION}
+# progman compiled below (i.e., only for preview)
+# progman not built for older dev versions or old stable
+TARGETPROGMAN=$TARGETMAIN/programming${GVERSION}
 
 MYBIN=$MAINDIR/binaries
 
@@ -191,31 +192,27 @@ $MYMAKE htmldocs-single || (echo "$0 htmldocs-single: an error occurred" ; exit 
 
 cd $GRASSBUILDDIR/
 
-## clean old TARGETPROGMAN stuff from last run
-#if  [ -z "$TARGETPROGMAN" ] ; then
-# echo "\$TARGETPROGMAN undefined, error!"
-# exit 1
-#fi
-#mkdir -p $TARGETPROGMAN
-#rm -f $TARGETPROGMAN/*.*
-#
-## copy over doxygen manual
-#cp -r html/*  $TARGETPROGMAN/
-#
-#echo "Copied HTML progman to https://grass.osgeo.org/programming${GVERSION}"
-## fix permissions
-#chgrp -R grass $TARGETPROGMAN/*
-#chmod -R a+r,g+w $TARGETPROGMAN/
-#chmod -R a+r,g+w $TARGETPROGMAN/*
-## bug in doxygen
-#(cd $TARGETPROGMAN/ ; ln -s index.html main.html)
+echo "Generating latest programmer's manual..."
+# clean old TARGETPROGMAN stuff from last run
+if  [ -z "$TARGETPROGMAN" ] ; then
+ echo "\$TARGETPROGMAN undefined, error!"
+ exit 1
+fi
+mkdir -p $TARGETPROGMAN
+rm -f $TARGETPROGMAN/*.*
 
-##### copy i18N POT files, originally needed for https://www.transifex.com/grass-gis/
-### note: from G82+ onwards the gettext POT files are managed in git and OSGeo Weblate
-#(cd locale ;
-#mkdir -p $TARGETDIR/transifex/
-#cp templates/*.pot $TARGETDIR/transifex/
-#)
+# copy over doxygen manual
+cp -r html/*  $TARGETPROGMAN/
+
+echo "Copied HTML progman to https://grass.osgeo.org/programming${GVERSION}"
+# fix permissions
+chgrp -R grass $TARGETPROGMAN/*
+chmod -R a+r,g+w $TARGETPROGMAN/
+chmod -R a+r,g+w $TARGETPROGMAN/*
+# bug in doxygen
+(cd $TARGETPROGMAN/ ; ln -s index.html main.html)
+
+# note: from G82+ onwards the gettext POT files are managed in git and OSGeo Weblate
 
 ##### generate i18N stats for HTML page path (WebSVN):
 ## Structure:  grasslibs_ar.po 144 translated messages 326 fuzzy translations 463 untranslated messages.
@@ -340,7 +337,7 @@ echo "Finished GRASS $VERSION $ARCH compilation."
 echo "Written to: $TARGETDIR"
 echo "Copied HTML ${GVERSION} manual to https://grass.osgeo.org/grass${VERSION}/manuals/"
 echo "Copied pygrass progman ${GVERSION} to https://grass.osgeo.org/grass${VERSION}/manuals/libpython/"
-#echo "Copied HTML ${GVERSION} progman to https://grass.osgeo.org/programming${GVERSION}"
+echo "Copied HTML ${GVERSION} progman to https://grass.osgeo.org/programming${GVERSION}"
 echo "Copied Addons ${GVERSION} to https://grass.osgeo.org/grass${VERSION}/manuals/addons/"
 
 exit 0


### PR DESCRIPTION
Fix accidentally disabled creation of programmer's manual (https://grass.osgeo.org/programming8/) which was disabled since May 2023.

- activate creation of programmer's manual in `cron_grass_preview_build_binaries.sh`
- minor cleanup and sync in the other `cron_grass_*_build_binaries.sh` files

(thanks to @pesekon2 for discovering this glitch)