### PR TITLE
i.eodag: Support AOIs from other mapsets (fix existence check)

### DIFF
--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -337,7 +337,7 @@ def get_aoi(vector=None):
     if "+proj" not in proj:
         gs.fatal(_("Unable to get AOI: unprojected location not supported"))
 
-    if vector not in gs.parse_command("g.list", type="vector"):
+    if not gs.find_file(vector, element="vector")["file"]:
         gs.fatal(
             _("Unable to get AOI: vector map <{}> could not be found".format(vector))
         )


### PR DESCRIPTION
This PR implements the existence check for AOI vector maps according to the [style guide](https://github.com/OSGeo/grass/blob/main/doc/development/style_guide.md#checking-inputs-of-a-tool)

The previous implementation fails for find AOI vector maps from other mapsets or if mapset qualifiers are used in general.