### PR TITLE
r.sun.daily/hourly: remove upper limit to linke turbidity

### DIFF
--- a/src/raster/r.sun.daily/r.sun.daily.py
+++ b/src/raster/r.sun.daily/r.sun.daily.py
@@ -58,7 +58,7 @@
 # % key_desc: float
 # % type: double
 # % description: A single value of the Linke atmospheric turbidity coefficient [-]
-# % options: 0.0-7.0
+# % options: 0.0-
 # % answer: 3.0
 # % required : no
 # %end

--- a/src/raster/r.sun.hourly/r.sun.hourly.py
+++ b/src/raster/r.sun.hourly/r.sun.hourly.py
@@ -49,7 +49,7 @@
 # % key: linke_value
 # % type: double
 # % description: A single value of the Linke atmospheric turbidity coefficient [-]
-# % options: 0.0-7.0
+# % options: 0.0-
 # % answer: 3.0
 # % required: no
 # %end


### PR DESCRIPTION
Addresses #1196 by removing the upper limit for the parameter.