### PR TITLE
cronjob: fix old stable build (G83)

### DIFF
--- a/utils/cronjobs_osgeo_lxd/README.md
+++ b/utils/cronjobs_osgeo_lxd/README.md
@@ -88,7 +88,7 @@ Important: there are two web related directories on the server:
 
 ## Infrastructure
 
-The server is hosted as LXD container on `osgeo7`, see:
+The server is hosted as LXD container on `osgeo8-grass`, see:
 <https://wiki.osgeo.org/wiki/SAC_Service_Status#grass>
 
 The container is only accessible via the related OSGeo ssh jumphost and

--- a/utils/cronjobs_osgeo_lxd/cron_grass_legacy_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_legacy_build_binaries.sh
@@ -299,14 +299,13 @@ python3 $GRASSBUILDDIR/man/build_keywords.py $TARGETHTMLDIR/ $TARGETHTMLDIR/addo
 unset ARCH ARCH_DISTDIR GISBASE VERSION_NUMBER
 
 ############################################
-
+# core manual pages
 echo "Injecting G8.x new current version hint in a red box into MAN pages..."
 # inject G8.x current stable version hint in a red box:
 (cd $TARGETHTMLDIR/ ; for myfile in `ls *.html` ; do sed -i -e "s:<hr class=\"header\">:<hr class=\"header\"><p style=\"border\:3px; border-style\:solid; border-color\:#BC1818; padding\: 1em;\">Note\: This document is for an older version of GRASS GIS that will be discontinued soon. You should upgrade, and read the <a href=\"../../../grass${NEW_CURRENT}/manuals/$myfile\">current manual page</a>.</p>:g" $myfile ; done)
-# also for addons
-(cd $TARGETHTMLDIR/addons/ ; for myfile in `ls *.html` ; do sed -i -e "s:<hr class=\"header\">:<hr class=\"header\"><p style=\"border\:3px; border-style\:solid; border-color\:#BC1818; padding\: 1em;\">Note\: This document is for an older version of GRASS GIS that will be discontinued soon. You should upgrade, and read the <a href=\"../../../grass${NEW_CURRENT}/manuals/addons/$myfile\">current manual page</a>.</p>:g" $myfile ; done)
 # also for Python
 (cd $TARGETHTMLDIR/libpython/ ; for myfile in `ls *.html` ; do sed -i -e "s:<hr class=\"header\">:<hr class=\"header\"><p style=\"border\:3px; border-style\:solid; border-color\:#FF2121; padding\: 1em;\">Note\: This document is for an older version of GRASS GIS that will be discontinued soon. You should upgrade, and read the <a href=\"../../../../grass${NEW_CURRENT}/manuals/libpython/$myfile\">current Python manual page</a>.</p>:g" $myfile ; done)
+# (addons are done above)
 
 # SEO: inject canonical link into all (old) manual pages to point to latest stable (avoid "duplicate content" SEO punishment)
 # see https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls

--- a/utils/cronjobs_osgeo_lxd/cron_grass_legacy_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_legacy_build_binaries.sh
@@ -187,9 +187,12 @@ echo "Injecting DuckDuckGo search field into manual main page..."
 # clean wxGUI sphinx manual etc
 (cd $GRASSBUILDDIR/ ; $MYMAKE cleansphinx)
 
+############
+# generate doxygen programmers's G8 manual -> only in GRASS GIS 8 versions
+
+##### generate i18N stats for HTML page path:
 # note: the gettext POT files are managed in git and OSGeo Weblate
 
-##### generate i18N stats for HTML page path (WebSVN):
 ## Structure:  grasslibs_ar.po 144 translated messages 326 fuzzy translations 463 untranslated messages.
 cd $GRASSBUILDDIR
 (cd locale/ ;
@@ -283,7 +286,7 @@ chmod -R a+r,g+w $TARGETHTMLDIR 2> /dev/null
 mkdir -p $TARGETMAIN/addons/grass$GMAJOR/logs/
 cp -p ~/.grass$GMAJOR/addons/logs/* $TARGETMAIN/addons/grass$GMAJOR/logs/
 
-# generate addons module.xml file (required for g.extension module)
+# generate addons modules.xml file (required for g.extension module)
 ~/src/$BRANCH/bin.$ARCH/grass$VERSION --tmp-location EPSG:4326 --exec ~/cronjobs/build-xml.py --build ~/.grass$GMAJOR/addons
 cp ~/.grass$GMAJOR/addons/modules.xml $TARGETMAIN/addons/grass$GMAJOR/modules.xml
 
@@ -298,7 +301,7 @@ unset ARCH ARCH_DISTDIR GISBASE VERSION_NUMBER
 ############################################
 
 echo "Injecting G8.x new current version hint in a red box into MAN pages..."
-# inject G8.x new version hint in a red box:
+# inject G8.x current stable version hint in a red box:
 (cd $TARGETHTMLDIR/ ; for myfile in `ls *.html` ; do sed -i -e "s:<hr class=\"header\">:<hr class=\"header\"><p style=\"border\:3px; border-style\:solid; border-color\:#BC1818; padding\: 1em;\">Note\: This document is for an older version of GRASS GIS that will be discontinued soon. You should upgrade, and read the <a href=\"../../../grass${NEW_CURRENT}/manuals/$myfile\">current manual page</a>.</p>:g" $myfile ; done)
 # also for addons
 (cd $TARGETHTMLDIR/addons/ ; for myfile in `ls *.html` ; do sed -i -e "s:<hr class=\"header\">:<hr class=\"header\"><p style=\"border\:3px; border-style\:solid; border-color\:#BC1818; padding\: 1em;\">Note\: This document is for an older version of GRASS GIS that will be discontinued soon. You should upgrade, and read the <a href=\"../../../grass${NEW_CURRENT}/manuals/addons/$myfile\">current manual page</a>.</p>:g" $myfile ; done)

--- a/utils/cronjobs_osgeo_lxd/cron_grass_old_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_old_build_binaries.sh
@@ -14,7 +14,7 @@
 # - generates the pyGRASS 8 HTML manual
 # - generates the user 8 HTML manuals
 # - injects DuckDuckGo search field
-# - injects "G8 is the new version" box into core and addon manual pages
+# - injects "G8.x is the new version" box into core and addon manual pages
 # - injects canonical URL
 
 # Preparations, on server:
@@ -333,7 +333,8 @@ unset ARCH ARCH_DISTDIR GISBASE VERSION_NUMBER
 echo "Injecting G8.x new current version hint in a red box into MAN pages..."
 # inject G8.x current stable version hint in a red box:
 (cd $TARGETHTMLDIR/ ; for myfile in `ls *.html` ; do sed -i -e "s:<hr class=\"header\">:<hr class=\"header\"><p style=\"border\:3px; border-style\:solid; border-color\:#BC1818; padding\: 1em;\">Note\: This document is for an older version of GRASS GIS that will be discontinued soon. You should upgrade, and read the <a href=\"../../../grass${NEW_CURRENT}/manuals/$myfile\">current manual page</a>.</p>:g" $myfile ; done)
-# also for addons
+# also for addons, separately for landing page and addons
+(cd $TARGETHTMLDIR/addons/ ; sed -i -e "s:<table><tr><td>:<hr class=\"header\"><p style=\"border\:3px; border-style\:solid; border-color\:#BC1818; padding\: 1em;\">Note\: This document is for an older version of GRASS GIS that will be discontinued soon. You should upgrade, and read the <a href=\"../../../grass${NEW_CURRENT}/manuals/addons/index.html\">current addon manual page</a>.</p> <table><tr><td>:g" index.html)
 (cd $TARGETHTMLDIR/addons/ ; for myfile in `ls *.html` ; do sed -i -e "s:<hr class=\"header\">:<hr class=\"header\"><p style=\"border\:3px; border-style\:solid; border-color\:#BC1818; padding\: 1em;\">Note\: This document is for an older version of GRASS GIS that will be discontinued soon. You should upgrade, and read the <a href=\"../../../grass${NEW_CURRENT}/manuals/addons/$myfile\">current manual page</a>.</p>:g" $myfile ; done)
 # also for Python
 (cd $TARGETHTMLDIR/libpython/ ; for myfile in `ls *.html` ; do sed -i -e "s:<hr class=\"header\">:<hr class=\"header\"><p style=\"border\:3px; border-style\:solid; border-color\:#FF2121; padding\: 1em;\">Note\: This document is for an older version of GRASS GIS that will be discontinued soon. You should upgrade, and read the <a href=\"../../../../grass${NEW_CURRENT}/manuals/libpython/$myfile\">current Python manual page</a>.</p>:g" $myfile ; done)

--- a/utils/cronjobs_osgeo_lxd/cron_grass_old_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_old_build_binaries.sh
@@ -182,10 +182,10 @@ rm -f $TARGETHTMLDIR/*.*
 cp -rp dist.$ARCH/docs/html/* $TARGETHTMLDIR/
 echo "Copied pygrass progman to http://grass.osgeo.org/grass${VERSION}/manuals/libpython/"
 
-cp -p AUTHORS CHANGES CITING CITATION.cff COPYING GPL.TXT INSTALL.md REQUIREMENTS.html $TARGETDIR/
-
 echo "Injecting DuckDuckGo search field into manual main page..."
 (cd $TARGETHTMLDIR/ ; sed -i -e "s+</table>+</table><\!\-\- injected in cron_grass8_relbranch_build_binaries.sh \-\-> <center><iframe src=\"https://duckduckgo.com/search.html?site=grass.osgeo.org%26prefill=Search%20manual%20pages%20at%20DuckDuckGo\" style=\"overflow:hidden;margin:0;padding:0;width:410px;height:40px;\" frameborder=\"0\"></iframe></center>+g" index.html)
+
+cp -p AUTHORS CHANGES CITING CITATION.cff COPYING GPL.TXT INSTALL.md REQUIREMENTS.md $TARGETDIR/
 
 # clean wxGUI sphinx manual etc
 (cd $GRASSBUILDDIR/ ; $MYMAKE cleansphinx)
@@ -219,9 +219,9 @@ cd $GRASSBUILDDIR/
 #(cd $TARGETPROGMAN/ ; ln -s index.html main.html)
 #### end unused
 
-# note: from G82+ onwards the gettext POT files are managed in git and OSGeo Weblate
+##### generate i18N stats for HTML page path:
+# note: the gettext POT files are managed in git and OSGeo Weblate
 
-##### generate i18N stats for HTML page path (WebSVN):
 ## Structure:  grasslibs_ar.po 144 translated messages 326 fuzzy translations 463 untranslated messages.
 cd $GRASSBUILDDIR
 (cd locale/ ;
@@ -331,7 +331,7 @@ unset ARCH ARCH_DISTDIR GISBASE VERSION_NUMBER
 ############################################
 
 echo "Injecting G8.x new current version hint in a red box into MAN pages..."
-# inject G8.x new current version hint in a red box:
+# inject G8.x current stable version hint in a red box:
 (cd $TARGETHTMLDIR/ ; for myfile in `ls *.html` ; do sed -i -e "s:<hr class=\"header\">:<hr class=\"header\"><p style=\"border\:3px; border-style\:solid; border-color\:#BC1818; padding\: 1em;\">Note\: This document is for an older version of GRASS GIS that will be discontinued soon. You should upgrade, and read the <a href=\"../../../grass${NEW_CURRENT}/manuals/$myfile\">current manual page</a>.</p>:g" $myfile ; done)
 # also for addons
 (cd $TARGETHTMLDIR/addons/ ; for myfile in `ls *.html` ; do sed -i -e "s:<hr class=\"header\">:<hr class=\"header\"><p style=\"border\:3px; border-style\:solid; border-color\:#BC1818; padding\: 1em;\">Note\: This document is for an older version of GRASS GIS that will be discontinued soon. You should upgrade, and read the <a href=\"../../../grass${NEW_CURRENT}/manuals/addons/$myfile\">current manual page</a>.</p>:g" $myfile ; done)
@@ -340,9 +340,10 @@ echo "Injecting G8.x new current version hint in a red box into MAN pages..."
 
 # SEO: inject canonical link into all (old) manual pages to point to latest stable (avoid "duplicate content" SEO punishment)
 # see https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls
-(cd $TARGETHTMLDIR/ ; for myfile in `ls *.html` ; do sed -i -e "s:</head>:<link rel=\"canonical\" href=\"https\://grass.osgeo.org/grass${NEW_CURRENT}/manuals/$myfile\">\n</head>:g" $myfile ; done)
-(cd $TARGETHTMLDIR/addons/ ; for myfile in `ls *.html` ; do sed -i -e "s:</head>:<link rel=\"canonical\" href=\"https\://grass.osgeo.org/grass${NEW_CURRENT}/manuals/addons/$myfile\">\n</head>:g" $myfile ; done)
-(cd $TARGETHTMLDIR/libpython/ ; for myfile in `ls *.html` ; do sed -i -e "s:</head>:<link rel=\"canonical\" href=\"https\://grass.osgeo.org/grass${NEW_CURRENT}/manuals/libpython/$myfile\">\n</head>:g" $myfile ; done)
+# canonical: once again after addon manual (re)creation, only where missing
+(cd $TARGETHTMLDIR/ ; for myfile in `grep -L 'link rel="canonical"' *.html` ; do sed -i -e "s:</head>:<link rel=\"canonical\" href=\"https\://grass.osgeo.org/grass${NEW_CURRENT}/manuals/$myfile\">\n</head>:g" $myfile ; done)
+(cd $TARGETHTMLDIR/addons/ ; for myfile in `grep -L 'link rel="canonical"' *.html` ; do sed -i -e "s:</head>:<link rel=\"canonical\" href=\"https\://grass.osgeo.org/grass${NEW_CURRENT}/manuals/addons/$myfile\">\n</head>:g" $myfile ; done)
+(cd $TARGETHTMLDIR/libpython/ ; for myfile in `grep -L 'link rel="canonical"' *.html` ; do sed -i -e "s:</head>:<link rel=\"canonical\" href=\"https\://grass.osgeo.org/grass${NEW_CURRENT}/manuals/libpython/$myfile\">\n</head>:g" $myfile ; done)
 
 ############################################
 # create sitemaps to expand the hugo sitemap

--- a/utils/cronjobs_osgeo_lxd/grass-addons-index.sh
+++ b/utils/cronjobs_osgeo_lxd/grass-addons-index.sh
@@ -120,7 +120,7 @@ generate () {
 <body bgcolor=\"#FFFFFF\">
 <h2>GRASS GIS ${major}.${minor} Addons Manual pages</h2>
 
-<!-- Generated from: grasslxd (on osgeo7): ~/cronjobs/grass-addons-index.sh -->
+<!-- Generated from: grasslxd (on osgeo8-grass): ~/cronjobs/grass-addons-index.sh -->
 <!--       See also: https://github.com/OSGeo/grass-addons/tree/grass8/utils/cronjobs_osgeo_lxd/README.md -->
 
 <table><tr><td>


### PR DESCRIPTION
Fix **build error** which broke the G83 cronjob prior to inject the "go-to-new-version" notification box.

Injects 'G8.x is the new version' box, separately for landing page and addon pages due to different HTML structure.

Also:
- inject canonical URL metadata only there still needed
- minor comment wording fixes.

Will fix:
- https://grass.osgeo.org/grass83/manuals/
- https://grass.osgeo.org/grass83/manuals/addons/
- https://grass.osgeo.org/grass78/manuals/addons/ (no duplicate box)

to look like shown below:

![image](https://github.com/user-attachments/assets/4606bf7b-ab5a-407e-a360-843eed656a5c)

addons:

![image](https://github.com/user-attachments/assets/7325591c-f5ca-44e5-a547-40f569da22ad)
