### PR TITLE
i.eodag: remove experimental tool warning

### DIFF
--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -1323,13 +1323,6 @@ def main():
 
 
 if __name__ == "__main__":
-    gs.warning(_("Experimental Version..."))
-    gs.warning(
-        _(
-            "This module is still under development, \
-            and its behaviour is not guaranteed to be reliable"
-        )
-    )
     options, flags = gs.parser()
 
     try:


### PR DESCRIPTION
I suggest removing the warning since the GSoC was completed successfully some months ago, EODAG released 3+ version that solved several issues we dealt with during the development of the tool and, last but not least, the warning clutters every text output in the terminal 

@HamedElgizery what do you say?