### PR TITLE
i.sentinel.download: address pandas iloc FutureWarning

### DIFF
--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -707,12 +707,16 @@ class SentinelDownloader(object):
             if kw_idx == 1:
                 time_string = self._products_df_sorted[time_kw[kw_idx]].iloc[idx]
             else:
-                time_string = self._products_df_sorted[time_kw[kw_idx]].iloc[idx].strftime(
-                    "%Y-%m-%dT%H:%M:%SZ"
+                time_string = (
+                    self._products_df_sorted[time_kw[kw_idx]]
+                    .iloc[idx]
+                    .strftime("%Y-%m-%dT%H:%M:%SZ")
                 )
             print_str += " {0} {1}".format(time_string, ccp)
             if kw_idx == 0:
-                print_str += " {0}".format(self._products_df_sorted["producttype"].iloc[idx])
+                print_str += " {0}".format(
+                    self._products_df_sorted["producttype"].iloc[idx]
+                )
                 print_str += " {0}".format(self._products_df_sorted["size"].iloc[idx])
 
             print(print_str)
@@ -819,7 +823,9 @@ class SentinelDownloader(object):
                     )
                 )
                 # download
-                out = self._api.download(self._products_df_sorted["uuid"].iloc[idx], output)
+                out = self._api.download(
+                    self._products_df_sorted["uuid"].iloc[idx], output
+                )
                 if sleep:
                     x = 1
                     online = out["Online"]
@@ -911,8 +917,10 @@ class SentinelDownloader(object):
                 feature.SetGeometry(newgeom)
             for key in attrs.keys():
                 if key == "ingestiondate":
-                    value = self._products_df_sorted[key].iloc[idx].strftime(
-                        "%Y-%m-%dT%H:%M:%SZ"
+                    value = (
+                        self._products_df_sorted[key]
+                        .iloc[idx]
+                        .strftime("%Y-%m-%dT%H:%M:%SZ")
                     )
                 else:
                     value = self._products_df_sorted[key].iloc[idx]

--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -695,25 +695,25 @@ class SentinelDownloader(object):
         for idx in range(len(self._products_df_sorted[id_kw[kw_idx]])):
             if cloud_kw[kw_idx] in self._products_df_sorted:
                 ccp = "{0:2.0f}%".format(
-                    float(self._products_df_sorted[cloud_kw[kw_idx]][idx])
+                    float(self._products_df_sorted[cloud_kw[kw_idx]].iloc[idx])
                 )
             else:
                 ccp = "cloudcover_NA"
 
             print_str = "{0} {1}".format(
-                self._products_df_sorted[id_kw[kw_idx]][idx],
-                self._products_df_sorted[identifier_kw[kw_idx]][idx],
+                self._products_df_sorted[id_kw[kw_idx]].iloc[idx],
+                self._products_df_sorted[identifier_kw[kw_idx]].iloc[idx],
             )
             if kw_idx == 1:
-                time_string = self._products_df_sorted[time_kw[kw_idx]][idx]
+                time_string = self._products_df_sorted[time_kw[kw_idx]].iloc[idx]
             else:
-                time_string = self._products_df_sorted[time_kw[kw_idx]][idx].strftime(
+                time_string = self._products_df_sorted[time_kw[kw_idx]].iloc[idx].strftime(
                     "%Y-%m-%dT%H:%M:%SZ"
                 )
             print_str += " {0} {1}".format(time_string, ccp)
             if kw_idx == 0:
-                print_str += " {0}".format(self._products_df_sorted["producttype"][idx])
-                print_str += " {0}".format(self._products_df_sorted["size"][idx])
+                print_str += " {0}".format(self._products_df_sorted["producttype"].iloc[idx])
+                print_str += " {0}".format(self._products_df_sorted["size"].iloc[idx])
 
             print(print_str)
 
@@ -749,11 +749,11 @@ class SentinelDownloader(object):
                 creation_time = datetime.fromtimestamp(
                     os.path.getctime(existing_file[0])
                 )
-                if self._products_df_sorted["ingestiondate"][idx] <= creation_time:
+                if self._products_df_sorted["ingestiondate"].iloc[idx] <= creation_time:
                     gs.message(
                         _(
                             "Skipping scene: {} which is already downloaded.".format(
-                                self._products_df_sorted["identifier"][idx]
+                                self._products_df_sorted["identifier"].iloc[idx]
                             )
                         )
                     )
@@ -788,8 +788,8 @@ class SentinelDownloader(object):
                 except EarthExplorerError as e:
                     time.sleep(1)
             for idx in range(len(self._products_df_sorted["entity_id"])):
-                scene = self._products_df_sorted["entity_id"][idx]
-                identifier = self._products_df_sorted["display_id"][idx]
+                scene = self._products_df_sorted["entity_id"].iloc[idx]
+                identifier = self._products_df_sorted["display_id"].iloc[idx]
                 zip_file = os.path.join(output, "{}.zip".format(identifier))
                 gs.message(_("Downloading {}...").format(identifier))
                 try:
@@ -812,14 +812,14 @@ class SentinelDownloader(object):
             for idx in range(len(self._products_df_sorted["uuid"])):
                 gs.message(
                     "{} -> {}.SAFE".format(
-                        self._products_df_sorted["uuid"][idx],
+                        self._products_df_sorted["uuid"].iloc[idx],
                         os.path.join(
-                            output, self._products_df_sorted["identifier"][idx]
+                            output, self._products_df_sorted["identifier"].iloc[idx]
                         ),
                     )
                 )
                 # download
-                out = self._api.download(self._products_df_sorted["uuid"][idx], output)
+                out = self._api.download(self._products_df_sorted["uuid"].iloc[idx], output)
                 if sleep:
                     x = 1
                     online = out["Online"]
@@ -827,7 +827,7 @@ class SentinelDownloader(object):
                         # sleep is in minutes so multiply by 60
                         time.sleep(int(sleep) * 60)
                         out = self._api.download(
-                            self._products_df_sorted["uuid"][idx], output
+                            self._products_df_sorted["uuid"].iloc[idx], output
                         )
                         x += 1
                         if x > maxretry:
@@ -898,7 +898,7 @@ class SentinelDownloader(object):
 
         # features
         for idx in range(len(self._products_df_sorted["uuid"])):
-            wkt = self._products_df_sorted["footprint"][idx]
+            wkt = self._products_df_sorted["footprint"].iloc[idx]
             feature = ogr.Feature(layer.GetLayerDefn())
             newgeom = ogr.CreateGeometryFromWkt(wkt)
             # convert polygons to multi-polygons
@@ -911,11 +911,11 @@ class SentinelDownloader(object):
                 feature.SetGeometry(newgeom)
             for key in attrs.keys():
                 if key == "ingestiondate":
-                    value = self._products_df_sorted[key][idx].strftime(
+                    value = self._products_df_sorted[key].iloc[idx].strftime(
                         "%Y-%m-%dT%H:%M:%SZ"
                     )
                 else:
-                    value = self._products_df_sorted[key][idx]
+                    value = self._products_df_sorted[key].iloc[idx]
                 feature.SetField(key, value)
             layer.CreateFeature(feature)
             feature = None


### PR DESCRIPTION
Currently, `i.sentinel.download` throws a _FutureWarning_ from the use of pandas:

E.g.:
```
.grass8/addons/scripts/i.sentinel.download:704: FutureWarning: Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`
  self._products_df_sorted[id_kw[kw_idx]][idx],
```

This PR addresses the FutureWarning....