### PR TITLE
CI: Update --tmp-location to --tmp-project

### DIFF
--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -4,14 +4,14 @@
 set -e
 
 # Install module from addons if not available (in v7).
-if ! grass --tmp-location XY --exec g.download.location --help; then
-    grass --tmp-location XY --exec \
+if ! grass --tmp-project XY --exec g.download.location --help; then
+    grass --tmp-project XY --exec \
         g.extension g.download.location
 fi
-grass --tmp-location XY --exec \
+grass --tmp-project XY --exec \
     g.download.location url=https://grass.osgeo.org/sampledata/north_carolina/nc_spm_full_v2alpha2.tar.gz path=$HOME
 
-grass --tmp-location XY --exec \
+grass --tmp-project XY --exec \
     python3 -m grass.gunittest.main \
         --grassdata $HOME --location nc_spm_full_v2alpha2 --location-type nc \
         --min-success 60

--- a/src/misc/m.csv.clean/m.csv.clean.html
+++ b/src/misc/m.csv.clean/m.csv.clean.html
@@ -30,7 +30,7 @@ so it is very easy to run it with an adhoc temporary location
 by executing a <code>grass --exec</code> command:
 
 <div class="code"><pre>
-grass --tmp-location XY --exec m.csv.clean input=sampling_sites_raw.csv output=sampling_sites.csv
+grass --tmp-project XY --exec m.csv.clean input=sampling_sites_raw.csv output=sampling_sites.csv
 </pre></div>
 
 

--- a/src/raster/r.pops.spread/README.md
+++ b/src/raster/r.pops.spread/README.md
@@ -153,7 +153,7 @@ cd ...
 Compile:
 
 ```bash
-grass --tmp-location XY --exec g.extension module=r.pops.spread url=.
+grass --tmp-project XY --exec g.extension module=r.pops.spread url=.
 ```
 
 Run (assuming you checked how to create a GRASS GIS mapset with our data):

--- a/utils/cronjobs_osgeo_lxd/cron_grass_current_stable_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_current_stable_build_binaries.sh
@@ -310,7 +310,7 @@ mkdir -p $TARGETMAIN/addons/grass$GMAJOR/logs/
 cp -p ~/.grass$GMAJOR/addons/logs/* $TARGETMAIN/addons/grass$GMAJOR/logs/
 
 # generate addons modules.xml file (required for g.extension module)
-~/src/$BRANCH/bin.$ARCH/grass --tmp-location EPSG:4326 --exec ~/cronjobs/build-xml.py --build ~/.grass$GMAJOR/addons
+~/src/$BRANCH/bin.$ARCH/grass --tmp-project EPSG:4326 --exec ~/cronjobs/build-xml.py --build ~/.grass$GMAJOR/addons
 cp ~/.grass$GMAJOR/addons/modules.xml $TARGETMAIN/addons/grass$GMAJOR/modules.xml
 
 # regenerate keywords.html file with addons modules keywords

--- a/utils/cronjobs_osgeo_lxd/cron_grass_preview_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_preview_build_binaries.sh
@@ -310,7 +310,7 @@ mkdir -p $TARGETMAIN/addons/grass$GMAJOR/logs/
 cp -p ~/.grass$GMAJOR/addons/logs/* $TARGETMAIN/addons/grass$GMAJOR/logs/
 
 # generate addons modules.xml file (required for g.extension module)
-~/src/$BRANCH/bin.$ARCH/grass --tmp-location EPSG:4326 --exec ~/cronjobs/build-xml.py --build ~/.grass$GMAJOR/addons
+~/src/$BRANCH/bin.$ARCH/grass --tmp-project EPSG:4326 --exec ~/cronjobs/build-xml.py --build ~/.grass$GMAJOR/addons
 cp ~/.grass$GMAJOR/addons/modules.xml $TARGETMAIN/addons/grass$GMAJOR/modules.xml
 
 # regenerate keywords.html file with addons modules keywords


### PR DESCRIPTION
Fix warning

`Option --tmp-location is deprecated, use --tmp-project instead`

but only from GRASS GIS 8.4 onwards.

Mostly in GitHub CI and cronjobs, but also documentation.