### PR TITLE
v.scatterplot add option to plot lines dividing plot in quandrants

### DIFF
--- a/src/vector/v.scatterplot/v.scatterplot.html
+++ b/src/vector/v.scatterplot/v.scatterplot.html
@@ -9,21 +9,21 @@ and tic labels.
 <p>
 Instead of a fixed color, dots can be colored using colors from a 
 user-defined column, or by the spatial density of nearby points, using 
-the option <em>type=density</em>. The spatial density is computed by 
+the option <tt>type=density</tt>. The spatial density is computed by 
 grouping the points in 2D bins. The number of bins along the x-axis and 
 y-axis is user-defined. The user can select a color map from a list of 
 sequential colormaps and perceptually uniform sequential colormaps. See 
 the matplotlib <a 
 href="https://matplotlib.org/stable/users/explain/colors/colormaps.html"> 
-manual page</a> for details. Use the <b>-r</b> flag to reverse the order of 
-the colors. 
+manual page</a> for details. Use the <b>-r</b> flag to reverse the 
+order of the colors. 
 
 <p>
 By default, the resulting plot is displayed on screen (default). 
 However, the user can also save the plot to a file using the 
-<em>file_name</em> option. The format is determined by the extension 
-given by the user. So, if <tt>file_name = outputfile.png</tt>, the plot will be 
-saved as a PNG file.
+<b>file_name</b> option. The format is determined by the extension 
+given by the user. So, if <tt>file_name = outputfile.png</tt>, the plot 
+will be saved as a PNG file.
 
 <p>
 A linear or polynomial trend line with user-defined degrees can be 
@@ -36,19 +36,18 @@ plotted on top of the scatterplot, following the method described <a
 href="https://carstenschelp.github.io/2018/09/14/Plot_Confidence_Ellipse_001.html">here</a>, 
 and using the code described <a 
 href="https://matplotlib.org/stable/gallery/statistics/confidence_ellipse.html">here</a>. 
-The radius of the ellipse can be controlled by n_sd which is the number 
-of standard deviations (SD). The default is 2 SD, which results in an 
-ellipse that encloses around 95% of the points. Optionally, separate 
-confidence ellipses can be drawn for groups defined in the column 
-<i>groups</i>. Groups can be assigned a random color, or a color based 
-on the RGB colors in a user-defined column. Note, all records in the 
-group should have the same color.
+The radius of the ellipse can be controlled by <b>n</b> which is the 
+number of standard deviations (SD). The default is 2 SD, which results 
+in an ellipse that encloses around 95% of the points. Optionally, 
+separate confidence ellipses can be drawn for groups defined in the 
+column <b>groups</b>. Groups can be assigned a random color, or a color 
+based on the RGB colors in a user-defined column. Note, all records in 
+the group should have the same color.
 
 <p>
-The user has the option to limit/expand the X-axis (<em>xlim</em>) and 
-Y-axis (<em>ylim</em>). This can e.g., make it easier to compare 
-different plots.
-
+The user has the option to limit/expand the X-axis 
+(<b>x_axis_limits</b>) and Y-axis (<b>y_axis_limits</b>). This can 
+e.g., make it easier to compare different plots.
 
 <h2>EXAMPLES</h2>
 

--- a/src/vector/v.scatterplot/v.scatterplot.py
+++ b/src/vector/v.scatterplot/v.scatterplot.py
@@ -228,10 +228,10 @@
 # % end
 
 # %option
-# % key: n_sd
+# % key: n
 # % type: string
 # % label: standard deviations
-# % description: Draw the covariance confidence ellipse(s) with radius of n standard deviations (n_sd).
+# % description: Draw the covariance confidence ellipse(s) with radius of n standard deviations.
 # % answer: 2
 # % guisection: Ellipse
 # %end
@@ -356,7 +356,7 @@
 
 
 # %option
-# % key: xlim
+# % key: x_axis_limits
 # % type: string
 # % label: X axis range (min,max)
 # % description: Set the X axis range to be displayed
@@ -364,7 +364,7 @@
 # %end
 
 # %option
-# % key: ylim
+# % key: y_axis_limits
 # % type: string
 # % label: Y axis range (min,max)
 # % description: Set the Y axis range to be displayed
@@ -542,14 +542,14 @@ def density_scatter(
     return ax, fig
 
 
-def confidence_ellipse(x, y, ax, n_sd, facecolor="none", **kwargs):
+def confidence_ellipse(x, y, ax, n, facecolor="none", **kwargs):
     """
     Create a plot of the covariance confidence ellipse of *x* and *y*.
 
     :param array x: input data x-axis.
     :param array y: input data y-axis.
     :param matplotlib.axes.Axes ax: The axes object to draw the ellipse into.
-    :param float n_sd: The number of standard deviations to determine the ellipse's radiuses.
+    :param float n: The number of standard deviations or errors to determine the ellipse's radiuses.
 
     :return matplotlib.patches.Ellipse
     """
@@ -570,11 +570,11 @@ def confidence_ellipse(x, y, ax, n_sd, facecolor="none", **kwargs):
     # Calculating the standard deviation of x from
     # the squareroot of the variance and multiplying
     # with the given number of standard deviations.
-    scale_x = np.sqrt(cov[0, 0]) * n_sd
+    scale_x = np.sqrt(cov[0, 0]) * n
     mean_x = np.mean(x)
 
     # calculating the standard deviation of y ...
-    scale_y = np.sqrt(cov[1, 1]) * n_sd
+    scale_y = np.sqrt(cov[1, 1]) * n
     mean_y = np.mean(y)
 
     transf = (
@@ -779,7 +779,7 @@ def main(options, flags):
                 X,
                 Y,
                 ax,
-                n_sd=float(options["n_sd"]),
+                n=float(options["n"]),
                 edgecolor="white",
                 linewidth=edge_width * 1.5,
                 linestyle=edge_style,
@@ -789,7 +789,7 @@ def main(options, flags):
                 X,
                 Y,
                 ax,
-                n_sd=float(options["n_sd"]),
+                n=float(options["n"]),
                 edgecolor=edge_color,
                 linewidth=edge_width,
                 linestyle=edge_style,
@@ -815,7 +815,7 @@ def main(options, flags):
                     sub_x,
                     sub_y,
                     ax,
-                    n_sd=float(options["n_sd"]),
+                    n=float(options["n"]),
                     edgecolor="white",
                     linewidth=edge_width * 1.8,
                     linestyle="-",
@@ -825,7 +825,7 @@ def main(options, flags):
                     sub_x,
                     sub_y,
                     ax,
-                    n_sd=float(options["n_sd"]),
+                    n=float(options["n"]),
                     edgecolor=edge_color,
                     linewidth=edge_width,
                     linestyle=edge_style,
@@ -836,11 +836,11 @@ def main(options, flags):
                 fontsize = float(options["fontsize"]) * 0.9
                 plt.legend(fontsize=fontsize)
 
-    if options["xlim"]:
-        xlim = [float(i) for i in options["xlim"].split(",")]
+    if options["x_axis_limits"]:
+        xlim = [float(i) for i in options["x_axis_limits"].split(",")]
         ax.set_xlim(xlim)
-    if options["ylim"]:
-        ylim = [float(i) for i in options["ylim"].split(",")]
+    if options["y_axis_limits"]:
+        ylim = [float(i) for i in options["y_axis_limits"].split(",")]
         ax.set_ylim(ylim)
 
     if bool(file_name):

--- a/src/vector/v.scatterplot/v.scatterplot.py
+++ b/src/vector/v.scatterplot/v.scatterplot.py
@@ -7,7 +7,7 @@
 # PURPOSE:      Plots the values of two columns in the attribute table
 #               of an input vector layer in a scatterplot.
 #
-# COPYRIGHT:    (c) 2023 Paulo van Breugel, and the GRASS Development Team
+# COPYRIGHT:    (c) 2023-2024 Paulo van Breugel, and the GRASS Development Team
 #               This program is free software under the GNU General Public
 #               License (>=v2). Read the file COPYING that comes with GRASS
 #               for details.
@@ -305,6 +305,36 @@
 # % guisection: Ellipse
 # %end
 
+# %option
+# % key: quadrants
+# % type: string
+# % label: quadrants
+# % description: Print the mean or median on x and y-axis
+# % required: no
+# % options: mean,median
+# % guisection: Quadrants
+# %end
+
+# %option G_OPT_C
+# % key: quandrant_linecolor
+# % type: string
+# % label: Line color
+# % description: Color of the lines making up the quadrants
+# % required: no
+# % answer: grey
+# % guisection: Quadrants
+# %end
+
+# %option
+# % key: quandrant_linewidth
+# % type: double
+# % label: quandrant line width
+# % description: Line width of the lines dividing the points in four quadrants.
+# % required: no
+# % answer: 1
+# % guisection: Quadrants
+# %end
+
 # %rules
 # % requires: groups_rgb,groups
 # %end
@@ -312,6 +342,18 @@
 # %rules
 # % requires: ellipse_legend,groups
 # %end
+
+# %flag
+# % key: g
+# % label: Add grid lines
+# % description: Add grid lines.
+# % guisection: Aesthetics
+# %end
+
+# %rules
+# % excludes: quadrants,-g
+# %end
+
 
 # %option
 # % key: xlim
@@ -652,6 +694,29 @@ def main(options, flags):
             reverse_colors=flags["r"],
         )
 
+    # Quadrants
+    if options["quadrants"]:
+        if options["quadrants"] == "mean":
+            X_div = np.mean(X)
+            Y_div = np.mean(Y)
+        else:
+            X_div = np.median(X)
+            Y_div = np.median(Y)
+        quadrant_color = get_valid_color(options["quandrant_linecolor"])
+        quadrant_linewidth = float(options["quandrant_linewidth"])
+        ax.axhline(
+            y=Y_div, color=quadrant_color, linewidth=quadrant_linewidth, zorder=0
+        )
+        ax.axvline(
+            x=X_div, color=quadrant_color, linewidth=quadrant_linewidth, zorder=0
+        )
+
+    # Set grid (optional)
+    if flags["g"]:
+        ax.xaxis.grid(linewidth=0.5, alpha=0.5)
+        ax.yaxis.grid(linewidth=0.5, alpha=0.5)
+
+    # Trendline
     if options["trendline"] == "linear":
         degree = 1
         if int(options["degree"]) != "1":
@@ -770,6 +835,7 @@ def main(options, flags):
             if options["ellipse_legend"]:
                 fontsize = float(options["fontsize"]) * 0.9
                 plt.legend(fontsize=fontsize)
+
     if options["xlim"]:
         xlim = [float(i) for i in options["xlim"].split(",")]
         ax.set_xlim(xlim)

--- a/src/vector/v.scatterplot/v.scatterplot.py
+++ b/src/vector/v.scatterplot/v.scatterplot.py
@@ -547,7 +547,7 @@ def confidence_ellipse(x, y, ax, n, facecolor="none", **kwargs):
     :param array x: input data x-axis.
     :param array y: input data y-axis.
     :param matplotlib.axes.Axes ax: The axes object to draw the ellipse into.
-    :param float n: The number of standard deviations or errors to determine the ellipse's radiuses.
+    :param float n: The number of standard deviations to determine the ellipse's radiuses.
 
     :return matplotlib.patches.Ellipse
     """

--- a/src/vector/v.scatterplot/v.scatterplot.py
+++ b/src/vector/v.scatterplot/v.scatterplot.py
@@ -22,7 +22,6 @@
 # %end
 
 # %option G_OPT_V_MAP
-# % key: map
 # % label: Input map
 # % description: input vector layer
 # % required: yes
@@ -57,7 +56,6 @@
 # %end
 
 # %option G_OPT_F_OUTPUT
-# % key: file_name
 # % label: Name of the output file (extension decides format)
 # % description: Name of the output file. The format is determined by the file extension.
 # % required: no
@@ -645,7 +643,7 @@ def main(options, flags):
     # Plot parameters & aesthetics
     plot_dimensions = [float(x) for x in options["plot_dimensions"].split(",")]
     plot_title = options["title"]
-    file_name = options["file_name"]
+    file_name = options["output"]
     bins = [int(x) for x in options["bins"].split(",")]
     if options["rgbcolumn"]:
         dot_color = rgbcolumn
@@ -713,6 +711,7 @@ def main(options, flags):
 
     # Set grid (optional)
     if flags["g"]:
+        ax.set_axisbelow(True)
         ax.xaxis.grid(linewidth=0.5, alpha=0.5)
         ax.yaxis.grid(linewidth=0.5, alpha=0.5)
 

--- a/src/vector/v.scatterplot/v.scatterplot.py
+++ b/src/vector/v.scatterplot/v.scatterplot.py
@@ -327,7 +327,7 @@
 # % key: quandrant_linewidth
 # % type: double
 # % label: quandrant line width
-# % description: Line width of the lines dividing the points in four quadrants.
+# % description: Line width of the lines dividing the points in four quadrants
 # % required: no
 # % answer: 1
 # % guisection: Quadrants

--- a/src/vector/v.scatterplot/v.scatterplot.py
+++ b/src/vector/v.scatterplot/v.scatterplot.py
@@ -344,7 +344,7 @@
 # %flag
 # % key: g
 # % label: Add grid lines
-# % description: Add grid lines.
+# % description: Add grid lines
 # % guisection: Aesthetics
 # %end
 


### PR DESCRIPTION
* Add an option to plot lines dividing the plot in four quadrants, representing four categories with HH, LL, LH and HL values.
* Changed the parameter n_sd to n (see #1075)
* Changes parameters xlim and ylim to x_axis_limits and y_axis_limits (see #1075)
* Changes parameter file_name to output (see #1075)
