### PR TITLE
cronjobs: further version related updates

### DIFF
--- a/utils/cronjobs_osgeo_lxd/README.md
+++ b/utils/cronjobs_osgeo_lxd/README.md
@@ -19,70 +19,70 @@ Web pages (Hugo based, <https://grass.osgeo.org/>). Furthermore, source code and
 binary snapshots are generated as well as all manual pages and the GRASS GIS
 programmer's manual.
 
-* cronjob schedule:
-  * `cron_job_list_grass`
-  * IMPORTANT: to activate any cronjob change, run the following on `grasslxd`
+- cronjob schedule:
+  - `cron_job_list_grass`
+  - IMPORTANT: to activate any cronjob change, run the following on `grasslxd`
     container (as user `neteler`):
-    * `crontab $HOME/cronjobs/cron_job_list_grass && crontab -l`
-* generate and deploy the GRASS GIS Web pages at <https://grass.osgeo.org/>:
-  * `hugo_clean_and_update_job.sh`
-* GRASS GIS source code weekly snapshots:
-  * `cron_grass_legacy_src_snapshot.sh`
-  * `cron_grass_old_src_snapshot.sh`
-  * `cron_grass_current_stable_src_snapshot.sh`
-  * `cron_grass_preview_src_snapshot.sh`
-* GRASS GIS Linux binary weekly snapshots:
-  * `cron_grass_legacy_build_binaries.sh`
-  * `cron_grass_old_build_binaries.sh`
-  * `cron_grass_current_stable_build_binaries.sh`
-  * `cron_grass_preview_build_binaries.sh`
-* GRASS GIS addons manual pages:
-  * addon manual pages are generated within above Linux binary weekly snapshots
-* GRASS GIS 7 addons overview page at <https://grass.osgeo.org/grass7/manuals/addons/>:
-  * `compile_addons_git.sh` - called from `cron_grass_legacy_build_binaries.sh`
-  * `build-xml.py` - called from `cron_grass_legacy_build_binaries.sh`,
+    - `crontab $HOME/cronjobs/cron_job_list_grass && crontab -l`
+- generate and deploy the GRASS GIS Web pages at <https://grass.osgeo.org/>:
+  - `hugo_clean_and_update_job.sh`
+- GRASS GIS source code weekly snapshots:
+  - `cron_grass_legacy_src_snapshot.sh`
+  - `cron_grass_old_src_snapshot.sh`
+  - `cron_grass_current_stable_src_snapshot.sh`
+  - `cron_grass_preview_src_snapshot.sh`
+- GRASS GIS Linux binary weekly snapshots:
+  - `cron_grass_legacy_build_binaries.sh`
+  - `cron_grass_old_build_binaries.sh`
+  - `cron_grass_current_stable_build_binaries.sh`
+  - `cron_grass_preview_build_binaries.sh`
+- GRASS GIS addons manual pages:
+  - addon manual pages are generated within above Linux binary weekly snapshots
+- GRASS GIS 7 addons overview page at <https://grass.osgeo.org/grass7/manuals/addons/>:
+  - `compile_addons_git.sh` - called from `cron_grass_legacy_build_binaries.sh`
+  - `build-xml.py` - called from `cron_grass_legacy_build_binaries.sh`,
     generates the modules.xml file required for the g.extension module
-  * `grass-addons-index.sh` - called from `cron_grass_legacy_build_binaries.sh`
-  * `get_page_description.py` - called from `grass-addons-index.sh`
-* GRASS GIS 8 addons overview page at <https://grass.osgeo.org/grass8/manuals/addons/>:
-  * `compile_addons_git.sh` - called from `cron_grass_XXX_build_binaries.sh`
-  * `build-xml.py` - called from `cron_grass_XXX_build_binaries.sh`
+  - `grass-addons-index.sh` - called from `cron_grass_legacy_build_binaries.sh`
+  - `get_page_description.py` - called from `grass-addons-index.sh`
+- GRASS GIS 8 addons overview page at <https://grass.osgeo.org/grass8/manuals/addons/>:
+  - `compile_addons_git.sh` - called from `cron_grass_XXX_build_binaries.sh`
+  - `build-xml.py` - called from `cron_grass_XXX_build_binaries.sh`
     generates the modules.xml file required for the g.extension module
-  * `grass-addons-index.sh` - called from `cron_grass_XXX_build_binaries.sh`
-  * `get_page_description.py` - called from `grass-addons-index.sh`
-* GRASS GIS programmer's manual:
-  * within `cron_grass_XXX_build_binaries.sh`
-* compilation addons:
-  * `compile_addons_git.sh` it's called with `$5` arg, addon is
-installed into own individual directory, with **bin/ docs/ etc/ scripts/**
-subdir e.g. db.join addon dir `$HOME/.grass8/addons/db.join/`, instead of
-directory structure`$HOME/.grass8/addons/` where **bin/ docs/ etc/ scripts/**
-subdir are shared across all installed addons (this dir structure is used
-to install the addon using the `g.extension` module). Addon installed directory
-is set via global variable [`GRASS_ADDON_BASE`](https://github.com/OSGeo/grass-addons/pull/656/commits/8c08184415ec32fe409bf09b2599b0506d7650ab#diff-f0fc8363c0e166fdbe9eecb74a9e261498ec0bbf15500e56b1bb1b5ba7afb900L119),
-e.g. for db.join addon is`GRASS_ADDON_BASE=$HOME/.grass8/addons/db.join/`.
-Before compilation and installation is downloaded [addons_paths.json](https://github.com/OSGeo/grass-addons/pull/656/commits/8c08184415ec32fe409bf09b2599b0506d7650ab#diff-f0fc8363c0e166fdbe9eecb74a9e261498ec0bbf15500e56b1bb1b5ba7afb900R128)
-but only once, for first compiled addon, and then this file is moved to
-[one level directory up](https://github.com/OSGeo/grass-addons/pull/656/commits/8c08184415ec32fe409bf09b2599b0506d7650ab#diff-f0fc8363c0e166fdbe9eecb74a9e261498ec0bbf15500e56b1bb1b5ba7afb900R133)
-to sharing for all next compiled add-ons, to prevent download this file
-again in next addon compilation loop e.g. move
-`$HOME/.grass8/addons/db.join/addons_paths.json` -> `$HOME/.grass8/addons/addons_paths.json`.
-Next during addon compilation addon is called
-[mkhtml.py](https://github.com/OSGeo/grass/blob/main/utils/mkhtml.py)
-script (generate html manual page), `get_addon_path()` function, where is
-the parsed global variable `GRASS_ADDON_BASE` (base directory of installed
-addon), where is trying to find the **addons_paths.json** file and in
-[directory one level up](https://github.com/OSGeo/grass/pull/2054/commits/5a374101a825c451675d18b0d59e6ac99ee6cb02#diff-3e1684c5c5d40b273b6488a9b5a5558f556d2bcf2973ba5106b6125e01aa6959R314).
-When the add-on was found among the official add-ons, the source code
-and add-on history URL are set on the html man page, the entire man
-page is generated.
+  - `grass-addons-index.sh` - called from `cron_grass_XXX_build_binaries.sh`
+  - `get_page_description.py` - called from `grass-addons-index.sh`
+- GRASS GIS programmer's manual:
+  - within `cron_grass_XXX_build_binaries.sh`
+- compilation addons:
+  - `compile_addons_git.sh` it's called with `$5` arg, addon is
+    installed into own individual directory, with **bin/ docs/ etc/ scripts/**
+    subdir e.g. db.join addon dir `$HOME/.grass8/addons/db.join/`, instead of
+    directory structure`$HOME/.grass8/addons/` where **bin/ docs/ etc/ scripts/**
+    subdir are shared across all installed addons (this dir structure is used
+    to install the addon using the `g.extension` module). Addon installed directory
+    is set via global variable [`GRASS_ADDON_BASE`](https://github.com/OSGeo/grass-addons/pull/656/commits/8c08184415ec32fe409bf09b2599b0506d7650ab#diff-f0fc8363c0e166fdbe9eecb74a9e261498ec0bbf15500e56b1bb1b5ba7afb900L119),
+    e.g. for db.join addon is`GRASS_ADDON_BASE=$HOME/.grass8/addons/db.join/`.
+    Before compilation and installation is downloaded [addons_paths.json](https://github.com/OSGeo/grass-addons/pull/656/commits/8c08184415ec32fe409bf09b2599b0506d7650ab#diff-f0fc8363c0e166fdbe9eecb74a9e261498ec0bbf15500e56b1bb1b5ba7afb900R128)
+    but only once, for first compiled addon, and then this file is moved to
+    [one level directory up](https://github.com/OSGeo/grass-addons/pull/656/commits/8c08184415ec32fe409bf09b2599b0506d7650ab#diff-f0fc8363c0e166fdbe9eecb74a9e261498ec0bbf15500e56b1bb1b5ba7afb900R133)
+    to sharing for all next compiled add-ons, to prevent download this file
+    again in next addon compilation loop e.g. move
+    `$HOME/.grass8/addons/db.join/addons_paths.json` -> `$HOME/.grass8/addons/addons_paths.json`.
+    Next during addon compilation addon is called
+    [mkhtml.py](https://github.com/OSGeo/grass/blob/main/utils/mkhtml.py)
+    script (generate html manual page), `get_addon_path()` function, where is
+    the parsed global variable `GRASS_ADDON_BASE` (base directory of installed
+    addon), where is trying to find the **addons_paths.json** file and in
+    [directory one level up](https://github.com/OSGeo/grass/pull/2054/commits/5a374101a825c451675d18b0d59e6ac99ee6cb02#diff-3e1684c5c5d40b273b6488a9b5a5558f556d2bcf2973ba5106b6125e01aa6959R314).
+    When the add-on was found among the official add-ons, the source code
+    and add-on history URL are set on the html man page, the entire man
+    page is generated.
 
 ## Web site organisation
 
 Important: there are two web related directories on the server:
 
-* `/var/www/code_and_data/`: contains source code, sample data, etc.
-* `/var/www/html/`: contains the hugo generated files. The relevant
+- `/var/www/code_and_data/`: contains source code, sample data, etc.
+- `/var/www/html/`: contains the hugo generated files. The relevant
   subdirectories of `/var/www/code_and_data/` are linked here.
 
 ## Infrastructure

--- a/utils/cronjobs_osgeo_lxd/README.md
+++ b/utils/cronjobs_osgeo_lxd/README.md
@@ -2,12 +2,12 @@
 
 ## Version overview
 
-| **label**   | **meaning**                                                     |
-| ----------- | --------------------------------------------------------------- |
-| legacy      | legacy stable version, no longer recommended for use            |
-| old current | current stable version, widely used                             |
-| new current | upcoming stable version, for early adopters                     |
-| preview     | development version, for developers and new feature enthusiasts |
+| **label**      | **meaning**                                                     |
+| -------------- | --------------------------------------------------------------- |
+| legacy         | legacy stable version, no longer recommended                    |
+| old            | old stable version, still in use                                |
+| current stable | current stable version (recommended)                            |
+| preview        | development version, for developers and new feature enthusiasts |
 
 The name of the cronjob files reflects the GRASS GIS version being compiled/packaged.
 The actual version numbers are only coded in the scripts themselves.
@@ -29,12 +29,12 @@ programmer's manual.
 * GRASS GIS source code weekly snapshots:
   * `cron_grass_legacy_src_snapshot.sh`
   * `cron_grass_old_src_snapshot.sh`
-  * `cron_grass_new_current_src_snapshot.sh`
+  * `cron_grass_current_stable_src_snapshot.sh`
   * `cron_grass_preview_src_snapshot.sh`
 * GRASS GIS Linux binary weekly snapshots:
   * `cron_grass_legacy_build_binaries.sh`
   * `cron_grass_old_build_binaries.sh`
-  * `cron_grass_new_current_build_binaries.sh`
+  * `cron_grass_current_stable_build_binaries.sh`
   * `cron_grass_preview_build_binaries.sh`
 * GRASS GIS addons manual pages:
   * addon manual pages are generated within above Linux binary weekly snapshots

--- a/utils/cronjobs_osgeo_lxd/README.md
+++ b/utils/cronjobs_osgeo_lxd/README.md
@@ -2,15 +2,16 @@
 
 ## Version overview
 
-| **label**      | **meaning**                                                     |
-| -------------- | --------------------------------------------------------------- |
-| legacy         | legacy stable version, no longer recommended                    |
-| old            | old stable version, still in use                                |
-| current stable | current stable version (recommended)                            |
-| preview        | development version, for developers and new feature enthusiasts |
+| **label**      | **version meaning**                                        |
+| -------------- | ---------------------------------------------------------- |
+| legacy         | legacy stable version, no longer recommended               |
+| old            | old stable version, still in use                           |
+| current stable | current stable version (recommended)                       |
+| preview        | devel. version, for developers and new feature enthusiasts |
 
-The name of the cronjob files reflects the GRASS GIS version being compiled/packaged.
-The actual version numbers are only coded in the scripts themselves.
+The name of the cronjob files reflects the GRASS GIS version being
+compiled/packaged. The actual version numbers are only coded in the scripts
+themselves.
 
 ## What's this?
 

--- a/utils/cronjobs_osgeo_lxd/cron_grass_current_stable_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_current_stable_build_binaries.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# script to build GRASS GIS new current binaries + addons + progman from the `releasebranch_8_3` binaries
+# script to build GRASS GIS new current binaries + addons + progman from the `releasebranch_8_4` binaries
 # (c) 2002-2024, GPL 2+ Markus Neteler <neteler@osgeo.org>
 #
 # GRASS GIS github, https://github.com/OSGeo/grass
@@ -21,14 +21,14 @@
 #  - Install apt-get install texlive-latex-extra python3-sphinxcontrib.apidoc
 #  - Clone source from github:
 #    mkdir -p ~/src ; cd ~/src
-#    git clone https://github.com/OSGeo/grass.git releasebranch_8_3
-#    cd releasebranch_8_3
-#    git checkout releasebranch_8_3
+#    git clone https://github.com/OSGeo/grass.git releasebranch_8_4
+#    cd releasebranch_8_4
+#    git checkout releasebranch_8_4
 #  - Prepare target directories:
 #    cd /var/www/code_and_data/
-#    mkdir grass83
+#    mkdir grass84
 #    cd /var/www/html/
-#    ln -s /var/www/code_and_data/grass83 .
+#    ln -s /var/www/code_and_data/grass84 .
 #
 #################################
 PATH=/home/neteler/binaries/bin:/usr/bin:/bin:/usr/X11R6/bin:/usr/local/bin
@@ -165,6 +165,7 @@ $MYMAKE sphinxdoclib
 ##
 echo "Copy over the manual + pygrass HTML pages:"
 mkdir -p $TARGETHTMLDIR
+mkdir -p $TARGETHTMLDIR/addons # indeed only relevant the very first compile time
 # don't destroy the addons
 \mv $TARGETHTMLDIR/addons /tmp
 rm -f $TARGETHTMLDIR/*.*

--- a/utils/cronjobs_osgeo_lxd/cron_grass_current_stable_src_snapshot.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_current_stable_src_snapshot.sh
@@ -53,11 +53,12 @@ date
 # clean up
 touch include/Make/Platform.make
 $MYMAKE distclean > /dev/null 2>&1
+rm -f grass-$GMAJOR.*-install.sh grass-$GMAJOR.*.tar.gz grass-$GMAJOR.*_bin.txt
 
 # cleanup leftover garbage
 git status | grep '.rst' | xargs rm -f
 rm -rf lib/python/docs/_build/ lib/python/docs/_templates/layout.html
-rm -f config_${DOTVERSION}.git_log.txt ChangeLog
+rm -f config_*.git_log.txt ChangeLog
 
 # reset i18N POT files to git, just to be sure
 git checkout locale/templates/*.pot

--- a/utils/cronjobs_osgeo_lxd/cron_grass_legacy_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_legacy_build_binaries.sh
@@ -169,6 +169,7 @@ $MYMAKE sphinxdoclib
 ##
 echo "Copy over the manual + pygrass HTML pages:"
 mkdir -p $TARGETHTMLDIR
+mkdir -p $TARGETHTMLDIR/addons # indeed only relevant the very first compile time
 # don't destroy the addons
 \mv $TARGETHTMLDIR/addons /tmp
 rm -f $TARGETHTMLDIR/*.*

--- a/utils/cronjobs_osgeo_lxd/cron_grass_legacy_src_snapshot.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_legacy_src_snapshot.sh
@@ -57,11 +57,12 @@ date
 # clean up
 touch include/Make/Platform.make
 $MYMAKE distclean > /dev/null 2>&1
+rm -f grass-$GMAJOR.*-install.sh grass-$GMAJOR.*.tar.gz grass-$GMAJOR.*_bin.txt
 
 # cleanup leftover garbage
 git status | grep '.rst' | xargs rm -f
 rm -rf lib/python/docs/_build/ lib/python/docs/_templates/layout.html
-rm -f config_${DOTVERSION}.git_log.txt ChangeLog
+rm -f config_*.git_log.txt ChangeLog
 
 # be sure to be on branch
 git checkout $BRANCH

--- a/utils/cronjobs_osgeo_lxd/cron_grass_old_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_old_build_binaries.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# script to build GRASS GIS old current binaries + addons from the `releasebranch_8_2` binaries
+# script to build GRASS GIS old current binaries + addons from the `releasebranch_8_3` binaries
 # (c) 2002-2024, GPL 2+ Markus Neteler <neteler@osgeo.org>
 #
 # GRASS GIS github, https://github.com/OSGeo/grass
@@ -23,14 +23,14 @@
 #  - Install apt-get install texlive-latex-extra python3-sphinxcontrib.apidoc
 #  - Clone source from github:
 #    mkdir -p ~/src ; cd ~/src
-#    git clone https://github.com/OSGeo/grass.git releasebranch_8_2
-#    cd releasebranch_8_2
-#    git checkout releasebranch_8_2
+#    git clone https://github.com/OSGeo/grass.git releasebranch_8_3
+#    cd releasebranch_8_3
+#    git checkout releasebranch_8_3
 #  - Prepare target directories:
 #    cd /var/www/code_and_data/
-#    mkdir grass82
+#    mkdir grass83
 #    cd /var/www/html/
-#    ln -s /var/www/code_and_data/grass82 .
+#    ln -s /var/www/code_and_data/grass83 .
 #
 #################################
 PATH=/home/neteler/binaries/bin:/usr/bin:/bin:/usr/X11R6/bin:/usr/local/bin
@@ -172,6 +172,7 @@ $MYMAKE sphinxdoclib
 ##
 echo "Copy over the manual + pygrass HTML pages:"
 mkdir -p $TARGETHTMLDIR
+mkdir -p $TARGETHTMLDIR/addons # indeed only relevant the very first compile time
 # don't destroy the addons
 \mv $TARGETHTMLDIR/addons /tmp
 rm -f $TARGETHTMLDIR/*.*

--- a/utils/cronjobs_osgeo_lxd/cron_grass_old_src_snapshot.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_old_src_snapshot.sh
@@ -53,11 +53,12 @@ date
 # clean up
 touch include/Make/Platform.make
 $MYMAKE distclean > /dev/null 2>&1
+rm -f grass-$GMAJOR.*-install.sh grass-$GMAJOR.*.tar.gz grass-$GMAJOR.*_bin.txt
 
 # cleanup leftover garbage
 git status | grep '.rst' | xargs rm -f
 rm -rf lib/python/docs/_build/ lib/python/docs/_templates/layout.html
-rm -f config_${DOTVERSION}.git_log.txt ChangeLog
+srm -f config_*.git_log.txt ChangeLog
 
 # reset i18N POT files to git, just to be sure
 git checkout locale/templates/*.pot

--- a/utils/cronjobs_osgeo_lxd/cron_grass_preview_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_preview_build_binaries.sh
@@ -166,6 +166,7 @@ $MYMAKE sphinxdoclib
 ##
 echo "Copy over the manual + pygrass HTML pages:"
 mkdir -p $TARGETHTMLDIR
+mkdir -p $TARGETHTMLDIR/addons # indeed only relevant the very first compile time
 # don't destroy the addons
 \mv $TARGETHTMLDIR/addons /tmp
 rm -f $TARGETHTMLDIR/*.*

--- a/utils/cronjobs_osgeo_lxd/cron_grass_preview_src_snapshot.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_preview_src_snapshot.sh
@@ -53,11 +53,12 @@ date
 # clean up
 touch include/Make/Platform.make
 $MYMAKE distclean > /dev/null 2>&1
+rm -f grass-$GMAJOR.*-install.sh grass-$GMAJOR.*.tar.gz grass-$GMAJOR.*_bin.txt
 
 # cleanup leftover garbage
 git status | grep '.rst' | xargs rm -f
 rm -rf lib/python/docs/_build/ lib/python/docs/_templates/layout.html
-rm -f config_${DOTVERSION}.git_log.txt ChangeLog
+rm -f config_*.git_log.txt ChangeLog
 
 # reset i18N POT files to git, just to be sure
 git checkout locale/templates/*.pot

--- a/utils/cronjobs_osgeo_lxd/cron_job_list_grass
+++ b/utils/cronjobs_osgeo_lxd/cron_job_list_grass
@@ -29,7 +29,7 @@
 # old stable
 30 02 * * 6 nice sh /home/neteler/cronjobs/cron_grass_old_src_snapshot.sh
 # new stable
-40 02 * * 6 nice sh /home/neteler/cronjobs/cron_grass_new_current_src_snapshot.sh
+40 02 * * 6 nice sh /home/neteler/cronjobs/cron_grass_current_stable_src_snapshot.sh
 # preview
 50 02 * * 6 nice sh /home/neteler/cronjobs/cron_grass_preview_src_snapshot.sh
 
@@ -40,7 +40,7 @@
 # old stable (no more releases planned)
 35 05 * * * nice sh /home/neteler/cronjobs/cron_grass_old_build_binaries.sh > /var/www/code_and_data/grass83/binary/linux/snapshot/build.log.txt 2>&1
 # new stable
-10 06 * * * nice sh /home/neteler/cronjobs/cron_grass_new_current_build_binaries.sh > /var/www/code_and_data/grass84/binary/linux/snapshot/build.log.txt 2>&1
+10 06 * * * nice sh /home/neteler/cronjobs/cron_grass_current_stable_build_binaries.sh > /var/www/code_and_data/grass84/binary/linux/snapshot/build.log.txt 2>&1
 # preview
 45 06 * * * nice sh /home/neteler/cronjobs/cron_grass_preview_build_binaries.sh     > /var/www/code_and_data/grass85/binary/linux/snapshot/build.log.txt 2>&1
 

--- a/utils/cronjobs_osgeo_lxd/cron_job_list_grass
+++ b/utils/cronjobs_osgeo_lxd/cron_job_list_grass
@@ -26,9 +26,9 @@
 # weekly source snapshots (target dir: /var/www/code_and_data/)
 # legacy
 20 02 * * 6 nice sh /home/neteler/cronjobs/cron_grass_legacy_src_snapshot.sh
-# old stable
+# old (former stable)
 30 02 * * 6 nice sh /home/neteler/cronjobs/cron_grass_old_src_snapshot.sh
-# new stable
+# current stable
 40 02 * * 6 nice sh /home/neteler/cronjobs/cron_grass_current_stable_src_snapshot.sh
 # preview
 50 02 * * 6 nice sh /home/neteler/cronjobs/cron_grass_preview_src_snapshot.sh


### PR DESCRIPTION
- version updates in comments (was unfortunately missing from #1147).
- remove compilation related cruft from src directories on build server
- if new branch is compiled the first time, do not fail on missing `addon/` subdir

For sake of clarity, "new_current" has been renamed to "current_stable" in filenames.
Crontab updated accordingly (needs to be deployed on server by MN).

Also addresses https://github.com/OSGeo/grass/issues/4099