### PR TITLE
CI(clang-format): Post fixes as code suggestions if possible when running on a PR

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -14,13 +14,10 @@ jobs:
   formatting-check:
     name: Formatting Check
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      checks: write
-      issues: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
       - uses: DoozyX/clang-format-lint-action@11b773b1598aa4ae3b32f023701bca5201c3817d # v0.17
         with:
           source: "."
@@ -57,25 +54,38 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
         env:
           CHANGED_FILES: ${{ steps.git-changed-files.outputs.CHANGED_FILES }}
-      - name: Add code suggestions
-        uses: reviewdog/action-suggester@3d7fde6859623ad6174df5fd662677a0eb63310a # v1.11.0
+      - name: Create unified diff of changes
+        if: ${{ steps.verify-changed-files.outputs.files_changed == 'true' }}
+        run: git diff --unified=0 --no-color --output=diff-clang-format.patch
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        if: ${{ steps.verify-changed-files.outputs.files_changed == 'true' }}
         with:
-          tool_name: clang-format
-          fail_on_error: true
-          cleanup: false
+          name: diff
+          if-no-files-found: ignore
+          retention-days: 1
+          path: |
+            diff-clang-format.patch
+      - name: Add note to summary explaining that code suggestions will be applied if it is a PR
+        if: ${{ (github.event_name == 'pull_request') && (steps.verify-changed-files.outputs.files_changed == 'true') }}
+        run: |
+          {
+            echo ''
+            echo 'Suggestions can only be added near to lines changed in this PR.'
+            echo 'If any fixes can be added as code suggestions, they will be added shortly from another workflow.'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        if: always()
+        with:
+          name: formatted-clang-format
+          retention-days: 10
+          path: |
+            .clang-format
+            ${{ steps.git-changed-files.outputs.CHANGED_FILES }}
       - name: Explain that more files need to be fixed
         if: ${{ steps.verify-changed-files.outputs.files_changed == 'true' }}
         run: |
           {
             echo ''
-            echo 'Suggestions can only be added near to lines changed in this PR.'
-            echo 'All these fixed files are included in the artifact. The artifact can be downloaded and copied to the the repository to replace unformatted files with the formatted files.'
+            echo 'All fixed files are included in the `formatted-*` artifact. This artifact can be downloaded and copied to the repository to replace unformatted files with the formatted files.'
           } >> "$GITHUB_STEP_SUMMARY"
           exit 1
-      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
-        if: always()
-        with:
-          name: formatted-clang-format
-          path: |
-            .clang-format
-            ${{ steps.git-changed-files.outputs.CHANGED_FILES }}

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -86,6 +86,7 @@ jobs:
         run: |
           {
             echo ''
+            # shellcheck disable=SC2016
             echo 'All fixed files are included in the `formatted-*` artifact. This artifact can be downloaded and copied to the repository to replace unformatted files with the formatted files.'
           } >> "$GITHUB_STEP_SUMMARY"
           exit 1

--- a/.github/workflows/post-pr-reviews.yml
+++ b/.github/workflows/post-pr-reviews.yml
@@ -1,0 +1,45 @@
+---
+name: Post PR code suggestions
+
+on:
+  workflow_run:
+    workflows: ["ClangFormat Check"]
+    types:
+      - completed
+permissions: {}
+jobs:
+  post-suggestions:
+    runs-on: ubuntu-latest
+    # Only run on failures, since no changes are needed on success
+    if: >
+      (github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'failure')
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Create a .git directory needed by reviewdog
+        run: git init
+      - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+        id: diff
+        continue-on-error: true
+        with:
+          name: diff
+          github-token: ${{ github.token }}
+          run-id: ${{github.event.workflow_run.id }}
+      - uses: reviewdog/action-setup@1d18b2938261447f64c39f831d7395e90ef5a40e # v1.2.1
+      - run: |
+          GITHUB_ACTIONS="" reviewdog \
+              -name="${INPUT_TOOL_NAME:-reviewdog-suggester}" \
+              -f=diff \
+              -f.diff.strip=1 \
+              -filter-mode=nofilter \
+              -guess \
+              -reporter="github-pr-review" < "${TMPFILE}"
+        env:
+          TMPFILE: diff-clang-format.patch
+          INPUT_TOOL_NAME: clang-format
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CI_COMMIT: ${{ github.event.workflow_run.head_sha }}
+          CI_REPO_OWNER: ${{ github.event.workflow_run.repository.owner.login }}
+          CI_REPO_NAME: ${{ github.event.workflow_run.repository.name }}
+          # CI_PULL_REQUEST: "" # Populated from reviewdog's "-guess" flag since hard to get


### PR DESCRIPTION
This is the continuation of https://github.com/OSGeo/grass-addons/pull/1035, and will be adapted back to https://github.com/OSGeo/grass/pull/3284 as a final solution.

After a hundred iterations or so, I've got a solution that I'm satisfied with. This allows linter formatting in a PR from a forked pull request to do so without any special secret access, and also be able to add PR review comments, that need `pull-request: write` permissions. These permissions cannot be granted for PRs coming from forks. Since all the PRs come from forks, we could never use any `write` permissions from our forks. It also avoids using `pull_request_target` with a checkout of the external code, which is something that should never be done.

Instead, it runs another workflow triggered by the completion of another workflow, through the `workflow_run` trigger. That second workflow takes 3 seconds, max 10 including startup. It won't appear as a check for a PR, but still manages to use the event's payload information available to apply to the PR. The fixes that need to be added as code suggestion comments are fed through the upload of a diff artifact. It is then easily downloaded in the second workflow.

Note that PR review comments can only be added to lines in the diff context, that is 3 lines above or below the changed lines of a PR, just like the web interface: the API isn't different. The code suggestion comments are added on a best-effort basis to facilitate contributors to finish a PR. So only upgrading the clang-format version in a PR won't be able to post suggestions on all changes in the repo, since the affected lines aren't changed in that PR.

I designed this solution to be able to accept and post code suggestions for other tools in the near future. Other workflows could upload diffs from multiple tools in the same artifact, and only the tool name and the file name needs to be handled by conditional expressions (`if: ...`) or a bash loop (careful to not inject the file names from the artifact, as it is untrusted inputs; prefer whitelisting the expected file names to match to). For now, it is implemented for clang-format.

This time, I created a new organization, so I could develop with the forked-repo situation from the start. Once this PR is merged, the "callback" workflow that post code suggestions will be enabled, and will work right away.