### PR TITLE
style: Also format markdown files with Prettier

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,9 +2,8 @@
 name: Bug report
 about: Create a report to help us improve
 title: "[Bug] "
-labels: ''
-assignees: ''
-
+labels: ""
+assignees: ""
 ---
 
 **Name of the addon**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,36 +23,36 @@ GRASS GIS developer mailing list.
 
 ### First time setup
 
-* Create an account on GitHub.
-* Install Git on your computer.
-* Set up Git with your name and email.
-* Fork the repository.
-* Clone your fork (use SSH or HTTPS URL):
+- Create an account on GitHub.
+- Install Git on your computer.
+- Set up Git with your name and email.
+- Fork the repository.
+- Clone your fork (use SSH or HTTPS URL):
 
 ```bash
 git clone git@github.com:your_GH_account/grass-addons.git
 ```
 
-* Enter the directory
+- Enter the directory
 
 ```bash
 cd grass-addons/
 ```
 
-* Add main GRASS GIS Addons repository as "upstream" (use HTTPS URL):
+- Add main GRASS GIS Addons repository as "upstream" (use HTTPS URL):
 
 ```bash
 git remote add upstream https://github.com/OSGeo/grass-addons
 ```
 
-* Your remotes now should be "origin" which is your fork and "upstream" which
+- Your remotes now should be "origin" which is your fork and "upstream" which
   is this main GRASS GIS Addons repository. You can confirm that using:
 
 ```bash
 git remote -v
 ```
 
-* You should see something like:
+- You should see something like:
 
 ```text
 origin  git@github.com:your_GH_account/grass-addons.git (fetch)
@@ -65,19 +65,19 @@ It is important that "origin" points to your fork.
 
 ### Update before creating a feature branch
 
-* Download updates from all branches from the _upstream_ remote:
+- Download updates from all branches from the _upstream_ remote:
 
 ```bash
 git fetch upstream
 ```
 
-* Make sure your are starting with the branch for the latest version, i.e., _grass8_:
+- Make sure your are starting with the branch for the latest version, i.e., _grass8_:
 
 ```bash
 git switch grass8
 ```
 
-* Update your local branch to match the one in the upstream repository:
+- Update your local branch to match the one in the upstream repository:
 
 ```bash
 git rebase upstream/grass8
@@ -92,13 +92,13 @@ then move your uncommitted local changes to "stash" using:
 git stash
 ```
 
-* Now you can rebase:
+- Now you can rebase:
 
 ```bash
 git rebase upstream/grass8
 ```
 
-* Apply your local changes on top of the updated code:
+- Apply your local changes on top of the updated code:
 
 ```bash
 git stash pop
@@ -109,7 +109,7 @@ git stash pop
 Now you have updated your local branch, you can create a feature branch
 based on it.
 
-* Create a new feature branch and switch to it:
+- Create a new feature branch and switch to it:
 
 ```bash
 git switch -c new-feature
@@ -123,14 +123,14 @@ general [GRASS GIS Programming Style Guide](https://github.com/OSGeo/grass/blob/
 
 ### Committing
 
-* Add files to the commit (changed ones or new ones):
+- Add files to the commit (changed ones or new ones):
 
 ```bash
 git add file1
 git add file2
 ```
 
-* Commit the change (first word is the module name):
+- Commit the change (first word is the module name):
 
 ```bash
 git commit -m "module: added a new feature"
@@ -138,7 +138,7 @@ git commit -m "module: added a new feature"
 
 ### Pushing changes to GitHub
 
-* Push your local feature branch to your fork:
+- Push your local feature branch to your fork:
 
 ```bash
 git push origin new-feature

--- a/src/imagery/i.fusion.hpf/README.md
+++ b/src/imagery/i.fusion.hpf/README.md
@@ -72,13 +72,13 @@ After installation, from within a GRASS-GIS session, see help details via
 
 ### Remarks
 
-* easy to use, i.e.:
-  * for one band `i.fusion.hpf pan=Panchromatic msx=${Band}`
-  * for multiple bands `i.fusion.hpf pan=Panchromatic msx=Red,Green,Blue,NIR`
-* easy to test various parameters that define the High-Pass filter’s
-  *kernel size* and *center value*
-* should work with **any** kind of imagery (think of bitness)
-* the "black border" effect, possibly caused due to a non-perfect match of the
+- easy to use, i.e.:
+  - for one band `i.fusion.hpf pan=Panchromatic msx=${Band}`
+  - for multiple bands `i.fusion.hpf pan=Panchromatic msx=Red,Green,Blue,NIR`
+- easy to test various parameters that define the High-Pass filter’s
+  _kernel size_ and _center value_
+- should work with **any** kind of imagery (think of bitness)
+- the "black border" effect, possibly caused due to a non-perfect match of the
   high vs. the low resolution of the input images, can be trimmed out by using
   the `trim` option --a floating point "trimming factor" with which to multiply
   the pixel size of the low resolution image-- and shrink the extent of the
@@ -86,47 +86,47 @@ After installation, from within a GRASS-GIS session, see help details via
 
 ## Implementation notes
 
-* First commit on Sat Oct 25 12:26:54 2014 +0300
-* Working state reached on Tue Nov 4 09:28:25 2014 +0200
+- First commit on Sat Oct 25 12:26:54 2014 +0300
+- Working state reached on Tue Nov 4 09:28:25 2014 +0200
 
 ## To Do
 
-* Go through <http://trac.osgeo.org/grass/wiki/Submitting/Python>
-* Access input raster by row I/O ?
-* Proper command history tracking. Not all "r" modules do it... ?
-* Add timestamps (r.timestamp)
-* Deduplicate code where applicable
-* Make the -v messages shorter, yet more informative (ie report center cell)
-* Test. Will it compile in other systems?
-* Checking options to integrate in `i.pansharpen`. Think of FFM methods vs.
+- Go through <http://trac.osgeo.org/grass/wiki/Submitting/Python>
+- Access input raster by row I/O ?
+- Proper command history tracking. Not all "r" modules do it... ?
+- Add timestamps (r.timestamp)
+- Deduplicate code where applicable
+- Make the -v messages shorter, yet more informative (ie report center cell)
+- Test. Will it compile in other systems?
+- Checking options to integrate in `i.pansharpen`. Think of FFM methods vs.
   Others?
-* Who else to thank?  Transfer from archive/
-* Improve [Documentation.lyx](https://gitlab.com/NikosAlexandris/i.fusion.hpf/blob/master/lyx/Documentation.lyx)
+- Who else to thank? Transfer from archive/
+- Improve [Documentation.lyx](https://gitlab.com/NikosAlexandris/i.fusion.hpf/blob/master/lyx/Documentation.lyx)
 
 ## Questions
 
-* To Ask!
+- To Ask!
 
 ## References
 
-* Gangkofner, U. G., Pradhan, P. S., and Holcomb, D. W. (2008). Optimizing
+- Gangkofner, U. G., Pradhan, P. S., and Holcomb, D. W. (2008). Optimizing
   the high-pass filter addition technique for image fusion.
   PHOTOGRAMMETRIC ENGINEERING & REMOTE SENSING, 74(9):1107–1118.
-* “ERDAS IMAGINE.” Accessed March 19, 2015. <http://doc.hexagongeospatial.com/ERDAS%20IMAGINE/ERDAS_IMAGINE_Help/#ii_hpfmerge_mergedialog.htm>.
+- “ERDAS IMAGINE.” Accessed March 19, 2015. <http://doc.hexagongeospatial.com/ERDAS%20IMAGINE/ERDAS_IMAGINE_Help/#ii_hpfmerge_mergedialog.htm>.
 
-* Aniruddha Ghosh & P.K. Joshi (2013) Assessment of pan-sharpened very
+- Aniruddha Ghosh & P.K. Joshi (2013) Assessment of pan-sharpened very
   high-resolution WorldView-2 images, International Journal of Remote Sensing,
   34:23, 8336-8359
 
 ## Ευχαριστώ
 
-* Nikos Ves
-* Ranjith, <https://class.coursera.org/interactivepython-005/forum/profile?user_id=9361576>
-* Anonymous on coursera's discussion forums
-* Pietro Zambelli
-* StackExchange contributors
-  * <http://stackoverflow.com/a/1140966/1172302>
-  * <http://stackoverflow.com/a/275025/1172302>
-* Yann Chemin
-* Aniruddha Ghosh
-* Παναγιώτης Μαυρογιώργος (<https://github.com/pmav99>)
+- Nikos Ves
+- Ranjith, <https://class.coursera.org/interactivepython-005/forum/profile?user_id=9361576>
+- Anonymous on coursera's discussion forums
+- Pietro Zambelli
+- StackExchange contributors
+  - <http://stackoverflow.com/a/1140966/1172302>
+  - <http://stackoverflow.com/a/275025/1172302>
+- Yann Chemin
+- Aniruddha Ghosh
+- Παναγιώτης Μαυρογιώργος (<https://github.com/pmav99>)

--- a/src/imagery/i.landsat8.swlst/README.md
+++ b/src/imagery/i.landsat8.swlst/README.md
@@ -1,12 +1,12 @@
 # i.landsat8.swist
 
-*i.landsat8.swlst* is a GRASS GIS add-on, implementing a practical Split-Window (SW)
+_i.landsat8.swlst_ is a GRASS GIS add-on, implementing a practical Split-Window (SW)
 algorithm, estimating land surface temperature (LST), from the Thermal Infra-Red
 Sensor (TIRS) aboard Landsat 8 with an accuracy of better than 1.0 K.
 
 ## Quick examples
 
-After installation (see section *Installation* below), from within a GRASS-GIS
+After installation (see section _Installation_ below), from within a GRASS-GIS
 session, retrieve usage details via `i.landsat8.swlst --help`
 
 The shortest call for processing a complete Landsat8 scene normally is:
@@ -58,7 +58,7 @@ brightness temperature (BT); land surface emissivities (LSEs); and the
 coefficients of the main Split-Window equation (SWCs).
 
 **LSEs** are derived from an established look-up table linking the FROM-GLC
-classification scheme to average emissivities. The NDVI and the FVC are *not*
+classification scheme to average emissivities. The NDVI and the FVC are _not_
 computed each time an LST estimation is requested. Read [0] for details.
 
 The **SWCs** depend on each pixel's column water vapor (CWV). **CWV** values are
@@ -70,7 +70,7 @@ size of the spatial window querying for CWV values in adjacent pixels, is a key
 parameter of the MSWCVMR method. It influences accuracy and performance. In [2]
 it is stated:
 
-> A small window size n (N = n * n, see equation (1a)) cannot ensure a high
+> A small window size n (N = n \* n, see equation (1a)) cannot ensure a high
 > correlation between two bands' temperatures due to the instrument noise. In
 > contrast, the size cannot be too large because the variations in the surface
 > and atmospheric conditions become larger as the size increases.
@@ -128,13 +128,14 @@ Making the script `i.lansat8.swlst` available from within any GRASS-GIS ver.
 - ~~Fix retrieval of adjacent subranges (exclude 6, get it only if there is no
   match for subranges 1, 2, 3, 4, and 5)~~
 
-- Evaluate BIG mapcalc expressions -- are they correct?  I guess so ;-)
+- Evaluate BIG mapcalc expressions -- are they correct? I guess so ;-)
+
   - ~~Expression for Column Water Vapor~~
   - ~~CWV output values range -- is it rational?~~ It was not. There is a
     typo in paper [0]. The correct order of the coefficients is in papers [1,
     2].
   - ~~Expression for Land Surface Temperature~~
-  - ~~LST output values range -- is it rational?  At the moment, not!~~
+  - ~~LST output values range -- is it rational? At the moment, not!~~
     Fixed. The main Split-Window equation was wrong.
 
 - ~~Why is the LST out of range when using a fixed land cover class?~~ Cloudy
@@ -155,9 +156,9 @@ Making the script `i.lansat8.swlst` available from within any GRASS-GIS ver.
 
 - ~~Redo the example screenshots for the manual after corrections for CWV, LST
   equations.~~
-- Use existing i.emissivity?  Not exactly compatible -- read paper for details.
+- Use existing i.emissivity? Not exactly compatible -- read paper for details.
   Anyhow, options to input average and delta emissivity maps implemented.
-- Raster Row I/O -- Maybe *not* an option: see discussion with Pietro Zambelli
+- Raster Row I/O -- Maybe _not_ an option: see discussion with Pietro Zambelli
 - How to perform pixel value validity checks for in-between and end products?
   `r.mapcalc` can't do this. Best to implement a test checking the values
   on-the-fly while they are created. A C-function?
@@ -167,8 +168,8 @@ Making the script `i.lansat8.swlst` available from within any GRASS-GIS ver.
 - ~~Test for too small region?~~ Works for a region of 267 rows x 267 cols
   (71289 cells)
 - Deduplicate code in `split_window_lst` class, in functions
-`_build_average_emissivity_mapcalc()` and
-`_build_delta_emissivity_mapcalc()`
+  `_build_average_emissivity_mapcalc()` and
+  `_build_delta_emissivity_mapcalc()`
 - Implement a median window filter, as another option in addition to mean.
 - Profiling
 - Implement a complete cloud masking function using the BQA image. Support for

--- a/src/raster/r.estimap.recreation/README.md
+++ b/src/raster/r.estimap.recreation/README.md
@@ -2,21 +2,22 @@
 
 ## Description
 
-*r.estimap.recreation*
+_r.estimap.recreation_
 is an implementation of the ESTIMAP recreation algorithm to support mapping
 and modelling of ecosystem services (Zulian, 2014).
 
 ## Examples
 
 For the sake of demonstrating the usage of the module, we use the following
-"component" maps to derive a recreation *potential* map:
+"component" maps to derive a recreation _potential_ map:
 
-* `input_area_of_interest`
-* `input_land_suitability`
-* `input_water_resources`
-* `input_protected_areas`
+- `input_area_of_interest`
+- `input_land_suitability`
+- `input_water_resources`
+- `input_protected_areas`
 
 <!-- markdownlint-disable no-inline-html -->
+
 <img alt="Area of interest" src="images/r_estimap_recreation_area_of_interest.png"
     width="190" />
 <img alt="Land suitability" src="images/r_estimap_recreation_land_suitability.png"
@@ -25,6 +26,7 @@ For the sake of demonstrating the usage of the module, we use the following
     width="190" />
 <img alt="Protected areas"  src="images/r_estimap_recreation_protected_areas.png"
     width="190" />
+
 <!-- markdownlint-enable no-inline-html -->
 
 The maps shown above are available to download, among other sample maps, at:
@@ -63,12 +65,12 @@ cells:      6231077
 The first four input options of the module, are designed to receive pre-processed
 input maps that classify as either `land`, `natural`, `water`, and
 `infrastructure` resources that add to the recreational value of the area.
-*Pro-processing* means here to derive a map that scores the given resources,
+_Pro-processing_ means here to derive a map that scores the given resources,
 in the context of recreation and the ESTIMAP algorithm.
 
 #### Potential
 
-To produce a recreation *potential* map, the simplest command requires the user
+To produce a recreation _potential_ map, the simplest command requires the user
 to define the input map option `land` and name the output map via the option
 `potential`. Using a pre-processed map that depicts the suitability of different
 land types to support for recreation (here the map named `land_suitability`),
@@ -137,7 +139,7 @@ map](images/r_estimap_recreation_potential_3.png)
 
 While the `land` option accepts only one map as an input, both the `water`
 and the `natural` options accept multiple maps as inputs. For example, we
-add a second map named `input_bathing_water_quality` to the *water* component
+add a second map named `input_bathing_water_quality` to the _water_ component
 and modify the output map name to `output_potential_4`:
 
 ```bash
@@ -170,10 +172,10 @@ of values due to the different set of input maps.
 
 :exclamation:
 All of the above examples base upon pre-processed maps that score the access to
-and quality of land, water and natural resources. For using *raw*, unprocessed
+and quality of land, water and natural resources. For using _raw_, unprocessed
 maps, read section **Using unprocessed maps**.
 
-We can remove all of the *potential* maps via
+We can remove all of the _potential_ maps via
 
 ```bash
 g.remove raster pattern=output_potential* -f
@@ -201,12 +203,14 @@ r.estimap.recreation  \
 ```
 
 or, the same command in a copy-paste friendly way for systems that won't
-understand the special  `\` character:
+understand the special `\` character:
 
 <!-- markdownlint-disable line-length -->
+
 ```bash
 r.estimap.recreation  land=input_land_suitability  water=input_water_resources,input_bathing_water_quality  natural=input_protected_areas  infrastructure=input_distance_to_infrastructure  spectrum=output_spectrum
 ```
+
 <!-- markdownlint-enable line-length -->
 
 ![Example of a recreation spectrum output map while using a MASK, a land
@@ -216,7 +220,7 @@ map](images/r_estimap_recreation_spectrum.png)
 Missing to define an `infrastructure` map, while asking for the `spectrum`
 output, the command will abort and inform about.
 
-The image of the *spectrum* map was produced via the following native
+The image of the _spectrum_ map was produced via the following native
 GRASS GIS commands
 
 ```bash
@@ -248,9 +252,11 @@ r.estimap.recreation --o \
 or, the same command in a copy-paste friendly way:
 
 <!-- markdownlint-disable line-length -->
+
 ```bash
 r.estimap.recreation  --o mask=input_area_of_interest  land=input_land_suitability  water=input_water_resources,input_bathing_water_quality  natural=input_protected_areas  infrastructure=input_distance_to_infrastructure  opportunity=output_opportunity  spectrum=output_spectrum
 ```
+
 <!-- markdownlint-enable line-length -->
 
 We also add the `--o` overwrite flag, because existing `output_spectrum` map
@@ -260,7 +266,7 @@ will cause the module to abort.
 suitability map, a water resources map and a natural resources
 map](images/r_estimap_recreation_opportunity.png)
 
-The image of the *opportunity* map was produced via the following native
+The image of the _opportunity_ map was produced via the following native
 GRASS GIS commands
 
 ```bash
@@ -321,7 +327,7 @@ infrastructure, population and base](images/r_estimap_recreation_demand.png)
 #### Unmet Demand
 
 In the following example, we add `unmet` output map option. In this case of
-the *unmet* distribution map too, by design the module requires the user
+the _unmet_ distribution map too, by design the module requires the user
 to define the `demand` output map option.
 
 ```bash
@@ -341,18 +347,18 @@ r.estimap.recreation --o \
 for land suitability, water resources, natural resources,
 infrastructure, population and base](images/r_estimap_recreation_unmet_demand.png)
 
-It is left as an exercise to the user to create screenshots of the *met*, the
-*unmet* demand distribution and the *flow* output maps. For example, is may be
+It is left as an exercise to the user to create screenshots of the _met_, the
+_unmet_ demand distribution and the _flow_ output maps. For example, is may be
 similar to the command examples that demonstrate the use of the commands
-`d.rast`, `d.legend` and `d.text`, that draw the *potential*, the *spectrum*
-and the *opportunity* maps.
+`d.rast`, `d.legend` and `d.text`, that draw the _potential_, the _spectrum_
+and the _opportunity_ maps.
 
 #### Flow
 
-The *flow* bases upon the same function used to quantify the attractiveness
-of locations for their recreational value. It includes an extra *score* term.
+The _flow_ bases upon the same function used to quantify the attractiveness
+of locations for their recreational value. It includes an extra _score_ term.
 
-The computation involves a *distance* map, reclassified in 5 categories as
+The computation involves a _distance_ map, reclassified in 5 categories as
 shown in the following table. For each distance category, a unique pair of
 coefficient values is assigned to the basic equation.
 
@@ -447,7 +453,7 @@ returns
 
 #### Supply and Use
 
-The module outputs by request the *supply* and *use* tables in form of CSV files.
+The module outputs by request the _supply_ and _use_ tables in form of CSV files.
 Here is how:
 
 ```bash
@@ -595,7 +601,7 @@ maybe this will be useful.
 
 #### Vector map
 
-A vector input map with the role of the *base* map, can be used too.
+A vector input map with the role of the _base_ map, can be used too.
 
 ![Example of a vector map showing local administrative units](images/r_estimap_recreation_input_vector_local_administrative_units.png)
 
@@ -617,9 +623,9 @@ r.estimap.recreation --o -r \
 
 This command will also:
 
-* export results of the mobility function in the files `output_supply.csv`
+- export results of the mobility function in the files `output_supply.csv`
   and `output_use.csv`
-* add the following columns in the attribute table linked to the
+- add the following columns in the attribute table linked to the
   `input_vector_local_administrative_units` vector map:
 
   ```text
@@ -643,7 +649,7 @@ For example, the
 v.db.select input_vector_local_administrative_units \
     columns=lau2_no_name,spectrum_sum,demand_sum,unmet_sum,flow_sum \
     where="flow_sum IS NOT NULL" | head
- ```
+```
 
 following the analysis, returns
 
@@ -681,50 +687,50 @@ short integer numbers to print as labels inside the units (in the vector map).
 The module offers a pre-processing functionality for all of the following
 input components:
 
-* landuse
-* suitability\_scores
+- landuse
+- suitability_scores
 
 <!-- -->
 
-* landcover
-* land\_classes
+- landcover
+- land_classes
 
 <!-- -->
 
-* lakes
-* lakes\_coefficients
-* default is set to: euclidean,1,30,0.008,1
+- lakes
+- lakes_coefficients
+- default is set to: euclidean,1,30,0.008,1
 
 <!-- -->
 
-* coastline
-* coastline\_coefficients
-* default is set to: euclidean,1,30,0.008,1
-* coast\_geomorphology
+- coastline
+- coastline_coefficients
+- default is set to: euclidean,1,30,0.008,1
+- coast_geomorphology
 
 <!-- -->
 
-* bathing\_water
-* bathing\_coefficients
-* default is set to: euclidean,1,5,0.01101
+- bathing_water
+- bathing_coefficients
+- default is set to: euclidean,1,5,0.01101
 
 <!-- -->
 
-* protected
-* protected\_scores
-* 11:11:0,12:12:0.6,2:2:0.8,3:3:0.6,4:4:0.6,5:5:1,6:6:0.8,7:7:0,8:8:0,9:9:0
+- protected
+- protected_scores
+- 11:11:0,12:12:0.6,2:2:0.8,3:3:0.6,4:4:0.6,5:5:1,6:6:0.8,7:7:0,8:8:0,9:9:0
 
 <!-- -->
 
-* anthropic
-* anthropic\_distances
-* 0:500:1,500.000001:1000:2,1000.000001:5000:3,5000.000001:10000:4,10000.00001:\*:5
+- anthropic
+- anthropic_distances
+- 0:500:1,500.000001:1000:2,1000.000001:5000:3,5000.000001:10000:4,10000.00001:\*:5
 
 <!-- -->
 
-* roads
-* roads\_distances
-* 0:500:1,500.000001:1000:2,1000.000001:5000:3,5000.000001:10000:4,10000.00001:\*:5
+- roads
+- roads_distances
+- 0:500:1,500.000001:1000:2,1000.000001:5000:3,5000.000001:10000:4,10000.00001:\*:5
 
 A first look on how this works, is to experiment with the `landuse` and
 `suitability_scores` input options.
@@ -786,12 +792,14 @@ on a fragment from the CORINE land data base](images/r_estimap_recreation_potent
 The same can be achieved with a long one-line string too:
 
 <!-- markdownlint-disable line-length -->
+
 ```bash
 r.estimap.recreation \
     landuse=input_corine_land_cover_2006 \
     suitability_scores="1:1:0:0,2:2:0.1:0.1,3:9:0:0,10:10:1:1,11:11:0.1:0.1,12:13:0.3:0.3,14:14:0.4:0.4,15:17:0.5:0.5,18:18:0.6:0.6,19:20:0.3:0.3,21:22:0.6:0.6,23:23:1:1,24:24:0.8:0.8,25:25:1:1,26:29:0.8:0.8,30:30:1:1,31:31:0.8:0.8,32:32:0.7:0.7,33:33:0:0,34:34:0.8:0.8,35:35:1:1,36:36:0.8:0.8,37:37:1:1,38:38:0.8:0.8,39:39:1:1,40:42:1:1,43:43:0.8:0.8,44:44:1:1,45:45:0.3:0.3" \
     potential=potential_1
 ```
+
 <!-- markdownlint-enable line-length -->
 
 In fact, this very scoring scheme, for CORINE land data sets, is integrated in
@@ -809,8 +817,8 @@ This is so because CORINE is a standard choice among existing land data bases
 that cover european territories. In case of a user requirement to provide an
 alternative scoring scheme, all what is required is either of
 
-* provide a new "rules" file with the desired set of scoring rules
-* provide a string to the `suitability_scores` option
+- provide a new "rules" file with the desired set of scoring rules
+- provide a string to the `suitability_scores` option
 
 ## Author
 

--- a/src/raster/r.findtheriver/README.md
+++ b/src/raster/r.findtheriver/README.md
@@ -14,10 +14,10 @@ Brian Miles - <brian_miles@unc.edu>
 ## DESCRIPTION
 
 r.findtheriver finds the nearest stream pixel to a coordinate pair
-using an upstream accumulating area (UAA) raster map.  This is
+using an upstream accumulating area (UAA) raster map. This is
 necessary because the coordinates for streamflow gages are often not
 perfectly registered to the topography represented by a digital
-elevation model (DEM) map.  This presents a problem when trying to
+elevation model (DEM) map. This presents a problem when trying to
 derive a watershed contributing area using r.water.outlet; if the
 streamflow gage does not fall on the stream as represented in the
 DEM, r.water.outlet can fail to derive the watershed area.
@@ -28,22 +28,22 @@ r.findtheriver attempts to "snap" the coordinates of the
 streamflow gage to the "true" stream location by first identifying
 stream pixels within a search window, and then selecting the stream
 pixel that is closest (cartesian distance) to the input gage
-coordinates.  Stream pixels are identified by searching the UAA
-raster window for pixels that exceed a threshold.  This is done by
+coordinates. Stream pixels are identified by searching the UAA
+raster window for pixels that exceed a threshold. This is done by
 computing the log10 of the UAA value for the pixel corresponding to
 the gage coordinates and subtracting from it the log10 of each pixel
 in the window; for a given pixel if this difference is greater than
 the threshold, the pixel is deemed to be a stream pixel.
 
 r.findtheriver will automatically compute the window and threshold if
-they are not supplied by the user.  The window is determined based on
-a THRESHOLD_DISTANCE / cell resolution of the UAA map.  The threshold
+they are not supplied by the user. The window is determined based on
+a THRESHOLD_DISTANCE / cell resolution of the UAA map. The threshold
 is determined by subtracting the log10 of the UAA value at the input
 gage coordinate from the log10 of the maximum UAA value of the map,
 and then rounding down to the nearest integer, in other words:
 threshold = floor( log(maxUAA) - log(gageUAA) ).
 
-The closest stream pixel is printed to standard output.  If no stream
+The closest stream pixel is printed to standard output. If no stream
 pixels were found nothing is printed.
 
 ## BUILDING
@@ -51,7 +51,7 @@ pixels were found nothing is printed.
 OS X
 
 First read William Kyngesburye's "Building Addon Modules for Mac OS X
-GRASS.app (see ReadMe-OSX.rtf).  To install, you will generally do:
+GRASS.app (see ReadMe-OSX.rtf). To install, you will generally do:
 
 make GRASS_HOME=./ GRASS_APP=/Applications/GRASS-6.4.app
 sudo make GRASS_HOME=./ GRASS_APP=/Applications/GRASS-6.4.app deploy

--- a/src/raster/r.landscape.evol/r.landscape.evol.md
+++ b/src/raster/r.landscape.evol/r.landscape.evol.md
@@ -37,18 +37,18 @@ a) GIS Implementation:
 
 b) Variables:
 
-* Tc = Transport Capacity [kg/meters.second]
-* K\*C\*P ~ Kt = mitigating effects of soil type, vegetation cover, and
+- Tc = Transport Capacity [kg/meters.second]
+- K\*C\*P ~ Kt = mitigating effects of soil type, vegetation cover, and
   land-use practices. [unitless]
-* gw = Hydrostatic pressure of water 9810 [kg/m2.second]
-* N = Manning's coefficient (0.3-0.6 for different types of stream channels) [unitless]
-* i = rainfall intensity [m/rainfall event]
-* A = upslope accumulated area per contour (cell) width [m2/m] = [m]
-* 0.595 = constant for time-lagged peak flow (assumes symmetrical unit-hydrograph)
-* t = length of rainfall event [seconds]
-* S = topographic slope [degrees]
-* m = transport coefficient for upslope area [unitless]
-* n = transport coefficient for slope [unitless]
+- gw = Hydrostatic pressure of water 9810 [kg/m2.second]
+- N = Manning's coefficient (0.3-0.6 for different types of stream channels) [unitless]
+- i = rainfall intensity [m/rainfall event]
+- A = upslope accumulated area per contour (cell) width [m2/m] = [m]
+- 0.595 = constant for time-lagged peak flow (assumes symmetrical unit-hydrograph)
+- t = length of rainfall event [seconds]
+- S = topographic slope [degrees]
+- m = transport coefficient for upslope area [unitless]
+- n = transport coefficient for slope [unitless]
 
 c) Converted to Map Algebra:
 
@@ -59,16 +59,16 @@ c) Converted to Map Algebra:
 
 d) NOTES:
 
-* This is likely the best of the three equations for simulating erosion at the
+- This is likely the best of the three equations for simulating erosion at the
   scale of small watersheds, including overland flow on hillslopes and
   channelized flow in gullies and streams.
-* It is likely not appropriate for simulating erosion and deposition processes
-  in larger rivers, especially meandering  flood plains.
-* `K*C*P` should equal an appropriate value of `Kt`: 0.001 for a soft
+- It is likely not appropriate for simulating erosion and deposition processes
+  in larger rivers, especially meandering flood plains.
+- `K*C*P` should equal an appropriate value of `Kt`: 0.001 for a soft
   substrate, 0.0001 for a normal substrate, 0.00001 for a hard substrate,
   0.000001 for a very hard substrate. See note below about methods for scaling
   these values.
-* `N` should likely scale with channel vegetation so that 0.03 = clean/straight
+- `N` should likely scale with channel vegetation so that 0.03 = clean/straight
   stream channel, 0.035 = major free-flowing river, 0.04 = sluggish stream with
   pools, 0.06 = very clogged streams. See below for methods to scale these
   values.
@@ -87,17 +87,17 @@ a) GIS Implmentation:
 
 b) Variables:
 
-* Tc = Transport Capacity [kg/meters.second]
-* K\*C\*P ~ Kt = mitigating effects of soil type, vegetation cover, and land-use
+- Tc = Transport Capacity [kg/meters.second]
+- K\*C\*P ~ Kt = mitigating effects of soil type, vegetation cover, and land-use
   practices. [unitless]
-* gw = Hydrostatic pressure of water 9810 [kg/m2.second]
-* N = Manning's coefficient ~0.3-0.6 for different types of stream channels [unitless]
-* i = rainfall intensity [m/rainfall event]
-* A = upslope accumulated area per contour (cell) width [m2/m] = [m]
-* 0.595 = constant for time-lagged peak flow (assumes symmetrical unit-hydrograph)
-* t = length of rainfall event [seconds]
-* B = topographic slope [degrees]
-* n = transport coefficient (here assumed to be scaled to slope) [unitless]
+- gw = Hydrostatic pressure of water 9810 [kg/m2.second]
+- N = Manning's coefficient ~0.3-0.6 for different types of stream channels [unitless]
+- i = rainfall intensity [m/rainfall event]
+- A = upslope accumulated area per contour (cell) width [m2/m] = [m]
+- 0.595 = constant for time-lagged peak flow (assumes symmetrical unit-hydrograph)
+- t = length of rainfall event [seconds]
+- B = topographic slope [degrees]
+- n = transport coefficient (here assumed to be scaled to slope) [unitless]
 
 c) Converted to Map Algebra:
 
@@ -107,16 +107,16 @@ c) Converted to Map Algebra:
 
 d) NOTES:
 
-* This implementation of the Shear Stress equation assumes the critical shear
+- This implementation of the Shear Stress equation assumes the critical shear
   stress is 0.
-* This means the equation is likely to over predict erosion in situations where
+- This means the equation is likely to over predict erosion in situations where
   shear stress is less than the actual critical shear stress, such as on
   vegetated hillslopes.
-* `K*C*P` should equal an appropriate value of `Kt`: 0.001 for a soft
+- `K*C*P` should equal an appropriate value of `Kt`: 0.001 for a soft
   substrate, 0.0001 for a normal substrate, 0.00001 for a hard substrate,
   0.000001 for a very hard substrate. See note below about methods for scaling
   these values.
-* `N` should likely scale with channel vegetation so that 0.03 = clean/straight
+- `N` should likely scale with channel vegetation so that 0.03 = clean/straight
   stream channel, 0.035 = major free-flowing river, 0.04 = sluggish stream with
   pools, 0.06 = very clogged streams. See below for methods to scale these
   values.
@@ -133,14 +133,14 @@ a) GIS Implementation:
 
 b) Variables:
 
-* Tc = Transport Capacity [kg/meters.second]
-* R = Rainfall intensity factor [MJ.mm/ha.h.yr]
-* K\*C\*P ~ Kt = mitigating effects of soil type, vegetation cover, and
+- Tc = Transport Capacity [kg/meters.second]
+- R = Rainfall intensity factor [MJ.mm/ha.h.yr]
+- K\*C\*P ~ Kt = mitigating effects of soil type, vegetation cover, and
   land-use practices. [unitless]
-* A = upslope accumulated area per contour (cell) width [m2/m] = [m]
-* S = topographic slope [degrees]
-* m = transport coefficient for upslope area [unitless]
-* n = transport coefficient for slope [unitless]
+- A = upslope accumulated area per contour (cell) width [m2/m] = [m]
+- S = topographic slope [degrees]
+- m = transport coefficient for upslope area [unitless]
+- n = transport coefficient for slope [unitless]
 
 c) Converted to Map Algebra:
 
@@ -150,9 +150,9 @@ c) Converted to Map Algebra:
 
 d) NOTES:
 
-* The USPED equation is best suited for modeling erosion and deposition on
+- The USPED equation is best suited for modeling erosion and deposition on
   hillslopes and small gullies.
-* It will vastly over predict erosion/deposition in channels and streams.
+- It will vastly over predict erosion/deposition in channels and streams.
 
 ### Scalar m and n exponents to simulate changing process across landscapes
 
@@ -181,8 +181,7 @@ exponent `m` to scale from 1.2 to 1 between a flow accumulation value of 5 and
 50, enter the following into the variable **m**: `"5,1.2,50,1"`. The exponent
 `m` will remain 1.2 for all cells where flow accumulation is below 5, and will
 remain 1 for all cells with flow accumulation above 50. It will scale linearly
-between 1.2 and 1 for all cells with values of flow accumulation between 5 and
-50.
+between 1.2 and 1 for all cells with values of flow accumulation between 5 and 50.
 
 A literature search indicates that maximum values of `m` should be less than or
 equal to 2, and that scaling between 1.2 and 1 is probably a good range to
@@ -190,7 +189,7 @@ start with.
 
 Exponent `n` relates to the influence of local topographic slope on transport
 capacity, and is used in the Stream Power, Shear Stress, and USPED equations.
-Values of `n` are  generally thought to be between 2 and 1, and experimentation
+Values of `n` are generally thought to be between 2 and 1, and experimentation
 suggests that they should scale _inversely_ with increasing local slope.
 Exponent `n` will scale linearly with slope between the two slope cutoff
 thresholds specified: `"thresh1,n1,thresh2,n2"`. So, for example, if you would
@@ -379,7 +378,7 @@ the value you input for **number**.
 
 Note that only the USPED equation needs a value for R factor, and USPED does
 not need the remaining climate variables. In the case of using USPED, only the
-first column  needs to contain data (for R factor), but you still need to
+first column needs to contain data (for R factor), but you still need to
 include all columns (the remaining columns can be with zeros or NaN's).
 
 In the case of using the Stream Power or Shear Stress equations, you still must
@@ -451,7 +450,9 @@ intensivity, as with USPED, as often R factor can only be estimated from
 rainfall totals at the timescale of the year or decade.
 
 <!-- markdownlint-disable line-length -->
+
 ### Conversion of output of divergence to calculated erosion and deposition in vertical meters of elevation change
+
 <!-- markdownlint-enable line-length -->
 
 In order to convert the changes in transport capacity into the amount of

--- a/src/raster/r.mblend/README.md
+++ b/src/raster/r.mblend/README.md
@@ -10,8 +10,8 @@ Manual and detailed description is available at the [GRASS manual pages](https:/
 To cite or reference r.mblend please use the following article:
 
 L. M. de Sousa, J. P. Leitão. [Improvements to DEM merging with `r.mblend`](http://www.scitepress.org/DigitalLibrary/Link.aspx?doi=10.5220/0006672500420049).
-*Proceedings of the Fourth International Conference on Geographical Information
-Systems Theory, Applications and Management: GISTAM*, 1, 2018.
+_Proceedings of the Fourth International Conference on Geographical Information
+Systems Theory, Applications and Management: GISTAM_, 1, 2018.
 
 ## Copyright
 

--- a/src/raster/r.pops.spread/CHANGELOG.md
+++ b/src/raster/r.pops.spread/CHANGELOG.md
@@ -6,82 +6,82 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## 2020-04-16 - SEI model
 
-* Added
-  * Add SEI modeling using model_type and latency_period parameters. (Vaclav Petras)
-* Changed
-  * Reduced scope of mortality_simulation_year variable. (Vaclav Petras)
+- Added
+  - Add SEI modeling using model_type and latency_period parameters. (Vaclav Petras)
+- Changed
+  - Reduced scope of mortality_simulation_year variable. (Vaclav Petras)
 
 ## 2018-09-18 - July 2019 improvements
 
-* Changed
-  * The Raster class now allows access to internal structures which is
+- Changed
+  - The Raster class now allows access to internal structures which is
     now used for initialization and saving of raster maps. (Vaclav Petras)
-    * The ability to change the raster types with one line is preserved.
-    * FCELL (float) rasters are now (properly) supported.
-  * Output rasters and vector now have metadata with the command used,
+    - The ability to change the raster types with one line is preserved.
+    - FCELL (float) rasters are now (properly) supported.
+  - Output rasters and vector now have metadata with the command used,
     simulation timestamp, and title. (Vaclav Petras)
-  * The remaining susceptible hosts check is now faster. (Vaclav Petras)
+  - The remaining susceptible hosts check is now faster. (Vaclav Petras)
 
 ## 2018-09-18 - Update to the next generation of PoPS library
 
-* Changed
-  * The direct support for reading NetCDF removed from the code (Vaclav Petras)
-  * Weather coefficient value input removed (Vaclav Petras)
-    * Not considered useful enough to keep around, can be replaced by
+- Changed
+  - The direct support for reading NetCDF removed from the code (Vaclav Petras)
+  - Weather coefficient value input removed (Vaclav Petras)
+    - Not considered useful enough to keep around, can be replaced by
       constant rasters and series of one raster.
-  * Using new names in PoPS API (Vaclav Petras)
-  * Weather coefficient represented as Raster with doubles (Vaclav Petras)
-    * This or one of the changes above or in the library changed result of
+  - Using new names in PoPS API (Vaclav Petras)
+  - Weather coefficient represented as Raster with doubles (Vaclav Petras)
+    - This or one of the changes above or in the library changed result of
       one stochastic run slightly (reason unknown, similar change as when
       multiplying coefficient by 1.000001). The new result is considered to
       be "more" correct.
 
 ## 2018-09-10 - Seasonality Fixes
 
-* Added
-  * Save GRASS GIS history for all raster outputs (Vaclav Petras)
-    * The executed command with all parameters is stored in the matadata.
-* Changed
-  * Seasonality parameter is checked for emptiness and empty string is
+- Added
+  - Save GRASS GIS history for all raster outputs (Vaclav Petras)
+    - The executed command with all parameters is stored in the matadata.
+- Changed
+  - Seasonality parameter is checked for emptiness and empty string is
     not allowed (Vaclav Petras)
-  * Seasonality is now mostly handled in a separate class.
-* Fixed
-  * Current month is now checked if it is in the season (Vaclav Petras)
-    * Fixes #1 (Metadata - missing full command used).
-  * GRASS GIS library function now used to generate random seed (Vaclav Petras)
-    * Previous implementation didn't give non-deterministic outputs with
+  - Seasonality is now mostly handled in a separate class.
+- Fixed
+  - Current month is now checked if it is in the season (Vaclav Petras)
+    - Fixes #1 (Metadata - missing full command used).
+  - GRASS GIS library function now used to generate random seed (Vaclav Petras)
+    - Previous implementation didn't give non-deterministic outputs with
       the -s flag on MS Windows.
-    * Fixes #2 (Stochastic runs with -s are always the same on Windows).
+    - Fixes #2 (Stochastic runs with -s are always the same on Windows).
 
 ## 2018-06-21 - Critical Temperature
 
-* Added
-  * Critical temperature as the lowest temperature spores can survive
+- Added
+  - Critical temperature as the lowest temperature spores can survive
     in a provided month (Vaclav Petras)
-    * Time-series of temperature raster maps specified as a text file.
-    * Temperature rasters are used at a specified month to check against
+    - Time-series of temperature raster maps specified as a text file.
+    - Temperature rasters are used at a specified month to check against
       a provided critical temperature and if the condition is met,
       infected trees become susceptible again.
-* Changed
-  * Img was replaced by a generalized Raster template class which can
+- Changed
+  - Img was replaced by a generalized Raster template class which can
     handle both integers and floating point numbers. (Vaclav Petras)
 
 ## 2018-06-13 - Spotted Lanternfly
 
-* Added
-  * The date class now supports also month increments. (Vaclav Petras)
-  * A new step option allows user to choose between weekly and monthly
+- Added
+  - The date class now supports also month increments. (Vaclav Petras)
+  - A new step option allows user to choose between weekly and monthly
     increments in simulation. (Vaclav Petras)
-  * A custom season can now be selected by the user. (Vaclav Petras)
-  * A new test executable for the date class added and available in an
+  - A custom season can now be selected by the user. (Vaclav Petras)
+  - A new test executable for the date class added and available in an
     alternative Makefile. (Vaclav Petras)
-* Changed
-  * The season option is no longer yes or no but a range of months.
+- Changed
+  - The season option is no longer yes or no but a range of months.
     (Vaclav Petras)
-* Fixed
-  * Avoid segmentation fault by using the weather coefficients only when
+- Fixed
+  - Avoid segmentation fault by using the weather coefficients only when
     available. (Vaclav Petras)
-  * Make the NetCDF time-series input option always present regardless
+  - Make the NetCDF time-series input option always present regardless
     compilation settings which avoids use of uninitialized variable later
     (and thus undefined behavior). Modules now produces error with
     explanation when option is used but it was compiled without NetCDF
@@ -89,100 +89,100 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## 2018-06-04 - Mortality Addition
 
-* Added
-  * Mortality (Vaclav Petras)
-    * Enabled by a flag, mandatory mortality rate, optional start time
-    * Optional output series of accumulated dead tree counts per cell
-  * Image class constructor taking another image using its dimensions
+- Added
+  - Mortality (Vaclav Petras)
+    - Enabled by a flag, mandatory mortality rate, optional start time
+    - Optional output series of accumulated dead tree counts per cell
+  - Image class constructor taking another image using its dimensions
     and a provided value (Vaclav Petras)
-  * Multiply for image class is commutative (Vaclav Petras)
+  - Multiply for image class is commutative (Vaclav Petras)
 
 ## 2018-03-26 - March 2018 Update
 
-* Changed
-  * Changes for automatic compilation in GRASS GIS Addons (Vaclav Petras)
-    * GDAL support optional using ifdef
-    * NetCDF support optional using ifdef
-    * Explicitly include necessary standard C++ headers
-    * Add formalities: basic documentation and a proper GRASS module name
+- Changed
+  - Changes for automatic compilation in GRASS GIS Addons (Vaclav Petras)
+    - GDAL support optional using ifdef
+    - NetCDF support optional using ifdef
+    - Explicitly include necessary standard C++ headers
+    - Add formalities: basic documentation and a proper GRASS module name
 
 ## 2017-09-05 - September 2017 Update
 
-* Added
-  * Long-range dispersal kernel (Anna Petrasova)
-    * Events are recorded.
-    * The affected points are exported as a vector map.
-  * Weather coefficients as GRASS GIS raster maps (Vaclav Petras)
-    * Input weather coefficients are obtained from a file with list of map
+- Added
+  - Long-range dispersal kernel (Anna Petrasova)
+    - Events are recorded.
+    - The affected points are exported as a vector map.
+  - Weather coefficients as GRASS GIS raster maps (Vaclav Petras)
+    - Input weather coefficients are obtained from a file with list of map
       names (ordering and naming is resolved separately, e.g. same raster
       can be used multiple times, i.e. temporal oversampling is possible).
-    * Weather rasters are now automatically resampled on the fly to the
+    - Weather rasters are now automatically resampled on the fly to the
       raster grid based the computational region.
-  * Output probability of cell being infected (Vaclav Petras)
-  * Optionally output one run for series instead of an average (Vaclav Petras)
-* Changed
-  * Spread of SOD based on a single species (Anna Petrasova)
-    * Spread for UMCA and oak replaced by single species, assumed tanoak.
-  * Final infected trees output is now optional (Vaclav Petras)
-* Fixed
-  * Interface now checks if only one way of providing weather coefficients
+  - Output probability of cell being infected (Vaclav Petras)
+  - Optionally output one run for series instead of an average (Vaclav Petras)
+- Changed
+  - Spread of SOD based on a single species (Anna Petrasova)
+    - Spread for UMCA and oak replaced by single species, assumed tanoak.
+  - Final infected trees output is now optional (Vaclav Petras)
+- Fixed
+  - Interface now checks if only one way of providing weather coefficients
     was used. (Vaclav Petras)
 
 ## 2017-01-28 - January 2017 Status
 
-* Added
-  * GRASS GIS interface added (Vaclav Petras)
-    * Main spatial inputs handled through GRASS GIS libraries so that
+- Added
+  - GRASS GIS interface added (Vaclav Petras)
+    - Main spatial inputs handled through GRASS GIS libraries so that
       different extents and resolutions can be used. (Not implemented for
       the weather time series.)
-    * Text and numerical inputs hardcoded in defines replaced by
+    - Text and numerical inputs hardcoded in defines replaced by
       description using GRASS GIS library. Command line parameters are now
       parsed, checked including dependencies, and it is possible to open
       GUI.
-    * All hardcoded parameters replaced by command line parameters.
-    * Basic descriptions for all parameters.
-    * GDAL input and output is in the code.
-  * Multiple stochastic runs and parallelization (Vaclav Petras)
-    * Optionally outputs also stdandard deviation.
-    * Aggregates series output from runs.
-    * Creates OpenMP threads for chunks of weeks.
-    * User can set number of threads from command line (or GUI).
-  * Simplified weather inputs (Vaclav Petras)
-    * Weather can be supplied as as a text file (spatially constant)
-    * Weather can be supplied as one variable (non-spatial and non-temporal)
-* Changed
-  * Efficiency improvements (Vaclav Petras)
-    * Enable inlining of size getters of Img class which makes all_infected
+    - All hardcoded parameters replaced by command line parameters.
+    - Basic descriptions for all parameters.
+    - GDAL input and output is in the code.
+  - Multiple stochastic runs and parallelization (Vaclav Petras)
+    - Optionally outputs also stdandard deviation.
+    - Aggregates series output from runs.
+    - Creates OpenMP threads for chunks of weeks.
+    - User can set number of threads from command line (or GUI).
+  - Simplified weather inputs (Vaclav Petras)
+    - Weather can be supplied as as a text file (spatially constant)
+    - Weather can be supplied as one variable (non-spatial and non-temporal)
+- Changed
+  - Efficiency improvements (Vaclav Petras)
+    - Enable inlining of size getters of Img class which makes all_infected
       function much faster.
-    * Move constructor and assignment operator added for cases when RVO
+    - Move constructor and assignment operator added for cases when RVO
       is not applied.
-    * Internal storage changed to one array (usually faster allocation).
-    * Use the interal data directly to write using GDAL output.
-  * Code cleanup (Vaclav Petras)
-    * Time measurement code removed (use external tool such as time instead).
-    * Commented-out code for seeding by time removed.
-    * Use same API style for Von Mises as for std lib distributions.
-    * Creating data for Img outside of the object is avoided.
-    * Indexing the Img done using operator ().
-    * Using operators for all operations which fit semantically.
-    * Remove unused variables from the code.
-    * The 'using namespace' statement replaced by explicit use 'using' for
+    - Internal storage changed to one array (usually faster allocation).
+    - Use the interal data directly to write using GDAL output.
+  - Code cleanup (Vaclav Petras)
+    - Time measurement code removed (use external tool such as time instead).
+    - Commented-out code for seeding by time removed.
+    - Use same API style for Von Mises as for std lib distributions.
+    - Creating data for Img outside of the object is avoided.
+    - Indexing the Img done using operator ().
+    - Using operators for all operations which fit semantically.
+    - Remove unused variables from the code.
+    - The 'using namespace' statement replaced by explicit use 'using' for
       string and other classes or objects.
-  * Date class API extended to provide readable comparison operators
+  - Date class API extended to provide readable comparison operators
     replacing usage of method with unclear name (Anna Petrasova)
-  * Random seed for generators is required or must be explicitly generated.
-  * The cpl_string dependency was removed. (Vaclav Petras)
-  * The sporulation object is now seeded only once in the beginning.
+  - Random seed for generators is required or must be explicitly generated.
+  - The cpl_string dependency was removed. (Vaclav Petras)
+  - The sporulation object is now seeded only once in the beginning.
     This changes the stochastic output of one run. (Anna Petrasova)
-* Fixed
-  * Initialize memory for the sporulation object for the cases when it is
+- Fixed
+  - Initialize memory for the sporulation object for the cases when it is
     zero cases to fix conditional jump which depends on uninitialised
     value. (Vaclav Petras)
-  * Memory allocation and deallocation is done by the right pair of
+  - Memory allocation and deallocation is done by the right pair of
     malloc-free or new-delete. (Vaclav Petras)
-  * Compilation output and other non-repository files removed from the
+  - Compilation output and other non-repository files removed from the
     repository. (Vaclav Petras)
-  * Von Mises distribution concentration parameter is float not integer.
+  - Von Mises distribution concentration parameter is float not integer.
     (Vaclav Petras)
-  * Copy of GDAL code was removed from the repository, using system GDAL
+  - Copy of GDAL code was removed from the repository, using system GDAL
     includes now. (Vaclav Petras)

--- a/src/raster/r.pops.spread/README.md
+++ b/src/raster/r.pops.spread/README.md
@@ -1,61 +1,61 @@
 # r.pops.spread
 
-This is a GRASS GIS module *r.pops.spread* for simulating spread of
+This is a GRASS GIS module _r.pops.spread_ for simulating spread of
 pests and pathogens. The module is a GRASS GIS interface to the PoPS
 (Pest or Pathogen Spread) model implemented in C++ library maintained
 in the [PoPS Core repository](https://github.com/ncsu-landscape-dynamics/pops-core).
 
-The purpose of the *r.pops.spread* module is to provide easy way of
+The purpose of the _r.pops.spread_ module is to provide easy way of
 running the model in GRASS GIS environment once you have calibrated
 the model for your purposes. You can obtain the calibration from a
 colleague or published work or you can calibrate the model manually (in
 GRASS GIS) or use the R interface to PoPS called
 [rpops](https://github.com/ncsu-landscape-dynamics/rpops) to do that.
 
-Note: Earlier versions of this module were called *r.spread.pest* and
-*r.spread.sod*.
+Note: Earlier versions of this module were called _r.spread.pest_ and
+_r.spread.sod_.
 
 ## How to cite
 
 If you use this software or code, please cite the following papers:
 
-* Ross K. Meentemeyer, Nik J. Cunniffe, Alex R. Cook, Joao A. N. Filipe,
+- Ross K. Meentemeyer, Nik J. Cunniffe, Alex R. Cook, Joao A. N. Filipe,
   Richard D. Hunter, David M. Rizzo, and Christopher A. Gilligan, 2011.
   Epidemiological modeling of invasion in heterogeneous landscapes:
   spread of sudden oak death in California (1990–2030).
-  *Ecosphere* 2:art17.
+  _Ecosphere_ 2:art17.
   [DOI: 10.1890/ES10-00192.1](https://doi.org/10.1890/ES10-00192.1)
 
-* Tonini, Francesco, Douglas Shoemaker, Anna Petrasova, Brendan Harmon,
+- Tonini, Francesco, Douglas Shoemaker, Anna Petrasova, Brendan Harmon,
   Vaclav Petras, Richard C. Cobb, Helena Mitasova,
   and Ross K. Meentemeyer, 2017.
   Tangible geospatial modeling for collaborative solutions
   to invasive species management.
-  *Environmental Modelling & Software* 92: 176-188.
+  _Environmental Modelling & Software_ 92: 176-188.
   [DOI: 10.1016/j.envsoft.2017.02.020](https://doi.org/10.1016/j.envsoft.2017.02.020)
 
 In case you are using the automatic management feature in rpops or the
 steering version of r.pops.spread (from the branch steering), please
 cite also:
 
-* Petrasova, A., Gaydos, D.A., Petras, V., Jones, C.M., Mitasova, H. and
+- Petrasova, A., Gaydos, D.A., Petras, V., Jones, C.M., Mitasova, H. and
   Meentemeyer, R.K., 2020.
   Geospatial simulation steering for adaptive management.
-  *Environmental Modelling & Software* 133: 104801.
+  _Environmental Modelling & Software_ 133: 104801.
   [DOI: 10.1016/j.envsoft.2020.104801](https://doi.org/10.1016/j.envsoft.2020.104801)
 
 In addition to citing the above paper, we also encourage you to
 reference, link, and/or acknowledge specific version of the software
 you are using for example:
 
-* *We have used rpops R package version 1.0.0 from
-  <https://github.com/ncsu-landscape-dynamics/rpops>*.
+- _We have used rpops R package version 1.0.0 from
+  <https://github.com/ncsu-landscape-dynamics/rpops>_.
 
 ## Download
 
 ### Download and install
 
-The latest release of the *r.pops.spread* module is available in GRASS GIS
+The latest release of the _r.pops.spread_ module is available in GRASS GIS
 Addons repository and can be installed directly in GRASS GIS through graphical
 user interface or using the following command:
 
@@ -166,20 +166,20 @@ grass .../modeling/scenario1 --exec r.pops.spread ...
 
 ### Authors
 
-*(alphabetical order)*:
+_(alphabetical order)_:
 
-* Chris Jones
-* Margaret Lawrimore
-* Vaclav Petras
-* Anna Petrasova
+- Chris Jones
+- Margaret Lawrimore
+- Vaclav Petras
+- Anna Petrasova
 
 ### Previous contributors
 
-*(alphabetical order)*:
+_(alphabetical order)_:
 
-* Zexi Chen
-* Devon Gaydos
-* Francesco Tonini
+- Zexi Chen
+- Devon Gaydos
+- Francesco Tonini
 
 See Git commit history, GitHub insights, or CHANGELOG.md file (if present)
 for details about contributions.

--- a/src/raster/r.pops.spread/TECHNICALDEBT.md
+++ b/src/raster/r.pops.spread/TECHNICALDEBT.md
@@ -19,71 +19,71 @@ optionally linked in an entry.
 
 ## 2018-06-20 - Critical Temperature
 
-* Add
-  * Add (rigorous) tests for the Raster class.
-  * Add more tests for the Date class.
-  * Documentation of the C++ functions and classes (use Doxygen).
-* Change
-  * Naming and descriptions of parameters related to weather
+- Add
+  - Add (rigorous) tests for the Raster class.
+  - Add more tests for the Date class.
+  - Documentation of the C++ functions and classes (use Doxygen).
+- Change
+  - Naming and descriptions of parameters related to weather
     (coefficients versus the actual values)
-  * Naming of critical temperature in interface and in code
-* Fix
-  * Temperature raster for critical temperature is represented as integer,
+  - Naming of critical temperature in interface and in code
+- Fix
+  - Temperature raster for critical temperature is represented as integer,
     not double or float.
-  * Even after the upgrade to Raster class, there are still some legacy
+  - Even after the upgrade to Raster class, there are still some legacy
     method names and integers instead of doubles (but does not influence
     computations).
-  * Numerous sign-compare warnings.
-  * Spelling in the code and comments.
+  - Numerous sign-compare warnings.
+  - Spelling in the code and comments.
 
 ## 2018-06-13 - Spotted Lanternfly
 
-* Add
-  * Add SLF parameters to documentation.
-  * Update README.
-* Change
-  * The decision if to increase by week or month is done with conditional
+- Add
+  - Add SLF parameters to documentation.
+  - Update README.
+- Change
+  - The decision if to increase by week or month is done with conditional
     (ternary) operator on one long line. Maybe enum and universal
     functions for increase and end of year would make it shorter.
-  * Season is just a std::pair, but a function to test if month is in
+  - Season is just a std::pair, but a function to test if month is in
     range (or a range class) would make shorter code without the access to
     first and second members and two queries for month.
-* Fix
-  * Compilation with and without the test module (now the test Makefile
+- Fix
+  - Compilation with and without the test module (now the test Makefile
     needs to be used always)
 
 ## 2018-06-04 - Mortality Addition
 
-* Add
-  * Add mortality to documentation.
-  * Update README.
-* Change
-  * Mortality cohorts may require better name since the individual can be
+- Add
+  - Add mortality to documentation.
+  - Update README.
+- Change
+  - Mortality cohorts may require better name since the individual can be
     potentially also a cohort or stand.
-* Fix
-  * Mortality-related objects are always created (and take memory).
+- Fix
+  - Mortality-related objects are always created (and take memory).
     need an additional parameter. However, the update is just a repeating
     previous line (perhaps some container optionally wrapping two images
     would be useful).
 
 ## 2017-09-05 - September 2017 Update
 
-* Fix
-  * Dead code for the specific multiple host species.
-  * Several new lines of non-trivial saving of escaping spores added to
+- Fix
+  - Dead code for the specific multiple host species.
+  - Several new lines of non-trivial saving of escaping spores added to
     already long main function.
 
 ## 2017-01-28 - January 2017 Status
 
-* Add
-  * Image class is only for integers but the weather is floating point,
+- Add
+  - Image class is only for integers but the weather is floating point,
     so it needs a different treatment in code than other data.
-  * The date class needs abstraction for the leap years and days in month.
-  * Tests needed for the image class.
-* Change
-  * Formatting of text and parameters for the date class (leading zeros).
-  * Create dedicated file for the direction enum and helper functions.
-  * Some of the Date class methods have still misleading names (e.g.,
+  - The date class needs abstraction for the leap years and days in month.
+  - Tests needed for the image class.
+- Change
+  - Formatting of text and parameters for the date class (leading zeros).
+  - Create dedicated file for the direction enum and helper functions.
+  - Some of the Date class methods have still misleading names (e.g.,
     increased versus increase).
-  * Methods and functions should use underscores not camel case (using
+  - Methods and functions should use underscores not camel case (using
     Python and GRASS GIS convention).

--- a/src/raster/r.pops.spread/pops-core/CHANGELOG.md
+++ b/src/raster/r.pops.spread/pops-core/CHANGELOG.md
@@ -6,92 +6,92 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## 2020-08-27 - Version 1 preparations
 
-* Changed
-  * The C++ library project renamed from PoPS to PoPS Core.
-  * Only the current weather coefficient is now passed to the model class.
-  * Raster class uses `int` by default for indexing.
-* Fixed
-  * Numerous compiler warnings fixed. Code now compiles with -Wall -Wextra.
+- Changed
+  - The C++ library project renamed from PoPS to PoPS Core.
+  - Only the current weather coefficient is now passed to the model class.
+  - Raster class uses `int` by default for indexing.
+- Fixed
+  - Numerous compiler warnings fixed. Code now compiles with -Wall -Wextra.
 
 ## 2020-08-12
 
-* Fixed
-  * Exposed class now being removed with treatments
-    * Added exposed class treatments to model class
+- Fixed
+  - Exposed class now being removed with treatments
+    - Added exposed class treatments to model class
 
 ## 2020-05-15 - Reducing stochasticity
 
-* Added
-  * Stochasticity in Simulation can now be optionally reduced. (Vaclav Petras)
-    * Simulation constructor takes additional parameters to disable
+- Added
+  - Stochasticity in Simulation can now be optionally reduced. (Vaclav Petras)
+    - Simulation constructor takes additional parameters to disable
       stochasticity in generate and disperse functions, particularly in
       generating and establishing dispersers.
-    * The disperse function takes additional parameter which is a fixed
+    - The disperse function takes additional parameter which is a fixed
       probability value when disperser is established.
 
 ## 2020-04-16 - SEI model
 
-* Added
-  * Exposed host tracking with latency period to run SEI models. (Vaclav Petras)
-* Changed
-  * Step numbering is now expected to start at zero. (Vaclav Petras)
+- Added
+  - Exposed host tracking with latency period to run SEI models. (Vaclav Petras)
+- Changed
+  - Step numbering is now expected to start at zero. (Vaclav Petras)
 
 ## 2020-01-04 - Movement Module
 
-* Added
-  * movement modeule to the simulation class to move hosts from one location
+- Added
+  - movement modeule to the simulation class to move hosts from one location
     to another. (Chris Jones)
 
 ## 2019-12-18 - More date functionality
 
-* Added
-  * functions to check if a date is the last day or week of a month
+- Added
+  - functions to check if a date is the last day or week of a month
 
 ## 2019-10-29 - More raster generalizations
 
-* Added
-  * Raster can now hold data from some other object as long as the types
+- Added
+  - Raster can now hold data from some other object as long as the types
     and layout match. (Vaclav Petras)
-  * Raster Index and Number types exposed using typedefs.
-* Changed
-  * Raster now has optional template parameter for the type of index used
+  - Raster Index and Number types exposed using typedefs.
+- Changed
+  - Raster now has optional template parameter for the type of index used
     in the class. (Vaclav Petras)
-* Changed
-  * Signed and unsigned types are no longer arbitrarily mixed in the
+- Changed
+  - Signed and unsigned types are no longer arbitrarily mixed in the
     interface, e.g., `(int, int)` constructor is now `(Index, Index)`
     being consistent with `cols()` and `rows()` functions. (Vaclav Petras)
 
 ## 2019-09-05 - Dispersal kernel rewrite
 
-* Added
-  * More complete list of operators supported by Raster. (Vaclav Petras)
-  * Rasters with different numerical types can be used in a single
+- Added
+  - More complete list of operators supported by Raster. (Vaclav Petras)
+  - Rasters with different numerical types can be used in a single
     expression (Vaclav Petras)
-* Changed
-  * Binary operators for rasters are now function templates
+- Changed
+  - Binary operators for rasters are now function templates
     instead of member functions (Vaclav Petras)
 
 ## 2019-08-11 - Dispersal kernel rewrite
 
-* Added
-  * Radial exponential kernel and a uniform kernel (Vaclav Petras)
-    * Any combination of kernels is now possible on the library level.
-  * Functions to convert from strings to kernel-related enums.
-* Changed
-  * Dispersal kernel are organized as classes (functors). (Vaclav Petras)
-    * The disperse function is now a function template in the Simulation.
-    * Dispersal kernel is a function (functor) called from the Simulation.
-    * The Simulation class does not have any kernel-related parameters
+- Added
+  - Radial exponential kernel and a uniform kernel (Vaclav Petras)
+    - Any combination of kernels is now possible on the library level.
+  - Functions to convert from strings to kernel-related enums.
+- Changed
+  - Dispersal kernel are organized as classes (functors). (Vaclav Petras)
+    - The disperse function is now a function template in the Simulation.
+    - Dispersal kernel is a function (functor) called from the Simulation.
+    - The Simulation class does not have any kernel-related parameters
       or members.
-  * Usage of std::cout related to kernels was replaced by exceptions
+  - Usage of std::cout related to kernels was replaced by exceptions
     in the new code. (Vaclav Petras)
-  * Kernel-related enums are not strongly typed using enum class
+  - Kernel-related enums are not strongly typed using enum class
     (Vaclav Petras)
-* Fixed
-  * A call to abs function on the distance used for spread caused
+- Fixed
+  - A call to abs function on the distance used for spread caused
     conversion to int. Now std::abs is used so double is used throughout.
     This changes simulation results. (Vaclav Petras)
-  * Resolution is now double instead of int. This changes results in cases
+  - Resolution is now double instead of int. This changes results in cases
     when the resolution is not a integer number (even when it is
     so close to the closest higher integer that it is printed out without
     any decimal places by software considering it, possibly correctly,
@@ -100,152 +100,152 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## 2019-07-11
 
-* Added
-  * The Raster class has a new function data() which provides access to
+- Added
+  - The Raster class has a new function data() which provides access to
     the underlying array. This follows the example of similar addition to
     std::vector in C++11. The Raster class is now handling the memory
     and provides raster algebra semantics, but its users have
     direct access to the underlying data. (Vaclav Petras)
-* Changed
-  * The optional support for GRASS GIS reading and writing GRASS GIS
+- Changed
+  - The optional support for GRASS GIS reading and writing GRASS GIS
     rasters was removed from the Raster class. This needs to be now
     handled in the GRASS GIS module. (Vaclav Petras)
-  * Formerly private variables in Raster class are now only protected
+  - Formerly private variables in Raster class are now only protected
     so that derived classes can have direct access to them, e.g., in the
     constructor. (Vaclav Petras)
-  * Private/protected variables in Raster class are now using the rows and
+  - Private/protected variables in Raster class are now using the rows and
     columns terminology and trailing underscores. (Vaclav Petras)
-* Fixed
-  * In some cases (depending on compiler and use of GRASS GIS), sqrt was
+- Fixed
+  - In some cases (depending on compiler and use of GRASS GIS), sqrt was
     not accessible in the simulation code leading to compilation error.
     Now std::sqrt is used. (Vaclav Petras)
 
 ## 2019-07-09
 
-* Added
-  * Added ability to set number of days for the timestep instead of
+- Added
+  - Added ability to set number of days for the timestep instead of
     day, week, or month. This is useful if the pest has multiple generations
     in a year. (Chris Jones)
-* Changed
-  * Made extension of the 52 week to be 8 or 9 (leap years) days instead of
+- Changed
+  - Made extension of the 52 week to be 8 or 9 (leap years) days instead of
     7 to ensure that the next year starts on Jan 1st. This makes forecasting
     into the future more streamlined. (Chris Jones)
 
 ## 2019-06-14
 
-* Added
-  * Added types of treatment application. Removing a portion for both
+- Added
+  - Added types of treatment application. Removing a portion for both
     susceptible and infected, like in SLF case, and a portion from
     susceptible all all infected in given cells, like in SOD case.
     (Vaclav Petras)
 
 ## 2018-11-17
 
-* Added
-  * Added mortality function to simulation class
+- Added
+  - Added mortality function to simulation class
 
 ## 2018-10-31 - Minor Refactoring
 
-* Added
-  * Added Season class to manage seasonality
-* Changed
-  * Removed resolution from the Raster class
+- Added
+  - Added Season class to manage seasonality
+- Changed
+  - Removed resolution from the Raster class
 
 ## 2018-09-20 - Variable Rename
 
-* Added
-  * Created a style guide in a CONTRIBUTING file. (Vaclav Petras)
-* Changed
-  * Renamed variables and functions to make the model more clear and easy
+- Added
+  - Created a style guide in a CONTRIBUTING file. (Vaclav Petras)
+- Changed
+  - Renamed variables and functions to make the model more clear and easy
     to understand. (Chris Jones)
-  * Renaming and partial unification of styles across all files. (Vaclav Petras)
-    * All is now in namespace called pops.
-    * Private variables use trailing underscore if needed.
-  * Removed unused and legacy functions and types. (Vaclav Petras)
+  - Renaming and partial unification of styles across all files. (Vaclav Petras)
+    - All is now in namespace called pops.
+    - Private variables use trailing underscore if needed.
+  - Removed unused and legacy functions and types. (Vaclav Petras)
 
 ## 2018-08-02 - PoPS Model Separation
 
-* Changed
-  * The general part of the simulation is now a separate library called
+- Changed
+  - The general part of the simulation is now a separate library called
     PoPS. GRASS GIS module code was removed together with some parts of
     this file completely unrelated to the library. (Vaclav Petras)
-  * All files which were not supposed to be part of the repository
+  - All files which were not supposed to be part of the repository
     were removed and purged from the history. However, all the relevant
     history is preserved. (Vaclav Petras)
 
 ## 2018-06-21 - Spotted Lanternfly
 
-* Added
-  * The date class now supports also month increments. (Vaclav Petras)
-  * Critical temperature as the lowest temperature spores can survive
+- Added
+  - The date class now supports also month increments. (Vaclav Petras)
+  - Critical temperature as the lowest temperature spores can survive
     in a provided month (Vaclav Petras)
-    * Temperature rasters are used at a specified month to check against
+    - Temperature rasters are used at a specified month to check against
       a provided critical temperature and if the condition is met,
       infected trees become susceptible again.
-* Changed
-  * Img was replaced by a generalized Raster template class which can
+- Changed
+  - Img was replaced by a generalized Raster template class which can
     handle both integers and floating point numbers. (Vaclav Petras)
 
 ## 2018-06-04 - Mortality Addition
 
-* Added
-  * Mortality (Vaclav Petras)
-  * Image class constructor taking another image using its dimensions
+- Added
+  - Mortality (Vaclav Petras)
+  - Image class constructor taking another image using its dimensions
     and a provided value (Vaclav Petras)
-  * Multiply for image class is commutative (Vaclav Petras)
+  - Multiply for image class is commutative (Vaclav Petras)
 
 ## 2018-03-26 - March 2018 Update
 
-* Changed
-  * Explicitly include necessary standard C++ headers (Vaclav Petras)
+- Changed
+  - Explicitly include necessary standard C++ headers (Vaclav Petras)
 
 ## 2017-09-05 - September 2017 Update
 
-* Added
-  * Long-range dispersal kernel (Anna Petrasova)
-    * Events are recorded.
-    * The affected points are exported as a vector map.
-  * Output probability of cell being infected (Vaclav Petras)
-  * Optionally output one run for series instead of an average (Vaclav Petras)
-* Changed
-  * Spread of SOD based on a single species (Anna Petrasova)
-    * Spread for UMCA and oak replaced by single species, assumed tanoak.
+- Added
+  - Long-range dispersal kernel (Anna Petrasova)
+    - Events are recorded.
+    - The affected points are exported as a vector map.
+  - Output probability of cell being infected (Vaclav Petras)
+  - Optionally output one run for series instead of an average (Vaclav Petras)
+- Changed
+  - Spread of SOD based on a single species (Anna Petrasova)
+    - Spread for UMCA and oak replaced by single species, assumed tanoak.
 
 ## 2017-01-28 - January 2017 Status
 
-* Added
-  * Simplified weather inputs (Vaclav Petras)
-    * Weather can be supplied as as a text file (spatially constant)
-    * Weather can be supplied as one variable (non-spatial and non-temporal)
-* Changed
-  * Efficiency improvements (Vaclav Petras)
-    * Enable inlining of size getters of Img class which makes all_infected
+- Added
+  - Simplified weather inputs (Vaclav Petras)
+    - Weather can be supplied as as a text file (spatially constant)
+    - Weather can be supplied as one variable (non-spatial and non-temporal)
+- Changed
+  - Efficiency improvements (Vaclav Petras)
+    - Enable inlining of size getters of Img class which makes all_infected
       function much faster.
-    * Move constructor and assignment operator added for cases when RVO
+    - Move constructor and assignment operator added for cases when RVO
       is not applied.
-    * Internal storage changed to one array (usually faster allocation).
-  * Code cleanup (Vaclav Petras)
-    * Use same API style for Von Mises as for std lib distributions.
-    * Creating data for Img outside of the object is avoided.
-    * Indexing the Img done using operator ().
-    * Using operators for all operations which fit semantically.
-    * Remove unused variables from the code.
-    * The 'using namespace' statement replaced by explicit use 'using' for
+    - Internal storage changed to one array (usually faster allocation).
+  - Code cleanup (Vaclav Petras)
+    - Use same API style for Von Mises as for std lib distributions.
+    - Creating data for Img outside of the object is avoided.
+    - Indexing the Img done using operator ().
+    - Using operators for all operations which fit semantically.
+    - Remove unused variables from the code.
+    - The 'using namespace' statement replaced by explicit use 'using' for
       string and other classes or objects.
-  * Date class API extended to provide readable comparison operators
+  - Date class API extended to provide readable comparison operators
     replacing usage of method with unclear name (Anna Petrasova)
-  * The cpl_string dependency was removed. (Vaclav Petras)
-  * The sporulation object is now seeded only once in the beginning.
+  - The cpl_string dependency was removed. (Vaclav Petras)
+  - The sporulation object is now seeded only once in the beginning.
     This changes the stochastic output of one run. (Anna Petrasova)
-* Fixed
-  * Initialize memory for the sporulation object for the cases when it is
+- Fixed
+  - Initialize memory for the sporulation object for the cases when it is
     zero cases to fix conditional jump which depends on uninitialised
     value. (Vaclav Petras)
-  * Memory allocation and deallocation is done by the right pair of
+  - Memory allocation and deallocation is done by the right pair of
     malloc-free or new-delete. (Vaclav Petras)
-  * Compilation output and other non-repository files removed from the
+  - Compilation output and other non-repository files removed from the
     repository. (Vaclav Petras)
-  * Von Mises distribution concentration parameter is float not integer.
+  - Von Mises distribution concentration parameter is float not integer.
     (Vaclav Petras)
-  * Copy of GDAL code was removed from the repository, using system GDAL
+  - Copy of GDAL code was removed from the repository, using system GDAL
     includes now. (Vaclav Petras)

--- a/src/raster/r.pops.spread/pops-core/README.md
+++ b/src/raster/r.pops.spread/pops-core/README.md
@@ -7,7 +7,7 @@ PoPS Core is the core C++ library for the PoPS Model.
 PoPS (Pest or Pathogen Spread) is a stochastic spread model of pests
 and pathogens in forest and agricultural landscapes.
 It is used for various pest, pathogens, and hosts.
-It was originally developed for *Phytophthora ramorum* and the original
+It was originally developed for _Phytophthora ramorum_ and the original
 version of the model was written in R, later with Rcpp,
 and was based on Meentemeyer (2011) paper.
 
@@ -20,37 +20,37 @@ required version.
 
 If you use this software or code, please cite the following papers:
 
-* Ross K. Meentemeyer, Nik J. Cunniffe, Alex R. Cook, Joao A. N. Filipe,
+- Ross K. Meentemeyer, Nik J. Cunniffe, Alex R. Cook, Joao A. N. Filipe,
   Richard D. Hunter, David M. Rizzo, and Christopher A. Gilligan, 2011.
   Epidemiological modeling of invasion in heterogeneous landscapes:
   spread of sudden oak death in California (1990–2030).
-  *Ecosphere* 2:art17.
+  _Ecosphere_ 2:art17.
   [DOI: 10.1890/ES10-00192.1](https://doi.org/10.1890/ES10-00192.1)
 
-* Tonini, Francesco, Douglas Shoemaker, Anna Petrasova, Brendan Harmon,
+- Tonini, Francesco, Douglas Shoemaker, Anna Petrasova, Brendan Harmon,
   Vaclav Petras, Richard C. Cobb, Helena Mitasova,
   and Ross K. Meentemeyer, 2017.
   Tangible geospatial modeling for collaborative solutions
   to invasive species management.
-  *Environmental Modelling & Software* 92: 176-188.
+  _Environmental Modelling & Software_ 92: 176-188.
   [DOI: 10.1016/j.envsoft.2017.02.020](https://doi.org/10.1016/j.envsoft.2017.02.020)
 
 In case you are using the automatic management feature in rpops or the
 steering version of r.pops.spread (from the branch steering), please
 cite also:
 
-* Petrasova, A., Gaydos, D.A., Petras, V., Jones, C.M., Mitasova, H. and
+- Petrasova, A., Gaydos, D.A., Petras, V., Jones, C.M., Mitasova, H. and
   Meentemeyer, R.K., 2020.
   Geospatial simulation steering for adaptive management.
-  *Environmental Modelling & Software* 133: 104801.
+  _Environmental Modelling & Software_ 133: 104801.
   [DOI: 10.1016/j.envsoft.2020.104801](https://doi.org/10.1016/j.envsoft.2020.104801)
 
 In addition to citing the above paper, we also encourage you to
 reference, link, and/or acknowledge specific version of the software
 you are using for example:
 
-* *We have used rpops R package version 1.0.0 from
-  <https://github.com/ncsu-landscape-dynamics/rpops>*.
+- _We have used rpops R package version 1.0.0 from
+  <https://github.com/ncsu-landscape-dynamics/rpops>_.
 
 ## Contributing
 
@@ -153,8 +153,8 @@ The PoPS Core library can be used directly in a C++ program or through other
 programs. It is used in R package called rpops and a GRASS GIS module
 called r.pops.spread.
 
-* <https://github.com/ncsu-landscape-dynamics/r.pops.spread>
-* <https://github.com/ncsu-landscape-dynamics/rpops>
+- <https://github.com/ncsu-landscape-dynamics/r.pops.spread>
+- <https://github.com/ncsu-landscape-dynamics/rpops>
 
 ## Integrating the library into your own project
 
@@ -251,7 +251,7 @@ Note that not all tests are not fully automatic, so in couple cases
 this only testing if the code is running and not crashing
 (you will need to examine the source code to see the details).
 
-Additionally, create documentation using the following (*Doxygen* required):
+Additionally, create documentation using the following (_Doxygen_ required):
 
 ```bash
 cmake --build build --target docs
@@ -285,20 +285,20 @@ target_link_libraries(your_target PRIVATE pops-core)
 
 ### Authors
 
-*(alphabetical order)*:
+_(alphabetical order)_:
 
-* Chris Jones
-* Margaret Lawrimore
-* Vaclav Petras
-* Anna Petrasova
+- Chris Jones
+- Margaret Lawrimore
+- Vaclav Petras
+- Anna Petrasova
 
 ### Previous contributors
 
-*(alphabetical order)*:
+_(alphabetical order)_:
 
-* Zexi Chen
-* Devon Gaydos
-* Francesco Tonini
+- Zexi Chen
+- Devon Gaydos
+- Francesco Tonini
 
 See Git commit history, GitHub insights, or CHANGELOG.md file (if present)
 for details about contributions.

--- a/src/raster/r.pops.spread/pops-core/TECHNICALDEBT.md
+++ b/src/raster/r.pops.spread/pops-core/TECHNICALDEBT.md
@@ -19,120 +19,120 @@ optionally linked in an entry.
 
 ## 2020-01-04 - Movement module improvements
 
-* Change
-  * Currently pass mortality tracker into the movement module but don't
+- Change
+  - Currently pass mortality tracker into the movement module but don't
     use it as it creates complexity. Will need to return to add this in
     the future.
 
 ## 2019-10-29 - More raster generalizations
 
-* Add
-  * We use the same type for index and size in Raster. We need to
+- Add
+  - We use the same type for index and size in Raster. We need to
     add size type parameter to allow for use of size_t and ssize_t
     together which is needed to fully map other types to Raster.
-  * Add container functions such `begin()` and `end()`.
-* Change
-  * Use member initialization for all variables in all Raster constructors.
-  * Binary operators of raster should be functions.
-    * Both scalar \* raster and raster \* scaler should be functions.
-* Fix
-  * Add return code to raster class template test.
+  - Add container functions such `begin()` and `end()`.
+- Change
+  - Use member initialization for all variables in all Raster constructors.
+  - Binary operators of raster should be functions.
+    - Both scalar \* raster and raster \* scaler should be functions.
+- Fix
+  - Add return code to raster class template test.
 
 ## 2019-08-11 - Dispersal kernel rewrite
 
-* Add
-  * Tests for kernel classes
-  * Documentation on how to use the kernel classes
-  * Support more spelling options for the types and wind directions.
-  * Better documentation for the short-long kernel.
-  * Better documentation or code related to reset() function of
+- Add
+  - Tests for kernel classes
+  - Documentation on how to use the kernel classes
+  - Support more spelling options for the types and wind directions.
+  - Better documentation for the short-long kernel.
+  - Better documentation or code related to reset() function of
     distributions.
-  * Add script for automatic code indentation.
-* Change
-  * Indices and sizes should be template parameters as some matrix or
-  raster libraries may use different types, e.g., Rcpp uses int as
-  indices while Armadillo uses typedef for an unsigned integer.
+  - Add script for automatic code indentation.
+- Change
+  - Indices and sizes should be template parameters as some matrix or
+    raster libraries may use different types, e.g., Rcpp uses int as
+    indices while Armadillo uses typedef for an unsigned integer.
 
 ## 2019-07-09
 
-* Add
-  * Tests need to be written for weekly, daily, and multi-day timesteps
+- Add
+  - Tests need to be written for weekly, daily, and multi-day timesteps
     for Date functionality.
 
 ## 2019-06-14
 
-* Add
-  * Documentation to previously implemented treatments is missing
+- Add
+  - Documentation to previously implemented treatments is missing
 
 ## 2018-09-14 - SEID and multiple host handling
 
-* Add
-  * Exposed and Diseased classes should be added (need to think about how to
+- Add
+  - Exposed and Diseased classes should be added (need to think about how to
     handle in disperse).
-  * 3-D array for Susceptible, Exposed, Infected, Diseased classes to handle
+  - 3-D array for Susceptible, Exposed, Infected, Diseased classes to handle
     multiple species up to N.
-  * Host-compentency score for handling multiple hosts.
+  - Host-compentency score for handling multiple hosts.
 
 ## 2018-08-02 - PoPS Model Separation
 
-* Add
-  * Most of mortality handling is now done outside of the library.
-  * A lot of post processing code may need to be repeated unless added to
+- Add
+  - Most of mortality handling is now done outside of the library.
+  - A lot of post processing code may need to be repeated unless added to
     the library.
-  * There is no code in the library to help with seasonality.
+  - There is no code in the library to help with seasonality.
 
 ## 2018-06-20 - Critical Temperature
 
-* Add
-  * Add (rigorous) tests for the Raster class.
-  * Add more tests for the Date class.
-  * Documentation of the C++ functions and classes (use Doxygen).
-* Change
-  * Naming and descriptions of parameters related to weather
+- Add
+  - Add (rigorous) tests for the Raster class.
+  - Add more tests for the Date class.
+  - Documentation of the C++ functions and classes (use Doxygen).
+- Change
+  - Naming and descriptions of parameters related to weather
     (coefficients versus the actual values)
-  * Naming of critical and actual temperature in code
-* Fix
-  * Even after the upgrade to Raster class, there are still some legacy
+  - Naming of critical and actual temperature in code
+- Fix
+  - Even after the upgrade to Raster class, there are still some legacy
     method names and integers instead of doubles (but does not influence
     computations).
-  * Spelling in the code and comments.
+  - Spelling in the code and comments.
 
 ## 2018-06-13 - Spotted Lanternfly
 
-* Add
-  * Add SLF parameters to documentation.
-  * Update README.
+- Add
+  - Add SLF parameters to documentation.
+  - Update README.
 
 ## 2018-06-04 - Mortality Addition
 
-* Add
-  * Add mortality to documentation.
-  * Update README.
-* Change
-  * Mortality cohorts may require better name since the individual can be
+- Add
+  - Add mortality to documentation.
+  - Update README.
+- Change
+  - Mortality cohorts may require better name since the individual can be
     potentially also a cohort or stand.
-* Fix
-  * Mortality-related infection cohort always updated in spore spread and
+- Fix
+  - Mortality-related infection cohort always updated in spore spread and
     need an additional parameter. However, the update is just a repeating
     previous line (perhaps some container optionally wrapping two images
     would be useful).
 
 ## 2017-09-05 - September 2017 Update
 
-* Fix
-  * Dead code for the specific multiple host species.
+- Fix
+  - Dead code for the specific multiple host species.
 
 ## 2017-01-28 - January 2017 Status
 
-* Add
-  * Image class is only for integers but the weather is floating point,
+- Add
+  - Image class is only for integers but the weather is floating point,
     so it needs a different treatment in code than other data.
-  * The date class needs abstraction for the leap years and days in month.
-  * Tests needed for the image class.
-* Change
-  * Formatting of text and parameters for the date class (leading zeros).
-  * Create dedicated file for the direction enum and helper functions.
-  * Some of the Date class methods have still misleading names (e.g.,
+  - The date class needs abstraction for the leap years and days in month.
+  - Tests needed for the image class.
+- Change
+  - Formatting of text and parameters for the date class (leading zeros).
+  - Create dedicated file for the direction enum and helper functions.
+  - Some of the Date class methods have still misleading names (e.g.,
     increased versus increase).
-  * Methods and functions should use underscores not camel case (using
+  - Methods and functions should use underscores not camel case (using
     Python and GRASS GIS convention).

--- a/src/raster/r.pops.spread/pops-core/contributing_docs/CONTRIBUTING.md
+++ b/src/raster/r.pops.spread/pops-core/contributing_docs/CONTRIBUTING.md
@@ -21,10 +21,10 @@ example reproducible: required packages, data, code.
 1. Spend a little bit of time ensuring that your **code** is easy for others to
    read:
 
-    * make sure you've used spaces and your variable names are concise, but
-      informative
-    * use comments to indicate where your problem lies
-    * do your best to remove everything that is not related to the problem.
+   - make sure you've used spaces and your variable names are concise, but
+     informative
+   - use comments to indicate where your problem lies
+   - do your best to remove everything that is not related to the problem.
      The shorter your code is, the easier it is to understand.
 
 ## Pull
@@ -41,14 +41,14 @@ To contribute a change to PoPS Core or rPoPS, follow these steps:
 Each of these steps are described in more detail below. This might feel
 overwhelming the first time you get set up, but it gets easier with practice.
 
-* [ ] Motivate the change in one paragraph, and include it in NEWS.
+- [ ] Motivate the change in one paragraph, and include it in NEWS.
       In parentheses, reference your github user name and this issue:
       `(@ChrisJones687, #1234)`
-* [ ] Check pull request only includes relevant changes.
-* [ ] Use the [PoPS Core style guide](contributing_docs/STYLE_GUIDE.md).
-* [ ] Update documentation to reflect your changes
-* [ ] Add test (if a new feature or a bug fix that needs a new test)
-* [ ] Add minimal example if new function in R.
+- [ ] Check pull request only includes relevant changes.
+- [ ] Use the [PoPS Core style guide](contributing_docs/STYLE_GUIDE.md).
+- [ ] Update documentation to reflect your changes
+- [ ] Add test (if a new feature or a bug fix that needs a new test)
+- [ ] Add minimal example if new function in R.
 
 Pull requests will be evaluated against a seven-point checklist:
 

--- a/src/raster/r.pops.spread/pops-core/contributing_docs/STYLE_GUIDE.md
+++ b/src/raster/r.pops.spread/pops-core/contributing_docs/STYLE_GUIDE.md
@@ -12,7 +12,7 @@ subset enforced by Black and for C++ specific items by mix of LLVM and Qt.
 
 #### Formatting
 
-Formatting is managed by *clang-format* tool. You need to have version 10
+Formatting is managed by _clang-format_ tool. You need to have version 10
 to produce results consistent with the current formatting.
 
 Run the formatting on all the files in the top directory:
@@ -21,7 +21,7 @@ Run the formatting on all the files in the top directory:
 clang-format -i include/*/*.hpp tests/*.cpp
 ```
 
-If you have other versions of *clang-format* than 10, use:
+If you have other versions of _clang-format_ than 10, use:
 
 ```sh
 clang-format-10 -i include/*/*.hpp tests/*.cpp
@@ -37,9 +37,11 @@ docker build -t doozyx/clang-format-lint-action "github.com/DoozyX/clang-format-
 Then run the formatting using a Docker container in the top directory:
 
 <!-- markdownlint-disable line-length -->
+
 ```sh
 docker run --rm --workdir /src -v $(pwd):/src --entrypoint /clang-format/clang-format10 doozyx/clang-format-lint-action -i include/*/*.hpp tests/*.cpp
 ```
+
 <!-- markdownlint-enable line-length -->
 
 #### Functions and methods


### PR DESCRIPTION
In preparation for #1174, super-linter 7.0.0 enabled Prettier for more file types.

I’m making a separate PR just because it will be easier to follow through than mixed with html changes