### PR TITLE
v.what.rast.multi.py: deal with @ in column names

### DIFF
--- a/src/vector/v.what.rast.multi/v.what.rast.multi.py
+++ b/src/vector/v.what.rast.multi/v.what.rast.multi.py
@@ -100,6 +100,12 @@
 # % description: Example: income < 1000 and population >= 10000
 # %end
 
+# %flag
+# % key: m
+# % label: Retain mapset name
+# % description: When no column names are provided, the column names are created using the names of the input layers. Using this flag will retain the mapset part of the name (if given), but replacing the @ for an underscore.
+# %end
+
 import sys
 import os
 import grass.script as grass
@@ -110,8 +116,12 @@ if "GISBASE" not in os.environ:
     sys.exit(1)
 
 
-def main():
+def strip_mapset(name, join_char="@"):
+    """Strip mapset part of the layer name"""
+    return name.split(join_char)[0] if join_char in name else name
 
+
+def main():
     # Get options
     vmap = options["map"]  # Vector points
     layer = options["layer"]
@@ -135,13 +145,15 @@ def main():
 
     # For each raster
     for i in range(len(rasters)):
-
+        # Determine column name
         r = rasters[i]
-
         if columns != [""]:
             c = columns[i]
         else:
-            c = r
+            if flags["m"]:
+                c = r.replace("@", "_")
+            else:
+                c = strip_mapset(r)
 
         # Sample using v.what.rast
         v.what_rast(


### PR DESCRIPTION
**Problem:**
When no column names are provided, the names of the input raster layers are used as column names. If these include the mapset suffix, an error is thrown (SQLite does not accept @).

**Provided solution:**
The mapset suffix is removed. Alternatively, if the mapset names should be in the column names, the -m flag can be set. In that case, the @ is replaced with an underscore