### PR TITLE
i.sentinel.mask: tuple accepts one argument only

### DIFF
--- a/src/imagery/i.sentinel/i.sentinel.mask/i.sentinel.mask.py
+++ b/src/imagery/i.sentinel/i.sentinel.mask/i.sentinel.mask.py
@@ -329,8 +329,10 @@ def get_sun_position(module_options, bands):
         with open(str(metadata_file), encoding="UTF8") as json_file:
             data = json.load(json_file)
         zenith_azimuth = tuple(
-            float(data["MEAN_SUN_ZENITH_ANGLE"]),
-            float(data["MEAN_SUN_AZIMUTH_ANGLE"]),
+            (
+                float(data["MEAN_SUN_ZENITH_ANGLE"]),
+                float(data["MEAN_SUN_AZIMUTH_ANGLE"]),
+            )
         )
     except OSError:
         gs.fatal(


### PR DESCRIPTION
When running `i.sentinel.mask` I receive the following error:
```
Traceback (most recent call last):
  File "/home/griembauer/.grass8/addons/scripts/i.sentinel.mask", line 779, in <module>
    main()
  File "/home/griembauer/.grass8/addons/scripts/i.sentinel.mask", line 540, in main
    sun_zenith, sun_azimuth = get_sun_position(options, bands)
  File "/home/griembauer/.grass8/addons/scripts/i.sentinel.mask", line 331, in get_sun_position
    zenith_azimuth = tuple(
TypeError: tuple expected at most 1 argument, got 2
```
This small PR fixes this issue but I wonder whether thats related to the Python version (In this example, Python 3.10.12 was used).
