### PR TITLE
r.accumulate: Fix a segfault error by assigning a default value to accum_type

### DIFF
--- a/src/raster/r.accumulate/main.c
+++ b/src/raster/r.accumulate/main.c
@@ -146,6 +146,7 @@ int main(int argc, char *argv[])
     opt.accum_type = G_define_standard_option(G_OPT_R_TYPE);
     opt.accum_type->key = "accumulation_type";
     opt.accum_type->required = NO;
+    opt.accum_type->answer = "CELL";
     opt.accum_type->description =
         _("Type of accumulation raster map to be created");
 


### PR DESCRIPTION
This PR fixes #1076 by using `CELL` as the default value for the accumulation type. It'll be promoted to `FCELL` or `DCELL` automatically when needed.