### PR TITLE
CI: Modernize workflows and adding concurrency groups to cancel outdated jobs

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - grass[0-9]+
-      - master
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -4,8 +4,18 @@ name: Python Black Formatting
 on:
   push:
     branches:
-      - grass*
+      - grass[0-9]+
+      - master
   pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress:
+    # Do not cancel on protected branches, like grass8
+    ${{ github.ref_protected != true }}
+
+permissions: {}
 
 jobs:
   run-black:
@@ -17,7 +27,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-            python-version: '3.10'
+            python-version: "3.10"
             black-version: 22.3.0
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Make simple grass command available (not needed in G8)
         run: |
           if [ ! -e "$HOME/install/bin/grass" ] ; then \
-            ln -s "$HOME"/install/bin/grass*   "$HOME"/install/bin/grass ; fi
+            ln -s "$HOME"/install/bin/grass* "$HOME"/install/bin/grass ; fi
 
       - name: Build addons
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,17 +3,27 @@ name: Build and test
 
 on:
   push:
+    branches:
+      - grass[0-9]+
+      - master
   pull_request:
   schedule:
     # 01:00 Pacific Time (in UTC), every day (late night PT)
     - cron: 0 8 * * *
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress:
+    # Do not cancel on protected branches, like grass8
+    ${{ github.ref_protected != true }}
+
+permissions: {}
 
 jobs:
   build:
     name: ${{ matrix.grass-version }} (Python ${{ matrix.python-version }})
-
     runs-on: ubuntu-22.04
-
     strategy:
       matrix:
         # Test with relevant active branches or tags and supported Python
@@ -22,15 +32,14 @@ jobs:
         # only.
         include:
           - grass-version: main
-            python-version: '3.10'
+            python-version: "3.11"
           - grass-version: releasebranch_8_2
-            python-version: '3.7'
+            python-version: "3.7"
           - grass-version: releasebranch_8_3
-            python-version: '3.10'
+            python-version: "3.10"
       fail-fast: false
 
     steps:
-
       - name: Checkout core
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,39 +71,40 @@ jobs:
 
       - name: Create installation directory
         run: |
-          mkdir $HOME/install
+          mkdir "$HOME/install"
 
       - name: Set number of cores for compilation
         run: |
-          echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV
+          echo "MAKEFLAGS=-j$(nproc)" >> "$GITHUB_ENV"
 
       - name: Set LD_LIBRARY_PATH for GRASS GIS compilation
         run: |
-          echo "LD_LIBRARY_PATH=$HOME/install/lib" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$HOME/install/lib" >> "$GITHUB_ENV"
 
       - name: Build GRASS GIS core
         run: |
           cd grass
-          ../grass-addons/.github/workflows/build_grass.sh $HOME/install
+          ../grass-addons/.github/workflows/build_grass.sh "$HOME/install"
 
       - name: Add the bin directory to PATH
         run: |
-          echo "$HOME/install/bin" >> $GITHUB_PATH
+          echo "$HOME/install/bin" >> "$GITHUB_PATH"
 
       - name: Make simple grass command available (not needed in G8)
         run: |
-          if [ ! -e $HOME/install/bin/grass ] ; then \
-            ln -s $HOME/install/bin/grass*   $HOME/install/bin/grass ; fi
+          if [ ! -e "$HOME/install/bin/grass" ] ; then \
+            ln -s "$HOME"/install/bin/grass*   "$HOME"/install/bin/grass ; fi
 
       - name: Build addons
         run: |
           cd grass-addons/src
-          GRASS_INSTALL=$($HOME/install/bin/grass --config | sed -n '4{p;q}')
-          make MODULE_TOPDIR=$GRASS_INSTALL
+          GRASS_INSTALL="$("$HOME/install/bin/grass" --config | sed -n '4{p;q}')"
+          make MODULE_TOPDIR="$GRASS_INSTALL"
 
       - name: Get extra Python dependencies
         run: |
-          export GDAL_VERSION=$(gdal-config --version)
+          GDAL_VERSION="$(gdal-config --version)"
+          export GDAL_VERSION
           pip install -r grass-addons/.github/workflows/extra_requirements.txt
 
       - name: Set up R

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - grass[0-9]+
-      - master
   pull_request:
   schedule:
     # 01:00 Pacific Time (in UTC), every day (late night PT)

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -4,16 +4,25 @@ name: ClangFormat Check
 on:
   push:
     branches:
-      - grass*
+      - grass[0-9]+
+      - master
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress:
+    # Do not cancel on protected branches, like grass8
+    ${{ github.ref_protected != true }}
+permissions: {}
 jobs:
   formatting-check:
     name: Formatting Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Run clang-format style check for C/C++/Protobuf programs.
         uses: jidicula/clang-format-action@v4.11.0
         with:
-          clang-format-version: '15'
+          clang-format-version: "15"
           check-path: .

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -20,8 +20,6 @@ jobs:
   formatting-check:
     name: Formatting Check
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Run clang-format style check for C/C++/Protobuf programs.

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - grass[0-9]+
-      - master
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -7,12 +7,16 @@ on:
       - grass[0-9]+
       - master
   pull_request:
+  workflow_dispatch:
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress:
     # Do not cancel on protected branches, like grass8
     ${{ github.ref_protected != true }}
+
 permissions: {}
+
 jobs:
   formatting-check:
     name: Formatting Check

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -2,8 +2,20 @@
 name: Python Flake8 Code Quality
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - grass[0-9]+
+      - master
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress:
+    # Do not cancel on protected branches, like grass8
+    ${{ github.ref_protected != true }}
+
+permissions: {}
 
 jobs:
   flake8:
@@ -15,7 +27,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Install
         run: |
@@ -24,4 +36,4 @@ jobs:
 
       - name: Run Flake8
         run: |
-          flake8 --count --statistics --show-source --jobs=$(nproc) .
+          flake8 --count --statistics --show-source --jobs="$(nproc)" .

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - grass[0-9]+
-      - master
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -33,6 +33,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILTER_REGEX_EXCLUDE: ".*/src/gui/wxpython/wx.metadata/profiles/.*.xml"
-          VALIDATE_BASH: false
           VALIDATE_PYTHON_FLAKE8: false
           IGNORE_GENERATED_FILES: true

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -37,5 +37,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILTER_REGEX_EXCLUDE: ".*/src/gui/wxpython/wx.metadata/profiles/.*.xml"
           IGNORE_GENERATED_FILES: true
+          VALIDATE_CLANG_FORMAT: false # Until we continue to check it in another workflow
+          VALIDATE_CPP: false # Until a configuration file is created to not contradict clang-format
           VALIDATE_PYTHON_FLAKE8: false
           VALIDATE_R: false

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -33,5 +33,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILTER_REGEX_EXCLUDE: ".*/src/gui/wxpython/wx.metadata/profiles/.*.xml"
-          VALIDATE_PYTHON_FLAKE8: false
           IGNORE_GENERATED_FILES: true
+          VALIDATE_PYTHON_FLAKE8: false
+          VALIDATE_R: false

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -2,33 +2,37 @@
 name: General linting
 
 on:
-  - push
-  - pull_request
+  push:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress:
+    # Do not cancel on protected branches, like grass8
+    ${{ github.ref_protected != true }}
+
+permissions: {}
 
 jobs:
   super-linter:
     name: GitHub Super Linter
-
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      packages: read
+      # To report GitHub Actions status checks
+      statuses: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          # super-linter needs the full git history to get the
+          # list of files that changed across commits
+          fetch-depth: 0
       - name: Lint code base
-        uses: github/super-linter@v5
+        uses: super-linter/super-linter@v6.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Listed but commented out linters would be nice to have.
-          # (see https://github.com/github/super-linter#environment-variables)
-          #
-          # Python (supported using Pylint) and C/C++ (not supported) are
-          # handled separately due to the complexity of the settings.
-          # VALIDATE_BASH: true
-          # VALIDATE_CSS: true
-          # VALIDATE_DOCKER: true
-          VALIDATE_JAVASCRIPT_ES: true
-          # VALIDATE_JAVASCRIPT_STANDARD: true
-          VALIDATE_JSON: true
-          VALIDATE_MARKDOWN: true
-          VALIDATE_POWERSHELL: true
-          # VALIDATE_XML: true
-          VALIDATE_YAML: true
+          FILTER_REGEX_EXCLUDE: ".*/src/gui/wxpython/wx.metadata/profiles/.*.xml"
+          VALIDATE_BASH: false
+          VALIDATE_PYTHON_FLAKE8: false
+          IGNORE_GENERATED_FILES: true

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -43,6 +43,7 @@ jobs:
           VALIDATE_CHECKOV: false # Until issues are fixed
           VALIDATE_CLANG_FORMAT: false # Until we continue to check it in another workflow
           VALIDATE_CPP: false # Until a configuration file is created to not contradict clang-format
+          VALIDATE_GITLEAKS: false # Until configured to ignore g.parser key in main.c files
           VALIDATE_HTML: false # Until configured, some valid findings
           VALIDATE_LATEX: false # Until issues are fixed, some valid findings
           VALIDATE_NATURAL_LANGUAGE: false # Until issues are fixed, lots of valid suggestions

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - grass[0-9]+
-      - master
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -45,6 +45,7 @@ jobs:
           VALIDATE_CPP: false # Until a configuration file is created to not contradict clang-format
           VALIDATE_HTML: false # Until configured, some valid findings
           VALIDATE_LATEX: false # Until issues are fixed, some valid findings
+          VALIDATE_NATURAL_LANGUAGE: false # Until issues are fixed, lots of valid suggestions
           VALIDATE_PERL: false # Until issues are fixed
           VALIDATE_PYTHON_BLACK: false # Until code is upgraded to a newer black version
           VALIDATE_PYTHON_FLAKE8: false

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -3,6 +3,9 @@ name: General linting
 
 on:
   push:
+    branches:
+      - grass[0-9]+
+      - master
   pull_request:
 
 concurrency:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -7,6 +7,7 @@ on:
       - grass[0-9]+
       - master
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -38,6 +39,7 @@ jobs:
           FILTER_REGEX_EXCLUDE: ".*/src/gui/wxpython/wx.metadata/profiles/.*.xml"
           IGNORE_GENERATED_FILES: true
           LOG_LEVEL: NOTICE
+          VALIDATE_BASH: false # Until issues are fixed, some valid warnings
           VALIDATE_CHECKOV: false # Until issues are fixed
           VALIDATE_CLANG_FORMAT: false # Until we continue to check it in another workflow
           VALIDATE_CPP: false # Until a configuration file is created to not contradict clang-format

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -33,7 +33,7 @@ jobs:
           # list of files that changed across commits
           fetch-depth: 0
       - name: Lint code base
-        uses: super-linter/super-linter@v6.2.0
+        uses: super-linter/super-linter@v6.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILTER_REGEX_EXCLUDE: ".*/src/gui/wxpython/wx.metadata/profiles/.*.xml"

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -37,7 +37,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILTER_REGEX_EXCLUDE: ".*/src/gui/wxpython/wx.metadata/profiles/.*.xml"
           IGNORE_GENERATED_FILES: true
+          LOG_LEVEL: NOTICE
+          VALIDATE_CHECKOV: false # Until issues are fixed
           VALIDATE_CLANG_FORMAT: false # Until we continue to check it in another workflow
           VALIDATE_CPP: false # Until a configuration file is created to not contradict clang-format
+          VALIDATE_HTML: false # Until configured, some valid findings
+          VALIDATE_LATEX: false # Until issues are fixed, some valid findings
+          VALIDATE_PERL: false # Until issues are fixed
+          VALIDATE_PYTHON_BLACK: false # Until code is upgraded to a newer black version
           VALIDATE_PYTHON_FLAKE8: false
+          VALIDATE_PYTHON_PYLINT: false # Until issues are fixed
           VALIDATE_R: false
+          VALIDATE_RENOVATE: false # Until configuration file is upgraded
+          VALIDATE_SHELL_SHFMT: false # Until reformatting failing files

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -48,6 +48,8 @@ jobs:
           VALIDATE_PERL: false # Until issues are fixed
           VALIDATE_PYTHON_BLACK: false # Until code is upgraded to a newer black version
           VALIDATE_PYTHON_FLAKE8: false
+          VALIDATE_PYTHON_ISORT: false # Until issues are fixed
+          VALIDATE_PYTHON_MYPY: false # Issue with module name wx.wms
           VALIDATE_PYTHON_PYLINT: false # Until issues are fixed
           VALIDATE_R: false
           VALIDATE_RENOVATE: false # Until configuration file is upgraded

--- a/src/raster/r.findtheriver/README.md
+++ b/src/raster/r.findtheriver/README.md
@@ -9,7 +9,7 @@ This program is free software under the GNU General Public License
 
 ## AUTHOR
 
-Brian Miles - brian_miles@unc.edu
+Brian Miles - <brian_miles@unc.edu>
 
 ## DESCRIPTION
 

--- a/src/raster/r.landscape.evol/r.landscape.evol.md
+++ b/src/raster/r.landscape.evol/r.landscape.evol.md
@@ -323,13 +323,13 @@ uniform stream width and depth. Ideally, the width and depth of the carved
 channels should decrease in width and depth from the basin outlet to the stream
 sources. To do this requires several steps. First extract an
 appropriately-scaled stream network using _r.watershed_ and/or
-_r.stream.extract__ and an appropriate interior basin threshold parameter to
+_r.stream.extract_ and an appropriate interior basin threshold parameter to
 isolate main trunk streams with some smaller tributary branches. Use this
 output raster streams map as the input to the addon module _r.stream.order_
 with the output option for the Shreve stream order. This will create a raster
 streams map where trunk streams are coded with a large number, and tributaries
 with smaller numbers. Use _r.univar_ to determine the maximum Shreve value, and
-then use _r.mapcalc__ to standardize the values between 0 and 1 by dividing the
+then use _r.mapcalc_ to standardize the values between 0 and 1 by dividing the
 Shreve-scaled streams map by the maximum Shreve order value (ensure that you
 use a decimal point behind the maximum value number so that a floating point
 map will be made). The standardized Shreve order streams raster map is then


### PR DESCRIPTION
Closes #1026

I made a pass of updating the workflows to more up-to-date patterns, sometimes syncing with some improvements from the main GRASS repo. I also configured super-linter to run everything, excluding what doesn't work for now, with notes on what prevents us from having that linter enabled.

I finally took the time to finish that work that was always staying uncompleted on my side.

I've been running this as a PR against my fork's default branch, and I think this simplified pattern for concurrency groups and cancel-in-progress is correct and adapted. Let's see how it goes for a while, and it might be ported back to the main GRASS repo after.

Next passes:
- Enabling CodeQL
- Adding a labeller here too
- Adding gitleaks in pre-commit
- Update pre-commit here too
- Verify that the renovate config file is still using the correct configuration. It seems there's a problem
- Fix the linter issues
- Upgrade black