### PR TITLE
i.sentinel.mask: fix no clouds/shadow overlap error

### DIFF
--- a/src/imagery/i.sentinel/i.sentinel.mask/i.sentinel.mask.py
+++ b/src/imagery/i.sentinel/i.sentinel.mask/i.sentinel.mask.py
@@ -356,18 +356,18 @@ def get_overlap(clouds, dark_pixels, old_region, new_region):
         w=new_region["west"],
     )
     # measure overlap
-    overlap = int(
-        gs.read_command(
-            "r.stats",
-            quiet=True,
-            flags="cn",
-            input=f"{clouds},{dark_pixels}",
-            separator=",",
-        )
-        .strip()
-        .split(",")[2]
-        .strip()
-    )
+    overlap_str = gs.read_command(
+        "r.stats",
+        quiet=True,
+        flags="cn",
+        input=f"{clouds},{dark_pixels}",
+        separator=",",
+    ).strip()
+    if len(overlap_str) == 0:
+        overlap = 0
+    else:
+        overlap = int(overlap_str.split(",")[2].strip())
+
     # move map back
     gs.run_command(
         "r.region",


### PR DESCRIPTION
Running `i.sentinel.mask`, I encountered

```
Traceback (most recent call last):
  File "/home/griembauer/.grass8/addons/scripts/i.sentinel.mask", line 780, in <module>
    main()
  File "/home/griembauer/.grass8/addons/scripts/i.sentinel.mask", line 708, in main
    compute_shadow_shift(clouds, dark_pixels, sun_zenith, sun_azimuth)
  File "/home/griembauer/.grass8/addons/scripts/i.sentinel.mask", line 438, in compute_shadow_shift
    get_overlap(TMP_NAME, dark_pixel_map, map_region, new_region)
  File "/home/griembauer/.grass8/addons/scripts/i.sentinel.mask", line 361, in get_overlap
    gs.read_command(
IndexError: list index out of range
```
which corresponds to 

```
    # measure overlap
    overlap = int(
        gs.read_command(
            "r.stats",
            quiet=True,
            flags="cn",
            input=f"{clouds},{dark_pixels}",
            separator=",",
        )
        .strip()
        .split(",")[2]    <---------
        .strip()
    )
```
Tested:
```
(Pdb) gs.read_command("r.stats",quiet=True, flags="cn",input=f"{clouds},{dark_pixels}",separator=",",)
 100%
''

```

I assume this occurs when the maps `clouds` and `dark_pixels` don't have any overlap. They contain only the values NoData and 0, so due to the `-n`flag, `r.stats` does not give any information on category combinations if the only occuring category combinations contain at least one NoData. 

This PR fixes this issue, but I am not sure if this is consistent with the remaining logic of the module



