### PR TITLE
CI(super-linter): Use default log level for super-linter

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -41,7 +41,6 @@ jobs:
           LINTER_RULES_PATH: .
           FILTER_REGEX_EXCLUDE: ".*/src/gui/wxpython/wx.metadata/profiles/.*.xml"
           IGNORE_GENERATED_FILES: true
-          LOG_LEVEL: NOTICE
           VALIDATE_BASH: false # Until issues are fixed, some valid warnings
           VALIDATE_CHECKOV: false # Until issues are fixed
           VALIDATE_CLANG_FORMAT: false # Until we continue to check it in another workflow


### PR DESCRIPTION
Default LOG_LEVEL is INFO. LOG_LEVEL: NOTICE doesn't contain enough info to know what is going on during the job, or what linter version is used.

