### PR TITLE
cronjobs: no need to use chgrp on files

### DIFF
--- a/utils/cronjobs_osgeo_lxd/cron_grass_legacy_src_snapshot.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_legacy_src_snapshot.sh
@@ -102,7 +102,7 @@ gzip $TARGETDIR/ChangeLog
 cp $PACKAGENAME\src_snapshot$DATE.tar.gz $TARGETDIR
 rm -f $PACKAGENAME\src_snapshot$DATE.tar.gz
 chmod a+r,g+w $TARGETDIR/* 2> /dev/null
-chgrp grass $TARGETDIR/*   2> /dev/null
+#chgrp grass $TARGETDIR/*   2> /dev/null
 
 # link for convenience:
 (cd $TARGETDIR ; rm -f $PACKAGENAME\src_snapshot_latest.tar.gz ; ln -s $PACKAGENAME\src_snapshot$DATE.tar.gz $PACKAGENAME\src_snapshot_latest.tar.gz)

--- a/utils/cronjobs_osgeo_lxd/cron_grass_new_current_src_snapshot.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_new_current_src_snapshot.sh
@@ -102,7 +102,7 @@ gzip $TARGETDIR/ChangeLog
 cp $PACKAGENAME\src_snapshot$DATE.tar.gz $TARGETDIR
 rm -f $PACKAGENAME\src_snapshot$DATE.tar.gz
 chmod a+r,g+w $TARGETDIR/* 2> /dev/null
-chgrp grass $TARGETDIR/*   2> /dev/null
+#chgrp grass $TARGETDIR/*   2> /dev/null
 
 # link for convenience:
 (cd $TARGETDIR ; rm -f $PACKAGENAME\src_snapshot_latest.tar.gz ; ln -s $PACKAGENAME\src_snapshot$DATE.tar.gz $PACKAGENAME\src_snapshot_latest.tar.gz)

--- a/utils/cronjobs_osgeo_lxd/cron_grass_old_current_src_snapshot.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_old_current_src_snapshot.sh
@@ -102,7 +102,7 @@ gzip $TARGETDIR/ChangeLog
 cp $PACKAGENAME\src_snapshot$DATE.tar.gz $TARGETDIR
 rm -f $PACKAGENAME\src_snapshot$DATE.tar.gz
 chmod a+r,g+w $TARGETDIR/* 2> /dev/null
-chgrp grass $TARGETDIR/*   2> /dev/null
+#chgrp grass $TARGETDIR/*   2> /dev/null
 
 # link for convenience:
 (cd $TARGETDIR ; rm -f $PACKAGENAME\src_snapshot_latest.tar.gz ; ln -s $PACKAGENAME\src_snapshot$DATE.tar.gz $PACKAGENAME\src_snapshot_latest.tar.gz)

--- a/utils/cronjobs_osgeo_lxd/cron_grass_preview_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_preview_build_binaries.sh
@@ -206,7 +206,7 @@ cp -r html/*  $TARGETPROGMAN/
 
 echo "Copied HTML progman to https://grass.osgeo.org/programming${GVERSION}"
 # fix permissions
-chgrp -R grass $TARGETPROGMAN/*
+#chgrp -R grass $TARGETPROGMAN/*
 chmod -R a+r,g+w $TARGETPROGMAN/
 chmod -R a+r,g+w $TARGETPROGMAN/*
 # bug in doxygen

--- a/utils/cronjobs_osgeo_lxd/cron_grass_preview_src_snapshot.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_preview_src_snapshot.sh
@@ -102,7 +102,7 @@ gzip $TARGETDIR/ChangeLog
 cp $PACKAGENAME\src_snapshot$DATE.tar.gz $TARGETDIR
 rm -f $PACKAGENAME\src_snapshot$DATE.tar.gz
 chmod a+r,g+w $TARGETDIR/* 2> /dev/null
-chgrp grass $TARGETDIR/*   2> /dev/null
+#chgrp grass $TARGETDIR/*   2> /dev/null
 
 # link for convenience:
 (cd $TARGETDIR ; rm -f $PACKAGENAME\src_snapshot_latest.tar.gz ; ln -s $PACKAGENAME\src_snapshot$DATE.tar.gz $PACKAGENAME\src_snapshot_latest.tar.gz)


### PR DESCRIPTION
Fixes broken https://grass.osgeo.org/grass84/binary/linux/snapshot/ creation.