### PR TITLE
v.transects: fix parsing vector ASCII file for features with multiple categories

### DIFF
--- a/src/vector/v.transects/v.transects.py
+++ b/src/vector/v.transects/v.transects.py
@@ -123,7 +123,7 @@ def loadVector(vector):
     while l < len(vectorAscii):
         line = vectorAscii[l].split()
         if line[0] in ["L", "B", "A"]:
-            skip = len(line) - 2
+            skip = int(line[2])
             vertices = int(line[1])
             l += 1
             v.append([])
@@ -132,7 +132,7 @@ def loadVector(vector):
                 l += 1
             l += skip
         elif line[0] in ["P", "C", "F", "K"]:
-            skip = len(line) - 2
+            skip = int(line[2])
             vertices = int(line[1])
             l += 1
             for i in range(vertices):


### PR DESCRIPTION
When running with features that have multiple categories, it failed with something like this:
```
ERROR: Problem with line: < 1     94906     >
```
The ASCII looks like:
```
L  42 3
 638629.28107696 225816.59649476
 638629.82606045 225816.24170685
...
 638807.31297943 225701.87381251
 638809.85562611 225701.34071625
 1     94905     
 1     94906     
 1     94907 
```
The changed line in the code previously always resulted in skip=1, now it skips by the number of categories as reported in the last number of the line `L 42 3`.
I didn't write a test, only tested manually.