### PR TITLE
i.eodag: add dynamic setting for Creodias OTP 

### DIFF
--- a/src/imagery/i.eodag/i.eodag.html
+++ b/src/imagery/i.eodag/i.eodag.html
@@ -282,6 +282,19 @@ cop_dataspace:
           password: password
 </pre></div>
 
+<h3>Creodias</h3>
+Using the provider Creodias is slightly different, since it requires TOTP for authentication.
+To register to credoias create an account
+<a href="https://portal.creodias.eu/register.php">here</a>,
+then use your username, password in eodag configuration file.
+You will also need totp, a temporary 6-digits OTP
+(One Time Password, see Creodias documentation) to be able to authenticate
+and download scenes, which shall not be set through the eodag configuration file,
+but instead a prompt will show asking for OTP in case <em>i.eodag</em> attempts to
+download a scene from creodias. To discard these scenes the prompt will
+ask you to input <b>"-"</b> instead of the OTP. Note that interactive prompt
+does not work in the graphical user interface.
+
 <p>
 See <a href="https://eodag.readthedocs.io/en/stable/getting_started_guide/configure.html" target="_blank">Configure EODAG</a>
 section for more details about configuration of the

--- a/src/imagery/i.eodag/i.eodag.html
+++ b/src/imagery/i.eodag/i.eodag.html
@@ -282,18 +282,19 @@ cop_dataspace:
           password: password
 </pre></div>
 
-<h3>Creodias</h3>
-Using the provider Creodias is slightly different, since it requires TOTP for authentication.
-To register to credoias create an account
-<a href="https://portal.creodias.eu/register.php">here</a>,
-then use your username, password in eodag configuration file.
-You will also need totp, a temporary 6-digits OTP
-(One Time Password, see Creodias documentation) to be able to authenticate
-and download scenes, which shall not be set through the eodag configuration file,
-but instead a prompt will show asking for OTP in case <em>i.eodag</em> attempts to
-download a scene from creodias. To discard these scenes the prompt will
-ask you to input <b>"-"</b> instead of the OTP. Note that interactive prompt
-does not work in the graphical user interface.
+<h4>Creodias</h4>
+To register to Creodias, users should create an account
+<a href="https://portal.creodias.eu/register.php">here</a>, and
+then use their username and password in the eodag configuration file.
+Users will also need TOTP, a 6-digits temporary one time password, 
+to be able to authenticate and download scenes (product search 
+within creodias can be done without registering). 
+This TOTP is only valid for very short time, i.e., 30 to 60 seconds, so it shall
+not be set through the eodag configuration file.
+When <em>i.eodag</em> attempts to download a scene from creodias,
+users will be prompted to input the TOTP. If they prefer to discard these
+scenes, they should enter <b>"-"</b> instead. Note that interactive 
+prompt does not work in the graphical user interface.
 
 <p>
 See <a href="https://eodag.readthedocs.io/en/stable/getting_started_guide/configure.html" target="_blank">Configure EODAG</a>

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -1272,7 +1272,7 @@ def main():
                 "wait": int(options["wait"]),
             }
             if not search_result:
-                gs.message(_("Nothing to download.\nexiting..."))
+                gs.message(_("Nothing to download.\nExiting..."))
             if options["output"]:
                 custom_config["outputs_prefix"] = options["output"]
             dag.download_all(search_result, **custom_config)


### PR DESCRIPTION
This PR will allow users to input their Creodias OTP on runtime, only if there is at least one scene that requires it.