### PR TITLE
i.landsat.download: change API from landsatxplore to EODAG using i.eodag

### DIFF
--- a/src/imagery/i.landsat/i.landsat.download/i.landsat.download.html
+++ b/src/imagery/i.landsat/i.landsat.download/i.landsat.download.html
@@ -1,12 +1,10 @@
 <h2>DESCRIPTION</h2>
 
 <em>i.landsat.download</em> allows to search and download Landsat TM, ETM and OLI data
-from USGS <a href="https://earthexplorer.usgs.gov/">EarthExplorer</a> through
-the <a href="https://github.com/yannforget/landsatxplore">landsatxplore</a>
-Python library. Datasets currently supported include
-<a href="https://www.usgs.gov/core-science-systems/nli/landsat/landsat-collection-1?qt-science_support_page_related_con=1#qt-science_support_page_related_con">Collection 1</a>
-and
-<a href="https://www.usgs.gov/core-science-systems/nli/landsat/landsat-collection-2?qt-science_support_page_related_con=2#qt-science_support_page_related_con">Collection 2</a>.
+from <a href="https://earthexplorer.usgs.gov/">USGS EarthExplorer</a> and
+<a href="https://planetarycomputer.microsoft.com/">Planetary Computer</a>
+using <a href="https://eodag.readthedocs.io/en/stable/">EODAG</a>
+Python library.
 
 <p>
 Landsat data are organized in tiers: Newly-acquired Landsat scenes are
@@ -26,6 +24,7 @@ The supported Landsat satellites include (see also
   <a href="https://www.usgs.gov/core-science-systems/nli/landsat/landsat-7">Landsat 7 ETM+ SLC-off error</a>
   after May 31, 2003)</li>
 <li>Landsat 8 (OLI): 2013 to present</li>
+<li>Landsat 9 (OLI-2): 2021 to present</li>
 </ul>
 
 The dataset names and IDs are:
@@ -39,20 +38,12 @@ The dataset names and IDs are:
 </thead>
 <tbody>
 <tr>
-<td>Landsat 5 TM Collection 1 Level 1</td>
-<td><code>landsat_tm_c1</code></td>
-</tr>
-<tr>
 <td>Landsat 5 TM Collection 2 Level 1</td>
 <td><code>landsat_tm_c2_l1</code></td>
 </tr>
 <tr>
 <td>Landsat 5 TM Collection 2 Level 2</td>
 <td><code>landsat_tm_c2_l2</code></td>
-</tr>
-<tr>
-<td>Landsat 7 ETM+ Collection 1 Level 1</td>
-<td><code>landsat_etm_c1</code></td>
 </tr>
 <tr>
 <td>Landsat 7 ETM+ Collection 2 Level 1</td>
@@ -63,49 +54,37 @@ The dataset names and IDs are:
 <td><code>landsat_etm_c2_l2</code></td>
 </tr>
 <tr>
-<td>Landsat 8 Collection 1 Level 1</td>
-<td><code>landsat_8_c1</code></td>
-</tr>
-<tr>
 <td>Landsat 8 Collection 2 Level 1</td>
-<td><code>landsat_ot_c2_l1</code></td>
+<td><code>landsat_8_ot_c2_l1</code></td>
 </tr>
 <tr>
 <td>Landsat 8 Collection 2 Level 2</td>
-<td><code>landsat_ot_c2_l2</code></td>
+<td><code>landsat_8_ot_c2_l2</code></td>
+</tr>
+<tr>
+<td>Landsat 9 Collection 2 Level 1</td>
+<td><code>landsat_9_ot_c2_l1</code></td>
+</tr>
+<tr>
+<td>Landsat 9 Collection 2 Level 2</td>
+<td><code>landsat_9_ot_c2_l2</code></td>
 </tr>
 </tbody>
 </table>
 
 <p>
-To connect to EarthExplorer both a <em>user</em> name and a <em>password</em>
-are required. See the <a href="https://ers.cr.usgs.gov/register">register</a>
-page for signing up.
-
+To connect to EODAG the credentials of the data source of interest
+(either USGS or Planetary Computer) have to be filled in the EODAG config file.
+See EODAG Configuration section in <a href="i.eodag.html">i.eodag</a> and
+<a href="https://eodag.readthedocs.io/en/stable/getting_started_guide/configure.html">EODAG Configuration</a>.
+The configuration file is stored by default in $HOME/.config/eodag/eodag.yml.
+If it is not there, it will be created after running the module.
 <p>
-<em>i.landsat.download</em> reads the user credentials either from the
-terminal or from the <b>settings</b> file. This file must contain two
-lines:
-
-<div class="code"><pre>
-myusername
-mypassword
-</pre></div>
-
-<p>
-User credentials can be also defined interactively when <b>settings=-</b>
-is given. Note that interactive prompt does not work in the graphical
-user interface.
-
-<div class="code"><pre>
-Insert username: myusername
-Insert password:
-</pre></div>
 
 <p>
 By default, only products which footprint intersects current computation
 region extent (area of interest, AOI) are filtered. The AOI can be optionally
-defined by a vector <b>map</b>. In this case, the vector extent will
+defined by a vector <b>map</b>. In this case, the vector will
 be used as AOI.
 
 <p>
@@ -118,42 +97,44 @@ To download all scenes found within the time frame provided, the user must
 remove the <b>l</b> flag and provide an <b>output</b> directory. Otherwise,
 files will be downloaded into <em>/tmp</em> directory.
 To download only selected scenes, one or more IDs must be provided
-through the <b>id</b> option, along with the <b>settings</b> file and an
-<b>output</b> directory. In addition, a <b>timeout</b> (in seconds)
+through the <b>id</b> option, along with an <b>output</b> directory.
+In addition, a <b>timeout</b> (in seconds)
 can be set to define how long a request should wait for a response before
 aborting (default is 300 seconds).
+
+<h2>NOTES</h2>
+USGS is still under development and can't be used for searching nor downloading.
 
 <h2>EXAMPLES</h2>
 
 Search available scenes:
 
 <div class="code"><pre>
-i.landsat.download -l settings=credentials.txt \
-    dataset=landsat_8_c1 clouds=15 \
-    start='2018-08-24' end='2018-12-21'
+i.landsat.download -l dataset=landsat_8_ot_c2_l2 \
+    clouds=15 start='2018-08-24' end='2018-12-21'
 <pre></div>
 
 Download all available scenes:
 
 <div class="code"><pre>
-i.landsat.download settings=credentials.txt \
-    dataset=landsat_8_c1 clouds=15 \
-    start='2018-08-24' end='2018-12-21' \
+i.landsat.download dataset=landsat_8_ot_c2_l2 \
+    clouds=15 start='2018-08-24' end='2018-12-21' \
     timeout=600
 <pre></div>
 
 Download selected scenes by ID:
 
 <div class="code"><pre>
-i.landsat.download settings=credentials.txt \
-    id=LC81391162018338LGN00,LC81301172018339LGN00 \
+i.landsat.download \
+    id=LC09_L2SP_015035_20240529_02_T1,LC09_L2SP_015035_20240614_02_T1 \
     output=/tmp
 <pre></div>
 
 <h2>REQUIREMENTS</h2>
 
 <ul>
-    <li><a href="https://github.com/yannforget/landsatxplore">landsatxplore library</a> (install with <code>pip install landsatxplore</code>)</li>
+    <li><a href="https://eodag.readthedocs.io/en/stable/getting_started_guide/install.html">EODAG library</a>
+    (install with <code>pip install eodag</code>)</li>
 </ul>
 
 <h2>SEE ALSO</h2>

--- a/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
+++ b/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
@@ -9,7 +9,7 @@
 # PURPOSE:     Downloads Landsat TM, ETM and OLI data from EarthExplorer
 #              and Planetary Computer using EODAG Python library.
 #
-# COPYRIGHT:   (C) 2020-2025 by Veronica Andreo, and the GRASS development team
+# COPYRIGHT:   (C) 2020-2024 by Veronica Andreo, and the GRASS development team
 #
 #              This program is free software under the GNU General Public
 #              License (>=v2). Read the file COPYING that comes with GRASS

--- a/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
+++ b/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
@@ -322,4 +322,16 @@ if __name__ == "__main__":
     except:
         gs.fatal(_("Cannot import eodag. Please intall the library first."))
 
+    # Check if eodag config file is created
+    file_path = os.path.join(os.path.expanduser("~"), ".config/eodag/eodag.yml")
+    if not os.path.isfile(file_path):
+        dag = EODataAccessGateway()
+        gs.info(
+            _(
+                "EODAG Config file is created, you can rerun the module after filling the necessary credentials in {}".format(
+                    file_path
+                )
+            )
+        )
+        sys.exit(0)
     sys.exit(main())

--- a/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
+++ b/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
@@ -197,7 +197,7 @@ def main():
         # https://github.com/CS-SI/eodag/issues/1252
         # TODO: set provider to USGS when the above changes goes into production
         if options["datasource"] == "usgs" and not (
-            eodag.__version__ == "3.0.0b3" or eodag.__version__ >= "3.0.0"
+            int(eodag.__version__.split(".")[0]) >= 3
         ):
             gs.fatal(
                 _(

--- a/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
+++ b/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
@@ -227,38 +227,23 @@ def main():
             gs.fatal(_("Dataset was not recognized"))
 
         eodag_sort = ""
-        eodag_query = ""  # Used with Planetary Computer
-        eodag_pattern = ""  # Used with USGS
+        eodag_pattern = ""
         for sort_var in options["sort"].split(","):
             if sort_var == "cloud_cover":
                 eodag_sort += "cloudcover,"
             if sort_var == "acquisition_date":
                 eodag_sort += "ingestiondate,"
 
-        if options["datasource"] == "planetary_computer":
-            if options["tier"]:
-                eodag_query += f"landsat:collection_category={options['tier']},"
-            if "tm" in options["dataset"]:
-                eodag_query += "platformSerialIdentifier=landsat-5"
-            if "etm" in options["dataset"]:
-                eodag_query += "platformSerialIdentifier=landsat-7"
-            if "8_ot" in options["dataset"]:
-                eodag_query += "platformSerialIdentifier=landsat-8"
-            if "9_ot" in options["dataset"]:
-                eodag_query += "platformSerialIdentifier=landsat-9"
-
-        elif options["datasource"] == "usgs":
-            eodag_pattern = ""
-            if "tm" in options["dataset"]:
-                eodag_pattern += "LM05.+"
-            if "etm" in options["dataset"]:
-                eodag_pattern += "LE07.+"
-            if "8_ot" in options["dataset"]:
-                eodag_pattern += "LC08.+"
-            if "9_ot" in options["dataset"]:
-                eodag_pattern += "LC09.+"
-            if options["tier"]:
-                eodag_pattern += options["tier"]
+        if "tm" in options["dataset"]:
+            eodag_pattern += "LM05.+"
+        if "etm" in options["dataset"]:
+            eodag_pattern += "LE07.+"
+        if "8_ot" in options["dataset"]:
+            eodag_pattern += "LC08.+"
+        if "9_ot" in options["dataset"]:
+            eodag_pattern += "LC09.+"
+        if options["tier"]:
+            eodag_pattern += options["tier"]
 
         try:
             scenes = json.loads(
@@ -274,8 +259,7 @@ def main():
                     order=options["order"],
                     sort=eodag_sort,
                     provider=options["datasource"],
-                    query=eodag_query,  # Used when searching with Planetary Computer
-                    pattern=eodag_pattern,  # Used when searching with USGS
+                    pattern=eodag_pattern,
                     quiet=True,
                 )
             )
@@ -344,8 +328,7 @@ def main():
                 order=options["order"],
                 sort=eodag_sort,
                 provider=options["datasource"],
-                query=eodag_query,  # Used when searching with Planetary Computer
-                pattern=eodag_pattern,  # Used when searching with USGS
+                pattern=eodag_pattern,
                 quiet=True,
             )
 

--- a/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
+++ b/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
@@ -375,5 +375,4 @@ if __name__ == "__main__":
                 )
             )
         )
-        sys.exit(0)
     sys.exit(main())

--- a/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
+++ b/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 ############################################################################
 #
@@ -359,7 +359,7 @@ def main():
         # https://github.com/CS-SI/eodag/issues/1252
         # TODO: set provider to USGS when the above changes goes into production
         gs.run_command(
-            "i.eodag", id=options["id"], output=outdir, provider=options["provider"]
+            "i.eodag", id=options["id"], output=outdir, provider=options["datasource"]
         )
     else:
         eodag_query = {"start_date": start_date, "end_date": end_date, "eodag_sort": ""}

--- a/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
+++ b/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
@@ -3,15 +3,19 @@
 ############################################################################
 #
 # MODULE:      i.landsat.download
-# AUTHOR(S):   Veronica Andreo
+# AUTHOR(S):   Veronica Andreo (original contributor)
+#              Hamed Elgizery <hamedashraf2004 gmail.com>
+#
 # PURPOSE:     Downloads Landsat TM, ETM and OLI data from EarthExplorer
-#              using landsatxplore Python library.
-# COPYRIGHT:   (C) 2020-2021 by Veronica Andreo, and the GRASS development team
+#              and Planetary Computer using EODAG Python library.
+#
+# COPYRIGHT:   (C) 2020-2025 by Veronica Andreo, and the GRASS development team
 #
 #              This program is free software under the GNU General Public
 #              License (>=v2). Read the file COPYING that comes with GRASS
 #              for details.
 #
+# CHANGELOG:   Switch API from landsatxplore to EODAG - Hamed Elgizery
 #############################################################################
 
 # %module

--- a/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
+++ b/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
@@ -196,9 +196,7 @@ def main():
         # as there was a bug in USGS API, fixed here
         # https://github.com/CS-SI/eodag/issues/1252
         # TODO: set provider to USGS when the above changes goes into production
-        if options["datasource"] == "usgs" and not (
-            int(eodag.__version__.split(".")[0]) >= 3
-        ):
+        if options["datasource"] == "usgs" and int(eodag.__version__.split(".")[0]) < 3:
             gs.fatal(
                 _(
                     "EODAG 3.0.0 or later is needed to search by IDs with USGS".format(

--- a/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
+++ b/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
@@ -51,7 +51,7 @@
 # % description: Landsat dataset to search for
 # % required: no
 # % options: landsat_tm_c2_l1, landsat_tm_c2_l2, landsat_etm_c2_l1, landsat_etm_c2_l2, landsat_8_ot_c2_l1, landsat_8_ot_c2_l2, landsat_9_ot_c2_l1, landsat_9_ot_c2_l2
-# % answer: landsat_9_ot_c2_l1
+# % answer: landsat_9_ot_c2_l2
 # % guisection: Filter
 # %end
 

--- a/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
+++ b/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
@@ -136,6 +136,7 @@ from datetime import *
 import grass.script as gs
 from grass.pygrass.modules import Module
 
+
 def normalize_time(datetime_str: str):
     """Unifies the different ISO formats into 'YYYY-MM-DDTHH:MM:SS'
 
@@ -155,6 +156,7 @@ def normalize_time(datetime_str: str):
     # Remove timezone info
     normalized_datetime = normalized_datetime.replace(tzinfo=None)
     return normalized_datetime.isoformat()
+
 
 def main():
     start_date = options["start"]
@@ -203,7 +205,9 @@ def main():
                 product_line += " " + scene["id"]
                 # Special formatting for datetime
                 try:
-                    acquisition_time = normalize_time(scene["properties"]["startTimeFromAscendingNode"])
+                    acquisition_time = normalize_time(
+                        scene["properties"]["startTimeFromAscendingNode"]
+                    )
                 except:
                     acquisition_time = scene["properties"]["startTimeFromAscendingNode"]
                 product_line += " " + acquisition_time
@@ -211,7 +215,6 @@ def main():
                 product_line += f" {cloud_cover:2.0f}%"
                 print(product_line)
         # TODO: Do extra landsat specifc filtering
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR will change the API used in i.landsat.download from **landsatxplore** to **EODAG** using the i.**eodag** addon.