### PR TITLE
style: Fix invalid html or Prettier html parsing errors

### DIFF
--- a/src/hadoop/hd/hd.hive.csv.table/hd.hive.csv.table.html
+++ b/src/hadoop/hd/hd.hive.csv.table/hd.hive.csv.table.html
@@ -21,7 +21,7 @@ to user make CSV based  table without advanced knowledge of Hive syntax.
 Creating table for storing  coordinates.
 
 <div class="code"><pre>
-hd.hive.json.table driver=hiveserver2 table=csv driver=hiveserver2 table=json struct="type string, properties STRUCT<cat:SMALLINT>, geometry string" -e -d
+hd.hive.json.table driver=hiveserver2 table=csv driver=hiveserver2 table=json struct="type string, properties STRUCT&lt;cat:SMALLINT&gt;, geometry string" -e -d
 </pre>
 </div>
 

--- a/src/imagery/i.eodag/i.eodag.html
+++ b/src/imagery/i.eodag/i.eodag.html
@@ -312,7 +312,7 @@ v.extract input=urbanarea where="NAME = 'Durham'" output=durham
 
 i.eodag -l start=2022-05-01 end=2022-06-01 \
     map=durham producttype=S2_MSI_L2A provider=cop_dataspace
-<pre></div>
+</pre></div>
 
 Search and list the available Sentinel 2 scenes in the Copernicus Data Space
 Ecosystem, with at least 70% of the AOI covered:
@@ -321,7 +321,7 @@ Ecosystem, with at least 70% of the AOI covered:
 i.eodag -l start=2022-05-01 end=2022-06-01 \
     producttype=S2_MSI_L2A provider=cop_dataspace \
     clouds=50 map=durham minimum_overlap=70
-<pre></div>
+</pre></div>
 
 Sort results descendingly by <b>cloudcover</b>, and then by <b>ingestiondate</b>.
 Note that sorting with <b>cloudcover</b> uses unrounded values,
@@ -331,7 +331,7 @@ while they are rounded to the nearest integer when listing.
 i.eodag -l start=2022-05-25 end=2022-06-01 \
     producttype=S2_MSI_L2A provider=cop_dataspace \
     sort=cloudcover,ingestiondate order=desc
-<pre></div>
+</pre></div>
 
 Search for scenes with a list of IDs, and filter the results with the
 provided parameters:
@@ -340,7 +340,7 @@ provided parameters:
 i.eodag -l file=ids_list.txt \
     start=2022-05-25 \
     area_relation=Contains clouds=3
-<pre></div>
+</pre></div>
 
 Search and list the available Sentinel 2 scenes in the Copernicus Data Space
 Ecosystem, with relative orbit number 54:
@@ -349,7 +349,7 @@ Ecosystem, with relative orbit number 54:
 i.eodag -l producttype=S2_MSI_L2A \
     provider=cop_dataspace save=search_result.geojson \
     query="relativeOrbitNumber=54"
-<pre></div>
+</pre></div>
 
 Search and list the available Tier 1 Landsat 9 Collection 2 Level 2 scenes in USGS,
 using filtering with a regular expression:
@@ -358,7 +358,7 @@ using filtering with a regular expression:
 i.eodag -l producttype=LANDSAT_C2L2 \
     provider=usgs save=search_result.geojson \
     pattern="LC09.*T1"
-<pre></div>
+</pre></div>
 
 Search and list Sentinel 2 scenes using IDs from Copernicus Data Space Ecosystem:<br>
 To download the selected scenes, simply remove the l flag.
@@ -366,14 +366,14 @@ To download the selected scenes, simply remove the l flag.
 i.eodag -l provider=cop_dataspace producttype=S2_MSI_L2A \
     id="S2A_MSIL2A_20240728T154941_N0511_R054_T17SPV_20240728T235651,
     S2A_MSIL2A_20240618T154941_N0510_R054_T17SPV_20240618T222157"
-<pre></div>
+</pre></div>
 
 Search and list for a Landsat scene using its ID from USGS:<br>
 To download the selected scene, remove the l flag.
 <div class="code"><pre>
 i.eodag -l provider=usgs producttype=LANDSAT_C2L2 \
     id=LC08_L2SP_016035_20240715_20240722_02_T1
-<pre></div>
+</pre></div>
 
 Download all available scenes with cloud coverage not exceeding 50%
 in the /tmp directory:
@@ -381,14 +381,14 @@ in the /tmp directory:
 <div class="code"><pre>
 i.eodag start=2022-05-25 end=2022-06-01 \
     producttype=S2_MSI_L2A provider=cop_dataspace clouds=50
-<pre></div>
+</pre></div>
 
 Download only selected scenes from a text file with IDs, using the Copernicus Data
 Space Ecosystem as the provider:
 
 <div class="code"><pre>
 i.eodag file=ids_list.txt provider=cop_dataspace
-<pre></div>
+</pre></div>
 
 
 
@@ -402,48 +402,48 @@ i.eodag provider=cop_dataspace \
     producttype=S2_MSI_L2A \
     config=full/path/to/eodag/config.yaml \
     output=download_here
-<pre></div>
+</pre></div>
 
 List recognized EODAG providers:
 <div class="code"><pre>
 i.eodag print=providers
-<pre></div>
+</pre></div>
 
 List recognized EODAG providers offering Sentinel 2 scenes:
 <div class="code"><pre>
 i.eodag print=providers producttype=S2_MSI_L2A
-<pre></div>
+</pre></div>
 
 List recognized EODAG products:
 <div class="code"><pre>
 i.eodag print=products
-<pre></div>
+</pre></div>
 
 List recognized EODAG products offered by Copernicus Data Space Ecosystem:
 <div class="code"><pre>
 i.eodag print=products provider=cop_dataspace
-<pre></div>
+</pre></div>
 
 List queryables for Sentinel 2 scenes offered by Copernicus
 Data Space Ecosystem:
 <div id="list_queryables_example" class="code"><pre>
 i.eodag print=queryables provider=cop_dataspace producttype=S2_MSI_L2A
-<pre></div>
+</pre></div>
 
 List current EODAG configuration:
 <div class="code"><pre>
 i.eodag print=config
-<pre></div>
+</pre></div>
 
 List current EODAG configuration for Copernicus Data Space Ecosystem:
 <div class="code"><pre>
 i.eodag print=config provider=cop_dataspace
-<pre></div>
+</pre></div>
 
 Print query summary:
 <div class="code"><pre>
 i.eodag -lp provider=usgs producttype=LANDSAT_C2L2 area_relation=IsWithin clouds=30
-<pre></div>
+</pre></div>
 
 
 <h2>REQUIREMENTS</h2>

--- a/src/imagery/i.landsat/i.landsat.download/i.landsat.download.html
+++ b/src/imagery/i.landsat/i.landsat.download/i.landsat.download.html
@@ -166,7 +166,7 @@ Search available scenes:
 i.landsat.download -l settings=credentials.txt \
     dataset=landsat_8_ot_c2_l2 clouds=15 \
     datasource=usgs start='2018-08-24' end='2018-12-21'
-<pre></div>
+</pre></div>
 
 Download all available scenes:
 
@@ -175,7 +175,7 @@ i.landsat.download settings=credentials.txt \
     dataset=landsat_8_ot_c2_l2 clouds=15 \
     datasource=usgs start='2018-08-24' end='2018-12-21' \
     timeout=600
-<pre></div>
+</pre></div>
 
 Download selected scenes by ID anonymously from Planetary Computer:
 
@@ -183,7 +183,7 @@ Download selected scenes by ID anonymously from Planetary Computer:
 i.landsat.download datasource=planetary_computer \
     id=LC09_L2SP_015035_20240529_02_T1,LC09_L2SP_015035_20240614_02_T1 \
     output=/tmp
-<pre></div>
+</pre></div>
 
 <h2>REQUIREMENTS</h2>
 

--- a/src/imagery/i.landsat/i.landsat.qa/i.landsat.qa.html
+++ b/src/imagery/i.landsat/i.landsat.qa/i.landsat.qa.html
@@ -152,7 +152,7 @@ in the Landsat QA band:</p>
 <h2>NOTES</h2>
 
 The Landsat Quality Assessment band is an artificial band which represents
-an analysis based on <a href=https://landsat.usgs.gov/documents/LDCM_CVT_ADD.pdf>
+an analysis based on <a href="https://landsat.usgs.gov/documents/LDCM_CVT_ADD.pdf">
 defined algorithms</a>. The USGS provides the users with the following note on
 how the QA band should be used:
 
@@ -192,9 +192,9 @@ r.reclass input=LC81980182015183LGN00_BQA \
 </em>
 
 <h2>REFERENCES</h2>
-<em><a href=https://www.usgs.gov/core-science-systems/nli/landsat/landsat-collection-1-level-1-quality-assessment-band>
+<em><a href="https://www.usgs.gov/core-science-systems/nli/landsat/landsat-collection-1-level-1-quality-assessment-band">
 Landsat Collection 1 Level 1 Quality Assessment bands</a>
-<a href=https://www.usgs.gov/core-science-systems/nli/landsat/landsat-collection-2-quality-assessment-bands>
+<a href="https://www.usgs.gov/core-science-systems/nli/landsat/landsat-collection-2-quality-assessment-bands">
 Landsat Collection 2 Level 1 Quality Assessment bands</a></em>
 
 <h2>AUTHOR</h2>

--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.html
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.html
@@ -349,20 +349,20 @@ Example of downloading a single Sentinel product by UUID:
 
 <div class="code"><pre>
 i.sentinel.download settings=credentials.txt uuid=6a10da0f-7777-4818-bc2c-4680e82297ac output=s2_data/
-<pre></div>
+</pre></div>
 
 <p>
 Example of downloading a single Sentinel product by UUID from <b>Google Cloud Storage</b>
 <div class="code"><pre>
 i.sentinel.download datasource=GCS settings=credentials.txt uuid=6a10da0f-7777-4818-bc2c-4680e82297ac output=s2_data/
-<pre></div>
+</pre></div>
 
 <p>
 Example of downloading a single Sentinel product by UUID from the <b>USGS Earth Explorer</b>:
 
 <div class="code"><pre>
 i.sentinel.download datasource=USGS_EE settings=credentials.txt uuid=2177169 output=s2_data/
-<pre></div>
+</pre></div>
 
 <h3>Download Sentinel products by scene name</h3>
 
@@ -400,7 +400,7 @@ i.sentinel.download settings=credentials.txt \
 i.sentinel.download settings=credentials.txt \
   query='filename=S2B_MSIL2A_20210120T155559_N0214_R054_T17SPV_20210120T201821.SAFE' \
   producttype=S2MSI2A start=2021-01-01 end=2021-02-15 output=s2_data/
-<pre></div>
+</pre></div>
 
 <p>
 Example of downloading a single Sentinel product by scene name from
@@ -409,7 +409,7 @@ Example of downloading a single Sentinel product by scene name from
 i.sentinel.download datasource=GCS start=2021-01-01 end=2021-02-15 producttype=S2MSI2A \
   query="filename=S2B_MSIL2A_20210120T155559_N0214_R054_T17SPV_20210120T201821.SAFE" settings=credentials.txt \
   output=s2_data/
-<pre></div>
+</pre></div>
 
   <p>
   Example of downloading a single Sentinel product by identifier from
@@ -418,7 +418,7 @@ i.sentinel.download datasource=GCS start=2021-01-01 end=2021-02-15 producttype=S
   # in this case, no settings file is required, because the identifier can be directly used to create a GCS download URL
   i.sentinel.download datasource=GCS query="identifier=S2B_MSIL2A_20210120T155559_N0214_R054_T17SPV_20210120T201821" \
     output=s2_data/
-  <pre></div>
+  </pre></div>
 
 <p>
 Example of downloading a single Sentinel product from <b>USGS Earth Explorer</b>
@@ -427,7 +427,7 @@ by the USGS-identifier:
 i.sentinel.download datasource=USGS_EE start=2017-09-01 end=2017-12-01 producttype=S2MSI1C \
   query="usgs_identifier=L1C_T32ULA_A003180_20171015T104525" settings=credentials.txt \
   output=s2_data/
-<pre></div>
+</pre></div>
 
 <p>
 It is also possible to use the keywords filename/identifier in ESA formatting in <b>query</b>
@@ -436,7 +436,7 @@ when downloading from the <b>USGS Earth Explorer</b>:
 i.sentinel.download datasource=USGS_EE start=2017-10-01 end=2017-11-01 producttype=S2MSI1C \
   query='filename=S2B_MSIL1C_20171015T104009_N0205_R008_T32ULA_20171015T104525' settings=credentials.txt \
   output=s2_data/
-<pre></div>
+</pre></div>
 
 
 <h2>REQUIREMENTS</h2>

--- a/src/raster/r.area.createweight/r.area.createweight.html
+++ b/src/raster/r.area.createweight/r.area.createweight.html
@@ -70,7 +70,7 @@ class values are used. Optionally, class labels can be used as plot
 labels, using the flags <b>-a</b> and <b>-b</b>, for <b>basemap_a</b>
 and <b>basemap_b</b> respectively. If these flags are used, the raster
 should already contain the associated category labels. The module
-<a href=https://grass.osgeo.org/grass-stable/manuals/r.category.html>r.category</a>
+<a href="https://grass.osgeo.org/grass-stable/manuals/r.category.html">r.category</a>
 can be used to set category labels for a raster map. If
 the flag(s) <b>-a</b> and/or <b>-b</b> is(are) selected without existing
 categories for the corresponding raster map, the class value will be
@@ -144,9 +144,9 @@ units (see examples).
 <table cellspacing="2" cellpadding="2" width="100%" align=center border="0">
 <tr>
   <th><a href="r_area_createweight_input_spatial_units.png">
-    <img src="r_area_createweight_input_spatial_units.png" width=300></a></th>
+    <img src="r_area_createweight_input_spatial_units.png" width="300"></a></th>
   <th><a href="r_area_createweight_gridded_spatial_units.png">
-    <img src="r_area_createweight_gridded_spatial_units.png" width=300></a>
+    <img src="r_area_createweight_gridded_spatial_units.png" width="300"></a>
 </th>
 </tr>
 <tr>
@@ -279,8 +279,8 @@ g.remove -f type=raster name=streets_wake_rast</pre></div>
 
 <div align="center" style="margin: 10px">
 <a href="r_area_createweight_distance_streets.png">
-<img src="r_area_createweight_distance_streets.png" width=300
-border=0><br></a>
+<img src="r_area_createweight_distance_streets.png" width="300"
+border="0"><br></a>
 <i><b>
 Distance to streets layer</b></i>
 </div>
@@ -351,17 +351,17 @@ g.remove -f type=vector \
 
 <p>
 
-<table cellspacing="2" cellpadding="2" width="100%" align=center
+<table cellspacing="2" cellpadding="2" width="100%" align="center"
 border="0">
   <tr>
   <th><a href="r_area_createweight_census_initial.png"><img
-src="r_area_createweight_census_initial.png" width=300 alt="[SDF]"></a></th>
+src="r_area_createweight_census_initial.png" width="300" alt="[SDF]"></a></th>
   <th><a href="r_area_createweight_census_merge.png"><img
 src="r_area_createweight_census_merge.png"
-width=300 alt="[SDF]"></a></th>
+width="300" alt="[SDF]"></a></th>
   <th><a href="r_area_createweight_census_final.png"><img
 src="r_area_createweight_census_final.png"
-width=300 alt="[SDF]"></a></th>
+width="300" alt="[SDF]"></a></th>
   </tr>
   <tr><th><i>Initial census layer</i></th>
   <th><i>Census layer after merging</i></th>
@@ -401,7 +401,7 @@ r.area.createweight -a vector=censusblk_swwake_final id=cat \
 
 <div align="center" style="margin: 10px">
 <a href="r_area_createweight_weights.png">
-<img src="r_area_createweight_weights.png" width=500 border=0><br></a>
+<img src="r_area_createweight_weights.png" width=500 border="0"><br></a>
 <i><b>Output weighting layer</b></i>
 </div>
 
@@ -409,10 +409,10 @@ r.area.createweight -a vector=censusblk_swwake_final id=cat \
 <table cellspacing="2" cellpadding="2" width="100%" align=center
 border="0">
   <tr><th><a href="r_area_createweight_importances_plot_nonames.png">
-    <img src="r_area_createweight_importances_plot_nonames.png" height=300 alt="[SDF]"></th>
+    <img src="r_area_createweight_importances_plot_nonames.png" height="300" alt="[SDF]"></a></th>
    <th><a href="r_area_createweight_importances_plot_names.png"><img
-src="r_area_createweight_importances_plot_names.png" height=300
-alt="[SDF]"></th>
+src="r_area_createweight_importances_plot_names.png" height="300"
+alt="[SDF]"></a></th>
   </tr>
   <tr>
   <th><i>Feature importances without names</i></th>

--- a/src/raster/r.flexure/r.flexure.html
+++ b/src/raster/r.flexure/r.flexure.html
@@ -1,6 +1,6 @@
 <h2>DESCRIPTION</h2>
 
-<em>r.flexure</em> computes how the rigid outer shell of a planet deforms elastically in response to surface-normal loads by solving equations for plate bending. This phenomenon is known as "flexural isostasy" and can be useful in cases of glacier/ice-cap/ice-sheet loading, sedimentary basin filling, mountain belt growth, volcano emplacement, sea-level change, and other geologic processes. <em>r.flexure</em> and <a href="v.flexure.html">v.flexure</a> are the GRASS GIS interfaces to the model <a href=http://csdms.colorado.edu/wiki/Model:gFlex><b>gFlex</b></a>.
+<em>r.flexure</em> computes how the rigid outer shell of a planet deforms elastically in response to surface-normal loads by solving equations for plate bending. This phenomenon is known as "flexural isostasy" and can be useful in cases of glacier/ice-cap/ice-sheet loading, sedimentary basin filling, mountain belt growth, volcano emplacement, sea-level change, and other geologic processes. <em>r.flexure</em> and <a href="v.flexure.html">v.flexure</a> are the GRASS GIS interfaces to the model <a href="http://csdms.colorado.edu/wiki/Model:gFlex"><b>gFlex</b></a>.
 
 As both <em>r.flexure</em> and <a href="v.flexure.html">v.flexure</a> are interfaces to gFlex, this must be downloaded and installed. The most recent versions of <b>gFlex</b> are available from <a href="https://github.com/awickert/gFlex">https://github.com/awickert/gFlex</a>, and installation instructions are available on that page via the <i>README.md</i> file.
 

--- a/src/raster/r.fuzzy.logic/r.fuzzy.logic.html
+++ b/src/raster/r.fuzzy.logic/r.fuzzy.logic.html
@@ -69,7 +69,7 @@ partial membership</dd>
 Computers & Geosciences (37) 1525-1531. DOI <a href="https://doi.org/10.1016/j.cageo.2010.09.008">https://doi.org/10.1016/j.cageo.2010.09.008</a>
 
 <li>Zadeh, L.A. (1965). "Fuzzy sets". Information and Control 8 (3): 338-353.
-<a href="https://doi.org/10.1016/S0019-9958(65)90241-X"><a href="https://doi.org/10.1016/S0019-9958(65)90241-X"</a>. ISSN 0019-9958.
+<a href="https://doi.org/10.1016/S0019-9958(65)90241-X">https://doi.org/10.1016/S0019-9958(65)90241-X</a>. ISSN 0019-9958.
 
 <li>Novák, Vilém (1989). Fuzzy Sets and Their Applications. Bristol: Adam Hilger.
 ISBN 0-85274-583-4.

--- a/src/raster/r.fuzzy.set/r.fuzzy.set.html
+++ b/src/raster/r.fuzzy.set/r.fuzzy.set.html
@@ -132,7 +132,7 @@ For default shape=0, m = 2 (most common parameter for that equation).
 
 <ul>
 <li>Jasiewicz, J. (2011). A new GRASS GIS fuzzy inference system for massive data analysis.
-Computers & Geosciences (37) 1525-1531. DOI <a href=https://doi.org/10.1016/j.cageo.2010.09.008>https://doi.org/10.1016/j.cageo.2010.09.008</a>
+Computers & Geosciences (37) 1525-1531. DOI <a href="https://doi.org/10.1016/j.cageo.2010.09.008">https://doi.org/10.1016/j.cageo.2010.09.008</a>
 
 <li>Zadeh, L.A. (1965). "Fuzzy sets". Information and Control 8 (3): 338–353.
 <a href="https://doi.org/10.1016/S0019-9958(65)90241-X">https://doi.org/10.1016/S0019-9958(65)90241-X</a>.

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.theoretical/r.green.hydro.theoretical.html
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.theoretical/r.green.hydro.theoretical.html
@@ -40,7 +40,7 @@ g is a gravity constant (9.81 m/s<sup>2</sup>);<br>
 &eta; is the overall electrical efficiency;<br>
 Q<SUB>up_hydro</SUB> is the mean annual discharge at the closure section for the upstream subbasin;<br>
 H<SUB>mean</SUB> is the mean elevation of the upstream subbasin calculated from the hypsographic curve, using the statistical tool of Arc-GIS;<br>
-H<SUB>closure</SUB> is the elevation at the closure point (point A in the figure);</Small><br><br></center>
+H<SUB>closure</SUB> is the elevation at the closure point (point A in the figure);</Small><br><br></blockquote></center>
 
 The downstream lower subbasin (between point A and B in the figure) has both energy components: the potential from the upstream subbasins and its own potential. The own potential is calculated taking into account the discharge coming from the sides of the downstream lower subbasin and the difference between the elevation of the lower subbasin and the elevation at the closure point (point B in the figure):<br><br>
 
@@ -49,7 +49,7 @@ The downstream lower subbasin (between point A and B in the figure) has both ene
 <blockquote><Small>where Q<SUB>aff</SUB> is the afferent discharge (own lower subbasin discharge). The afferent discharge is the difference of the discharge observed at the
 closure section (point B in the figure) and the sum of the upstream discharges;<br>
 H<SUB>mean</SUB> is the elevation of lower subbasin;<br>
-H<SUB>closure</SUB> is the elevation at closure point (point B in the figure);</Small><br><br></center>
+H<SUB>closure</SUB> is the elevation at closure point (point B in the figure);</Small><br><br></blockquote></center>
 
 The upstream component to the potential of the downstream lower subbasin is calculated taking into account the discharge coming from the upstream subbasins and the difference between the elevation of the upstream closure point (point A in the figure) and the elevation at the basin closure (point B in the figure):<br><br>
 
@@ -57,7 +57,7 @@ The upstream component to the potential of the downstream lower subbasin is calc
 <i><BIG>E<SUB>up_max</SUB> = conv * g * &eta; * &sum;Q<SUB>up_hydro</SUB> * (H<SUB>up_closure</SUB> - H<SUB>closure</SUB>)</BIG></i><br>
 <blockquote><Small>where Q<SUB>up_hydro</SUB> is the sum of the mean annual discharges coming from the upstream subbasins;<br>
 H<SUB>up_closure</SUB> is the elevation at the upstream closure point (point A in the figure);<br>
-H<SUB>closure</SUB> is the elevation at closure point (point B in the figure);</Small><br><br></center>
+H<SUB>closure</SUB> is the elevation at closure point (point B in the figure);</Small><br><br></blockquote></center>
 
 The total maximum hydropower potential of the overall given basin is the sum of the different contributions computed at the subbasin level:<br><br>
 

--- a/src/raster/r.hants/r.hants.html
+++ b/src/raster/r.hants/r.hants.html
@@ -233,7 +233,7 @@ t.rast.univar -h tempmean_hants > stats_hants.txt
 Roerink, G. J., Menenti, M. and Verhoef, W., 2000. Reconstructing
 cloudfree NDVI composites using Fourier analysis of time series.
 International Journal of Remote Sensing, 21 (9), 1911-1917.
-DOI: <a href=http://dx.doi.org/10.1080/014311600209814>10.1080/014311600209814</a>
+DOI: <a href="http://dx.doi.org/10.1080/014311600209814">10.1080/014311600209814</a>
 
 <h2>AUTHOR</h2>
 

--- a/src/raster/r.hydrodem/r.hydrodem.html
+++ b/src/raster/r.hydrodem/r.hydrodem.html
@@ -65,7 +65,7 @@ like <em>r.watershed</em>.
 Lindsay, J. B., and Creed, I. F. 2005. Removal of artifact depressions
 from digital elevation models: towards a minimum impact approach.
 Hydrological Processes 19, 3113-3126.
-DOI: <a href=http://dx.doi.org/10.1002/hyp.5835>10.1002/hyp.5835</a>
+DOI: <a href="http://dx.doi.org/10.1002/hyp.5835">10.1002/hyp.5835</a>
 
 
 <h2>SEE ALSO</h2>

--- a/src/raster/r.in.ahn/r.in.ahn.html
+++ b/src/raster/r.in.ahn/r.in.ahn.html
@@ -1,7 +1,7 @@
 <h2>DESCRIPTION</h2>
 
 <em>r.in.ahn</em> imports the Actueel Hoogtebestand Nederland (<a
-href="https"//www.ahn.nl">AHN</a>, version 4) for the current region.
+href="https://www.ahn.nl">AHN</a>, version 4) for the current region.
 The AHN is a digital elevation model (DEM) of the Netherlands with a
 resolution of of 0.5 meter.
 
@@ -57,7 +57,7 @@ r.in.ahn product=dsm output=dsm_crevecoeur
 <p>
 <div align="center" style="margin: 10px">
 <a href="r_in_ahn_01.png">
-<img src="r_in_ahn_01.png" alt="r.in.ahn example" width="600" border=0>
+<img src="r_in_ahn_01.png" alt="r.in.ahn example" width="600" border="0">
 </a><br>
 <i>Figure: DSM map of Fort Crèvecoeur</i>
 </div>
@@ -83,7 +83,7 @@ layer <i>dsm_crevecoeur2_tiles</i>
 <p>
 <div align="center" style="margin: 10px">
 <a href="r_in_ahn_02.png">
-<img src="r_in_ahn_02.png" alt="r.in.ahn example" width="600" border=0>
+<img src="r_in_ahn_02.png" alt="r.in.ahn example" width="600" border="0">
 </a><br>
 <i>Figure: DSM map of Fort Crèvecoeur. Left shows the extent (red
 outline) after running example 2. The extent equals the extent of the

--- a/src/raster/r.in.nasadem/r.in.nasadem.html
+++ b/src/raster/r.in.nasadem/r.in.nasadem.html
@@ -57,7 +57,7 @@ r.univar nasadem_sicily_1arc
 
 <div align="center" style="margin: 10px">
 <a href="r_in_nasadem_etna.jpg">
-<img src="r_in_nasadem_etna.jpg" width="600" alt="r.in.nasadem example" border=0>
+<img src="r_in_nasadem_etna.jpg" width="600" alt="r.in.nasadem example" border="0">
 </a><br>
 <i>Figure: Eta volcano (Sicily, Italy) shown in NVIZ</i>
 </div>

--- a/src/raster/r.in.srtm.region/r.in.srtm.region.html
+++ b/src/raster/r.in.srtm.region/r.in.srtm.region.html
@@ -45,7 +45,7 @@ r.univar srtm_sicily_1arc
 
 <div align="center" style="margin: 10px">
 <a href="r_in_srtm_region_etna.png">
-<img src="r_in_srtm_region_etna.png" width="600" alt="r.in.srtm.region example" border=0>
+<img src="r_in_srtm_region_etna.png" width="600" alt="r.in.srtm.region example" border="0">
 </a><br>
 <i>Figure: Eta volcano (Sicily, Italy) shown in NVIZ</i>
 </div>

--- a/src/raster/r.mblend/r.mblend.html
+++ b/src/raster/r.mblend/r.mblend.html
@@ -8,7 +8,7 @@ producing a smooth transition from the high resolution DEM to the low
 resolution DEM.<br><br>
 
 <center>
-<img width=40% align=center src=both_inputs.png><br><br>
+<img width="40%" align="center" src="both_inputs.png"><br><br>
 </center>
 
 The module works by identifying the edge between the two rasters (near edge,
@@ -22,7 +22,7 @@ trends from the full difference at the near edge towards zero at the far edge.
 <br><br>
 
 <center>
-<img width=40% align=center src=edges.png><br><br>
+<img width="40%" align="center" src="edges.png"><br><br>
 </center>
 
 The differences raster is finally added to the low resolution DEM given as
@@ -32,7 +32,7 @@ the far edge) the closer is their value is to the low resolution raster,
 producing a smooth transition, without artefacts.<br><br>
 
 <center>
-<img width=40% src=blended.png>
+<img width="40%" src="blended.png">
 </center>
 
 <h2>EXAMPLES</h2>
@@ -51,11 +51,11 @@ r.mblend high=best_dem low=other_dem output=result far_edge=90
 
 <h2>REFERENCES</h2>
 
-J.P. Leit&atilde;o, L.M. de Sousa, <a href=https://doi.org/10.1016/j.jhydrol.2018.04.043>Towards the optimal fusion of high-resolution Digital Elevation Models for detailed urban flood assessment</a>, <i>Journal of Hydrology</i>, Volume 561, June 2018, Pages 651-661, DOI: <a href=https://doi.org/10.1016/j.jhydrol.2018.04.043>10.1016/j.jhydrol.2018.04.043</a>.
+J.P. Leit&atilde;o, L.M. de Sousa, <a href="https://doi.org/10.1016/j.jhydrol.2018.04.043">Towards the optimal fusion of high-resolution Digital Elevation Models for detailed urban flood assessment</a>, <i>Journal of Hydrology</i>, Volume 561, June 2018, Pages 651-661, DOI: <a href="https://doi.org/10.1016/j.jhydrol.2018.04.043">10.1016/j.jhydrol.2018.04.043</a>.
 <br><br>
-L.M. de Sousa, J.P. Leit&atilde;o, <a href=http://www.scitepress.org/PublicationsDetail.aspx?ID=mcJr0zto14w=&t=1>Improvements to DEM Merging with r.mblend</a>. In <i>Proceedings of the 4th International Conference on Geographical Information Systems Theory, Applications and Management - Volume 1: GISTAM</i>, March 2018, pages 42-49. ISBN 978-989-758-294-3 DOI: <a href=http://www.scitepress.org/DigitalLibrary/Link.aspx?doi=10.5220/0006672500420049>10.5220/0006672500420049</a>.
+L.M. de Sousa, J.P. Leit&atilde;o, <a href="http://www.scitepress.org/PublicationsDetail.aspx?ID=mcJr0zto14w=&t=1">Improvements to DEM Merging with r.mblend</a>. In <i>Proceedings of the 4th International Conference on Geographical Information Systems Theory, Applications and Management - Volume 1: GISTAM</i>, March 2018, pages 42-49. ISBN 978-989-758-294-3 DOI: <a href="http://www.scitepress.org/DigitalLibrary/Link.aspx?doi=10.5220/0006672500420049">10.5220/0006672500420049</a>.
 <br><br>
-J.P. Leit&atilde;o, D. Prodanovic, C. Maksimovic, <a href=http://www.sciencedirect.com/science/article/pii/S0098300416300012>Improving merge methods for grid-based digital elevation models</a>, <i>Computers & Geosciences</i>, Volume 88, March 2016, Pages 115-131, ISSN 0098-3004, DOI: <a href=http://doi.org/10.1016/j.cageo.2016.01.001>10.1016/j.cageo.2016.01.001</a>.
+J.P. Leit&atilde;o, D. Prodanovic, C. Maksimovic, <a href="http://www.sciencedirect.com/science/article/pii/S0098300416300012">Improving merge methods for grid-based digital elevation models</a>, <i>Computers & Geosciences</i>, Volume 88, March 2016, Pages 115-131, ISSN 0098-3004, DOI: <a href="http://doi.org/10.1016/j.cageo.2016.01.001">10.1016/j.cageo.2016.01.001</a>.
 
 
 <h2>AUTHORS</h2>

--- a/src/raster/r.mcda.roughset/r.mcda.roughset.html
+++ b/src/raster/r.mcda.roughset/r.mcda.roughset.html
@@ -6,22 +6,21 @@
 <p>An information system is generated and Domlem algorithm is applied for extraction a minimal set of rules.</P>  The algorithm builds two text  files (<b>outputTxt</b>=<em>name</em>): the first with isf extension for more deep  analysis with non geographic software like 4emka and  JAMM ; the second file with rls extension hold all the set of rules generate. An output map (<b>outputMap</b>=<em>string</em>)is generated for  region  classification with the rules finded and the criteria stored in GRASS geodb.
 
 <h2>NOTES</h2>
-<p> The module can work very slowly with high number of criteria and sample. For bug please contact Gianluca Massei (g_mass@libero.it)</P>
+<p> The module can work very slowly with high number of criteria and sample. For bug please contact Gianluca Massei (g_mass@libero.it)</p>
 
 
 <h2>REFERENCE</h2>
 <ol>
-	<li><p>Greco S., Matarazzo B., Slowinski R.: <i>Rough sets theory for multicriteria decision analysis</i>. European Journal of Operational Research, 129, 1 (2001) 1-47.</P>
-	<li><p>Greco S., Matarazzo B., Slowinski R.:<i> Multicriteria classification by dominance-based rough set approach</i>. In: W.Kloesgen and J.Zytkow (eds.), Handbook of Data Mining and Knowledge Discovery, Oxford University Press, New York, 2002.</P>
-	<li><p>Greco S., Matarazzo B., Slowinski, R., Stefanowski, J.: <i>An Algorithm for Induction of Decision Rules Consistent with the Dominance Principle</i>. In W. Ziarko, Y. Yao (eds.): Rough Sets and Current Trends in Computing. Lecture Notes in Artificial Intelligence 2005 (2001) 304 - 313. Springer-Verlag</P>
-	<li><p>Greco, S., B. Matarazzo, R. Slowinski and J. Stefanowski:<i> Variable consistency model of dominance-based rough set approach.</i> In W.Ziarko, Y.Yao (eds.): Rough Sets and Current Trends in Computing. Lecture Notes in Artificial Intelligence 2005 (2001) 170 - 181. Springer-Verlag</P>
-	<li><p><a href="http://en.wikipedia.org/wiki/Dominance-based_rough_set_approach">http://en.wikipedia.org/wiki/Dominance-based_rough_set_approach</a> - &ldquo;Dominance-based rough set approach&rdquo;</P>
-	<li><p><a href="https://fcds.cs.put.poznan.pl/IDSS/software/software_and_projects.htm">https://fcds.cs.put.poznan.pl/IDSS/software/software_and_projects.htm</a> - Software from Laboratory of intelligent decision support system in Poznań University of Technology
-	</P>
+	<li><p>Greco S., Matarazzo B., Slowinski R.: <i>Rough sets theory for multicriteria decision analysis</i>. European Journal of Operational Research, 129, 1 (2001) 1-47.</p>
+	<li><p>Greco S., Matarazzo B., Slowinski R.:<i> Multicriteria classification by dominance-based rough set approach</i>. In: W.Kloesgen and J.Zytkow (eds.), Handbook of Data Mining and Knowledge Discovery, Oxford University Press, New York, 2002.</p>
+	<li><p>Greco S., Matarazzo B., Slowinski, R., Stefanowski, J.: <i>An Algorithm for Induction of Decision Rules Consistent with the Dominance Principle</i>. In W. Ziarko, Y. Yao (eds.): Rough Sets and Current Trends in Computing. Lecture Notes in Artificial Intelligence 2005 (2001) 304 - 313. Springer-Verlag</p>
+	<li><p>Greco, S., B. Matarazzo, R. Slowinski and J. Stefanowski:<i> Variable consistency model of dominance-based rough set approach.</i> In W.Ziarko, Y.Yao (eds.): Rough Sets and Current Trends in Computing. Lecture Notes in Artificial Intelligence 2005 (2001) 170 - 181. Springer-Verlag</p>
+	<li><p><a href="http://en.wikipedia.org/wiki/Dominance-based_rough_set_approach">http://en.wikipedia.org/wiki/Dominance-based_rough_set_approach</a> - &ldquo;Dominance-based rough set approach&rdquo;</p>
+	<li><p><a href="https://fcds.cs.put.poznan.pl/IDSS/software/software_and_projects.htm">https://fcds.cs.put.poznan.pl/IDSS/software/software_and_projects.htm</a> - Software from Laboratory of intelligent decision support system in Poznań University of Technology</p>
 </ol>
 
 <h2>SEE ALSO</h2>
-<p><em>r.mcda.fuzzy, r.mcda.electre, r.mcda.regime, r.to.drsa, r.in.drsa</em></P>
+<p><em>r.mcda.fuzzy, r.mcda.electre, r.mcda.regime, r.to.drsa, r.in.drsa</em></p>
 
 <h2>AUTHORS</h2>
 

--- a/src/raster/r.mcda.topsis/r.mcda.topsis.html
+++ b/src/raster/r.mcda.topsis/r.mcda.topsis.html
@@ -8,10 +8,11 @@
 
 <h2>REFERENCE</h2>
 <ol>
-	<li><p>Hwang C. L. and Yoon K. Multiple Objective Decision Making Methods and Applications, A State-of-the-Art Survey.Springer - Verlag , 1981.</</ol>
+	<li><p>Hwang C. L. and Yoon K. Multiple Objective Decision Making Methods and Applications, A State-of-the-Art Survey.Springer - Verlag , 1981.</p></li>
+</ol>
 
 <h2>SEE ALSO</h2>
-<p><em>r.mcda.fuzzy, r.mcda.electre, r.mcda.roughset, r.to.drsa, r.in.drsa</em></P>
+<p><em>r.mcda.fuzzy, r.mcda.electre, r.mcda.roughset, r.to.drsa, r.in.drsa</em></p>
 
 <h2>AUTHORS</h2>
 

--- a/src/raster/r.out.legend/r.out.legend.html
+++ b/src/raster/r.out.legend/r.out.legend.html
@@ -100,7 +100,7 @@ printed horizontal, with the labels below the legend bar.
 <div class="code"><pre>
 r.out.legend raster=elevation file=r_out_legend_1.png filetype=png \
     dimensions=4,0.4 labelnum=3 fontsize=7 unit="cm" resolution=150
-</pre></div
+</pre></div>
 
 <p><img src="r_out_legend_1.png">
 
@@ -150,7 +150,7 @@ The difference is that the cairo driver uses anti-aliasing.
 <div class="code"><pre>
 r.out.legend raster=elevation file=r_out_legend_4.png filetype=cairo \
     dimensions=4,0.4 labelnum=3 fontsize=7 unit="cm" resolution=150
-</pre></div
+</pre></div>
 
 <p><img src="r_out_legend_4.png">
 
@@ -176,7 +176,7 @@ same as in the previous example).
 <div class="code"><pre>
 r.out.legend raster=elevation file=r_out_legend_5.png filetype=cairo \
     dimensions=4,0.4 labelnum=3 fontsize=7 unit="cm" resolution=150 -d
-</pre></div
+</pre></div>
 
 <p><img src="r_out_legend_5.png">
 

--- a/src/raster/r.patch.smooth/r.patch.smooth.html
+++ b/src/raster/r.patch.smooth/r.patch.smooth.html
@@ -19,7 +19,7 @@ If option <b>overlap</b> is specified, a map representing the spatially variable
 is created and can be used for inspecting the fusion results.
 
 <center>
-<img src="r_patch_smooth_overview.png" width=600 border=0><br>
+<img src="r_patch_smooth_overview.png" width="600" border="0"><br>
 Difference between fixed overlap width and spatially variable overlap.
 </center>
 
@@ -33,7 +33,7 @@ differences on the edges by taking maximum difference values in the cells
 close to edges.
 
 <center>
-<img src="r_patch_smooth_parallel_smoothing.png" border=0><br>
+<img src="r_patch_smooth_parallel_smoothing.png" border="0"><br>
 Effect of <b>parallel_smoothing</b> option shown on overlap zone (created by specifying <b>overlap</b> option).
 Image A shows result with value 3 and B with value 9.
 </center>

--- a/src/raster/r.pi/r.pi.html
+++ b/src/raster/r.pi/r.pi.html
@@ -162,7 +162,7 @@ the module and might also be influenced by the resolution.
 <h2>REFERENCE</h2>
 
 <ul>
-<li>Wegmann, M., Leutner, B. F., Metz, M., Neteler, M., Dech, S., &amb; Rocchini, D. (2018).
+<li>Wegmann, M., Leutner, B. F., Metz, M., Neteler, M., Dech, S., &amp; Rocchini, D. (2018).
 <i>r. pi: A grass gis package for semi‐automatic spatial pattern analysis of remotely sensed
 land cover data.</i> Methods in Ecology and Evolution, 9(1), 191-199.
 <a href="https://doi.org/10.1111/2041-210X.12827">https://doi.org/10.1111/2041-210X.12827</a></li>

--- a/src/raster/r.random.walk/r.random.walk.html
+++ b/src/raster/r.random.walk/r.random.walk.html
@@ -18,7 +18,7 @@ g.region raster=elevation -p
 r.random.walk -at output=random_walk_smooth_paths directions=8 steps=100000 memory=1800 seed=1 nprocs=6 nwalkers=100
 </pre></div>
 <center>
-    <img src="r_random_walk_example.png" width=600 border=0><br>
+    <img src="r_random_walk_example.png" width="600" border="0"><br>
     Smoothed random walk (Single Starting Location)
 </center>
 
@@ -28,7 +28,7 @@ r.random.walk -as output=random_walk_smooth directions=8 steps=100000 memory=180
 </pre></div>
 
 <center>
-    <img src="r_random_walk_example_2.png" width=600 border=0><br>
+    <img src="r_random_walk_example_2.png" width="600" border="0"><br>
     Smoothed random walk (Multiple Starting Locations)
 </center>
 

--- a/src/raster/r.seasons/r.seasons.html
+++ b/src/raster/r.seasons/r.seasons.html
@@ -112,9 +112,9 @@ g.gui.tplot strds=ndvi_16_5600m coordinates=146.537059538,-29.744835966
 
 <div align="center" style="margin: 10px">
 <a href="global_ndvi.png">
-<img src="global_ndvi.png" width="500" height="361" alt="Global NDVI from MOD13C1 product" border=0>
+<img src="global_ndvi.png" width="500" height="361" alt="Global NDVI from MOD13C1 product" border="0"></a>
 <a href="time_series_ndvi.png">
-<img src="time_series_ndvi.png" width="400" height="329" alt="NDVI time series, 2015-2016" border=0>
+<img src="time_series_ndvi.png" width="400" height="329" alt="NDVI time series, 2015-2016" border="0">
 </a><br>
 <i>Global NDVI from MOD13C1 product (right) and an example of a time series in southeastern Australia (left).</i>
 </div>
@@ -155,7 +155,7 @@ r.colors map=ndvi_season2_start1,ndvi_season2_end1 color=viridis
 
 <div align="center" style="margin: 10px">
 <a href="number_seasons_ndvi.png">
-<img src="number_seasons_ndvi.png" width="600" height="433" alt="Number of seasons in global NDVI" border=0>
+<img src="number_seasons_ndvi.png" width="600" height="433" alt="Number of seasons in global NDVI" border="0">
 </a><br>
 <i>Number of seasons in global NDVI, 2015-2016.</i>
 </div>
@@ -163,9 +163,9 @@ r.colors map=ndvi_season2_start1,ndvi_season2_end1 color=viridis
 <p>
 <div align="center" style="margin: 10px">
 <a href="ndvi_season2_start1.png">
-<img src="ndvi_season2_start1.png" width="500" height="361" alt="Start of season 2" border=0>
+<img src="ndvi_season2_start1.png" width="500" height="361" alt="Start of season 2" border="0"></a>
 <a href="ndvi_season2_end1.png">
-<img src="ndvi_season2_end1.png" width="500" height="361" alt="End of season 2" border=0>
+<img src="ndvi_season2_end1.png" width="500" height="361" alt="End of season 2" border="0">
 </a><br>
 <i>Start (right) and end (left) of season 2 (unit is map index).</i>
 </div>

--- a/src/raster/r.series.diversity/r.series.diversity.html
+++ b/src/raster/r.series.diversity/r.series.diversity.html
@@ -196,7 +196,7 @@ max=0.5658
 <h2>REFERENCES</h2>
 <ul>
 <li>Chase and Knight (2013). "Scale-dependent effect sizes of ecological drivers on biodiversity: why standardised sampling is not enough". Ecology Letters, Volume 16, Issue Supplement s1, pgs 17-26.</li>
-<li>Gini, C. 1912. Variabilit&#224 e mutabilit&#224. Reprinted in Memorie di metodologica statistica (Ed. Pizetti E, Salvemini, T). Rome: Libreria Eredi Virgilio Veschi 1.</li>
+<li>Gini, C. 1912. Variabilit&#224; e mutabilit&#224;. Reprinted in Memorie di metodologica statistica (Ed. Pizetti E, Salvemini, T). Rome: Libreria Eredi Virgilio Veschi 1.</li>
 <li>Jost L. 2006. Entropy and diversity. Oikos 113:363-75</li>
 <li>Legendre P, Legendre L. 1998. Numerical Ecology. Second English edition. Elsevier, Amsterdam</li>
 <li>Simpson, E. H. 1949. Measurement of Diversity Nature 163</li>

--- a/src/raster/r.series.lwr/r.series.lwr.html
+++ b/src/raster/r.series.lwr/r.series.lwr.html
@@ -215,19 +215,19 @@ g.gui.tplot strds=cla_lwr5,cla_2012_2013 coordinates=-61.196485623,-45.323216187
 <p>
 <div align="center" style="margin: 10px">
 <a href="r_series_lwr_cla_orig.png">
-<img src="r_series_lwr_cla_orig.png" width="490" height="287" alt="Original time series" border=0>
+<img src="r_series_lwr_cla_orig.png" width="490" height="287" alt="Original time series" border="0">
 </a><br>
 <i>Original series (cla_2012_2013)</i><br>
 <a href="r_series_lwr_cla_lwr1_lwr2.png">
-<img src="r_series_lwr_cla_lwr1_lwr2.png" width="490" height="287" alt="Comparison order=1 vs order=2" border=0>
+<img src="r_series_lwr_cla_lwr1_lwr2.png" width="490" height="287" alt="Comparison order=1 vs order=2" border="0">
 </a><br>
 <i>Outputs of LWR with order=1 (cla_lwr1) and order=2 (cla_lwr2).</i><br>
 <a href="r_series_lwr_cla_lwr3_lwr4.png">
-<img src="r_series_lwr_cla_lwr3_lwr4.png" width="490" height="287" alt="Comparison dod > 1 vs dod > 1 plus -h and fet" border=0>
+<img src="r_series_lwr_cla_lwr3_lwr4.png" width="490" height="287" alt="Comparison dod > 1 vs dod > 1 plus -h and fet" border="0">
 </a><br>
 <i>Outputs of LWR with dod=5 (cla_lwr3) and dod=5 plus -h flag and fet=0.5 (cla_lwr4).</i><br>
 <a href="r_series_lwr_cla_orig_lwr5.png">
-<img src="r_series_lwr_cla_orig_lwr5.png" width="490" height="287" alt="Gap-filled series up to maxgap=4" border=0>
+<img src="r_series_lwr_cla_orig_lwr5.png" width="490" height="287" alt="Gap-filled series up to maxgap=4" border="0">
 </a><br>
 <i>Original series (cla_2012_2013) and the output of LWR with maxgap=4 (cla_lwr5).</i>
 </div>
@@ -235,9 +235,9 @@ g.gui.tplot strds=cla_lwr5,cla_2012_2013 coordinates=-61.196485623,-45.323216187
 <p>
 <div align="center" style="margin: 10px">
 <a href="r_series_lwr_cla_201281.png">
-<img src="r_series_lwr_cla_201281.png" width="400" height="386" alt="Original map" border=0>
+<img src="r_series_lwr_cla_201281.png" width="400" height="386" alt="Original map" border="0"></a>
 <a href="r_series_lwr_cla_lwr7_201281.png">
-<img src="r_series_lwr_cla_lwr7_201281.png" width="400" height="386" alt="Gap-filled map" border=0>
+<img src="r_series_lwr_cla_lwr7_201281.png" width="400" height="386" alt="Gap-filled map" border="0">
 </a><br>
 <i>Comparison of an original Chlorophyll-a map and a reconstructed map (dod=5).</i>
 </div>

--- a/src/raster/r.sim.terrain/r.sim.terrain.html
+++ b/src/raster/r.sim.terrain/r.sim.terrain.html
@@ -104,7 +104,7 @@ so that it can be registered in the temporal database.
 
 <ul>
 <li>
-Harmon, B. A., Mitasova, H., Petrasova, A., and Petras, V.: r.sim.terrain 1.0: a landscape evolution model with dynamic hydrology, Geosci. Model Dev., 12, 2837–2854, <a href=https://doi.org/10.5194/gmd-12-2837-2019>https://doi.org/10.5194/gmd-12-2837-2019</a>, 2019.
+Harmon, B. A., Mitasova, H., Petrasova, A., and Petras, V.: r.sim.terrain 1.0: a landscape evolution model with dynamic hydrology, Geosci. Model Dev., 12, 2837–2854, <a href="https://doi.org/10.5194/gmd-12-2837-2019">https://doi.org/10.5194/gmd-12-2837-2019</a>, 2019.
 </li>
 <li>
 Mitasova H., Barton M., Ullah I., Hofierka J., Harmon R.S., 2013.

--- a/src/raster/r.sun.hourly/r.sun.hourly.html
+++ b/src/raster/r.sun.hourly/r.sun.hourly.html
@@ -81,7 +81,7 @@ g.gui.tplot strds=beam_m2_step_short,beam_m2_step_long,beam_m2_step_short_cum,be
 </pre></div>
 
 <center>
-<a href="r_sun_hourly.png"><img src="r_sun_hourly.png" alt="Plot" width=600></a>
+<a href="r_sun_hourly.png"><img src="r_sun_hourly.png" alt="Plot" width="600"></a>
 </center>
 
 <h2>NOTE</h2>

--- a/src/temporal/t.rast.import.netcdf/t.rast.import.netcdf.html
+++ b/src/temporal/t.rast.import.netcdf/t.rast.import.netcdf.html
@@ -43,7 +43,7 @@ is currently not supported on MS Windows.
 GDAL versions prior to 3.4.1 do not support reading NetCDF files directly
 via HTTP protocol on newer Linux kernels either. Please make sure to have
 at least GDAL version 3.4.1 on recent Linux systems. See posts on the
-<a href=https://www.mail-archive.com/gdal-dev@lists.osgeo.org/msg37419.html>GDAL-dev mailing list</a>.
+<a href="https://www.mail-archive.com/gdal-dev@lists.osgeo.org/msg37419.html">GDAL-dev mailing list</a>.
 for reference.
 
 <h2>REQUIREMENTS</h2>

--- a/src/vector/v.class.mlR/v.class.mlR.html
+++ b/src/vector/v.class.mlR/v.class.mlR.html
@@ -16,7 +16,7 @@ of objects to be classified.
 and <em>training_map</em>, or as csv files (<em>segments_file</em> and
 <em>training file</em>, or a combination of both. Csv files have to be
 formatted in line with the default output of
-<a href"v.db.select.html">v.db.select</a>, i.e. with a header. The field
+<a href="v.db.select.html">v.db.select</a>, i.e. with a header. The field
 separator can be set with the <em>separator</em> parameter.
 Output can consist of either additional columns in the vector input map
 of features, a text file (<em>classification_results</em>) or reclassed

--- a/src/vector/v.flexure/v.flexure.html
+++ b/src/vector/v.flexure/v.flexure.html
@@ -1,8 +1,8 @@
 <h2>DESCRIPTION</h2>
 
-<em>v.flexure</em> computes how the rigid outer shell of a planet deforms elastically in response to surface-normal loads by solving equations for plate bending. This phenomenon is known as "flexural isostasy" and can be useful in cases of glacier/ice-cap/ice-sheet loading, sedimentary basin filling, mountain belt growth, volcano emplacement, sea-level change, and other geologic processes. <em>v.flexure</em> and <a href="r.flexure.html">r.flexure</a> are the GRASS GIS interfaces to the the model <a href=http://csdms.colorado.edu/wiki/Model:gFlex><b>gFlex</b></a>.
+<em>v.flexure</em> computes how the rigid outer shell of a planet deforms elastically in response to surface-normal loads by solving equations for plate bending. This phenomenon is known as "flexural isostasy" and can be useful in cases of glacier/ice-cap/ice-sheet loading, sedimentary basin filling, mountain belt growth, volcano emplacement, sea-level change, and other geologic processes. <em>v.flexure</em> and <a href="r.flexure.html">r.flexure</a> are the GRASS GIS interfaces to the the model <a href="http://csdms.colorado.edu/wiki/Model:gFlex"><b>gFlex</b></a>.
 
-As both <em>v.flexure</em> and <a href="r.flexure.html">r.flexure</a> are interfaces to gFlex, this must be downloaded and installed. The most recent versions of <b>gFlex</b> are available from <a href=https://github.com/awickert/gFlex>https://github.com/awickert/gFlex</a>, and installation instructions are avaliable on that page via the <em>README.md</em> file.
+As both <em>v.flexure</em> and <a href="r.flexure.html">r.flexure</a> are interfaces to gFlex, this must be downloaded and installed. The most recent versions of <b>gFlex</b> are available from <a href="https://github.com/awickert/gFlex">https://github.com/awickert/gFlex</a>, and installation instructions are avaliable on that page via the <em>README.md</em> file.
 
 <h2>NOTES</h2>
 

--- a/src/vector/v.gsflow.export/v.gsflow.export.html
+++ b/src/vector/v.gsflow.export/v.gsflow.export.html
@@ -1,6 +1,6 @@
 <h2>DESCRIPTION</h2>
 
-<em>v.gsflow.export</em> produces output tables and maps that are used for the USGS combined groundwater (MODFLOW) and surface-water (PRMS) model GSFLOW. These are read in through a sequence of <a href=https://github.com/UMN-Hydro/GSFLOW_pre-processor>"GSFLOW pre-processor" scripts available at the University of Minnesota's Hydro GitHub page</a>.
+<em>v.gsflow.export</em> produces output tables and maps that are used for the USGS combined groundwater (MODFLOW) and surface-water (PRMS) model GSFLOW. These are read in through a sequence of <a href="https://github.com/UMN-Hydro/GSFLOW_pre-processor">"GSFLOW pre-processor" scripts available at the University of Minnesota's Hydro GitHub page</a>.
 
 <h2>NOTES</h2>
 


### PR DESCRIPTION
Also in relation to #1174. Prettier was complaining about parsing errors even without reformatted files.

So I investigated each one to fix them. Even if I might end up disabling the formatted for now, these were valid errors that needed to be addressed.

examples are bad or missing closing tags, bad order of closing tags, html attributes not quoted that resulted in parsing errors etc.

I extracted these changes so they don’t interfere with formatting