### PR TITLE
i.eodag: add query, print, and footprints options

### DIFF
--- a/src/imagery/i.eodag/i.eodag.html
+++ b/src/imagery/i.eodag/i.eodag.html
@@ -62,9 +62,16 @@ Search and list the available Sentinel 2 scenes in the Copernicus Data Space Eco
 <div class="code"><pre>
 v.extract input=urbanarea where="NAME = 'Durham'" output=durham
 
-i.eodag -l start=2022-05-25 end=2022-06-01 \
-    map=durham producttype=S2_MSI_L2A provider=cop_dataspace \
-    sort=cloudcover,ingestiondate order=asc,desc
+i.eodag -l start=2022-05-01 end=2022-06-01 \
+    map=durham producttype=S2_MSI_L2A provider=cop_dataspace
+
+6 scenes(s) found.
+S2B_MSIL2A_20220518T155819_N0400_R097_T17SPV_20220518T204903 2022-05-18T15:58:19 24% S2MSI2A
+S2A_MSIL2A_20220513T155821_N0400_R097_T17SPV_20220514T002317 2022-05-13T15:58:21 99% S2MSI2A
+S2B_MSIL2A_20220508T155819_N0400_R097_T17SPV_20220508T205707 2022-05-08T15:58:19 100% S2MSI2A
+S2A_MSIL2A_20220523T155831_N0400_R097_T17SPV_20220524T002713 2022-05-23T15:58:31 95% S2MSI2A
+S2A_MSIL2A_20220503T155831_N0400_R097_T17SPV_20220503T233818 2022-05-03T15:58:31 86% S2MSI2A
+S2B_MSIL2A_20220528T155819_N0400_R097_T17SPV_20220528T205325 2022-05-28T15:58:19  2% S2MSI2A
 <pre></div>
 
 Search and list the available Sentinel 2 scenes in the Copernicus Data Space
@@ -72,7 +79,7 @@ Ecosystem, with at least 70% of the AOI covered:
 <div class="code"><pre>
 v.extract input=urbanarea where="NAME = 'Durham'" output=durham
 
-i.eodag -l start=2022-05-25 end=2022-06-01 \
+i.eodag -l start=2022-05-01 end=2022-06-01 \
     producttype=S2_MSI_L2A provider=cop_dataspace \
     clouds=50 map=durham minimum_overlap=70
 <pre></div>
@@ -129,6 +136,41 @@ i.eodag -e provider=cop_dataspace \
     S2B_MSIL2A_20240529T081609_N0510_R121_T37SED_20240529T124818" \
     config=full/path/to/eodag/config.yaml \
     output=download_here
+<pre></div>
+
+List recognized eodag providers:
+<div class="code"><pre>
+i.eodag print=providers
+<pre></div>
+
+List recognized eodag providers, offering Sentinel 2 scenes:
+<div class="code"><pre>
+i.eodag print=providers producttype=S2_MSI_L2A
+<pre></div>
+
+List recognized eodag products:
+<div class="code"><pre>
+i.eodag print=products
+<pre></div>
+
+List recognized eodag products, offered by Copernicus Data Space Ecosystem:
+<div class="code"><pre>
+i.eodag print=products provider=cop_dataspace
+<pre></div>
+
+List queryables for Sentinel 2 scenes, that is offered by Copernicus Data Space Ecosystem:
+<div class="code"><pre>
+i.eodag print=queryables provider=cop_dataspace producttype=S2_MSI_L2A
+<pre></div>
+
+List current EODAG configuration:
+<div class="code"><pre>
+i.eodag print=config
+<pre></div>
+
+List current EODAG configuration for Copernicus Data Space Ecosystem:
+<div class="code"><pre>
+i.eodag print=config provider=cop_dataspace
 <pre></div>
 
 <h2>REQUIREMENTS</h2>

--- a/src/imagery/i.eodag/i.eodag.html
+++ b/src/imagery/i.eodag/i.eodag.html
@@ -100,7 +100,7 @@ Search and list the available Sentinel 2 scenes in the Copernicus Data Space
 Ecosystem, with relative orbit number 54:
 
 <div class="code"><pre>
-./i.eodag.py -l producttype=S2_MSI_L2A \
+i.eodag -l producttype=S2_MSI_L2A \
     provider=cop_dataspace save=search_result.geojson \
     query="relativeOrbitNumber=54"
 <pre></div>

--- a/src/imagery/i.eodag/i.eodag.html
+++ b/src/imagery/i.eodag/i.eodag.html
@@ -63,24 +63,56 @@ Search and list the available Sentinel 2 scenes in the Copernicus Data Space Eco
 v.extract input=urbanarea where="NAME = 'Durham'" output=durham
 
 i.eodag -l start=2022-05-25 end=2022-06-01 \
-    map=durham dataset=S2_MSI_L2A provider=cop_dataspace
+    map=durham dataset=S2_MSI_L2A provider=cop_dataspace \
+    sort=cloudcover,ingestiondate order=asc,desc
 <pre></div>
 
-Download all available scenes in the tmp directory, with Cloud Coverage not exceeding 50%:
+Search and list the available Sentinel 2 scenes in the Copernicus Data Space
+Ecosystem, with at least 70% of the AOI covered:
+<div class="code"><pre>
+v.extract input=urbanarea where="NAME = 'Durham'" output=durham
+
+i.eodag -l start=2021-05-25 end=2022-06-01 \
+    dataset=S2_MSI_L2A provider=cop_dataspace \
+    clouds=50 map=durham minimum_overlap=70
+<pre></div>
+
+Sort results by <b>cloudcover</b>, and then by <b>ingestiondate</b> descendingly
+(latest to earliest):<br><em> Note that sorting with <b>cloudcover</b> use
+unrounded values, while they are rounded to the nearest intger when listing.</em>
+
+<div class="code"><pre>
+i.eodag -l start=2021-05-25 end=2022-06-01 \
+    dataset=S2_MSI_L2A provider=cop_dataspace \
+    sort=cloudcover,ingestiondate order=asc,desc
+<pre></div>
+
+Search for scenes with a list of IDs text file, and filter the results with the
+provided parameters:
+
+<div class="code"><pre>
+i.eodag -l file=ids_list.txt \
+  area_relation=Contains \
+  clouds=3
+<pre></div>
+
+Download all available scenes in the tmp directory, with Cloud Coverage not
+exceeding 50%:
 
 <div class="code"><pre>
 i.eodag start=2022-05-25 end=2022-06-01 \
     dataset=S2_MSI_L2A provider=cop_dataspace clouds=50
 <pre></div>
 
-Download only selected scenes from a text file of IDs, using the Copernicus Data Space Ecosystem as the provider:
+Download only selected scenes from a text file of IDs, using the Copernicus Data
+Space Ecosystem as the provider:
 
 <div class="code"><pre>
 i.eodag file=ids_list.txt provider=cop_dataspace
 <pre></div>
 
-Download and extract only selected scenes into the <em>download_here</em> directory,
-using a custom config file:
+Download and extract only selected scenes into the <em>download_here</em>
+directory, using a custom config file:
 
 <div class="code"><pre>
 i.eodag -e provider=cop_dataspace \

--- a/src/imagery/i.eodag/i.eodag.html
+++ b/src/imagery/i.eodag/i.eodag.html
@@ -92,8 +92,8 @@ provided parameters:
 
 <div class="code"><pre>
 i.eodag -l file=ids_list.txt \
-  area_relation=Contains \
-  clouds=3
+    start=2022-05-25 \
+    area_relation=Contains clouds=3
 <pre></div>
 
 Download all available scenes in the tmp directory, with Cloud Coverage not

--- a/src/imagery/i.eodag/i.eodag.html
+++ b/src/imagery/i.eodag/i.eodag.html
@@ -95,8 +95,6 @@ i.eodag -e provider=cop_dataspace \
 <ul>
     <li><a href="https://eodag.readthedocs.io/en/stable/getting_started_guide/install.html">EODAG library</a>
     (install with <code>pip install eodag</code>)</li>
-    <li><a href="https://pandas.pydata.org/">Pandas</a>
-    (install with <code>pip install pandas</code>)</li>
 </ul>
 
 <h2>SEE ALSO</h2>

--- a/src/imagery/i.eodag/i.eodag.html
+++ b/src/imagery/i.eodag/i.eodag.html
@@ -1,11 +1,11 @@
 <h2>DESCRIPTION</h2>
 <h3>WARNING: I.EODAG IS UNDER DEVELOPMENT. THIS IS AN EXPERIMENTAL VERSION.</h3>
 
-<em>i.eodag</em> allows to search and download imagery datasets, e.g. Sentinel,
+<em>i.eodag</em> allows to search and download imagery scenes, e.g. Sentinel,
 Landsat, and MODIS, from a number of different providers.
 The module utilizes the
 <a href="https://eodag.readthedocs.io/en/stable/">EODAG API</a>,
-as a single interface to search for datasets on the providers that EODAG supports.
+as a single interface to search for scenes on the providers that EODAG supports.
 
 
 <p>
@@ -63,7 +63,7 @@ Search and list the available Sentinel 2 scenes in the Copernicus Data Space Eco
 v.extract input=urbanarea where="NAME = 'Durham'" output=durham
 
 i.eodag -l start=2022-05-25 end=2022-06-01 \
-    map=durham dataset=S2_MSI_L2A provider=cop_dataspace \
+    map=durham producttype=S2_MSI_L2A provider=cop_dataspace \
     sort=cloudcover,ingestiondate order=asc,desc
 <pre></div>
 
@@ -73,17 +73,17 @@ Ecosystem, with at least 70% of the AOI covered:
 v.extract input=urbanarea where="NAME = 'Durham'" output=durham
 
 i.eodag -l start=2022-05-25 end=2022-06-01 \
-    dataset=S2_MSI_L2A provider=cop_dataspace \
+    producttype=S2_MSI_L2A provider=cop_dataspace \
     clouds=50 map=durham minimum_overlap=70
 <pre></div>
 
-Sort results, descendingly, by <b>cloudcover</b>, and then by <b>ingestiondate</b> 
+Sort results, descendingly, by <b>cloudcover</b>, and then by <b>ingestiondate</b>
 Note that sorting with <b>cloudcover</b> use
 unrounded values, while they are rounded to the nearest integer when listing.
 
 <div class="code"><pre>
 i.eodag -l start=2022-05-25 end=2022-06-01 \
-    dataset=S2_MSI_L2A provider=cop_dataspace \
+    producttype=S2_MSI_L2A provider=cop_dataspace \
     sort=cloudcover,ingestiondate order=desc
 <pre></div>
 
@@ -96,12 +96,21 @@ i.eodag -l file=ids_list.txt \
     area_relation=Contains clouds=3
 <pre></div>
 
-Download all available scenes with cloud coverage not exceeding 50% 
+Search and list the available Sentinel 2 scenes in the Copernicus Data Space
+Ecosystem, with relative orbit number 54:
+
+<div class="code"><pre>
+./i.eodag.py -l producttype=S2_MSI_L2A \
+    provider=cop_dataspace save=search_result.geojson \
+    query="relativeOrbitNumber=54"
+<pre></div>
+
+Download all available scenes with cloud coverage not exceeding 50%
 in the tmp directory:
 
 <div class="code"><pre>
 i.eodag start=2022-05-25 end=2022-06-01 \
-    dataset=S2_MSI_L2A provider=cop_dataspace clouds=50
+    producttype=S2_MSI_L2A provider=cop_dataspace clouds=50
 <pre></div>
 
 Download only selected scenes from a text file of IDs, using the Copernicus Data

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -674,6 +674,12 @@ def save_search_result(search_result, file_name):
 
 
 def print_eodag_configuration(provider=None):
+    """Print EODAG currently recognized configurations in JSON format.
+
+    :param provider: Print the configuration for only the given provider.
+    :type provider: dict
+    """
+
     def to_dict(config):
         ret_dict = dict()
         if isinstance(config, dict):

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -56,7 +56,7 @@
 # %option
 # % key: producttype
 # % type: string
-# % description: Imagery producttype to search for
+# % description: Imagery product type to search for
 # % required: no
 # % guisection: Filter
 # %end

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -157,7 +157,7 @@
 
 # %option
 # % key: query
-# % label: Extra searching parameters to use in query
+# % label: Extra searching parameters to use in the search
 # % description: Note: Make sure to use provided options when possible, otherwise the values mignt not be recognized
 # % guisection: Filter
 # %end

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -43,7 +43,7 @@
 
 # %flag
 # % key: e
-# % description: Extract the downloaded the scenes, not considered unless provider is set
+# % description: Extract the downloaded scenes, not considered unless provider is set
 # %end
 
 # %flag

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -180,7 +180,7 @@
 # % key: save
 # % type: string
 # % description: File name to save in (the format will be adjusted according to the file extension)
-# % label: Supported files extensions [geojson: Rreadable by i.eodag | json: Beautified]
+# % label: Supported file extensions [geojson: Readable by i.eodag | json: Beautified]
 # % guisection: Save
 # %end
 

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -368,11 +368,21 @@ def list_products(products):
                         )
                     except:
                         product_attribute_value = product.properties[column]
-                    product_attribute_value += "Z"
             if i != 0:
                 product_line += " "
             product_line += product_attribute_value
         print(product_line)
+
+
+def remove_duplicates(search_result):
+    filtered_result = []
+    is_added = set()
+    for product in search_result:
+        if product.properties["id"] in is_added:
+            continue
+        is_added.add(product.properties["id"])
+        filtered_result.append(product)
+    return SearchResult(filtered_result)
 
 
 def filter_result(search_result, geometry, **kwargs):
@@ -404,6 +414,9 @@ def filter_result(search_result, geometry, **kwargs):
         search_result = search_result.filter_property(
             operator="le", cloudCover=int(cloud_cover)
         )
+
+    search_result = remove_duplicates(search_result)
+
     postfilter_count = len(search_result)
     gs.verbose(
         _("{} product(s) filtered out.".format(prefilter_count - postfilter_count))
@@ -448,7 +461,6 @@ def main():
 
     # Download by IDs
     # Searching for additional products will not take place
-
     ids_set = set()
     if options["id"]:
         # Parse IDs
@@ -529,6 +541,8 @@ def main():
     search_result = sort_result(search_result)
 
     gs.message(_("{} product(s) found.").format(len(search_result)))
+    # TODO: Add a way to search in multiple providers at once
+    #       Check for when this feature is added https://github.com/CS-SI/eodag/issues/163
     if flags["l"]:
         list_products(search_result)
     else:

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -753,6 +753,8 @@ def main():
     gs.message(_("{} product(s) found.").format(len(search_result)))
     # TODO: Add a way to search in multiple providers at once
     #       Check for when this feature is added https://github.com/CS-SI/eodag/issues/163
+    if options["footprints"]:
+        save_footprints(search_result, options["footprints"])
     if flags["l"]:
         list_products(search_result)
     else:
@@ -760,8 +762,6 @@ def main():
         # TODO: Add timeout and wait parameters for downloading offline products...
         # https://eodag.readthedocs.io/en/stable/getting_started_guide/product_storage_status.html
         dag.download_all(search_result)
-        if options["footprints"]:
-            save_footprints(search_result, options["footprints"])
 
 
 if __name__ == "__main__":

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -188,8 +188,7 @@
 # %option G_OPT_F_OUTPUT
 # % key: save
 # % type: string
-# % description: File name to save the search results in (the format will be adjusted according to the file extension)
-# % label: Supported file extensions [geojson: Readable by i.eodag | json: Beautified]
+# % description: Geojson file name to save the search results in
 # % required: no
 # % guisection: Output
 # %end
@@ -724,11 +723,8 @@ def save_footprints(search_result, map_name):
 def save_search_result(search_result, file_name):
     """Save search results to files.
 
-    If the file is a json file,
-    the search result is saved in a beautified JSON format.
-    If the file is a geojson file,
-    the search result is saved using EODAG serialize method,
-    saving it in a format that can be read again by i.eodag,
+    The search result is saved using EODAG serialize method,
+    saving it in a format that can be read again by i.eodag
     to restore the search results.
 
     :param search_result: Search result with EO products to be saved.
@@ -737,17 +733,17 @@ def save_search_result(search_result, file_name):
     :param file_name: File to save search result in.
     :type file_name: str
     """
-    if file_name[-5:].lower() == ".json":
-        gs.verbose(_("Saving searchin result in '{}'".format(file_name)))
-        with open(file_name, "w") as f:
-            f.write(
-                json.dumps(
-                    search_result.as_geojson_object(), ensure_ascii=False, indent=4
-                )
-            )
     if file_name[-8:].lower() == ".geojson":
         gs.verbose(_("Saving searchin result in '{}'".format(file_name)))
         dag.serialize(search_result, filename=file_name)
+        return
+    gs.fatal(
+        _(
+            "Search result couldn't be saved in '{}'. Please make sure to use a 'geojson' file.".format(
+                file_name
+            )
+        )
+    )
 
 
 def print_eodag_configuration(**kwargs):

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -32,23 +32,26 @@
 # FLAGS
 # %flag
 # % key: l
-# % description: List available searching parameters
-# % guisection: List
+# % description: List filtered products scenes and exit
+# % guisection: Print
 # %end
 
 # %flag
 # % key: j
-# % description: Print extended metadata information in JSON style
+# % description: Print scenes extended metadata information in JSON style and exit
+# % guisection: Print
 # %end
 
 # %flag
 # % key: e
 # % description: Extract the downloaded the scenes, not considered unless provider is set
+# % guisection: Config
 # %end
 
 # %flag
 # % key: d
 # % description: Delete the product archive after downloading, not considered unless provider is set
+# % guisection: Config
 # %end
 
 
@@ -78,7 +81,7 @@
 
 # %option G_OPT_M_DIR
 # % key: output
-# % description: Name for output directory where to store downloaded data OR search results
+# % description: Name for output directory where to store downloaded scenes data
 # % required: no
 # % guisection: Output
 # %end
@@ -87,6 +90,7 @@
 # % key: config
 # % label: Full path to yaml config file
 # % required: no
+# % guisection: Config
 # %end
 
 # %option
@@ -118,15 +122,17 @@
 # % type: string
 # % multiple: yes
 # % description: List of scenes IDs to download
+# % required: no
 # % guisection: Filter
 # %end
 
-# %option
+# %option G_OPT_F_INPUT
 # % key: file
 # % type: string
 # % multiple: no
-# % label: File with list of products to read
+# % label: File with a list of scenes to read
 # % description: Can be either a text file (one product ID per line), or a geojson file that was created by i.eodag
+# % required: no
 # % guisection: Filter
 # %end
 
@@ -145,6 +151,7 @@
 # % multiple: yes
 # % options: ingestiondate,cloudcover
 # % answer: cloudcover,ingestiondate
+# % required: no
 # % guisection: Sort
 # %end
 
@@ -153,36 +160,44 @@
 # % description: Sort order (see sort parameter)
 # % options: asc,desc
 # % answer: asc
+# % required: no
 # % guisection: Sort
 # %end
 
 # %option
 # % key: query
+# % multiple: yes
 # % label: Extra searching parameters to use in query
 # % description: Note: Make sure to use provided options when possible, otherwise the values mignt not be recognized
+# % required: no
 # % guisection: Filter
 # %end
 
 # %option
 # % key: start
 # % type: string
-# % description: Start date (in any ISO 8601 format), by default it is 60 days ago
+# % label: Start date (ISO 8601 Format)
+# % description: By default it is 60 days ago
+# % required: no
 # % guisection: Filter
 # %end
 
 # %option
 # % key: end
 # % type: string
-# % description: End date (in any ISO 8601 format)
+# % label: End date (ISO 8601 Format)
+# % description: By default it is the current date and time
+# % required: no
 # % guisection: Filter
 # %end
 
-# %option
+# %option G_OPT_F_OUTPUT
 # % key: save
 # % type: string
 # % description: File name to save in (the format will be adjusted according to the file extension)
 # % label: Supported files extensions [geojson: Rreadable by i.eodag | json: Beautified]
-# % guisection: Save
+# % required: no
+# % guisection: Output
 # %end
 
 # %option
@@ -190,7 +205,8 @@
 # % type: string
 # % description: Print the available options of the given value in JSON
 # % options: products,providers,queryables,config
-# % guisection: Metadata
+# % required: no
+# % guisection: Print
 # %end
 
 # %rules
@@ -198,6 +214,8 @@
 # % exclusive: -l, -j
 # % requires: -l, producttype, file
 # % requires: -j, producttype, file
+# % exclusive: -l, print
+# % exclusive: -j, print
 # % exclusive: minimum_overlap, area_relation
 # %end
 
@@ -242,11 +260,12 @@ def get_bb(proj):
     if proj["+proj"] != "longlat":
         info = gs.parse_command("g.region", flags="uplg")
         return {
-            "lonmin": info["nw_long"],
-            "latmin": info["sw_lat"],
-            "lonmax": info["ne_long"],
-            "latmax": info["nw_lat"],
+            "lonmin": float(info["nw_long"]),
+            "latmin": float(info["sw_lat"]),
+            "lonmax": float(info["ne_long"]),
+            "latmax": float(info["nw_lat"]),
         }
+    print("HERE")
     info = gs.parse_command("g.region", flags="upg")
     return {
         "lonmin": info["w"],

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -73,6 +73,13 @@
 # % guisection: Output
 # %end
 
+# %option
+# % key: limit
+# % type: integer
+# % description: Limit number of scenes
+# % guisection: Filter
+# %end
+
 # %option G_OPT_F_INPUT
 # % key: config
 # % label: Full path to yaml config file
@@ -984,6 +991,8 @@ def main():
         search_result, geometry if "geometry" in locals() else None, **options
     )
     search_result = sort_result(search_result)
+    if options["limit"]:
+        search_result = SearchResult(search_result[: int(options["limit"])])
 
     gs.message(_("{} scenes(s) found.").format(len(search_result)))
     # TODO: Add a way to search in multiple providers at once

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -179,7 +179,7 @@
 # %option
 # % key: save
 # % type: string
-# % description: File name to save in (the format will be adjusted according to the file extension)
+# % description: File name to save the search results in (the format will be adjusted according to the file extension)
 # % label: Supported file extensions [geojson: Readable by i.eodag | json: Beautified]
 # % guisection: Save
 # %end

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -168,22 +168,6 @@
 # %end
 
 # %option
-# % key: extract
-# % type: string
-# % description: Whether to extract downloaded scenes zip files or not (will override values set in the config file)
-# % options: Yes,No
-# % guisection: Config
-# %end
-
-# %option
-# % key: deletearchive
-# % type: string
-# % label: Whether to delete downloaded scenes zip files or not (will override values set in the config file)
-# % options: Yes,No
-# % guisection: Config
-# %end
-
-# %option
 # % key: start
 # % type: string
 # % label: Start date (ISO 8601 Format)
@@ -1025,14 +1009,6 @@ def main():
         # https://eodag.readthedocs.io/en/stable/getting_started_guide/product_storage_status.html
         try:
             override_config = {}
-            if options["extract"]:
-                override_config["extract"] = (
-                    True if options["extract"].lower() == "yes" else False
-                )
-            if options["deletearchive"]:
-                override_config["delete_archive"] = (
-                    True if options["deletearchive"].lower() == "yes" else False
-                )
             if options["output"]:
                 override_config["outputs_prefix"] = options["output"]
             dag.download_all(search_result, **override_config)

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -796,17 +796,17 @@ def print_eodag_configuration(**kwargs):
 def print_eodag_providers(**kwargs):
     """Print providers available in JSON format.
 
-    :param producType: Restricts providers to given product.
-    :type productType: dict
+    :param kwargs: Restricts providers to providers offering specified product type.
+    :type kwargs: dict
     """
-    productType = kwargs["producttype"]
-    if productType:
-        gs.message(_("Recongnized providers offering {}".format(productType)))
+    product_type = kwargs["producttype"]
+    if product_type:
+        gs.message(_("Recongnized providers offering {}".format(product_type)))
     else:
         gs.message(_("Recongnizaed providers"))
     print(
         json.dumps(
-            {"providers": dag.available_providers(productType or None)}, indent=4
+            {"providers": dag.available_providers(product_type or None)}, indent=4
         )
     )
 
@@ -814,15 +814,22 @@ def print_eodag_providers(**kwargs):
 def print_eodag_products(**kwargs):
     """Print products available in JSON format.
 
-    :param provider: Restricts products to given provider.
-    :type provider: dict
+    :param kwargs: Restricts products to products offered by specific provider
+                   or specifies product type.
+    :type kwargs: dict
     """
     provider = kwargs["provider"]
+    product_type = kwargs["producttype"]
     if provider:
         gs.message(_("Recognized products offered by {}".format(provider)))
     else:
         gs.message(_("Recongnizaed providers"))
-    print(json.dumps({"products": dag.list_product_types(provider or None)}, indent=4))
+    products = dag.list_product_types(provider or None)
+    if product_type:
+        for product in products:
+            if product["ID"] == product_type:
+                products = [product]
+    print(json.dumps({"products": products}, indent=4))
 
 
 def print_eodag_queryables(**kwargs):
@@ -832,10 +839,10 @@ def print_eodag_queryables(**kwargs):
     :type kwargs: dict
     """
     provider = kwargs["provider"]
-    productType = kwargs["producttype"]
+    product_type = kwargs["producttype"]
     gs.message(_("Available queryables"))
     queryables = dag.list_queryables(
-        provider=provider or None, productType=productType or None
+        provider=provider or None, productType=product_type or None
     )
 
     # Literal is for queryables that have a certain list of options to choose from.

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -149,6 +149,13 @@
 # %end
 
 # %option
+# % key: query
+# % label: Extra searching parameters to use in query
+# % description: Note: Make sure to use provided options when possible, otherwise the values mignt not be recognized
+# % guisection: Filter
+# %end
+
+# %option
 # % key: start
 # % type: string
 # % description: Start date (in any ISO 8601 format), by default it is 60 days ago
@@ -447,7 +454,10 @@ def list_products(products):
     for product in products:
         product_line = ""
         for i, column in enumerate(columns):
-            product_attribute_value = product.properties[column]
+            if column in product.properties:
+                product_attribute_value = product.properties[column]
+            else:
+                product_attribute_value = None
             # Display NA if not available
             if product_attribute_value is None:
                 product_attribute_value = columns_NA[i]
@@ -660,7 +670,7 @@ def save_search_result(search_result, file_name):
         dag.serialize(search_result, filename=file_name)
 
 
-def list_providers(productType=None):
+def list_eodag_providers(productType=None):
     """Print providers available in JSON format.
 
     :param producType: Restricts providers to given product.
@@ -677,7 +687,7 @@ def list_providers(productType=None):
     )
 
 
-def list_products(provider=None):
+def list_eodag_products(provider=None):
     """Print products available in JSON format.
 
     :param provider: Restricts products to given provider.
@@ -690,7 +700,7 @@ def list_products(provider=None):
     print(json.dumps(dag.list_product_types(provider or None), indent=4))
 
 
-def list_queryables(**kwargs):
+def list_eodag_queryables(**kwargs):
     """Print queryables info for given provider and/or product type in JSON format.
 
     :param kwargs: Presit parameters values.
@@ -775,11 +785,11 @@ def main():
 
     if options["list"]:
         if options["list"] == "providers":
-            list_providers(options["prodcuttype"])
+            list_eodag_providers(options["prodcuttype"])
         elif options["list"] == "products":
-            list_products(options["provider"])
+            list_eodag_products(options["provider"])
         elif options["list"] == "queryables":
-            list_queryables(**options, **flags)
+            list_eodag_queryables(**options, **flags)
         return
 
     # Download by IDs
@@ -821,6 +831,10 @@ def main():
             "productType": product_type,
             "geom": geometry,
         }
+        if options["query"]:
+            for parameter in options["query"].split(","):
+                key, value = parameter.split("=")
+                search_parameters[key] = value
 
         if options["clouds"]:
             search_parameters["cloudCover"] = options["clouds"]

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -241,10 +241,10 @@ def get_bb(proj):
     if proj["+proj"] != "longlat":
         info = gs.parse_command("g.region", flags="uplg")
         return {
-            "lonmin": info["nw_long"],
-            "latmin": info["sw_lat"],
-            "lonmax": info["ne_long"],
-            "latmax": info["nw_lat"],
+            "lonmin": float(info["nw_long"]),
+            "latmin": float(info["sw_lat"]),
+            "lonmax": float(info["ne_long"]),
+            "latmax": float(info["nw_lat"]),
         }
     info = gs.parse_command("g.region", flags="upg")
     return {

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -353,6 +353,9 @@ def setup_environment_variables(env, **kwargs):
 
     # Setting the envirionmnets variables has to come before the eodag initialization
     if config:
+        config_file = Path(options["config"])
+        if not config_file.is_file():
+            gs.fatal(_("Config file '{}' not found.".format(options["config"])))
         env["EODAG_CFG_FILE"] = options["config"]
     if provider:
         # Flags can't be taken into consideration without specifying the provider

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -649,7 +649,7 @@ def save_footprints(search_result, map_name):
 
     Reprojection is done on the fly.
 
-    :param search_result: EO products to be sorted
+    :param search_results: EO products whose footprints are to be saved.
     :type search_result: class'eodag.api.search_result.SearchResult'
 
     :param map_name: Footprint name to be used.

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -7,7 +7,7 @@
 # AUTHOR(S):   Hamed Elgizery
 # MENTOR(S):   Luca Delucchi, Veronica Andreo, Stefan Blumentrath
 #
-# PURPOSE:     Downloads imagery datasets e.g. Landsat, Sentinel, and MODIS
+# PURPOSE:     Downloads imagery secens e.g. Landsat, Sentinel, and MODIS
 #              using EODAG API.
 # COPYRIGHT:   (C) 2024-2025 by Hamed Elgizery, and the GRASS development team
 #
@@ -18,13 +18,14 @@
 #############################################################################
 
 # %Module
-# % description: Downloads imagery datasets from various providers through the EODAG API.
+# % description: Downloads imagery scenes from various providers through the EODAG API.
 # % keyword: imagery
 # % keyword: eodag
 # % keyword: sentinel
 # % keyword: landsat
 # % keyword: modis
-# % keyword: datasets
+# % keyword: dataset
+# % keyword: scene
 # % keyword: download
 # %end
 
@@ -48,7 +49,7 @@
 
 # %flag
 # % key: e
-# % description: Extract the downloaded the datasets, not considered unless provider is set
+# % description: Extract the downloaded the scenes, not considered unless provider is set
 # %end
 
 # %flag
@@ -59,9 +60,9 @@
 
 # OPTIONS
 # %option
-# % key: dataset
+# % key: producttype
 # % type: string
-# % description: Imagery dataset to search for
+# % description: Imagery producttype to search for
 # % required: no
 # % guisection: Filter
 # %end
@@ -179,7 +180,8 @@
 # %rules
 # % exclusive: file, id
 # % exclusive: -l, -j, -m
-# % requires: -m, dataset, provider
+# % requires: -m, producttype, provider
+# % requires: -l, producttype
 # %end
 
 
@@ -659,13 +661,13 @@ def save_search_result(search_result, file_name):
 
 
 def list_queryables(**kwargs):
-    """Print queryables info for given provider and/or productType in JSON format.
+    """Print queryables info for given provider and/or product type in JSON format.
 
     :param kwargs: Presit parameters values.
     :type kwargs: dict
     """
     provider = kwargs["provider"]
-    productType = kwargs["dataset"]
+    productType = kwargs["producttype"]
     queryables = dag.list_queryables(
         provider=provider or None, productType=productType or None
     )
@@ -772,7 +774,7 @@ def main():
         items_per_page = 40
         # TODO: Check that the product exists,
         # could be handled by catching exceptions when searching...
-        product_type = options["dataset"]
+        product_type = options["producttype"]
 
         # HARDCODED VALUES FOR TESTING { "lonmin": 1.9, "latmin": 43.9, "lonmax": 2, "latmax": 45, }
         geometry = get_aoi(options["map"])
@@ -842,4 +844,5 @@ if __name__ == "__main__":
             setup_logging(2)
         else:
             setup_logging(3)
+    setup_logging(3)
     sys.exit(main())

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -275,7 +275,6 @@ def get_bb(proj):
             "lonmax": float(info["ne_long"]),
             "latmax": float(info["nw_lat"]),
         }
-    print("HERE")
     info = gs.parse_command("g.region", flags="upg")
     return {
         "lonmin": info["w"],

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -178,7 +178,7 @@
 # %end
 
 # %option
-# % key: list
+# % key: print
 # % type: string
 # % description: Print the available options of the given value in JSON
 # % options: products,providers,queryables
@@ -670,7 +670,7 @@ def save_search_result(search_result, file_name):
         dag.serialize(search_result, filename=file_name)
 
 
-def list_eodag_providers(productType=None):
+def print_eodag_providers(productType=None):
     """Print providers available in JSON format.
 
     :param producType: Restricts providers to given product.
@@ -687,7 +687,7 @@ def list_eodag_providers(productType=None):
     )
 
 
-def list_eodag_products(provider=None):
+def print_eodag_products(provider=None):
     """Print products available in JSON format.
 
     :param provider: Restricts products to given provider.
@@ -700,7 +700,7 @@ def list_eodag_products(provider=None):
     print(json.dumps(dag.list_product_types(provider or None), indent=4))
 
 
-def list_eodag_queryables(**kwargs):
+def print_eodag_queryables(**kwargs):
     """Print queryables info for given provider and/or product type in JSON format.
 
     :param kwargs: Presit parameters values.
@@ -783,13 +783,13 @@ def main():
 
     dates_to_iso_format()
 
-    if options["list"]:
-        if options["list"] == "providers":
-            list_eodag_providers(options["prodcuttype"])
-        elif options["list"] == "products":
-            list_eodag_products(options["provider"])
-        elif options["list"] == "queryables":
-            list_eodag_queryables(**options, **flags)
+    if options["print"]:
+        if options["print"] == "providers":
+            print_eodag_providers(options["prodcuttype"])
+        elif options["print"] == "products":
+            print_list_eodag_products(options["provider"])
+        elif options["print"] == "queryables":
+            print_list_eodag_queryables(**options, **flags)
         return
 
     # Download by IDs

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -525,7 +525,6 @@ def filter_result(search_result, geometry, **kwargs):
             )
         # Product's geometry contains the AOI
         elif area_relation == "Contains":
-            print("HERE")
             search_result = search_result.filter_overlap(
                 geometry=geometry, contains=True
             )

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -162,7 +162,7 @@
 # % key: query
 # % multiple: yes
 # % label: Extra searching parameters to use in the search
-# % description: Note: Make sure to use provided options when possible, otherwise the values mignt not be recognized
+# % description: Note: Make sure to use provided options when possible, otherwise the values might not be recognized
 # % required: no
 # % guisection: Filter
 # %end

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -634,6 +634,8 @@ def sort_result(search_result):
     # Sort keys and sort orders are matched respectively
     def products_compare(first, second):
         for sort_key in sort_keys:
+            if sort_key not in first.properties:
+                continue
             if sort_key == "ingestiondate":
                 first_value = first.properties["startTimeFromAscendingNode"]
                 second_value = second.properties["startTimeFromAscendingNode"]
@@ -745,10 +747,10 @@ def save_search_result(search_result, file_name):
     saving it in a format that can be read again by i.eodag,
     to restore the search results.
 
-    :param search_result: EO products to be sorted
+    :param search_result: Search result with EO products to be saved.
     :type search_result: class'eodag.api.search_result.SearchResult'
 
-    :param file_name: EO products to be sorted
+    :param file_name: File to save search result in.
     :type file_name: str
     """
     if file_name[-5:].lower() == ".json":

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -764,12 +764,13 @@ def save_search_result(search_result, file_name):
         dag.serialize(search_result, filename=file_name)
 
 
-def print_eodag_configuration(provider=None):
+def print_eodag_configuration(**kwargs):
     """Print EODAG currently recognized configurations in JSON format.
 
     :param provider: Print the configuration for only the given provider.
     :type provider: dict
     """
+    provider = kwargs["provider"]
 
     def to_dict(config):
         ret_dict = dict()
@@ -792,12 +793,13 @@ def print_eodag_configuration(provider=None):
         print(json.dumps(to_dict(dag.providers_config), indent=4))
 
 
-def print_eodag_providers(productType=None):
+def print_eodag_providers(**kwargs):
     """Print providers available in JSON format.
 
     :param producType: Restricts providers to given product.
     :type productType: dict
     """
+    productType = kwargs["producttype"]
     if productType:
         gs.message(_("Recongnized providers offering {}".format(productType)))
     else:
@@ -809,12 +811,13 @@ def print_eodag_providers(productType=None):
     )
 
 
-def print_eodag_products(provider=None):
+def print_eodag_products(**kwargs):
     """Print products available in JSON format.
 
     :param provider: Restricts products to given provider.
     :type provider: dict
     """
+    provider = kwargs["provider"]
     if provider:
         gs.message(_("Recognized products offered by {}".format(provider)))
     else:
@@ -909,14 +912,13 @@ def main():
     dates_to_iso_format()
 
     if options["print"]:
-        if options["print"] == "providers":
-            print_eodag_providers(options["producttype"])
-        elif options["print"] == "products":
-            print_eodag_products(options["provider"])
-        elif options["print"] == "config":
-            print_eodag_configuration(options["provider"])
-        elif options["print"] == "queryables":
-            print_eodag_queryables(**options, **flags)
+        print_functions = {
+            "providers": print_eodag_providers,
+            "products": print_eodag_products,
+            "config": print_eodag_configuration,
+            "queryables": print_eodag_queryables,
+        }
+        print_functions[options["print"]](**options)
         return
 
     # Download by IDs

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -37,12 +37,6 @@
 # %end
 
 # %flag
-# % key: m
-# % description: List filtered products and exit
-# % guisection: List
-# %end
-
-# %flag
 # % key: j
 # % description: Print extended metadata information in JSON style
 # %end
@@ -176,11 +170,17 @@
 # % guisection: Save
 # %end
 
+# %option
+# % key: list
+# % type: string
+# % description: Print the available options of the given value in JSON
+# % options: products,providers,queryables
+# % guisection: Metadata
+# %end
 
 # %rules
 # % exclusive: file, id
-# % exclusive: -l, -j, -m
-# % requires: -m, producttype, provider
+# % exclusive: -l, -j
 # % requires: -l, producttype
 # %end
 
@@ -660,6 +660,36 @@ def save_search_result(search_result, file_name):
         dag.serialize(search_result, filename=file_name)
 
 
+def list_providers(productType=None):
+    """Print providers available in JSON format.
+
+    :param producType: Restricts providers to given product.
+    :type productType: dict
+    """
+    if productType:
+        gs.message(_("Recongnized providers offering {}".format(productType)))
+    else:
+        gs.message(_("Recongnizaed providers"))
+    print(
+        json.dumps(
+            {"providers": dag.available_providers(productType or None)}, indent=4
+        )
+    )
+
+
+def list_products(provider=None):
+    """Print products available in JSON format.
+
+    :param provider: Restricts products to given provider.
+    :type provider: dict
+    """
+    if provider:
+        gs.message(_("Recognized products offered by {}".format(provider)))
+    else:
+        gs.message(_("Recongnizaed providers"))
+    print(json.dumps(dag.list_product_types(provider or None), indent=4))
+
+
 def list_queryables(**kwargs):
     """Print queryables info for given provider and/or product type in JSON format.
 
@@ -668,6 +698,7 @@ def list_queryables(**kwargs):
     """
     provider = kwargs["provider"]
     productType = kwargs["producttype"]
+    gs.message(_("Available queryables"))
     queryables = dag.list_queryables(
         provider=provider or None, productType=productType or None
     )
@@ -742,8 +773,13 @@ def main():
 
     dates_to_iso_format()
 
-    if flags["m"]:
-        list_queryables(**options, **flags)
+    if options["list"]:
+        if options["list"] == "providers":
+            list_providers(options["prodcuttype"])
+        elif options["list"] == "products":
+            list_products(options["provider"])
+        elif options["list"] == "queryables":
+            list_queryables(**options, **flags)
         return
 
     # Download by IDs
@@ -844,5 +880,4 @@ if __name__ == "__main__":
             setup_logging(2)
         else:
             setup_logging(3)
-    setup_logging(3)
     sys.exit(main())

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -835,7 +835,8 @@ def print_eodag_products(**kwargs):
 def print_eodag_queryables(**kwargs):
     """Print queryables info for given provider and/or product type in JSON format.
 
-    :param kwargs: Presit parameters values.
+    :param kwargs: options/flags from gs.parser, with the crietria that will
+                   be used for filtering.
     :type kwargs: dict
     """
     provider = kwargs["provider"]


### PR DESCRIPTION
- [x] Add `query` option, from which one can set extra querayables for searching.

- [x] Add `print` option to allow printing of the following in JSON format:
  - Current EODAG configuration.
  - Available products.
  - Available products for a given provider.
  - Available providers. 
  - Available providers offering a specific product.
  - Queryables for a given provider and/or product. 
  
**Note**: Queryables from the above list can then be used in the query option.

- [x] Add `foorprints` option to allow saving the scenes in a single combined footprint vector map.