### PR TITLE
i.eodag: add operators to queryables and allow multiple values

### DIFF
--- a/src/imagery/i.eodag/i.eodag.html
+++ b/src/imagery/i.eodag/i.eodag.html
@@ -32,6 +32,153 @@ from the EODAG YAML config file.  User have to specify the config file path
 location through the <b>config</b> option, otherwise <em>i.eodag</em>
 will use the credentials found in the default config file <em>~/.config/eodag/eodag.yml</em>
 
+<h2>NOTES</h2>
+<h3>Querying</h3>
+<p>
+Querying, aka. Filtering, is a method introduced to i.eodag to filter search results based on an extended list of Products' properties, called
+<a href=""https://eodag.readthedocs.io/en/stable/notebooks/api_user_guide/4_search.html?highlight=queryables#Queryables>queryables</a>.<br>
+The <b>print</b> option can be used to get hint of the avaible queryables, refere to <a href="#list_queryables_example">examples</a>.<br>
+For example, to get the queryables for the product "S2_MSI_L2A" that is offered by Copernicus Data Space Ecosystem, aka. "cop_dataspace":
+<div class="code"><pre>
+i.eodag print=queryables provider=cop_dataspace producttype=S2_MSI_L2A
+</pre>
+</div>
+Note that the <b>print</b> option only gives a subset of the avaible queryables,
+and you can in fact use any of the product's properties, for filtering.
+If you are not sure about the all the available properties,
+you can run a generic search with the <b>j</b> flag and setting <b>limit=1</b>,
+to see an instance of the product of interest.
+The available queryables will be found in
+the JSON output in the "properties" section.
+
+<p>
+<h4>The possible types of these parameters are:</h4>
+<ul>
+  <li><b>str</b> most common type.</li>
+  <li><b>int</b> may have a specified range, e.g. the above cloudCover queryable.</li>
+  <li><b>float</b> may have a specified range.</li>
+  <li><b>Literal</b> has a list of options to choose from.</li>
+</ul>
+
+<p>
+The <b>query</b> option is used for querying. There is a list of rules that you need to follow when composing your queries:
+<h4>Operators</h4>
+<table border="1">
+<thead>
+<tr>
+<th>Relation</th>
+<th>Operator</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Equal</td>
+<td style="text-align: center"><code>eq</code></td>
+</tr>
+<tr>
+<td>Not Equal</td>
+<td style="text-align: center"><code>ne</code></td>
+</tr>
+<tr>
+<td>Less Than or Equal</td>
+<td style="text-align: center"><code>le</code></td>
+</tr>
+<tr>
+<td>Less Than</td>
+<td style="text-align: center"><code>lt</code></td>
+</tr>
+<tr>
+<td>Greater Than or Equal</td>
+<td style="text-align: center"><code>ge</code></td>
+</tr>
+<tr>
+<td>Greater Than</td>
+<td style="text-align: center"><code>gt</code></td>
+</tr>
+</tbody>
+</table>
+
+<h3>Query Structure</h3>
+
+<h4>Basic Structure:</h4>
+<div class="code"><pre>
+{queryable} = {value} \ {operator}
+</pre></div>
+<h4>Example</h4>
+Print products whose <b>orbitDirection</b> property equals "DESCENDING":
+<div class="code"><pre>
+i.eodag -l start=2022-05-01 end=2022-06-01 \
+provider=cop_dataspace producttype=S2_MSI_L2A \
+query="orbitDirection=DESCENDING\eq"
+</pre></div>
+NOTE: If no operator is specified then the 'eq' opeartor will be used <b>(default)</b>.
+<br>
+
+<h4>Multiple Values per Queryable:</h4>
+<div class="code"><pre>
+{queryable} = {value_1} \ {operator_1} | {value_2} \ {opeartor_2}
+</pre></div>
+
+<h4>Examples</h4>
+
+Print products whose <b>cloudCover</b> is either less than 30 <b>OR</b> greater than 60, aka. [0, 30) &cup; (60, 100].<br>
+Notice here that multiple values are used to indicate the <b>OR relation</b>.<br>
+<div class="code"><pre>
+i.eodag -l start=2022-05-01 end=2022-06-01 \
+provider=cop_dataspace producttype=S2_MSI_L2A \
+query="cloudCover=30\lt | 60\gt"
+</pre></div>
+
+To use the <b>AND relation</b> instead, write them in seperate queries, as in the following example.<br>
+Print products whose <b>cloudCover</b> are greater than 30 <b>AND</b> less than 60, aka. (30, 60).<br>
+<div class="code"><pre>
+i.eodag -l start=2022-05-01 end=2022-06-01 \
+provider=cop_dataspace producttype=S2_MSI_L2A \
+query="cloudCover=30\gt, cloudCover=60\lt"
+</pre></div>
+
+Print products whose <b>cloudCover</b> is Greater Than 30 <b>AND</b> Less Than 60, and having a descending orbit direction.
+<div class="code"><pre>
+i.eodag -l start=2022-05-01 end=2022-06-01 \
+provider=cop_dataspace producttype=S2_MSI_L2A \
+query="cloudCover=30\gt, cloudCover=60\lt, orbitDirection=DESCENDING"
+</pre></div>
+
+<h4>Null Values</h4>
+In some cases, products might have <b>Null</b> as the value of a some properties (aka. queryables).
+In these cases, if you attempt to filter with a queryable the products having this queryable set as <b>Null</b> will be filtered out.
+In case you don't want them to be filtered out, you will have to give an additional <b>Null</b> value to the queryable.
+
+<h4>Examples</h4>
+Print products whose <b>orbitDirection</b> is and only is <b>DESCENDING</b>.
+<div class="code"><pre>
+i.eodag -l start=2022-05-01 end=2022-06-01 \
+provider=cop_dataspace producttype=S2_MSI_L2A \
+query="orbitDirection=DESCENDING"
+</pre></div>
+Print products whose <b>orbitDirection</b> is <b>DESCENDING OR Null</b>.
+<div class="code"><pre>
+i.eodag -l start=2022-05-01 end=2022-06-01 \
+provider=cop_dataspace producttype=S2_MSI_L2A \
+query="orbitDirection=DESCENDING|Null"
+</pre></div>
+
+
+
+<h4>List of Frequently Used Queryables</h4>
+<ul>
+  <li><b>cloudCover</b> [0, 100]</li>
+  <li><b>orbitNumber</b></li>
+  <li><b>orbitDirection</b></li>
+  <li><b>storageStatus</b></li>
+  <li><b>start</b> ISO formated date referring to products caputred on start date or later.</li>
+  <li><b>end</b> ISO formated date referring to products caputred on end date or earlier.</li>
+</ul>
+
+<p>
+<b>NOTE: These queryables are only for reference, and they might not always be avaiable for all providers/products.</b>
+
+<h2>EODAG Configuration</h2>
 <p>
 Following is an example for a config YAML file with <em>Copernicus Dataspace</em> credentials:
 <div class="code"><pre>
@@ -46,6 +193,7 @@ cop_dataspace:
           username: email@email.com
           password: password
 </pre></div>
+
 
 <p>
 See
@@ -64,14 +212,6 @@ v.extract input=urbanarea where="NAME = 'Durham'" output=durham
 
 i.eodag -l start=2022-05-01 end=2022-06-01 \
     map=durham producttype=S2_MSI_L2A provider=cop_dataspace
-
-6 scenes(s) found.
-S2B_MSIL2A_20220518T155819_N0400_R097_T17SPV_20220518T204903 2022-05-18T15:58:19 24% S2MSI2A
-S2A_MSIL2A_20220513T155821_N0400_R097_T17SPV_20220514T002317 2022-05-13T15:58:21 99% S2MSI2A
-S2B_MSIL2A_20220508T155819_N0400_R097_T17SPV_20220508T205707 2022-05-08T15:58:19 100% S2MSI2A
-S2A_MSIL2A_20220523T155831_N0400_R097_T17SPV_20220524T002713 2022-05-23T15:58:31 95% S2MSI2A
-S2A_MSIL2A_20220503T155831_N0400_R097_T17SPV_20220503T233818 2022-05-03T15:58:31 86% S2MSI2A
-S2B_MSIL2A_20220528T155819_N0400_R097_T17SPV_20220528T205325 2022-05-28T15:58:19  2% S2MSI2A
 <pre></div>
 
 Search and list the available Sentinel 2 scenes in the Copernicus Data Space
@@ -159,7 +299,7 @@ i.eodag print=products provider=cop_dataspace
 <pre></div>
 
 List queryables for Sentinel 2 scenes, that is offered by Copernicus Data Space Ecosystem:
-<div class="code"><pre>
+<div id="list_queryables_example" class="code"><pre>
 i.eodag print=queryables provider=cop_dataspace producttype=S2_MSI_L2A
 <pre></div>
 

--- a/src/imagery/i.eodag/i.eodag.html
+++ b/src/imagery/i.eodag/i.eodag.html
@@ -25,20 +25,25 @@ To download only selected scenes, one or more IDs must be provided
 through the <b>id</b> option.
 
 <p>
-To be able to download data through <em>i.eodag</em>, the user will need to register for the
+To be able to download data through <em>i.eodag</em>, the user will
+need to register for the
 providers of interest.
-<em>i.eodag</em> reads the user credentials, which the user should have acquired,
-from the EODAG YAML config file.  User have to specify the config file path
-location through the <b>config</b> option, otherwise <em>i.eodag</em>
-will use the credentials found in the default config file <em>~/.config/eodag/eodag.yml</em>
+<em>i.eodag</em> reads the user credentials, which the user should have
+acquired, from the EODAG YAML config file.  User have to specify the config
+file path location through the <b>config</b> option, otherwise <em>i.eodag</em>
+will use the credentials found in the default config file
+<em>~/.config/eodag/eodag.yml</em>
 
 <h2>NOTES</h2>
 <h3>Querying</h3>
 <p>
-Querying, aka. Filtering, is a method introduced to i.eodag to filter search results based on an extended list of Products' properties, called
-<a href=""https://eodag.readthedocs.io/en/stable/notebooks/api_user_guide/4_search.html?highlight=queryables#Queryables>queryables</a>.<br>
-The <b>print</b> option can be used to get hint of the avaible queryables, refere to <a href="#list_queryables_example">examples</a>.<br>
-For example, to get the queryables for the product "S2_MSI_L2A" that is offered by Copernicus Data Space Ecosystem, aka. "cop_dataspace":
+Querying, aka. Filtering, is a method introduced to i.eodag to filter search
+results based on an extended list of Products' properties, called
+<a href="https://eodag.readthedocs.io/en/stable/notebooks/api_user_guide/4_search.html?highlight=queryables#Queryables">queryables</a>.<br>
+The <b>print</b> option can be used to get hint of the avaible queryables,
+refere to <a href="#list_queryables_example">examples</a>.<br>
+For example, to get the queryables for the product "S2_MSI_L2A" that is
+offered by Copernicus Data Space Ecosystem, aka. "cop_dataspace":
 <div class="code"><pre>
 i.eodag print=queryables provider=cop_dataspace producttype=S2_MSI_L2A
 </pre>
@@ -55,13 +60,15 @@ the JSON output in the "properties" section.
 <h4>The possible types of these parameters are:</h4>
 <ul>
   <li><b>str</b> most common type.</li>
-  <li><b>int</b> may have a specified range, e.g. the above cloudCover queryable.</li>
+  <li><b>int</b> may have a specified range, e.g. the above cloudCover
+    queryable.</li>
   <li><b>float</b> may have a specified range.</li>
   <li><b>Literal</b> has a list of options to choose from.</li>
 </ul>
 
 <p>
-The <b>query</b> option is used for querying. There is a list of rules that you need to follow when composing your queries:
+The <b>query</b> option is used for querying. There is a list of rules that you
+need to follow when composing your queries:
 <h4>Operators</h4>
 <table border="1">
 <thead>
@@ -111,8 +118,8 @@ i.eodag -l start=2022-05-01 end=2022-06-01 \
 provider=cop_dataspace producttype=S2_MSI_L2A \
 query="orbitDirection=DESCENDING\eq"
 </pre></div>
-NOTE: If no operator is specified then the 'eq' opeartor will be used <b>(default)</b>.
-<br>
+NOTE: If no operator is specified then the 'eq' opeartor will be used
+<b>(default)</b>.
 
 <h4>Multiple Values per Queryable:</h4>
 <div class="code"><pre>
@@ -121,23 +128,27 @@ NOTE: If no operator is specified then the 'eq' opeartor will be used <b>(defaul
 
 <h4>Examples</h4>
 
-Print products whose <b>cloudCover</b> is either less than 30 <b>OR</b> greater than 60, aka. [0, 30) &cup; (60, 100].<br>
-Notice here that multiple values are used to indicate the <b>OR relation</b>.<br>
+Print products whose <b>cloudCover</b> is either less than 30 <b>OR</b> greater
+than 60, aka. [0, 30) &cup; (60, 100].<br>
+Notice here that multiple values are used to indicate the <b>OR relation</b>.
 <div class="code"><pre>
 i.eodag -l start=2022-05-01 end=2022-06-01 \
 provider=cop_dataspace producttype=S2_MSI_L2A \
 query="cloudCover=30\lt | 60\gt"
 </pre></div>
 
-To use the <b>AND relation</b> instead, write them in seperate queries, as in the following example.<br>
-Print products whose <b>cloudCover</b> are greater than 30 <b>AND</b> less than 60, aka. (30, 60).<br>
+To use the <b>AND relation</b> instead, write them in seperate queries,
+as in the following example.<br>
+Print products whose <b>cloudCover</b> are greater than 30 <b>AND</b>
+less than 60, aka. (30, 60).
 <div class="code"><pre>
 i.eodag -l start=2022-05-01 end=2022-06-01 \
 provider=cop_dataspace producttype=S2_MSI_L2A \
 query="cloudCover=30\gt, cloudCover=60\lt"
 </pre></div>
 
-Print products whose <b>cloudCover</b> is Greater Than 30 <b>AND</b> Less Than 60, and having a descending orbit direction.
+Print products whose <b>cloudCover</b> is Greater Than 30 <b>AND</b> Less Than
+60, and having a descending orbit direction.
 <div class="code"><pre>
 i.eodag -l start=2022-05-01 end=2022-06-01 \
 provider=cop_dataspace producttype=S2_MSI_L2A \
@@ -145,9 +156,12 @@ query="cloudCover=30\gt, cloudCover=60\lt, orbitDirection=DESCENDING"
 </pre></div>
 
 <h4>Null Values</h4>
-In some cases, products might have <b>Null</b> as the value of a some properties (aka. queryables).
-In these cases, if you attempt to filter with a queryable the products having this queryable set as <b>Null</b> will be filtered out.
-In case you don't want them to be filtered out, you will have to give an additional <b>Null</b> value to the queryable.
+In some cases, products might have <b>Null</b> as the value of a some properties
+(aka. queryables).
+In these cases, if you attempt to filter with a queryable the products having
+this queryable set as <b>Null</b> will be filtered out.
+In case you don't want them to be filtered out, you will have to give
+an additional <b>Null</b> value to the queryable.
 
 <h4>Examples</h4>
 Print products whose <b>orbitDirection</b> is and only is <b>DESCENDING</b>.
@@ -171,16 +185,90 @@ query="orbitDirection=DESCENDING|Null"
   <li><b>orbitNumber</b></li>
   <li><b>orbitDirection</b></li>
   <li><b>storageStatus</b></li>
-  <li><b>start</b> ISO formated date referring to products caputred on start date or later.</li>
-  <li><b>end</b> ISO formated date referring to products caputred on end date or earlier.</li>
+  <li><b>start</b> ISO formated date referring to products caputred on
+    start date or later.</li>
+  <li><b>end</b> ISO formated date referring to products caputred on
+    end date or earlier.</li>
 </ul>
 
 <p>
-<b>NOTE: These queryables are only for reference, and they might not always be avaiable for all providers/products.</b>
+<b>NOTE: These queryables are only for reference,
+  and they might not always be avaiable for all providers/products.</b>
+
+<h3>Use Cases</h3>
+There are multiple use cases for <em>i.eodag</em> described below:
+<h4>Searching from Scratch</h4>
+<p>
+This is when you are searching for scenes for the first time and you don't
+know the IDs of the scenes you are looking for.
+The searching is done by setting the main options e.g. <b>producttype</b>,
+<b>start</b>, <b>end</b>, and, possibly, a <b>provider</b>.
+
+<h4>Searching using Scenes IDs</h4>
+<p>
+The use case is that you have a set of scenes IDs that you want to
+search for and download.
+You are able to do that through two methods:
+<ol>
+  <li>Use the <b>id</b>.</li>
+  <li>Use the <b>file</b> with a text file, having one ID per line.
+</ol>
+In both cases you can either specify a provider, or not.
+In case you don't specify the provider, products might be offered
+from different providers.
+
+<h4>Reading Products from a GeoJSON File</h4>
+<p>
+This use case is used if you have already done your searching,
+and you have a GeoJSON file produced by <em>i.eodag</em> using
+the <b>save</b> option. To do that you will have to use the <b>file</b>
+option and pass the GeoJSON file to it. No additional searching will be
+done in this case, but you will be able to further filter the products
+saved in the GeoJSON file through the different options,
+e.g. <b>start, end, query, area_relation, etc...</b>
+<p>
+<h4>Filtering by AOI</h4>
+When filtering scenes through the area related options
+(<b>area_relation</b> and/or <b>minimum_overlap</b>),
+<em>i.eodag</em> expects you to provide an
+<b>AOI</b> (Area of Interest), by providing a vector map from the current
+mapset, through the <b>map</b> option. In case you didn't provide an <b>AOI</b>,
+<em>i.eodag</em> will automatically use the <b>current computational region</b>
+to do the searching instead. That provides a more flexible approach in regard
+of specifying the <b>AOI</b> as you could modify the <b>current
+computationl region</b> through
+<a href="https://grass.osgeo.org/grass83/manuals/g.region.html">g.region</a>.
 
 <h2>EODAG Configuration</h2>
 <p>
-Following is an example for a config YAML file with <em>Copernicus Dataspace</em> credentials:
+EODAG configuration <b>YAML</b> file is used to set multiple values, including:
+<p>
+<dl>
+<dt><b>Priority</b>
+<dd>Used when the <em>i.eodag</em> tries to search for a product,
+with no <b>provider</b> specified. Searching is attempted with providers
+with higher priority first.
+
+<p>
+<dt><b>Credentials</b>
+<dd>Some providers require credentials to conduct searching,
+while others don't. However, you will need to set the credentials for downloading, in most cases.<br>
+See
+<a href="https://eodag.readthedocs.io/en/stable/getting_started_guide/register.html" target="_blank">
+  Providers Registration</a> for more details about registration and credentials.
+<p>
+NOTE: If you notice that <em>i.eodag</em> doesn't recognize
+a specific provider when searching or downloading,
+it might be that you need to specify the providers credentials.
+
+<p>
+<dt><b>Output Prefix</b>
+  <dd>Setting the output_prefix is similar to using the <b>output</b> option. It is the directory into which downloaded scenes will be saved.
+</dl>
+
+<p>
+Following is an example for a config YAML file with <em>Copernicus
+  Dataspace</em> credentials:
 <div class="code"><pre>
 cop_dataspace:
     priority: # Lower value means lower priority (Default: 0)
@@ -196,16 +284,15 @@ cop_dataspace:
 
 
 <p>
-See
-<a href="https://eodag.readthedocs.io/en/stable/getting_started_guide/register.html" target="_blank">
-  Providers Registration</a>,
-and <a href="https://eodag.readthedocs.io/en/stable/getting_started_guide/configure.html" target="_blank">
+See <a href="https://eodag.readthedocs.io/en/stable/getting_started_guide/configure.html" target="_blank">
   Configure EODAG</a>
-sections for more details about registration and configuration of the providers' credentials.
+section for more details about configuration of the
+providers' credentials and other EODAG YAML config file parameters.
 
 <h2>EXAMPLES</h2>
 
-Search and list the available Sentinel 2 scenes in the Copernicus Data Space Ecosystem, using a Vector Map as an AOI:
+Search and list the available Sentinel 2 scenes in the Copernicus Data Space
+Ecosystem, using a Vector Map as an AOI:
 
 <div class="code"><pre>
 v.extract input=urbanarea where="NAME = 'Durham'" output=durham
@@ -224,7 +311,8 @@ i.eodag -l start=2022-05-01 end=2022-06-01 \
     clouds=50 map=durham minimum_overlap=70
 <pre></div>
 
-Sort results, descendingly, by <b>cloudcover</b>, and then by <b>ingestiondate</b>
+Sort results, descendingly, by <b>cloudcover</b>,
+and then by <b>ingestiondate</b>
 Note that sorting with <b>cloudcover</b> use
 unrounded values, while they are rounded to the nearest integer when listing.
 
@@ -298,7 +386,8 @@ List recognized eodag products, offered by Copernicus Data Space Ecosystem:
 i.eodag print=products provider=cop_dataspace
 <pre></div>
 
-List queryables for Sentinel 2 scenes, that is offered by Copernicus Data Space Ecosystem:
+List queryables for Sentinel 2 scenes, that is offered by Copernicus
+Data Space Ecosystem:
 <div id="list_queryables_example" class="code"><pre>
 i.eodag print=queryables provider=cop_dataspace producttype=S2_MSI_L2A
 <pre></div>

--- a/src/imagery/i.eodag/i.eodag.html
+++ b/src/imagery/i.eodag/i.eodag.html
@@ -30,10 +30,11 @@ through the <b>id</b> option.
 To be able to download data through <em>i.eodag</em>, users will
 need to register for the providers of interest.
 <em>i.eodag</em> reads user credentials from the EODAG YAML config file.
-Users have to specify the config file path through the <b>config</b>
+Users have to specify the configuration file path through the <b>config</b>
 option, otherwise <em>i.eodag</em> will use the credentials found in
-the default config file <em>~/.config/eodag/eodag.yml</em> which is auto-generated the
-first time eodag is used after an install in `$HOME/.config/eodag/eodag.yml`.
+the default config file which is auto-generated the first time EODAG is used 
+after installation. The configuration file is stored by default in 
+<code>$HOME/.config/eodag/eodag.yml</code>.
 
 <h3>Use Cases</h3>
 

--- a/src/imagery/i.eodag/i.eodag.html
+++ b/src/imagery/i.eodag/i.eodag.html
@@ -32,7 +32,8 @@ need to register for the providers of interest.
 <em>i.eodag</em> reads user credentials from the EODAG YAML config file.
 Users have to specify the config file path through the <b>config</b>
 option, otherwise <em>i.eodag</em> will use the credentials found in
-the default config file <em>~/.config/eodag/eodag.yml</em>
+the default config file <em>~/.config/eodag/eodag.yml</em> which is auto-generated the
+first time eodag is used after an install in `$HOME/.config/eodag/eodag.yml`.
 
 <h3>Use Cases</h3>
 

--- a/src/imagery/i.eodag/i.eodag.html
+++ b/src/imagery/i.eodag/i.eodag.html
@@ -2,15 +2,17 @@
 <h3>WARNING: I.EODAG IS UNDER DEVELOPMENT. THIS IS AN EXPERIMENTAL VERSION.</h3>
 
 <em>i.eodag</em> allows to search and download imagery scenes, e.g. Sentinel,
-Landsat, and MODIS, from a number of different providers.
-The module utilizes the
+Landsat, and MODIS, as well as other Earth Observation products, from a number 
+of different providers. The module utilizes the
 <a href="https://eodag.readthedocs.io/en/stable/">EODAG API</a>,
-as a single interface to search for scenes on the providers that EODAG supports.
-
+as a single interface to search for products within the supported providers.
 
 <p>
-Currently, only products which footprint intersects the current computational
-region extent (area of interest, AOI) are retrieved.
+By default <em>i.eodag</em> will search for products which footprint intersects
+the current computational region extent. Users can alternatively opt to pass a 
+vector map throught the <b>map</b> option to define the area of interest (AOI) 
+and change the relation with product footprints by means of the 
+<b>area_relation</b> or <b>minimum_overlap</b> options.
 
 <p>
 To only list available scenes, <b>l</b> flag must be set. If no <b>start</b>
@@ -18,46 +20,75 @@ or <b>end</b> dates are provided, the module will search scenes from the
 past 60 days.
 
 <p>
-To download all scenes found within the time frame provided, the user must
+To download all scenes found within the time frame provided, users must
 remove the <b>l</b> flag and provide an <b>output</b> directory. Otherwise,
-files will be downloaded into <em>/tmp</em> directory.
+files will be downloaded into the /tmp directory.
 To download only selected scenes, one or more IDs must be provided
 through the <b>id</b> option.
 
 <p>
-To be able to download data through <em>i.eodag</em>, the user will
-need to register for the
-providers of interest.
-<em>i.eodag</em> reads the user credentials, which the user should have
-acquired, from the EODAG YAML config file.  User have to specify the config
-file path location through the <b>config</b> option, otherwise <em>i.eodag</em>
-will use the credentials found in the default config file
-<em>~/.config/eodag/eodag.yml</em>
+To be able to download data through <em>i.eodag</em>, users will
+need to register for the providers of interest.
+<em>i.eodag</em> reads user credentials from the EODAG YAML config file.  
+Users have to specify the config file path through the <b>config</b> 
+option, otherwise <em>i.eodag</em> will use the credentials found in 
+the default config file <em>~/.config/eodag/eodag.yml</em>
+
+<h3>Use Cases</h3>
+
+There are different ways to use <em>i.eodag</em>:
+
+<h4>Searching from scratch</h4>
+<p>
+When users are searching for scenes for the first time and they don't
+know the IDs of specific scenes.
+The searching is done by setting the main options e.g. <b>producttype</b>,
+<b>start</b>, <b>end</b>, <b>clouds</b> and, possibly, <b>provider</b>.
+
+<h4>Searching using scenes IDs</h4>
+<p>
+Users have a set of scenes IDs that they want to search for and download.
+They can either use the <b>id</b> option or use the <b>file</b> option 
+and pass a text file, with one ID per line.
+In both cases, specifying a provider is optional. In case users do 
+not specify the provider, products might be offered
+from different providers as long as the user provides the 
+credentials in the configuration file.
+
+<h4>Reading products from a GeoJSON file</h4>
+<p>
+When the user has already performed a first search and saved the results into
+a GeoJSON file using the <b>save</b> option. 
+Users will then pass the GeoJSON file through the <b>file</b>
+option. No additional searching will be done in this case, but users will be
+able to further filter the products saved in the GeoJSON file through the 
+different options, e.g. <b>start, end, query, area_relation, etc.</b>
+
 
 <h2>NOTES</h2>
+
 <h3>Querying</h3>
 <p>
-Querying, aka. Filtering, is a method introduced to i.eodag to filter search
-results based on an extended list of Products' properties, called
+Querying, aka. filtering, is a method introduced to <em>i.eodag</em> to further
+filter the search results based on an extended list of products' properties, called
 <a href="https://eodag.readthedocs.io/en/stable/notebooks/api_user_guide/4_search.html?highlight=queryables#Queryables">queryables</a>.<br>
-The <b>print</b> option can be used to get hint of the avaible queryables,
-refere to <a href="#list_queryables_example">examples</a>.<br>
+The <b>print</b> option can be used to get hints of the avaible queryables.
 For example, to get the queryables for the product "S2_MSI_L2A" that is
-offered by Copernicus Data Space Ecosystem, aka. "cop_dataspace":
+offered by Copernicus Data Space Ecosystem (cop_dataspace):
 <div class="code"><pre>
 i.eodag print=queryables provider=cop_dataspace producttype=S2_MSI_L2A
 </pre>
 </div>
 Note that the <b>print</b> option only gives a subset of the avaible queryables,
-and you can in fact use any of the product's properties, for filtering.
-If you are not sure about the all the available properties,
-you can run a generic search with the <b>j</b> flag and setting <b>limit=1</b>,
+and users can in fact use any of the product's properties for filtering.
+If users are not sure about the all the available properties for a product,
+they can run a generic search with the <b>j</b> flag and <b>limit=1</b>,
 to see an instance of the product of interest.
-The available queryables will be found in
-the JSON output in the "properties" section.
+The available queryables will be found in the JSON output within the 
+"properties" section.
 
 <p>
-<h4>The possible types of these parameters are:</h4>
+The possible types of these properties are:
 <ul>
   <li><b>str</b> most common type.</li>
   <li><b>int</b> may have a specified range, e.g. the above cloudCover
@@ -67,8 +98,8 @@ the JSON output in the "properties" section.
 </ul>
 
 <p>
-The <b>query</b> option is used for querying. There is a list of rules that you
-need to follow when composing your queries:
+The <b>query</b> option is used for querying. There is a list of rules that users 
+need to follow when composing queries:
 <h4>Operators</h4>
 <table border="1">
 <thead>
@@ -105,41 +136,47 @@ need to follow when composing your queries:
 </tbody>
 </table>
 
-<h3>Query Structure</h3>
+<h4>Query Structure</h4>
 
-<h4>Basic Structure:</h4>
+<p>
+Basic structure:
+
 <div class="code"><pre>
 {queryable} = {value} \ {operator}
 </pre></div>
-<h4>Example</h4>
-Print products whose <b>orbitDirection</b> property equals "DESCENDING":
+
+<p>
+Example
+
+Print products which <b>orbitDirection</b> property is "DESCENDING":
 <div class="code"><pre>
 i.eodag -l start=2022-05-01 end=2022-06-01 \
 provider=cop_dataspace producttype=S2_MSI_L2A \
 query="orbitDirection=DESCENDING\eq"
 </pre></div>
-NOTE: If no operator is specified then the 'eq' opeartor will be used
-<b>(default)</b>.
+NOTE: If no operator is specified then the 'eq' opeartor will be used.
 
-<h4>Multiple Values per Queryable:</h4>
+<p>
+Multiple values per queryable:
+
 <div class="code"><pre>
 {queryable} = {value_1} \ {operator_1} | {value_2} \ {opeartor_2}
 </pre></div>
 
-<h4>Examples</h4>
+<p>
+Examples
 
-Print products whose <b>cloudCover</b> is either less than 30 <b>OR</b> greater
+Print products which <b>cloudCover</b> is either less than 30 <b>OR</b> greater
 than 60, aka. [0, 30) &cup; (60, 100].<br>
-Notice here that multiple values are used to indicate the <b>OR relation</b>.
+Notice here that multiple values are used to indicate the <b>OR</b> relation.
 <div class="code"><pre>
 i.eodag -l start=2022-05-01 end=2022-06-01 \
 provider=cop_dataspace producttype=S2_MSI_L2A \
 query="cloudCover=30\lt | 60\gt"
 </pre></div>
 
-To use the <b>AND relation</b> instead, write them in seperate queries,
-as in the following example.<br>
-Print products whose <b>cloudCover</b> are greater than 30 <b>AND</b>
+To use the <b>AND</b> relation instead, write them in separate queries.<br>
+Print products which <b>cloudCover</b> is greater than 30 <b>AND</b>
 less than 60, aka. (30, 60).
 <div class="code"><pre>
 i.eodag -l start=2022-05-01 end=2022-06-01 \
@@ -147,30 +184,32 @@ provider=cop_dataspace producttype=S2_MSI_L2A \
 query="cloudCover=30\gt, cloudCover=60\lt"
 </pre></div>
 
-Print products whose <b>cloudCover</b> is Greater Than 30 <b>AND</b> Less Than
-60, and having a descending orbit direction.
+Print products which <b>cloudCover</b> is greater than 30 <b>AND</b> less than
+60, and having a descending orbit.
 <div class="code"><pre>
 i.eodag -l start=2022-05-01 end=2022-06-01 \
 provider=cop_dataspace producttype=S2_MSI_L2A \
 query="cloudCover=30\gt, cloudCover=60\lt, orbitDirection=DESCENDING"
 </pre></div>
 
-<h4>Null Values</h4>
-In some cases, products might have <b>Null</b> as the value of a some properties
-(aka. queryables).
-In these cases, if you attempt to filter with a queryable the products having
-this queryable set as <b>Null</b> will be filtered out.
-In case you don't want them to be filtered out, you will have to give
+<p>
+Null Values
+
+In some cases, products might have <b>Null</b> as the value of some properties
+(aka. queryables). These products will be filtered out by default.
+In case users do not want them to be filtered out, they need to provide
 an additional <b>Null</b> value to the queryable.
 
-<h4>Examples</h4>
-Print products whose <b>orbitDirection</b> is and only is <b>DESCENDING</b>.
+<p>
+Examples
+
+Print products which <b>orbitDirection</b> is <b>DESCENDING</b>.
 <div class="code"><pre>
 i.eodag -l start=2022-05-01 end=2022-06-01 \
 provider=cop_dataspace producttype=S2_MSI_L2A \
 query="orbitDirection=DESCENDING"
 </pre></div>
-Print products whose <b>orbitDirection</b> is <b>DESCENDING OR Null</b>.
+Print products which <b>orbitDirection</b> is <b>DESCENDING OR Null</b>.
 <div class="code"><pre>
 i.eodag -l start=2022-05-01 end=2022-06-01 \
 provider=cop_dataspace producttype=S2_MSI_L2A \
@@ -178,8 +217,8 @@ query="orbitDirection=DESCENDING|Null"
 </pre></div>
 
 
+<h4>Frequently used queryables</h4>
 
-<h4>List of Frequently Used Queryables</h4>
 <ul>
   <li><b>cloudCover</b> [0, 100]</li>
   <li><b>orbitNumber</b></li>
@@ -192,54 +231,12 @@ query="orbitDirection=DESCENDING|Null"
 </ul>
 
 <p>
-<b>NOTE: These queryables are only for reference,
-  and they might not always be avaiable for all providers/products.</b>
+NOTE: These queryables are only for reference, and they might not always 
+be avaiable for all providers/products.
 
-<h3>Use Cases</h3>
-There are multiple use cases for <em>i.eodag</em> described below:
-<h4>Searching from Scratch</h4>
-<p>
-This is when you are searching for scenes for the first time and you don't
-know the IDs of the scenes you are looking for.
-The searching is done by setting the main options e.g. <b>producttype</b>,
-<b>start</b>, <b>end</b>, and, possibly, a <b>provider</b>.
 
-<h4>Searching using Scenes IDs</h4>
-<p>
-The use case is that you have a set of scenes IDs that you want to
-search for and download.
-You are able to do that through two methods:
-<ol>
-  <li>Use the <b>id</b>.</li>
-  <li>Use the <b>file</b> with a text file, having one ID per line.
-</ol>
-In both cases you can either specify a provider, or not.
-In case you don't specify the provider, products might be offered
-from different providers.
+<h3>EODAG configuration</h3>
 
-<h4>Reading Products from a GeoJSON File</h4>
-<p>
-This use case is used if you have already done your searching,
-and you have a GeoJSON file produced by <em>i.eodag</em> using
-the <b>save</b> option. To do that you will have to use the <b>file</b>
-option and pass the GeoJSON file to it. No additional searching will be
-done in this case, but you will be able to further filter the products
-saved in the GeoJSON file through the different options,
-e.g. <b>start, end, query, area_relation, etc...</b>
-<p>
-<h4>Filtering by AOI</h4>
-When filtering scenes through the area related options
-(<b>area_relation</b> and/or <b>minimum_overlap</b>),
-<em>i.eodag</em> expects you to provide an
-<b>AOI</b> (Area of Interest), by providing a vector map from the current
-mapset, through the <b>map</b> option. In case you didn't provide an <b>AOI</b>,
-<em>i.eodag</em> will automatically use the <b>current computational region</b>
-to do the searching instead. That provides a more flexible approach in regard
-of specifying the <b>AOI</b> as you could modify the <b>current
-computationl region</b> through
-<a href="https://grass.osgeo.org/grass83/manuals/g.region.html">g.region</a>.
-
-<h2>EODAG Configuration</h2>
 <p>
 EODAG configuration <b>YAML</b> file is used to set multiple values, including:
 <p>
@@ -252,23 +249,25 @@ with higher priority first.
 <p>
 <dt><b>Credentials</b>
 <dd>Some providers require credentials to conduct searching,
-while others don't. However, you will need to set the credentials for downloading, in most cases.<br>
-See
+while others do not. However, users will need to set the credentials for downloading, 
+in most cases. See
 <a href="https://eodag.readthedocs.io/en/stable/getting_started_guide/register.html" target="_blank">
   Providers Registration</a> for more details about registration and credentials.
-<p>
-NOTE: If you notice that <em>i.eodag</em> doesn't recognize
+
+  <p>
+NOTE: If users notice that <em>i.eodag</em> doesn't recognize
 a specific provider when searching or downloading,
-it might be that you need to specify the providers credentials.
+it might be that they need to specify the credentials for that provider.
 
 <p>
 <dt><b>Output Prefix</b>
-  <dd>Setting the output_prefix is similar to using the <b>output</b> option. It is the directory into which downloaded scenes will be saved.
+<dd>Setting the output_prefix is similar to using the <b>output</b> option. 
+  It is the directory into which downloaded products will be saved.
 </dl>
 
 <p>
-Following is an example for a config YAML file with <em>Copernicus
-  Dataspace</em> credentials:
+Following is an example for a config YAML file with Copernicus Dataspace 
+credentials:
 <div class="code"><pre>
 cop_dataspace:
     priority: # Lower value means lower priority (Default: 0)
@@ -282,17 +281,15 @@ cop_dataspace:
           password: password
 </pre></div>
 
-
 <p>
-See <a href="https://eodag.readthedocs.io/en/stable/getting_started_guide/configure.html" target="_blank">
-  Configure EODAG</a>
+See <a href="https://eodag.readthedocs.io/en/stable/getting_started_guide/configure.html" target="_blank">Configure EODAG</a>
 section for more details about configuration of the
 providers' credentials and other EODAG YAML config file parameters.
 
 <h2>EXAMPLES</h2>
 
 Search and list the available Sentinel 2 scenes in the Copernicus Data Space
-Ecosystem, using a Vector Map as an AOI:
+Ecosystem, using a vector map as an AOI:
 
 <div class="code"><pre>
 v.extract input=urbanarea where="NAME = 'Durham'" output=durham
@@ -303,18 +300,16 @@ i.eodag -l start=2022-05-01 end=2022-06-01 \
 
 Search and list the available Sentinel 2 scenes in the Copernicus Data Space
 Ecosystem, with at least 70% of the AOI covered:
-<div class="code"><pre>
-v.extract input=urbanarea where="NAME = 'Durham'" output=durham
 
+<div class="code"><pre>
 i.eodag -l start=2022-05-01 end=2022-06-01 \
     producttype=S2_MSI_L2A provider=cop_dataspace \
     clouds=50 map=durham minimum_overlap=70
 <pre></div>
 
-Sort results, descendingly, by <b>cloudcover</b>,
-and then by <b>ingestiondate</b>
-Note that sorting with <b>cloudcover</b> use
-unrounded values, while they are rounded to the nearest integer when listing.
+Sort results descendingly by <b>cloudcover</b>, and then by <b>ingestiondate</b>.
+Note that sorting with <b>cloudcover</b> uses unrounded values, 
+while they are rounded to the nearest integer when listing.
 
 <div class="code"><pre>
 i.eodag -l start=2022-05-25 end=2022-06-01 \
@@ -322,7 +317,7 @@ i.eodag -l start=2022-05-25 end=2022-06-01 \
     sort=cloudcover,ingestiondate order=desc
 <pre></div>
 
-Search for scenes with a list of IDs text file, and filter the results with the
+Search for scenes with a list of IDs, and filter the results with the
 provided parameters:
 
 <div class="code"><pre>
@@ -341,52 +336,52 @@ i.eodag -l producttype=S2_MSI_L2A \
 <pre></div>
 
 Download all available scenes with cloud coverage not exceeding 50%
-in the tmp directory:
+in the /tmp directory:
 
 <div class="code"><pre>
 i.eodag start=2022-05-25 end=2022-06-01 \
     producttype=S2_MSI_L2A provider=cop_dataspace clouds=50
 <pre></div>
 
-Download only selected scenes from a text file of IDs, using the Copernicus Data
+Download only selected scenes from a text file with IDs, using the Copernicus Data
 Space Ecosystem as the provider:
 
 <div class="code"><pre>
 i.eodag file=ids_list.txt provider=cop_dataspace
 <pre></div>
 
-Download and extract only selected scenes into the <em>download_here</em>
+Download only selected scenes into the <em>download_here</em>
 directory, using a custom config file:
 
 <div class="code"><pre>
-i.eodag -e provider=cop_dataspace \
+i.eodag provider=cop_dataspace \
     id="S2B_MSIL2A_20240526T080609_N0510_R078_T37SDD_20240526T094753,
     S2B_MSIL2A_20240529T081609_N0510_R121_T37SED_20240529T124818" \
     config=full/path/to/eodag/config.yaml \
     output=download_here
 <pre></div>
 
-List recognized eodag providers:
+List recognized EODAG providers:
 <div class="code"><pre>
 i.eodag print=providers
 <pre></div>
 
-List recognized eodag providers, offering Sentinel 2 scenes:
+List recognized EODAG providers offering Sentinel 2 scenes:
 <div class="code"><pre>
 i.eodag print=providers producttype=S2_MSI_L2A
 <pre></div>
 
-List recognized eodag products:
+List recognized EODAG products:
 <div class="code"><pre>
 i.eodag print=products
 <pre></div>
 
-List recognized eodag products, offered by Copernicus Data Space Ecosystem:
+List recognized EODAG products offered by Copernicus Data Space Ecosystem:
 <div class="code"><pre>
 i.eodag print=products provider=cop_dataspace
 <pre></div>
 
-List queryables for Sentinel 2 scenes, that is offered by Copernicus
+List queryables for Sentinel 2 scenes offered by Copernicus
 Data Space Ecosystem:
 <div id="list_queryables_example" class="code"><pre>
 i.eodag print=queryables provider=cop_dataspace producttype=S2_MSI_L2A
@@ -401,6 +396,7 @@ List current EODAG configuration for Copernicus Data Space Ecosystem:
 <div class="code"><pre>
 i.eodag print=config provider=cop_dataspace
 <pre></div>
+  
 
 <h2>REQUIREMENTS</h2>
 

--- a/src/imagery/i.eodag/i.eodag.html
+++ b/src/imagery/i.eodag/i.eodag.html
@@ -2,16 +2,16 @@
 <h3>WARNING: I.EODAG IS UNDER DEVELOPMENT. THIS IS AN EXPERIMENTAL VERSION.</h3>
 
 <em>i.eodag</em> allows to search and download imagery scenes, e.g. Sentinel,
-Landsat, and MODIS, as well as other Earth Observation products, from a number 
+Landsat, and MODIS, as well as other Earth Observation products, from a number
 of different providers. The module utilizes the
 <a href="https://eodag.readthedocs.io/en/stable/">EODAG API</a>,
 as a single interface to search for products within the supported providers.
 
 <p>
 By default <em>i.eodag</em> will search for products which footprint intersects
-the current computational region extent. Users can alternatively opt to pass a 
-vector map throught the <b>map</b> option to define the area of interest (AOI) 
-and change the relation with product footprints by means of the 
+the current computational region extent. Users can alternatively opt to pass a
+vector map throught the <b>map</b> option to define the area of interest (AOI)
+and change the relation with product footprints by means of the
 <b>area_relation</b> or <b>minimum_overlap</b> options.
 
 <p>
@@ -29,9 +29,9 @@ through the <b>id</b> option.
 <p>
 To be able to download data through <em>i.eodag</em>, users will
 need to register for the providers of interest.
-<em>i.eodag</em> reads user credentials from the EODAG YAML config file.  
-Users have to specify the config file path through the <b>config</b> 
-option, otherwise <em>i.eodag</em> will use the credentials found in 
+<em>i.eodag</em> reads user credentials from the EODAG YAML config file.
+Users have to specify the config file path through the <b>config</b>
+option, otherwise <em>i.eodag</em> will use the credentials found in
 the default config file <em>~/.config/eodag/eodag.yml</em>
 
 <h3>Use Cases</h3>
@@ -48,20 +48,20 @@ The searching is done by setting the main options e.g. <b>producttype</b>,
 <h4>Searching using scenes IDs</h4>
 <p>
 Users have a set of scenes IDs that they want to search for and download.
-They can either use the <b>id</b> option or use the <b>file</b> option 
+They can either use the <b>id</b> option or use the <b>file</b> option
 and pass a text file, with one ID per line.
-In both cases, specifying a provider is optional. In case users do 
+In both cases, specifying a provider is optional. In case users do
 not specify the provider, products might be offered
-from different providers as long as the user provides the 
+from different providers as long as the user provides the
 credentials in the configuration file.
 
 <h4>Reading products from a GeoJSON file</h4>
 <p>
 When the user has already performed a first search and saved the results into
-a GeoJSON file using the <b>save</b> option. 
+a GeoJSON file using the <b>save</b> option.
 Users will then pass the GeoJSON file through the <b>file</b>
 option. No additional searching will be done in this case, but users will be
-able to further filter the products saved in the GeoJSON file through the 
+able to further filter the products saved in the GeoJSON file through the
 different options, e.g. <b>start, end, query, area_relation, etc.</b>
 
 
@@ -84,21 +84,20 @@ and users can in fact use any of the product's properties for filtering.
 If users are not sure about the all the available properties for a product,
 they can run a generic search with the <b>j</b> flag and <b>limit=1</b>,
 to see an instance of the product of interest.
-The available queryables will be found in the JSON output within the 
+The available queryables will be found in the JSON output within the
 "properties" section.
 
 <p>
 The possible types of these properties are:
 <ul>
   <li><b>str</b> most common type.</li>
-  <li><b>int</b> may have a specified range, e.g. the above cloudCover
-    queryable.</li>
+  <li><b>int</b> may have a specified range.</li>
   <li><b>float</b> may have a specified range.</li>
   <li><b>Literal</b> has a list of options to choose from.</li>
 </ul>
 
 <p>
-The <b>query</b> option is used for querying. There is a list of rules that users 
+The <b>query</b> option is used for querying. There is a list of rules that users
 need to follow when composing queries:
 <h4>Operators</h4>
 <table border="1">
@@ -165,7 +164,7 @@ Multiple values per queryable:
 
 <p>
 Examples
-
+<p>
 Print products which <b>cloudCover</b> is either less than 30 <b>OR</b> greater
 than 60, aka. [0, 30) &cup; (60, 100].<br>
 Notice here that multiple values are used to indicate the <b>OR</b> relation.
@@ -194,7 +193,7 @@ query="cloudCover=30\gt, cloudCover=60\lt, orbitDirection=DESCENDING"
 
 <p>
 Null Values
-
+<p>
 In some cases, products might have <b>Null</b> as the value of some properties
 (aka. queryables). These products will be filtered out by default.
 In case users do not want them to be filtered out, they need to provide
@@ -202,7 +201,7 @@ an additional <b>Null</b> value to the queryable.
 
 <p>
 Examples
-
+<p>
 Print products which <b>orbitDirection</b> is <b>DESCENDING</b>.
 <div class="code"><pre>
 i.eodag -l start=2022-05-01 end=2022-06-01 \
@@ -231,7 +230,7 @@ query="orbitDirection=DESCENDING|Null"
 </ul>
 
 <p>
-NOTE: These queryables are only for reference, and they might not always 
+NOTE: These queryables are only for reference, and they might not always
 be avaiable for all providers/products.
 
 
@@ -249,7 +248,7 @@ with higher priority first.
 <p>
 <dt><b>Credentials</b>
 <dd>Some providers require credentials to conduct searching,
-while others do not. However, users will need to set the credentials for downloading, 
+while others do not. However, users will need to set the credentials for downloading,
 in most cases. See
 <a href="https://eodag.readthedocs.io/en/stable/getting_started_guide/register.html" target="_blank">
   Providers Registration</a> for more details about registration and credentials.
@@ -261,12 +260,12 @@ it might be that they need to specify the credentials for that provider.
 
 <p>
 <dt><b>Output Prefix</b>
-<dd>Setting the output_prefix is similar to using the <b>output</b> option. 
+<dd>Setting the output_prefix is similar to using the <b>output</b> option.
   It is the directory into which downloaded products will be saved.
 </dl>
 
 <p>
-Following is an example for a config YAML file with Copernicus Dataspace 
+Following is an example for a config YAML file with Copernicus Dataspace
 credentials:
 <div class="code"><pre>
 cop_dataspace:
@@ -308,7 +307,7 @@ i.eodag -l start=2022-05-01 end=2022-06-01 \
 <pre></div>
 
 Sort results descendingly by <b>cloudcover</b>, and then by <b>ingestiondate</b>.
-Note that sorting with <b>cloudcover</b> uses unrounded values, 
+Note that sorting with <b>cloudcover</b> uses unrounded values,
 while they are rounded to the nearest integer when listing.
 
 <div class="code"><pre>
@@ -396,7 +395,7 @@ List current EODAG configuration for Copernicus Data Space Ecosystem:
 <div class="code"><pre>
 i.eodag print=config provider=cop_dataspace
 <pre></div>
-  
+
 
 <h2>REQUIREMENTS</h2>
 

--- a/src/imagery/i.eodag/i.eodag.html
+++ b/src/imagery/i.eodag/i.eodag.html
@@ -141,7 +141,7 @@ need to follow when composing queries:
 Basic structure:
 
 <div class="code"><pre>
-{queryable} = {value} \ {operator}
+{queryable} = {value} ; {operator}
 </pre></div>
 
 <p>
@@ -151,7 +151,7 @@ Print products which <b>orbitDirection</b> property is "DESCENDING":
 <div class="code"><pre>
 i.eodag -l start=2022-05-01 end=2022-06-01 \
 provider=cop_dataspace producttype=S2_MSI_L2A \
-query="orbitDirection=DESCENDING\eq"
+query="orbitDirection=DESCENDING;eq"
 </pre></div>
 NOTE: If no operator is specified then the 'eq' opeartor will be used.
 
@@ -159,7 +159,7 @@ NOTE: If no operator is specified then the 'eq' opeartor will be used.
 Multiple values per queryable:
 
 <div class="code"><pre>
-{queryable} = {value_1} \ {operator_1} | {value_2} \ {opeartor_2}
+{queryable} = {value_1} ; {operator_1} | {value_2} ; {opeartor_2}
 </pre></div>
 
 <p>
@@ -171,7 +171,7 @@ Notice here that multiple values are used to indicate the <b>OR</b> relation.
 <div class="code"><pre>
 i.eodag -l start=2022-05-01 end=2022-06-01 \
 provider=cop_dataspace producttype=S2_MSI_L2A \
-query="cloudCover=30\lt | 60\gt"
+query="cloudCover=30;lt | 60;gt"
 </pre></div>
 
 To use the <b>AND</b> relation instead, write them in separate queries.<br>
@@ -180,7 +180,7 @@ less than 60, aka. (30, 60).
 <div class="code"><pre>
 i.eodag -l start=2022-05-01 end=2022-06-01 \
 provider=cop_dataspace producttype=S2_MSI_L2A \
-query="cloudCover=30\gt, cloudCover=60\lt"
+query="cloudCover=30;gt, cloudCover=60;lt"
 </pre></div>
 
 Print products which <b>cloudCover</b> is greater than 30 <b>AND</b> less than
@@ -188,7 +188,7 @@ Print products which <b>cloudCover</b> is greater than 30 <b>AND</b> less than
 <div class="code"><pre>
 i.eodag -l start=2022-05-01 end=2022-06-01 \
 provider=cop_dataspace producttype=S2_MSI_L2A \
-query="cloudCover=30\gt, cloudCover=60\lt, orbitDirection=DESCENDING"
+query="cloudCover=30;gt, cloudCover=60;lt, orbitDirection=DESCENDING"
 </pre></div>
 
 <p>

--- a/src/imagery/i.eodag/i.eodag.html
+++ b/src/imagery/i.eodag/i.eodag.html
@@ -219,7 +219,7 @@ query="orbitDirection=DESCENDING|Null"
 <h4>Frequently used queryables</h4>
 
 <ul>
-  <li><b>cloudCover</b> [0, 100]</li>
+  <li><b>cloudCover</b> range [0, 100]</li>
   <li><b>orbitNumber</b></li>
   <li><b>orbitDirection</b></li>
   <li><b>storageStatus</b></li>

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -62,7 +62,6 @@
 # % key: clouds
 # % type: integer
 # % description: Maximum cloud cover percentage for scene [0, 100]
-# % answer: 20
 # % required: no
 # % guisection: Filter
 # %end
@@ -77,6 +76,7 @@
 # %option
 # % key: limit
 # % type: integer
+# % answer: 50
 # % description: Limit number of scenes
 # % guisection: Filter
 # %end
@@ -93,7 +93,6 @@
 # % type: string
 # % description: Spatial relation of footprint to AOI
 # % options: Intersects,Contains,IsWithin
-# % answer: Intersects
 # % required: no
 # % guisection: Region
 # %end
@@ -1005,7 +1004,6 @@ def main():
                 gs.fatal(_("Queryable <end> can not be set twice"))
             # there will only be one value in the values, values[0][0] is the date
             options["end"] = values[0][0]
-    dates_to_iso_format()
 
     if options["print"]:
         print_functions = {
@@ -1054,7 +1052,9 @@ def main():
 
         # Search for products found from options["file"] or options["id"]
         search_result = search_by_ids(ids_set)
+        limit = len(search_result)  # Disable limit option
     elif "search_result" not in locals():
+        dates_to_iso_format()
         items_per_page = 40
         # TODO: Check that the product exists,
         # could be handled by catching exceptions when searching...

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -62,6 +62,7 @@
 # % key: clouds
 # % type: integer
 # % description: Maximum cloud cover percentage for scene [0, 100]
+# % answer: 20
 # % required: no
 # % guisection: Filter
 # %end
@@ -92,6 +93,7 @@
 # % type: string
 # % description: Spatial relation of footprint to AOI
 # % options: Intersects,Contains,IsWithin
+# % answer: Intersects
 # % required: no
 # % guisection: Region
 # %end

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -292,6 +292,11 @@ def get_aoi(vector=None):
     if not vector:
         return get_bb(proj)
 
+    if vector not in gs.parse_command("g.list", type="vector"):
+        gs.fatal(
+            _("Unable to get AOI: vector map <{}> could not be found".format(vector))
+        )
+
     args = {}
     args["input"] = vector
 

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -62,6 +62,7 @@
 # % key: clouds
 # % type: integer
 # % description: Maximum cloud cover percentage for scene [0, 100]
+# % answer: 100
 # % required: no
 # % guisection: Filter
 # %end

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -584,8 +584,14 @@ def filter_result(search_result, geometry, **kwargs):
     if options["query"]:
         VALID_OPERATORS = ["eq", "ne", "ge", "gt", "le", "lt"]
         DEFAULT_OPERATOR = "eq"
-        for parameter in options["query"].split(","):
-            key, values = parameter.strip().split("=")
+        for parameter in map(str.strip, options["query"].split(",")):
+            if parameter == "":
+                continue
+            try:
+                key, values = map(str.strip, parameter.split("="))
+            except Exception as e:
+                gs.debug(e)
+                gs.fatal(_("Missing value for queryable <{}>".format(parameter)))
             if key == "start":
                 if start_date is not None:
                     gs.fatal(_("Queryable <start> can not be set multiple times"))
@@ -615,12 +621,11 @@ def filter_result(search_result, geometry, **kwargs):
                 continue
             operator = None
             tmp_search_result_list = []
-            for value in values.split("\\"):
-                value = value.strip()
+            for value in map(str.strip, values.split("\\")):
                 if value == "":
                     continue
                 if value.find("|") != -1:
-                    value, operator = [v.strip() for v in value.split("|")]
+                    value, operator = map(str.strip, value.split("|"))
                     if operator not in VALID_OPERATORS:
                         gs.fatal(
                             _(


### PR DESCRIPTION
This PR fixes the current faulty query option, and add the ability to use **operators** (eq, lt, gt, le, etc...). 
It also allows the query option to have multiple queryables (emulating the **AND** relation), and allows each queryable to have multiple value (emulating the **OR** relation).

Querying section is also added to the manual, with examples on how to use the query option.
Multiple use cases for i.eodag is also added to the manual.