### PR TITLE
r.flowaccumulation: Support FCELL and DCELL outputs

### DIFF
--- a/src/raster/r.flowaccumulation/accumulate.c
+++ b/src/raster/r.flowaccumulation/accumulate.c
@@ -1,164 +1,114 @@
-#include <stdlib.h>
 #include <grass/raster.h>
 #include "global.h"
 
-#define ACCUM(row, col) accum_map->cells[(size_t)(row)*ncols + (col)]
-#define FIND_UP(row, col)                                                     \
-    ((row > 0 ? (col > 0 && DIR(row - 1, col - 1) == SE ? NW : 0) |           \
-                    (DIR(row - 1, col) == S ? N : 0) |                        \
-                    (col < ncols - 1 && DIR(row - 1, col + 1) == SW ? NE : 0) \
-              : 0) |                                                          \
-     (col > 0 && DIR(row, col - 1) == E ? W : 0) |                            \
-     (col < ncols - 1 && DIR(row, col + 1) == W ? E : 0) |                    \
-     (row < nrows - 1                                                         \
-          ? (col > 0 && DIR(row + 1, col - 1) == NE ? SW : 0) |               \
-                (DIR(row + 1, col) == N ? S : 0) |                            \
-                (col < ncols - 1 && DIR(row + 1, col + 1) == NW ? SE : 0)     \
-          : 0))
-
-#ifdef USE_LESS_MEMORY
-#define UP(row, col) FIND_UP(row, col)
-#else
-#define UP(row, col) up_cells[(size_t)(row)*ncols + (col)]
-static unsigned char *up_cells;
-#endif
-
-static int nrows, ncols;
-
-static void trace_down(struct raster_map *, struct raster_map *, int, int, int);
-static int sum_up(struct raster_map *, int, int, int);
-
-void accumulate(struct raster_map *dir_map, struct raster_map *accum_map)
+void accumulate(struct raster_map *dir_map, struct raster_map *accum_map,
+                int check_overflow, int use_less_memory, int use_zero)
 {
-    int row, col;
-
-    nrows = dir_map->nrows;
-    ncols = dir_map->ncols;
-
-#ifndef USE_LESS_MEMORY
-    up_cells = calloc((size_t)nrows * ncols, sizeof *up_cells);
-
-#pragma omp parallel for schedule(dynamic) private(col)
-    for (row = 0; row < nrows; row++) {
-        for (col = 0; col < ncols; col++)
-            if (!Rast_is_c_null_value(&DIR(row, col)))
-                UP(row, col) = FIND_UP(row, col);
+    switch (accum_map->type) {
+    case CELL_TYPE:
+        if (check_overflow) {
+            if (use_less_memory) {
+                if (use_zero)
+                    accumulate_comz(dir_map, accum_map);
+                else
+                    accumulate_com(dir_map, accum_map);
+            }
+            else {
+                if (use_zero)
+                    accumulate_coz(dir_map, accum_map);
+                else
+                    accumulate_co(dir_map, accum_map);
+            }
+        }
+        else {
+            if (use_less_memory) {
+                if (use_zero)
+                    accumulate_cmz(dir_map, accum_map);
+                else
+                    accumulate_cm(dir_map, accum_map);
+            }
+            else {
+                if (use_zero)
+                    accumulate_cz(dir_map, accum_map);
+                else
+                    accumulate_c(dir_map, accum_map);
+            }
+        }
+        break;
+    case FCELL_TYPE:
+        if (check_overflow) {
+            if (use_less_memory) {
+                if (use_zero)
+                    accumulate_fomz(dir_map, accum_map);
+                else
+                    accumulate_fom(dir_map, accum_map);
+            }
+            else {
+                if (use_zero)
+                    accumulate_foz(dir_map, accum_map);
+                else
+                    accumulate_fo(dir_map, accum_map);
+            }
+        }
+        else {
+            if (use_less_memory) {
+                if (use_zero)
+                    accumulate_fmz(dir_map, accum_map);
+                else
+                    accumulate_fm(dir_map, accum_map);
+            }
+            else {
+                if (use_zero)
+                    accumulate_fz(dir_map, accum_map);
+                else
+                    accumulate_f(dir_map, accum_map);
+            }
+        }
+        break;
+    default:
+        if (check_overflow) {
+            if (use_less_memory) {
+                if (use_zero)
+                    accumulate_domz(dir_map, accum_map);
+                else
+                    accumulate_dom(dir_map, accum_map);
+            }
+            else {
+                if (use_zero)
+                    accumulate_doz(dir_map, accum_map);
+                else
+                    accumulate_do(dir_map, accum_map);
+            }
+        }
+        else {
+            if (use_less_memory) {
+                if (use_zero)
+                    accumulate_dmz(dir_map, accum_map);
+                else
+                    accumulate_dm(dir_map, accum_map);
+            }
+            else {
+                if (use_zero)
+                    accumulate_dz(dir_map, accum_map);
+                else
+                    accumulate_d(dir_map, accum_map);
+            }
+        }
+        break;
     }
-#endif
-
-#pragma omp parallel for schedule(dynamic) private(col)
-    for (row = 0; row < nrows; row++) {
-        for (col = 0; col < ncols; col++)
-            /* if the current cell is not null and has no upstream cells, start
-             * tracing down */
-            if (!Rast_is_c_null_value(&DIR(row, col)) && !UP(row, col))
-                trace_down(dir_map, accum_map, row, col, 1);
-    }
-
-#ifndef USE_LESS_MEMORY
-    free(up_cells);
-#endif
 }
 
-static void trace_down(struct raster_map *dir_map, struct raster_map *accum_map,
-                       int row, int col, int accum)
+void nullify_zero(struct raster_map *accum_map)
 {
-    int up, accum_up = 0;
-
-    /* accumulate the current cell itself */
-    ACCUM(row, col) = accum;
-
-    /* find the downstream cell */
-    switch (DIR(row, col)) {
-    case NW:
-        row--;
-        col--;
+    switch (accum_map->type) {
+    case CELL_TYPE:
+        nullify_zero_c(accum_map);
         break;
-    case N:
-        row--;
+    case FCELL_TYPE:
+        nullify_zero_f(accum_map);
         break;
-    case NE:
-        row--;
-        col++;
-        break;
-    case W:
-        col--;
-        break;
-    case E:
-        col++;
-        break;
-    case SW:
-        row++;
-        col--;
-        break;
-    case S:
-        row++;
-        break;
-    case SE:
-        row++;
-        col++;
+    default:
+        nullify_zero_d(accum_map);
         break;
     }
-
-    /* if the downstream cell is null or any upstream cells of the downstream
-     * cell have never been visited, stop tracing down */
-    if (row < 0 || row >= nrows || col < 0 || col >= ncols ||
-        Rast_is_c_null_value(&DIR(row, col)) || !(up = UP(row, col)) ||
-        !(accum_up = sum_up(accum_map, row, col, up)))
-        return;
-
-    /* use gcc -O2 or -O3 flags for tail-call optimization
-     * (-foptimize-sibling-calls) */
-    trace_down(dir_map, accum_map, row, col, accum_up + 1);
-}
-
-/* if any upstream cells have never been visited, 0 is returned; otherwise, the
- * sum of upstream accumulation is returned */
-static int sum_up(struct raster_map *accum_map, int row, int col, int up)
-{
-    int sum = 0, accum;
-
-#pragma omp flush(accum_map)
-    if (up & NW) {
-        if (!(accum = ACCUM(row - 1, col - 1)))
-            return 0;
-        sum += accum;
-    }
-    if (up & N) {
-        if (!(accum = ACCUM(row - 1, col)))
-            return 0;
-        sum += accum;
-    }
-    if (up & NE) {
-        if (!(accum = ACCUM(row - 1, col + 1)))
-            return 0;
-        sum += accum;
-    }
-    if (up & W) {
-        if (!(accum = ACCUM(row, col - 1)))
-            return 0;
-        sum += accum;
-    }
-    if (up & E) {
-        if (!(accum = ACCUM(row, col + 1)))
-            return 0;
-        sum += accum;
-    }
-    if (up & SW) {
-        if (!(accum = ACCUM(row + 1, col - 1)))
-            return 0;
-        sum += accum;
-    }
-    if (up & S) {
-        if (!(accum = ACCUM(row + 1, col)))
-            return 0;
-        sum += accum;
-    }
-    if (up & SE) {
-        if (!(accum = ACCUM(row + 1, col + 1)))
-            return 0;
-        sum += accum;
-    }
-
-    return sum;
 }

--- a/src/raster/r.flowaccumulation/accumulate_c.c
+++ b/src/raster/r.flowaccumulation/accumulate_c.c
@@ -1,0 +1,2 @@
+#define ACCUM_RAST_TYPE CELL_TYPE
+#include "accumulate_funcs.h"

--- a/src/raster/r.flowaccumulation/accumulate_cm.c
+++ b/src/raster/r.flowaccumulation/accumulate_cm.c
@@ -1,0 +1,3 @@
+#define ACCUM_RAST_TYPE CELL_TYPE
+#define USE_LESS_MEMORY
+#include "accumulate_funcs.h"

--- a/src/raster/r.flowaccumulation/accumulate_cmz.c
+++ b/src/raster/r.flowaccumulation/accumulate_cmz.c
@@ -1,0 +1,4 @@
+#define ACCUM_RAST_TYPE CELL_TYPE
+#define USE_LESS_MEMORY
+#define USE_ZERO
+#include "accumulate_funcs.h"

--- a/src/raster/r.flowaccumulation/accumulate_co.c
+++ b/src/raster/r.flowaccumulation/accumulate_co.c
@@ -1,0 +1,3 @@
+#define ACCUM_RAST_TYPE CELL_TYPE
+#define CHECK_OVERFLOW
+#include "accumulate_funcs.h"

--- a/src/raster/r.flowaccumulation/accumulate_com.c
+++ b/src/raster/r.flowaccumulation/accumulate_com.c
@@ -1,0 +1,4 @@
+#define ACCUM_RAST_TYPE CELL_TYPE
+#define CHECK_OVERFLOW
+#define USE_LESS_MEMORY
+#include "accumulate_funcs.h"

--- a/src/raster/r.flowaccumulation/accumulate_comz.c
+++ b/src/raster/r.flowaccumulation/accumulate_comz.c
@@ -1,0 +1,5 @@
+#define ACCUM_RAST_TYPE CELL_TYPE
+#define CHECK_OVERFLOW
+#define USE_LESS_MEMORY
+#define USE_ZERO
+#include "accumulate_funcs.h"

--- a/src/raster/r.flowaccumulation/accumulate_coz.c
+++ b/src/raster/r.flowaccumulation/accumulate_coz.c
@@ -1,0 +1,4 @@
+#define ACCUM_RAST_TYPE CELL_TYPE
+#define CHECK_OVERFLOW
+#define USE_ZERO
+#include "accumulate_funcs.h"

--- a/src/raster/r.flowaccumulation/accumulate_cz.c
+++ b/src/raster/r.flowaccumulation/accumulate_cz.c
@@ -1,0 +1,3 @@
+#define ACCUM_RAST_TYPE CELL_TYPE
+#define USE_ZERO
+#include "accumulate_funcs.h"

--- a/src/raster/r.flowaccumulation/accumulate_d.c
+++ b/src/raster/r.flowaccumulation/accumulate_d.c
@@ -1,0 +1,2 @@
+#define ACCUM_RAST_TYPE DCELL_TYPE
+#include "accumulate_funcs.h"

--- a/src/raster/r.flowaccumulation/accumulate_dm.c
+++ b/src/raster/r.flowaccumulation/accumulate_dm.c
@@ -1,0 +1,3 @@
+#define ACCUM_RAST_TYPE DCELL_TYPE
+#define USE_LESS_MEMORY
+#include "accumulate_funcs.h"

--- a/src/raster/r.flowaccumulation/accumulate_dmz.c
+++ b/src/raster/r.flowaccumulation/accumulate_dmz.c
@@ -1,0 +1,4 @@
+#define ACCUM_RAST_TYPE DCELL_TYPE
+#define USE_LESS_MEMORY
+#define USE_ZERO
+#include "accumulate_funcs.h"

--- a/src/raster/r.flowaccumulation/accumulate_do.c
+++ b/src/raster/r.flowaccumulation/accumulate_do.c
@@ -1,0 +1,3 @@
+#define ACCUM_RAST_TYPE DCELL_TYPE
+#define CHECK_OVERFLOW
+#include "accumulate_funcs.h"

--- a/src/raster/r.flowaccumulation/accumulate_dom.c
+++ b/src/raster/r.flowaccumulation/accumulate_dom.c
@@ -1,0 +1,4 @@
+#define ACCUM_RAST_TYPE DCELL_TYPE
+#define CHECK_OVERFLOW
+#define USE_LESS_MEMORY
+#include "accumulate_funcs.h"

--- a/src/raster/r.flowaccumulation/accumulate_domz.c
+++ b/src/raster/r.flowaccumulation/accumulate_domz.c
@@ -1,0 +1,5 @@
+#define ACCUM_RAST_TYPE DCELL_TYPE
+#define CHECK_OVERFLOW
+#define USE_LESS_MEMORY
+#define USE_ZERO
+#include "accumulate_funcs.h"

--- a/src/raster/r.flowaccumulation/accumulate_doz.c
+++ b/src/raster/r.flowaccumulation/accumulate_doz.c
@@ -1,0 +1,4 @@
+#define ACCUM_RAST_TYPE DCELL_TYPE
+#define CHECK_OVERFLOW
+#define USE_ZERO
+#include "accumulate_funcs.h"

--- a/src/raster/r.flowaccumulation/accumulate_dz.c
+++ b/src/raster/r.flowaccumulation/accumulate_dz.c
@@ -1,0 +1,3 @@
+#define ACCUM_RAST_TYPE DCELL_TYPE
+#define USE_ZERO
+#include "accumulate_funcs.h"

--- a/src/raster/r.flowaccumulation/accumulate_f.c
+++ b/src/raster/r.flowaccumulation/accumulate_f.c
@@ -1,0 +1,2 @@
+#define ACCUM_RAST_TYPE FCELL_TYPE
+#include "accumulate_funcs.h"

--- a/src/raster/r.flowaccumulation/accumulate_fm.c
+++ b/src/raster/r.flowaccumulation/accumulate_fm.c
@@ -1,0 +1,3 @@
+#define ACCUM_RAST_TYPE FCELL_TYPE
+#define USE_LESS_MEMORY
+#include "accumulate_funcs.h"

--- a/src/raster/r.flowaccumulation/accumulate_fmz.c
+++ b/src/raster/r.flowaccumulation/accumulate_fmz.c
@@ -1,0 +1,4 @@
+#define ACCUM_RAST_TYPE FCELL_TYPE
+#define USE_LESS_MEMORY
+#define USE_ZERO
+#include "accumulate_funcs.h"

--- a/src/raster/r.flowaccumulation/accumulate_fo.c
+++ b/src/raster/r.flowaccumulation/accumulate_fo.c
@@ -1,0 +1,3 @@
+#define ACCUM_RAST_TYPE FCELL_TYPE
+#define CHECK_OVERFLOW
+#include "accumulate_funcs.h"

--- a/src/raster/r.flowaccumulation/accumulate_fom.c
+++ b/src/raster/r.flowaccumulation/accumulate_fom.c
@@ -1,0 +1,4 @@
+#define ACCUM_RAST_TYPE FCELL_TYPE
+#define CHECK_OVERFLOW
+#define USE_LESS_MEMORY
+#include "accumulate_funcs.h"

--- a/src/raster/r.flowaccumulation/accumulate_fomz.c
+++ b/src/raster/r.flowaccumulation/accumulate_fomz.c
@@ -1,0 +1,5 @@
+#define ACCUM_RAST_TYPE FCELL_TYPE
+#define CHECK_OVERFLOW
+#define USE_LESS_MEMORY
+#define USE_ZERO
+#include "accumulate_funcs.h"

--- a/src/raster/r.flowaccumulation/accumulate_foz.c
+++ b/src/raster/r.flowaccumulation/accumulate_foz.c
@@ -1,0 +1,4 @@
+#define ACCUM_RAST_TYPE FCELL_TYPE
+#define CHECK_OVERFLOW
+#define USE_ZERO
+#include "accumulate_funcs.h"

--- a/src/raster/r.flowaccumulation/accumulate_funcs.h
+++ b/src/raster/r.flowaccumulation/accumulate_funcs.h
@@ -1,0 +1,289 @@
+#include <stdlib.h>
+#include <grass/raster.h>
+#include "global.h"
+#ifdef CHECK_OVERFLOW
+#include <grass/glocale.h>
+#endif
+#if ACCUM_RAST_TYPE != CELL_TYPE
+#include <math.h>
+#endif
+
+#if ACCUM_RAST_TYPE == CELL_TYPE
+#define ACCUMULATE(o, m, z)  accumulate_c##o##m##z
+#define NULLIFY_ZERO         nullify_zero_c
+#define ACCUM_MAP_CELLS      accum_map->cells.c
+#define ACCUM_TYPE           int
+#define SET_ACCUM_NULL(cell) Rast_set_c_null_value(cell, 1)
+#define IS_ACCUM_NULL(cell)  Rast_is_c_null_value(cell)
+#elif ACCUM_RAST_TYPE == FCELL_TYPE
+#define ACCUMULATE(o, m, z)  accumulate_f##o##m##z
+#define NULLIFY_ZERO         nullify_zero_f
+#define ACCUM_MAP_CELLS      accum_map->cells.f
+#define ACCUM_TYPE           float
+#define SET_ACCUM_NULL(cell) Rast_set_f_null_value(cell, 1)
+#define IS_ACCUM_NULL(cell)  Rast_is_f_null_value(cell)
+#else
+#define ACCUMULATE(o, m, z)  accumulate_d##o##m##z
+#define NULLIFY_ZERO         nullify_zero_d
+#define ACCUM_MAP_CELLS      accum_map->cells.d
+#define ACCUM_TYPE           double
+#define SET_ACCUM_NULL(cell) Rast_set_d_null_value(cell, 1)
+#define IS_ACCUM_NULL(cell)  Rast_is_d_null_value(cell)
+#endif
+
+#define ACCUM(row, col) ACCUM_MAP_CELLS[(size_t)(row)*ncols + (col)]
+#define FIND_UP(row, col)                                                     \
+    ((row > 0 ? (col > 0 && DIR(row - 1, col - 1) == SE ? NW : 0) |           \
+                    (DIR(row - 1, col) == S ? N : 0) |                        \
+                    (col < ncols - 1 && DIR(row - 1, col + 1) == SW ? NE : 0) \
+              : 0) |                                                          \
+     (col > 0 && DIR(row, col - 1) == E ? W : 0) |                            \
+     (col < ncols - 1 && DIR(row, col + 1) == W ? E : 0) |                    \
+     (row < nrows - 1                                                         \
+          ? (col > 0 && DIR(row + 1, col - 1) == NE ? SW : 0) |               \
+                (DIR(row + 1, col) == N ? S : 0) |                            \
+                (col < ncols - 1 && DIR(row + 1, col + 1) == NW ? SE : 0)     \
+          : 0))
+
+#ifdef USE_LESS_MEMORY
+#define UP(row, col) FIND_UP(row, col)
+#else
+#define UP(row, col) up_cells[(size_t)(row)*ncols + (col)]
+static unsigned char *up_cells;
+#endif
+
+static int nrows, ncols;
+
+static void trace_down(struct raster_map *, struct raster_map *, int, int,
+                       ACCUM_TYPE);
+static ACCUM_TYPE sum_up(struct raster_map *, int, int, int);
+
+void ACCUMULATE(
+#ifdef CHECK_OVERFLOW
+    o
+#endif
+    ,
+#ifdef USE_LESS_MEMORY
+    m
+#endif
+    ,
+#ifdef USE_ZERO
+    z
+#endif
+    )(struct raster_map *dir_map, struct raster_map *accum_map)
+{
+    int row, col;
+
+    nrows = dir_map->nrows;
+    ncols = dir_map->ncols;
+
+#ifndef USE_ZERO
+#pragma omp parallel for schedule(dynamic)
+    for (row = 0; row < nrows; row++)
+        Rast_set_null_value((char *)accum_map->cells.v +
+                                accum_map->cell_size * ncols * row,
+                            ncols, accum_map->type);
+#endif
+
+#ifndef USE_LESS_MEMORY
+    up_cells = calloc((size_t)nrows * ncols, sizeof *up_cells);
+
+#pragma omp parallel for schedule(dynamic) private(col)
+    for (row = 0; row < nrows; row++) {
+        for (col = 0; col < ncols; col++)
+            if (DIR(row, col))
+                UP(row, col) = FIND_UP(row, col);
+    }
+#endif
+
+#pragma omp parallel for schedule(dynamic) private(col)
+    for (row = 0; row < nrows; row++) {
+        for (col = 0; col < ncols; col++)
+            /* if the current cell is not null and has no upstream cells, start
+             * tracing down */
+            if (DIR(row, col) && !UP(row, col))
+                trace_down(dir_map, accum_map, row, col, 1);
+    }
+
+#ifndef USE_LESS_MEMORY
+    free(up_cells);
+#endif
+}
+
+#if !defined CHECK_OVERFLOW && !defined USE_LESS_MEMORY && !defined USE_ZERO
+void NULLIFY_ZERO(struct raster_map *accum_map)
+{
+    int row, col;
+
+    nrows = accum_map->nrows;
+    ncols = accum_map->ncols;
+
+#pragma omp parallel for schedule(dynamic) private(col)
+    for (row = 0; row < nrows; row++)
+        for (col = 0; col < ncols; col++)
+            if (!ACCUM(row, col))
+                SET_ACCUM_NULL(&ACCUM(row, col));
+}
+#endif
+
+static void trace_down(struct raster_map *dir_map, struct raster_map *accum_map,
+                       int row, int col, ACCUM_TYPE accum)
+{
+    int up;
+    ACCUM_TYPE accum_up = 0;
+
+#ifdef CHECK_OVERFLOW
+    if (
+#if ACCUM_RAST_TYPE == CELL_TYPE
+        Rast_is_c_null_value(&accum) || accum <= 0
+#else
+        isinf(accum)
+#endif
+    )
+        G_fatal_error(
+#if ACCUM_RAST_TYPE == CELL_TYPE
+            _("Flow accumulation is too large. Try FCELL or DCELL type.")
+#elif ACCUM_RAST_TYPE == FCELL_TYPE
+            _("Flow accumulation is too large. Try DCELL type.")
+#else
+            _("Flow accumulation is too large.")
+#endif
+        );
+#endif
+
+    /* accumulate the current cell itself */
+    ACCUM(row, col) = accum;
+
+    /* find the downstream cell */
+    switch (DIR(row, col)) {
+    case NW:
+        row--;
+        col--;
+        break;
+    case N:
+        row--;
+        break;
+    case NE:
+        row--;
+        col++;
+        break;
+    case W:
+        col--;
+        break;
+    case E:
+        col++;
+        break;
+    case SW:
+        row++;
+        col--;
+        break;
+    case S:
+        row++;
+        break;
+    case SE:
+        row++;
+        col++;
+        break;
+    }
+
+    /* if the downstream cell is null or any upstream cells of the downstream
+     * cell have never been visited, stop tracing down */
+    if (row < 0 || row >= nrows || col < 0 || col >= ncols || !DIR(row, col) ||
+        !(up = UP(row, col)) || !(accum_up = sum_up(accum_map, row, col, up)))
+        return;
+
+    /* use gcc -O2 or -O3 flags for tail-call optimization
+     * (-foptimize-sibling-calls) */
+    trace_down(dir_map, accum_map, row, col, accum_up + 1);
+}
+
+/* if any upstream cells have never been visited, 0 is returned; otherwise, the
+ * sum of upstream accumulation is returned */
+static ACCUM_TYPE sum_up(struct raster_map *accum_map, int row, int col, int up)
+{
+    ACCUM_TYPE sum = 0, accum;
+
+#pragma omp flush(accum_map)
+    if (up & NW) {
+#ifdef USE_ZERO
+        if (!(accum = ACCUM(row - 1, col - 1)))
+#else
+        accum = ACCUM(row - 1, col - 1);
+        if (IS_ACCUM_NULL(&accum))
+#endif
+            return 0;
+        sum += accum;
+    }
+    if (up & N) {
+#ifdef USE_ZERO
+        if (!(accum = ACCUM(row - 1, col)))
+#else
+        accum = ACCUM(row - 1, col);
+        if (IS_ACCUM_NULL(&accum))
+#endif
+            return 0;
+        sum += accum;
+    }
+    if (up & NE) {
+#ifdef USE_ZERO
+        if (!(accum = ACCUM(row - 1, col + 1)))
+#else
+        accum = ACCUM(row - 1, col + 1);
+        if (IS_ACCUM_NULL(&accum))
+#endif
+            return 0;
+        sum += accum;
+    }
+    if (up & W) {
+#ifdef USE_ZERO
+        if (!(accum = ACCUM(row, col - 1)))
+#else
+        accum = ACCUM(row, col - 1);
+        if (IS_ACCUM_NULL(&accum))
+#endif
+            return 0;
+        sum += accum;
+    }
+    if (up & E) {
+#ifdef USE_ZERO
+        if (!(accum = ACCUM(row, col + 1)))
+#else
+        accum = ACCUM(row, col + 1);
+        if (IS_ACCUM_NULL(&accum))
+#endif
+            return 0;
+        sum += accum;
+    }
+    if (up & SW) {
+#ifdef USE_ZERO
+        if (!(accum = ACCUM(row + 1, col - 1)))
+#else
+        accum = ACCUM(row + 1, col - 1);
+        if (IS_ACCUM_NULL(&accum))
+#endif
+            return 0;
+        sum += accum;
+    }
+    if (up & S) {
+#ifdef USE_ZERO
+        if (!(accum = ACCUM(row + 1, col)))
+#else
+        accum = ACCUM(row + 1, col);
+        if (IS_ACCUM_NULL(&accum))
+#endif
+            return 0;
+        sum += accum;
+    }
+    if (up & SE) {
+#ifdef USE_ZERO
+        if (!(accum = ACCUM(row + 1, col + 1)))
+#else
+        accum = ACCUM(row + 1, col + 1);
+        if (IS_ACCUM_NULL(&accum))
+#endif
+            return 0;
+        sum += accum;
+    }
+
+    return sum;
+}

--- a/src/raster/r.flowaccumulation/accumulate_fz.c
+++ b/src/raster/r.flowaccumulation/accumulate_fz.c
@@ -1,0 +1,3 @@
+#define ACCUM_RAST_TYPE FCELL_TYPE
+#define USE_ZERO
+#include "accumulate_funcs.h"

--- a/src/raster/r.flowaccumulation/global.h
+++ b/src/raster/r.flowaccumulation/global.h
@@ -19,17 +19,101 @@ int gettimeofday(struct timeval *, struct timezone *);
 #define N             64
 #define NE            128
 
-#define DIR(row, col) dir_map->cells[(size_t)(row)*ncols + (col)]
+#define DIR(row, col) dir_map->cells.uint8[(size_t)(row)*ncols + (col)]
 
 struct raster_map {
+    RASTER_MAP_TYPE type;
+    size_t cell_size;
     int nrows, ncols;
-    CELL *cells;
+    union {
+        void *v;
+        unsigned char *uint8;
+        CELL *c;
+        FCELL *f;
+        DCELL *d;
+    } cells;
 };
 
 /* timeval_diff.c */
 long long timeval_diff(struct timeval *, struct timeval *, struct timeval *);
 
 /* accumulate.c */
-void accumulate(struct raster_map *, struct raster_map *);
+void accumulate(struct raster_map *, struct raster_map *, int, int, int);
+void nullify_zero(struct raster_map *);
+
+/* accumulate_c.c */
+void accumulate_c(struct raster_map *, struct raster_map *);
+void nullify_zero_c(struct raster_map *);
+
+/* accumulate_co.c */
+void accumulate_co(struct raster_map *, struct raster_map *);
+
+/* accumulate_cm.c */
+void accumulate_cm(struct raster_map *, struct raster_map *);
+
+/* accumulate_cz.c */
+void accumulate_cz(struct raster_map *, struct raster_map *);
+
+/* accumulate_com.c */
+void accumulate_com(struct raster_map *, struct raster_map *);
+
+/* accumulate_coz.c */
+void accumulate_coz(struct raster_map *, struct raster_map *);
+
+/* accumulate_cmz.c */
+void accumulate_cmz(struct raster_map *, struct raster_map *);
+
+/* accumulate_comz.c */
+void accumulate_comz(struct raster_map *, struct raster_map *);
+
+/* accumulate_f.c */
+void accumulate_f(struct raster_map *, struct raster_map *);
+void nullify_zero_f(struct raster_map *);
+
+/* accumulate_fo.c */
+void accumulate_fo(struct raster_map *, struct raster_map *);
+
+/* accumulate_fm.c */
+void accumulate_fm(struct raster_map *, struct raster_map *);
+
+/* accumulate_fz.c */
+void accumulate_fz(struct raster_map *, struct raster_map *);
+
+/* accumulate_fom.c */
+void accumulate_fom(struct raster_map *, struct raster_map *);
+
+/* accumulate_foz.c */
+void accumulate_foz(struct raster_map *, struct raster_map *);
+
+/* accumulate_fmz.c */
+void accumulate_fmz(struct raster_map *, struct raster_map *);
+
+/* accumulate_fomz.c */
+void accumulate_fomz(struct raster_map *, struct raster_map *);
+
+/* accumulate_d.c */
+void accumulate_d(struct raster_map *, struct raster_map *);
+void nullify_zero_d(struct raster_map *);
+
+/* accumulate_do.c */
+void accumulate_do(struct raster_map *, struct raster_map *);
+
+/* accumulate_dm.c */
+void accumulate_dm(struct raster_map *, struct raster_map *);
+
+/* accumulate_dz.c */
+void accumulate_dz(struct raster_map *, struct raster_map *);
+
+/* accumulate_dom.c */
+void accumulate_dom(struct raster_map *, struct raster_map *);
+
+/* accumulate_doz.c */
+void accumulate_doz(struct raster_map *, struct raster_map *);
+
+/* accumulate_dmz.c */
+void accumulate_dmz(struct raster_map *, struct raster_map *);
+
+/* accumulate_domz.c */
+void accumulate_domz(struct raster_map *, struct raster_map *);
 
 #endif

--- a/src/raster/r.flowaccumulation/main.c
+++ b/src/raster/r.flowaccumulation/main.c
@@ -118,7 +118,8 @@ int main(int argc, char *argv[])
 
     flag.leave_zero = G_define_flag();
     flag.leave_zero->key = 'Z';
-    flag.leave_zero->label = _("Use and leave zero instead of nullifying it");
+    flag.leave_zero->label =
+        _("Initialize to and leave zero instead of nullifying it");
 
     G_option_exclusive(flag.use_zero, flag.leave_zero, NULL);
 

--- a/src/raster/r.flowaccumulation/r.flowaccumulation.html
+++ b/src/raster/r.flowaccumulation/r.flowaccumulation.html
@@ -21,9 +21,31 @@ weighted flow accumulation, use <em>r.accumulate</em>.
 <img src="r_flowaccumulation_formats.png" alt="degree">
 </div>
 
-<p>Since the module does not use elevation data (i.e., slope), flow
+<p>Since the module does not use elevation data (e.g., slope), flow
 accumulation is calculated by single flow direction (SFD) routing and may not
-be comparable to the result from multiple flow direction (MFD) routing.
+be comparable to the result from multiple flow direction (MFD) routing
+
+<p>The module allows cell values to overflow the maximum value of the specified
+output <b>type</b> to avoid excessive checks. With the <b>-o</b> flag, it
+prints a fatal error and exits if an overflow occurs.
+
+<p>The module uses extra memory to store an intermediate output matrix and it
+is generally faster than with the <b>-m</b> flag because intermediate results
+need not be calculated repeatedly. On heavy swapping, however, computation can
+be faster with the <b>-m</b> flag because of reduced memory allocation. With
+this flag, intermediate results are calculated as needed and never stored in
+memory.
+
+<p>Cells in the output matrix are initialized to null and need not be nullified
+after computation. With the <b>-z</b> flag, they are initialized to zero and
+those outside flow accumulation are nullified later. With this flag, it can be
+faster on heavy swapping because of less write operations for nullifying
+remaining zero cells outside flow accumulation, compared to null-initialization
+of the entire region without this flag. However, when there is not much
+swapping (e.g., data fit in the physical memory), the <b>-z</b> flag can be
+slower with additional zero-comparison operations. The <b>-Z</b> flag is
+similar to the <b>-z</b> flag, but zero cells are not nullified and are saved
+in the output map.
 
 <h2>EXAMPLES</h2>
 


### PR DESCRIPTION
This PR
* reduces memory usage by using `unsigned char` for flow direction buffer
* adds the `-o` flag to check for an overflow and exit if it occurs
* supports FCELL (`type=FCELL`) and DCELL (`type=DCELL`) outputs for larger inputs that can cause an integer overflow for CELL type (`type=CELL` by default)
* adds the `-m` flag to use less memory on heavy swapping for larger inputs that cannot fit in the physical memory (can be faster on heavy swapping, but adds an overhead for recalculation of intermediate results)
* adds the `-z` flag to initialize the output map to zero using `G_calloc()` and nullify zero cells outside flow accumulation later (can be faster on heavy swapping, but adds additional zero-comparison operations); without this flag, the output map is initialized to null (**TODO**: use this for weighted flow accumulation in a new PR)
* adds the `-Z` flag similar to `-z` to leave the zeros as is in the output
* uses the standard convention of the `nprocs=` (`0` doesn't mean `OMP_NUM_THREADS` anymore).