### PR TITLE
i.sentinel.import: do not ignore pattern when importing cloud masks

### DIFF
--- a/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
+++ b/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
@@ -407,7 +407,7 @@ class SentinelImporter(object):
             pass  # error already printed
 
     def get_safe_dir(self, filename):
-        return filename[:filename.find(".SAFE")+len(".SAFE")].split(os.path.sep)[-1]
+        return filename[: filename.find(".SAFE") + len(".SAFE")].split(os.path.sep)[-1]
 
     def get_unique_safe_dirs(self, files):
         return set(map(lambda f: self.get_safe_dir(f), files))
@@ -461,7 +461,10 @@ class SentinelImporter(object):
             )
 
             # check if mask alrady exist
-            if gs.find_file(name=map_name, element=output, mapset=".")["file"] and not overwrite:
+            if (
+                gs.find_file(name=map_name, element=output, mapset=".")["file"]
+                and not overwrite
+            ):
                 gs.message(
                     _(
                         "option <output>: <{}> exists. To overwrite, use the --overwrite flag".format(

--- a/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
+++ b/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
@@ -406,9 +406,24 @@ class SentinelImporter(object):
         except CalledModuleError as e:
             pass  # error already printed
 
+    def get_safe_dir(self, filename):
+        return filename[:filename.find(".SAFE")+len(".SAFE")].split(os.path.sep)[-1]
+
+    def get_unique_safe_dirs(self, files):
+        return set(map(lambda f: self.get_safe_dir(f), files))
+
     def import_cloud_masks(
-        self, area_threshold, prob_threshold, output, shadows, reproject
+        self, pattern, area_threshold, prob_threshold, output, shadows, reproject
     ):
+        def filter_cloud_masks(files, pattern):
+            files_safe_dirs = self.get_unique_safe_dirs(files)
+            files_f = []
+            for f in self._filter(pattern):
+                safe_dir = self.get_safe_dir(f)
+                if safe_dir in files_safe_dirs:
+                    files_f.append(f)
+            return files_f
+
         try:
             if os.environ["GRASS_OVERWRITE"] == "1":
                 overwrite = True
@@ -416,10 +431,13 @@ class SentinelImporter(object):
             overwrite = False
 
         # Import cloud masks for L2A products
-        files_L2A = self._filter("MSK_CLDPRB_20m.jp2")
+        if pattern:
+            files_L2A = filter_cloud_masks(self.files, "MSK_CLDPRB_20m.jp2")
+        else:
+            files_L2A = self._filter("MSK_CLDPRB_20m.jp2")
 
         for f in files_L2A:
-            safe_dir = os.path.dirname(f).split(os.path.sep)[-4]
+            safe_dir = self.get_safe_dir(f)
             items = safe_dir.split("_")
 
             # Define names of final & temporary maps
@@ -443,7 +461,7 @@ class SentinelImporter(object):
             )
 
             # check if mask alrady exist
-            if gs.find_file(name=map_name, element=output)["file"] and not overwrite:
+            if gs.find_file(name=map_name, element=output, mapset=".")["file"] and not overwrite:
                 gs.message(
                     _(
                         "option <output>: <{}> exists. To overwrite, use the --overwrite flag".format(
@@ -625,21 +643,23 @@ class SentinelImporter(object):
                 )
 
         # Import of simplified cloud masks for Level-1C products
-        all_files = self._filter("MSK_CLOUDS_B00.gml")
-        files_L1C = []
+        if pattern:
+            all_files = filter_cloud_masks(self.files, "MSK_CLOUDS_B00.gml")
+        else:
+            all_files = self._filter("MSK_CLOUDS_B00.gml")
 
+        files_L1C = []
+        safe_dirs_l2a = self.get_unique_safe_dirs(files_L2A)
         for f in all_files:
-            safe_dir = os.path.dirname(f).split(os.path.sep)[-4]
-            if safe_dir not in [
-                os.path.dirname(file).split(os.path.sep)[-4] for file in files_L2A
-            ]:
+            if self.get_safe_dir(f) not in safe_dirs_l2a:
+                # processes only cloud mask which were not already processed as L2A
                 files_L1C.append(f)
 
         if len(files_L1C) > 0:
             from osgeo import ogr
 
             for f in files_L1C:
-                safe_dir = os.path.dirname(f).split(os.path.sep)[-4]
+                safe_dir = self.get_safe_dir(f)
                 items = safe_dir.split("_")
 
                 # Define names of final & temporary maps
@@ -650,7 +670,7 @@ class SentinelImporter(object):
 
                 # check if mask alrady exist
                 if (
-                    gs.find_file(name=map_name, element=output)["file"]
+                    gs.find_file(name=map_name, element=output, mapset=".")["file"]
                     and not overwrite
                 ):
                     gs.fatal(
@@ -1027,6 +1047,7 @@ def main():
     if flags["c"]:
         # import cloud mask if requested
         importer.import_cloud_masks(
+            options["pattern"],
             options["cloud_area_threshold"],
             options["cloud_probability_threshold"],
             options["cloud_output"],

--- a/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
+++ b/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
@@ -180,11 +180,11 @@ class SentinelImporter(object):
     def __del__(self):
         # remove temporary maps
         for map in self._map_list:
-            if gs.find_file(map, element="cell")["file"]:
+            if gs.find_file(map, element="cell", mapset=".")["file"]:
                 gs.run_command(
                     "g.remove", flags="fb", type="raster", name=map, quiet=True
                 )
-            if gs.find_file(map, element="vector")["file"]:
+            if gs.find_file(map, element="vector", mapset=".")["file"]:
                 gs.run_command(
                     "g.remove", flags="f", type="vector", name=map, quiet=True
                 )


### PR DESCRIPTION
Currently, `i.sentinel.import` ignores `pattern` when importing cloud masks ([sample data](https://geo.fsv.cvut.cz/data/geoforall/jena-sample-dataset.7z) used in example below):

```
i.sentinel.import input=~/Downloads/jena-sample-dataset/sentinel/2019 pattern="20190626T102031_B0[4|8]_10m" -c
````

The command imports only two channels from the single scene:

```
g.list rast m=.
T32UPB_20190626T102031_B04_10m
T32UPB_20190626T102031_B08_10m
```

but cloud masks are imported for all scenes regardless `pattern`:

```
g.list vect m=.
T32UPB_20190407T102021_MSK_CLOUDS
T32UPB_20190417T102031_MSK_CLOUDS
T32UPB_20190422T102029_MSK_CLOUDS
T32UPB_20190626T102031_MSK_CLOUDS
T32UPB_20190825T102031_MSK_CLOUDS
T32UPB_20190904T102021_MSK_CLOUDS
T32UPB_20191014T102031_MSK_CLOUDS
```

This PR fixes this bug, the command just creates one cloud mask based on the `pattern` above:

```
T32UPB_20190626T102031_MSK_CLOUDS
```
