### PR TITLE
v.stream.profiler: fix lazy loading of matplotlib

### DIFF
--- a/src/vector/v.convert.all/v.convert.all.html
+++ b/src/vector/v.convert.all/v.convert.all.html
@@ -15,7 +15,7 @@ use <em>v.out.ogr</em> (to SHAPE format) and then <em>v.in.shape</em>
 in the old GRASS program.
 <p>
 As this GRASS version uses SQL for attribute management, there are
-some <"a href="sql.html">SQL restrictings concerning the file names</a>.
+some <a href="sql.html">SQL restrictings concerning the file names</a>.
 This script changes dots (e.g. "foo.bar") in old vector map names into
 underline(s) (e.g. "foo_bar").
 

--- a/src/vector/v.scatterplot/v.scatterplot.py
+++ b/src/vector/v.scatterplot/v.scatterplot.py
@@ -394,7 +394,9 @@ def lazy_import_matplotlib():
         from matplotlib import cm
         from matplotlib.colors import Normalize
     except ModuleNotFoundError:
-        gs.fatal(_("Matplotlib is not installed. Please, install it."))
+        gs.fatal(
+            _("Matplotlib (python-matplotlib) is not installed. Please, install it.")
+        )
 
 
 def get_valid_color(color):

--- a/src/vector/v.stream.profiler/v.stream.profiler.py
+++ b/src/vector/v.stream.profiler/v.stream.profiler.py
@@ -153,24 +153,30 @@ def moving_average(x, y, window):
 ###############
 
 
+def lazy_import_matplotlib():
+    """Lazy import matplotlib modules"""
+    global matplotlib
+    global plt
+    try:
+        import matplotlib
+
+        matplotlib.use("WXAgg")
+        from matplotlib import pyplot as plt
+    except ModuleNotFoundError:
+        gs.fatal(
+            _("Matplotlib (python-matplotlib) is not installed. Please, install it.")
+        )
+
+
 def main():
     """
     Links each river segment to the next downstream segment in a tributary
     network by referencing its category (cat) number in a new column. "0"
     means that the river exits the map.
     """
-    try:
-        import matplotlib
 
-        matplotlib.use("WXAgg")
-        from matplotlib import pyplot as plt
-    except ImportError as e:
-        raise ImportError(
-            _(
-                'v.stream.profiler needs the "matplotlib" '
-                "(python-matplotlib) package to be installed. {0}"
-            ).format(e)
-        )
+    # lazy import modules
+    lazy_import_matplotlib()
 
     options, flags = gscript.parser()
 


### PR DESCRIPTION
Fixes 

`ImportError: Cannot load backend 'WXAgg' which requires the 'wx' interactive framework, as 'headless' is currently running` (seen in [v.stream.profiler.log](https://grass.osgeo.org/addons/grass8/logs/v.stream.profiler.log))

Inspired by `vector/v.scatterplot/v.scatterplot.py`.

Additionally, small HTML fix for` v.convert.all.html` which was preventing compilation.