### PR TITLE
v.maxent.swd: Fix overwrite behavior for existing species SWD file

### DIFF
--- a/src/vector/v.maxent.swd/v.maxent.swd.py
+++ b/src/vector/v.maxent.swd/v.maxent.swd.py
@@ -298,13 +298,13 @@ def main(options, flags):
     if os.path.isfile(bgrout):
         os.remove(bgrout)
         gs.message(
-            _("The file {} already existed and will be overwritten".format(bgrout))
+            _("The file {} already exists and will be overwritten".format(bgrout))
         )
     specout = options["species_output"]
     if os.path.isfile(specout):
         os.remove(specout)
         gs.message(
-            _("The file {} already existed and will be overwritten".format(specout))
+            _("The file {} already exists and will be overwritten".format(specout))
         )
     bgpn = options["nbgp"]
     nodata = options["nodata"]

--- a/src/vector/v.maxent.swd/v.maxent.swd.py
+++ b/src/vector/v.maxent.swd/v.maxent.swd.py
@@ -259,20 +259,6 @@ def cleanup():
                 )
 
 
-def CreateFileName(outputfile):
-    """Create temporary file name"""
-    flname = outputfile
-    k = 0
-    while os.path.isfile(flname):
-        k = k + 1
-        fn = flname.split(".")
-        if len(fn) == 1:
-            flname = fn[0] + "_" + str(k)
-        else:
-            flname = fn[0] + "_" + str(k) + "." + fn[1]
-    return flname
-
-
 def thin_points(layer, newname):
     """
     Thin point layer, reducing to density to maximum one per raster layer
@@ -311,10 +297,16 @@ def main(options, flags):
     bkgr_file_extension = pathlib.Path(bgrout).suffix
     if os.path.isfile(bgrout):
         bgrout2 = CreateFileName(bgrout)
+        os.remove(bgrout)
         gs.message(
-            _("The file {} already exist. Using {} instead".format(bgrout, bgrout2))
+            _("The file {} already existed and will be overwritten".format(bgrout))
         )
-        bgrout = bgrout2
+    specout = options["species_output"]
+    if os.path.isfile(specout):
+        os.remove(specout)
+        gs.message(
+            _("The file {} already existed and will be overwritten".format(specout))
+        )
     bgpn = options["nbgp"]
     nodata = options["nodata"]
     flag_h = flags["h"]
@@ -519,7 +511,6 @@ def main(options, flags):
                         " \nof provided species names. No SWD file with presences created"
                     )
                 )
-        specout = options["species_output"]
         spec_file_extension = pathlib.Path(specout).suffix
 
         # Write for each species a temp swd file

--- a/src/vector/v.maxent.swd/v.maxent.swd.py
+++ b/src/vector/v.maxent.swd/v.maxent.swd.py
@@ -296,7 +296,6 @@ def main(options, flags):
     bgrout = options["bgr_output"]
     bkgr_file_extension = pathlib.Path(bgrout).suffix
     if os.path.isfile(bgrout):
-        bgrout2 = CreateFileName(bgrout)
         os.remove(bgrout)
         gs.message(
             _("The file {} already existed and will be overwritten".format(bgrout))


### PR DESCRIPTION
When the species swd file already existed, and the option “overwrite” was selected, new species data was appended to the existing species swd file. With this fix, when there is already a species swd file with the user-defined name, and the option “overwrite” is selected, the existing species swd file is removed before a new one is created. 