### PR TITLE
CI: Remove 8.2 from tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,6 @@ jobs:
         include:
           - grass-version: main
             python-version: "3.11"
-          - grass-version: releasebranch_8_2
-            python-version: "3.7"
           - grass-version: releasebranch_8_3
             python-version: "3.10"
       fail-fast: false


### PR DESCRIPTION
We don't support the 8.2 release series anymore, so no need to test against it in the CI. Also: The CI was using Python 3.7 which is end-of-life now.
