### PR TITLE
r.lake.series: Improve frange function

### DIFF
--- a/src/raster/r.lake.series/r.lake.series.py
+++ b/src/raster/r.lake.series/r.lake.series.py
@@ -136,12 +136,10 @@ def frange(x, y, step, precision):
     scale = 10**precision
     array = [
         val / scale
-        for val in range(
-            int(x * scale), int((y + float(step)) * scale), int(float(step) * scale)
-        )
+        for val in range(int(x * scale), int((y + step) * scale), int(step * scale))
+        if val / scale <= y
     ]
     return array
-
 
 def check_maps_exist(maps, mapset):
     for map_ in maps:
@@ -194,7 +192,7 @@ def main():
 
     precision = abs(decimal.Decimal(water_level_step).as_tuple().exponent)
     water_levels = frange(
-        start_water_level, end_water_level, water_level_step, precision
+        start_water_level, end_water_level, float(water_level_step), precision
     )
     outputs = [
         f"{basename}_{water_level:.{precision}f}" for water_level in water_levels

--- a/src/raster/r.lake.series/r.lake.series.py
+++ b/src/raster/r.lake.series/r.lake.series.py
@@ -133,12 +133,8 @@ def format_order(number, zeros):
 
 def frange(x, y, step):
     return [
-        val / 1000 
-        for val in range(
-            int(x * 1000), 
-            int((y + step) * 1000), 
-            int(step * 1000)
-        )
+        val / 1000
+        for val in range(int(x * 1000), int((y + step) * 1000), int(step * 1000))
     ]
 
 

--- a/src/raster/r.lake.series/r.lake.series.py
+++ b/src/raster/r.lake.series/r.lake.series.py
@@ -132,9 +132,14 @@ def format_order(number, zeros):
 
 
 def frange(x, y, step):
-    while x <= y:
-        yield x
-        x += step
+    return [
+        val / 1000 
+        for val in range(
+            int(x * 1000), 
+            int((y + step) * 1000), 
+            int(step * 1000)
+        )
+    ]
 
 
 def check_maps_exist(maps, mapset):

--- a/src/raster/r.lake.series/r.lake.series.py
+++ b/src/raster/r.lake.series/r.lake.series.py
@@ -191,9 +191,7 @@ def main():
     title = _("r.lake series")
     desctiption = _("r.lake series")
 
-    water_levels = [
-        step for step in frange(start_water_level, end_water_level, water_level_step)
-    ]
+    water_levels = frange(start_water_level, end_water_level, water_level_step)
     outputs = ["%s%s%s" % (basename, "_", water_level) for water_level in water_levels]
 
     if not gcore.overwrite():

--- a/src/raster/r.lake.series/r.lake.series.py
+++ b/src/raster/r.lake.series/r.lake.series.py
@@ -141,6 +141,7 @@ def frange(x, y, step, precision):
     ]
     return array
 
+
 def check_maps_exist(maps, mapset):
     for map_ in maps:
         if gcore.find_file(map_, element="cell", mapset=mapset)["file"]:

--- a/src/raster/r.lake.series/r.lake.series.py
+++ b/src/raster/r.lake.series/r.lake.series.py
@@ -132,14 +132,15 @@ def format_order(number, zeros):
     return str(number).zfill(zeros)
 
 
-def frange(x, y, step):
-    exponent = abs(decimal.Decimal(str(step)).as_tuple().exponent)
-    scale = 10**exponent
+def frange(x, y, step, precision):
+    scale = 10**precision
     array = [
         val / scale
-        for val in range(int(x * scale), int((y + step) * scale), int(step * scale))
+        for val in range(
+            int(x * scale), int((y + float(step)) * scale), int(float(step) * scale)
+        )
     ]
-    return array, exponent
+    return array
 
 
 def check_maps_exist(maps, mapset):
@@ -166,7 +167,7 @@ def main():
     basename = strds
     start_water_level = float(options["start_water_level"])
     end_water_level = float(options["end_water_level"])
-    water_level_step = float(options["water_level_step"])
+    water_level_step = options["water_level_step"]
     # if options['coordinates']:
     #    options['coordinates'].split(',')
     # passing coordinates parameter as is
@@ -191,12 +192,12 @@ def main():
     title = _("r.lake series")
     desctiption = _("r.lake series")
 
-    water_levels, number_of_decimals = frange(
-        start_water_level, end_water_level, water_level_step
+    precision = abs(decimal.Decimal(water_level_step).as_tuple().exponent)
+    water_levels = frange(
+        start_water_level, end_water_level, water_level_step, precision
     )
     outputs = [
-        f"{basename}_{water_level:.{number_of_decimals}f}"
-        for water_level in water_levels
+        f"{basename}_{water_level:.{precision}f}" for water_level in water_levels
     ]
 
     if not gcore.overwrite():


### PR DESCRIPTION
The previous version of the frange function would return bad arrays for steps <0.25. For example:
```
>>> [step for step in frange(2.0, 3.0, 0.1)]
[2.0, 2.1, 2.2, 2.3000000000000003, 2.4000000000000004, 2.5000000000000004, 2.6000000000000005, 2.7000000000000006, 2.8000000000000007, 2.900000000000001]
```

This new version will work for steps with up to 3 decimal places.