### PR TITLE
cronjobs: update versions after G8.4.0 release

### DIFF
--- a/utils/cronjobs_osgeo_lxd/README.md
+++ b/utils/cronjobs_osgeo_lxd/README.md
@@ -28,12 +28,12 @@ programmer's manual.
   * `hugo_clean_and_update_job.sh`
 * GRASS GIS source code weekly snapshots:
   * `cron_grass_legacy_src_snapshot.sh`
-  * `cron_grass_old_current_src_snapshot.sh`
+  * `cron_grass_old_src_snapshot.sh`
   * `cron_grass_new_current_src_snapshot.sh`
   * `cron_grass_preview_src_snapshot.sh`
 * GRASS GIS Linux binary weekly snapshots:
   * `cron_grass_legacy_build_binaries.sh`
-  * `cron_grass_old_current_build_binaries.sh`
+  * `cron_grass_old_build_binaries.sh`
   * `cron_grass_new_current_build_binaries.sh`
   * `cron_grass_preview_build_binaries.sh`
 * GRASS GIS addons manual pages:

--- a/utils/cronjobs_osgeo_lxd/cron_grass_legacy_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_legacy_build_binaries.sh
@@ -37,12 +37,13 @@ PATH=/home/neteler/binaries/bin:/usr/bin:/bin:/usr/X11R6/bin:/usr/local/bin
 GMAJOR=7
 GMINOR=8
 GPATCH=7 # required by grass-addons-index.sh
+
+# NEW_CURRENT: set to same value as in cron_grass_old_build_binaries.sh
+NEW_CURRENT=84
+
 DOTVERSION=$GMAJOR.$GMINOR
 VERSION=$GMAJOR$GMINOR
 GVERSION=$GMAJOR
-
-# NEW_CURRENT: set to same value as in cron_grass_old_current_build_binaries.sh
-NEW_CURRENT=83
 
 ###################
 # fail early

--- a/utils/cronjobs_osgeo_lxd/cron_grass_new_current_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_new_current_build_binaries.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # script to build GRASS GIS new current binaries + addons + progman from the `releasebranch_8_3` binaries
-# (c) GPL 2+ Markus Neteler <neteler@osgeo.org>
-# 2022-2023
+# (c) 2002-2024, GPL 2+ Markus Neteler <neteler@osgeo.org>
 #
 # GRASS GIS github, https://github.com/OSGeo/grass
 #
@@ -35,7 +34,7 @@
 PATH=/home/neteler/binaries/bin:/usr/bin:/bin:/usr/X11R6/bin:/usr/local/bin
 
 GMAJOR=8
-GMINOR=3
+GMINOR=4
 GPATCH="0dev"  # required by grass-addons-index.sh
 DOTVERSION=$GMAJOR.$GMINOR
 VERSION=$GMAJOR$GMINOR

--- a/utils/cronjobs_osgeo_lxd/cron_grass_new_current_src_snapshot.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_new_current_src_snapshot.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # script to build GRASS GIS new current sources package from the main branch
-# (c) GPL 2+ Markus Neteler <neteler@osgeo.org>
-# Markus Neteler 2002-2022
+# (c) 2002-2024, GPL 2+ Markus Neteler <neteler@osgeo.org>
 #
 # GRASS GIS github, https://github.com/OSGeo/grass
 #
@@ -13,7 +12,7 @@
 
 MAINDIR=/home/neteler
 GMAJOR=8
-GMINOR=3
+GMINOR=4
 GVERSION=$GMAJOR.$GMINOR.git
 DOTVERSION=$GMAJOR.$GMINOR
 GSHORTGVERSION=$GMAJOR$GMINOR

--- a/utils/cronjobs_osgeo_lxd/cron_grass_old_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_old_build_binaries.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # script to build GRASS GIS old current binaries + addons from the `releasebranch_8_2` binaries
-# (c) GPL 2+ Markus Neteler <neteler@osgeo.org>
-# 2014-2024
+# (c) 2002-2024, GPL 2+ Markus Neteler <neteler@osgeo.org>
 #
 # GRASS GIS github, https://github.com/OSGeo/grass
 #
@@ -38,14 +37,15 @@ PATH=/home/neteler/binaries/bin:/usr/bin:/bin:/usr/X11R6/bin:/usr/local/bin
 
 # https://github.com/OSGeo/grass/tags
 GMAJOR=8
-GMINOR=2
-GPATCH=1 # required by grass-addons-index.sh
+GMINOR=3
+GPATCH=2 # required by grass-addons-index.sh
+
+# NEW_CURRENT: set to GMINOR from above + 1:
+NEW_CURRENT=84
+
 DOTVERSION=$GMAJOR.$GMINOR
 VERSION=$GMAJOR$GMINOR
 GVERSION=$GMAJOR
-
-# NEW_CURRENT: set to GMINOR from above + 1:
-NEW_CURRENT=83
 
 ###################
 # fail early

--- a/utils/cronjobs_osgeo_lxd/cron_grass_old_src_snapshot.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_old_src_snapshot.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # script to build GRASS GIS old current source package from the release branch
-# (c) GPL 2+ Markus Neteler <neteler@osgeo.org>
-# Markus Neteler 2002-2023
+# (c) 2002-2024, GPL 2+ Markus Neteler <neteler@osgeo.org>
 #
 # GRASS GIS github, https://github.com/OSGeo/grass
 #
@@ -13,7 +12,7 @@
 
 MAINDIR=/home/neteler
 GMAJOR=8
-GMINOR=2
+GMINOR=3
 GVERSION=$GMAJOR.$GMINOR.git
 DOTVERSION=$GMAJOR.$GMINOR
 GSHORTGVERSION=$GMAJOR$GMINOR

--- a/utils/cronjobs_osgeo_lxd/cron_grass_preview_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_preview_build_binaries.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # script to build GRASS GIS preview binaries + addons from the `main`
-# (c) GPL 2+ Markus Neteler <neteler@osgeo.org>
-# 2022-2024
+# (c) 2002-2024, GPL 2+ Markus Neteler <neteler@osgeo.org>
 #
 # GRASS GIS github, https://github.com/OSGeo/grass
 #
@@ -34,7 +33,7 @@
 PATH=/home/neteler/binaries/bin:/usr/bin:/bin:/usr/X11R6/bin:/usr/local/bin
 
 GMAJOR=8
-GMINOR=4
+GMINOR=5
 GPATCH="0dev"  # required by grass-addons-index.sh
 DOTVERSION=$GMAJOR.$GMINOR
 VERSION=$GMAJOR$GMINOR

--- a/utils/cronjobs_osgeo_lxd/cron_grass_preview_src_snapshot.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_preview_src_snapshot.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # script to build GRASS GIS preview source package from the main branch
-# (c) GPL 2+ Markus Neteler <neteler@osgeo.org>
-# Markus Neteler 2002-2023
+# (c) 2002-2024, GPL 2+ Markus Neteler <neteler@osgeo.org>
 #
 # GRASS GIS github, https://github.com/OSGeo/grass
 #
@@ -13,7 +12,7 @@
 
 MAINDIR=/home/neteler
 GMAJOR=8
-GMINOR=4
+GMINOR=5
 GVERSION=$GMAJOR.$GMINOR.git
 DOTVERSION=$GMAJOR.$GMINOR
 GSHORTGVERSION=$GMAJOR$GMINOR

--- a/utils/cronjobs_osgeo_lxd/cron_job_list_grass
+++ b/utils/cronjobs_osgeo_lxd/cron_job_list_grass
@@ -27,7 +27,7 @@
 # legacy
 20 02 * * 6 nice sh /home/neteler/cronjobs/cron_grass_legacy_src_snapshot.sh
 # old stable
-30 02 * * 6 nice sh /home/neteler/cronjobs/cron_grass_old_current_src_snapshot.sh
+30 02 * * 6 nice sh /home/neteler/cronjobs/cron_grass_old_src_snapshot.sh
 # new stable
 40 02 * * 6 nice sh /home/neteler/cronjobs/cron_grass_new_current_src_snapshot.sh
 # preview
@@ -36,13 +36,13 @@
 
 # daily Linux binary snapshots, also creates main manuals, addon manuals, and prog-manual (target dir: /var/www/code_and_data/)
 # legacy
-00 05 * * * nice sh /home/neteler/cronjobs/cron_grass_legacy_build_binaries.sh > /var/www/code_and_data/grass78/binary/linux/snapshot/build.log.txt 2>&1
-# old stable
-35 05 * * * nice sh /home/neteler/cronjobs/cron_grass_old_current_build_binaries.sh > /var/www/code_and_data/grass82/binary/linux/snapshot/build.log.txt 2>&1
+00 05 * * * nice sh /home/neteler/cronjobs/cron_grass_legacy_build_binaries.sh      > /var/www/code_and_data/grass78/binary/linux/snapshot/build.log.txt 2>&1
+# old stable (no more releases planned)
+35 05 * * * nice sh /home/neteler/cronjobs/cron_grass_old_build_binaries.sh > /var/www/code_and_data/grass83/binary/linux/snapshot/build.log.txt 2>&1
 # new stable
-10 06 * * * nice sh /home/neteler/cronjobs/cron_grass_new_current_build_binaries.sh > /var/www/code_and_data/grass83/binary/linux/snapshot/build.log.txt 2>&1
+10 06 * * * nice sh /home/neteler/cronjobs/cron_grass_new_current_build_binaries.sh > /var/www/code_and_data/grass84/binary/linux/snapshot/build.log.txt 2>&1
 # preview
-45 06 * * * nice sh /home/neteler/cronjobs/cron_grass_preview_build_binaries.sh > /var/www/code_and_data/grass84/binary/linux/snapshot/build.log.txt 2>&1
+45 06 * * * nice sh /home/neteler/cronjobs/cron_grass_preview_build_binaries.sh     > /var/www/code_and_data/grass85/binary/linux/snapshot/build.log.txt 2>&1
 
 
 # generate osgeo_mailman_stats/ + email


### PR DESCRIPTION
After release of https://github.com/OSGeo/grass/releases/tag/8.4.0 the new stable version is G8.4.0.

Hence, in the scripts generating snapshots and manual pages, all version variables are updated accordingly.

For sake of clarity, "old_current" has been renamed to "old" in filenames.

Crontab updated as well.

Addresses https://github.com/OSGeo/grass/issues/4099