### PR TITLE
v.delaunay3D: remove -lCGAL

### DIFF
--- a/src/vector/v.delaunay3d/Makefile
+++ b/src/vector/v.delaunay3d/Makefile
@@ -16,9 +16,9 @@ DEPENDENCIES = $(GPROJDEP) $(VECTORDEP) $(GISDEP)
 EXTRA_INC = $(VECT_INC) $(PROJINC)
 EXTRA_CFLAGS = $(VECT_CFLAGS) -frounding-math
 ifeq ($(detected_OS),FreeBSD)
-EXTRA_LDFLAGS = -lCGAL -lgmp -lcxxrt -lstdc++
+EXTRA_LDFLAGS = -lgmp -lcxxrt -lstdc++
 else
-EXTRA_LDFLAGS = -lCGAL -lgmp -lstdc++
+EXTRA_LDFLAGS = -lgmp -lstdc++
 endif
 
 LINK = $(CXX)


### PR DESCRIPTION
CGAL is header only since v5 and no need to link against a lib