### PR TITLE
r.estimap.recreation: Also format yaml files with Prettier

### DIFF
--- a/src/raster/r.estimap.recreation/tests/test_demand.yml
+++ b/src/raster/r.estimap.recreation/tests/test_demand.yml
@@ -1,5 +1,4 @@
 ---
-
 - mapset: demand
   flags: []
   inputs:

--- a/src/raster/r.estimap.recreation/tests/test_flow.yml
+++ b/src/raster/r.estimap.recreation/tests/test_flow.yml
@@ -1,5 +1,4 @@
 ---
-
 - mapset: flow
   flags: []
   inputs:

--- a/src/raster/r.estimap.recreation/tests/test_potential.yml
+++ b/src/raster/r.estimap.recreation/tests/test_potential.yml
@@ -1,5 +1,4 @@
 ---
-
 - mapset: potential_land
   flags: []
   inputs:

--- a/src/raster/r.estimap.recreation/tests/test_spectrum.yml
+++ b/src/raster/r.estimap.recreation/tests/test_spectrum.yml
@@ -1,5 +1,4 @@
 ---
-
 - mapset: spectrum_land_natural_water_infrastructure
   flags: []
   inputs:

--- a/src/raster/r.estimap.recreation/tests/test_supply_and_use.yml
+++ b/src/raster/r.estimap.recreation/tests/test_supply_and_use.yml
@@ -1,5 +1,4 @@
 ---
-
 - mapset: supply_and_use
   flags: []
   inputs:

--- a/src/raster/r.estimap.recreation/tests/test_vector.yml
+++ b/src/raster/r.estimap.recreation/tests/test_vector.yml
@@ -1,5 +1,4 @@
 ---
-
 - mapset: vector_supply_and_use
   flags: []
   inputs:

--- a/src/raster/r.estimap.recreation/tests/test_zcomplete.yml
+++ b/src/raster/r.estimap.recreation/tests/test_zcomplete.yml
@@ -1,5 +1,4 @@
 ---
-
 - mapset: complete_example
   flags: []
   inputs:
@@ -26,7 +25,7 @@
     population:
       - input_population_2015
     timestamp:
-      - '2015'
+      - "2015"
   outputs:
     csvs:
       supply:


### PR DESCRIPTION
Also for #1174, super-linter 7 enables Prettier to format yaml files. This is a smaller PR to not burry the changes of src/raster/r.estimap.recreation if they need to be changed later on.