### PR TITLE
CI: add liblapacke-dev as dependency

### DIFF
--- a/.github/workflows/apt.txt
+++ b/.github/workflows/apt.txt
@@ -8,7 +8,7 @@ libgdal-dev
 libgl1-mesa-dev
 libglu1-mesa-dev
 libnetcdf-dev
-libopenblas-dev
+liblapacke-dev
 libpng-dev
 libproj-dev
 libreadline-dev


### PR DESCRIPTION
Add `liblapacke-dev` as dependency, to adopt to changes in GRASS GIS main.