### PR TITLE
r.learn.ml2: lazy import to avoid compilation issues

### DIFF
--- a/src/raster/r.learn.ml2/r.learn.predict/r.learn.predict.py
+++ b/src/raster/r.learn.ml2/r.learn.predict/r.learn.predict.py
@@ -75,10 +75,6 @@ import math
 from grass.pygrass.gis.region import Region
 from grass.pygrass.modules.shortcuts import raster as r
 
-gs.utils.set_path(modulename="r.learn.ml2", dirname="rlearnlib", path="..")
-
-from rlearnlib.raster import RasterStack
-
 
 def string_to_rules(string):
     """Converts a string to a file for input as a GRASS Rules File"""
@@ -99,6 +95,9 @@ def main():
 
     except ImportError:
         gs.fatal("Package python3-scikit-learn 0.20 or newer is not installed")
+
+    gs.utils.set_path(modulename="r.learn.ml2", dirname="rlearnlib", path="..")
+    from rlearnlib.raster import RasterStack
 
     # parser options
     group = options["group"]


### PR DESCRIPTION
Recently broken `r.learn.ml2` Windows package has been reported: https://lists.osgeo.org/pipermail/grass-user/2024-March/083542.html

Reason: currently `r.learn.ml2` requires scikit-learn package for its compilation which is not really necessary.

## Current  behaviour

```
g.extension url=src/raster/r.learn.ml2 ext=r.learn.ml2
Compiling...
ERROR: Package python3-scikit-learn 0.20 or newer is not installed
Installing...
Updating extensions metadata file...
Updating extension modules metadata file...
```

As a result the `r.learn.predict` command is missing.

## New behaviour

Compilation not depending on scikit-learn:

```
g.extension url=src/raster/r.learn.ml2 ext=r.learn.ml2
Compiling...
Installing...
Updating extensions metadata file...
Updating extension modules metadata file...
Installation of <r.learn.ml2> successfully finished
```

`r.learn.predict` fails to run on missing dependecies:

```
r.learn.predict g=x l=x o=y
ERROR: Package python3-scikit-learn 0.20 or newer is not installed
```