### PR TITLE
cronjobs: remove outdated liblas support

### DIFF
--- a/utils/cronjobs_osgeo_lxd/cron_grass_legacy_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_legacy_build_binaries.sh
@@ -106,7 +106,6 @@ CFLAGS=$CFLAGSSTRING LDFLAGS=$LDFLAGSSTRING ./configure \
   --with-blas --with-blas-includes=/usr/include/atlas/ \
   --with-lapack --with-lapack-includes=/usr/include/atlas/ \
   --with-zstd \
-  --with-liblas \
   2>&1 | tee config_$DOTVERSION.git_log.txt
 
  if [ $? -ne 0 ] ; then

--- a/utils/cronjobs_osgeo_lxd/cron_grass_new_current_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_new_current_build_binaries.sh
@@ -108,7 +108,6 @@ CFLAGS=$CFLAGSSTRING LDFLAGS=$LDFLAGSSTRING ./configure \
   --with-blas --with-blas-includes=/usr/include/atlas/ \
   --with-lapack --with-lapack-includes=/usr/include/atlas/ \
   --with-zstd \
-  --with-liblas \
   2>&1 | tee config_$DOTVERSION.git_log.txt
 
  if [ $? -ne 0 ] ; then

--- a/utils/cronjobs_osgeo_lxd/cron_grass_old_current_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_old_current_build_binaries.sh
@@ -110,7 +110,6 @@ CFLAGS=$CFLAGSSTRING LDFLAGS=$LDFLAGSSTRING ./configure \
   --with-blas --with-blas-includes=/usr/include/atlas/ \
   --with-lapack --with-lapack-includes=/usr/include/atlas/ \
   --with-zstd \
-  --with-liblas \
   2>&1 | tee config_$DOTVERSION.git_log.txt
 
  if [ $? -ne 0 ] ; then

--- a/utils/cronjobs_osgeo_lxd/cron_grass_preview_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_preview_build_binaries.sh
@@ -108,7 +108,6 @@ CFLAGS=$CFLAGSSTRING LDFLAGS=$LDFLAGSSTRING ./configure \
   --with-blas --with-blas-includes=/usr/include/atlas/ \
   --with-lapack --with-lapack-includes=/usr/include/atlas/ \
   --with-zstd \
-  --with-liblas \
   2>&1 | tee config_$DOTVERSION.git_log.txt
 
  if [ $? -ne 0 ] ; then


### PR DESCRIPTION
Compilation of binaries (also performing addon compilation) without liblas which is outdated and requires a very old GDAL installation.