### PR TITLE
i.eodag: Adjust configuration to breaking changes in EODAG 3.0

### DIFF
--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -879,11 +879,7 @@ def skip_existing(output, search_result):
             if scene_file.exists():
                 creation_time = datetime.utcfromtimestamp(os.path.getctime(scene_file))
                 ingestion_time = scene.properties.get("modificationDate")
-                if (
-                    ingestion_time
-                    and datetime.fromisoformat(ingestion_time).replace(tzinfo=None)
-                    <= creation_time
-                ):
+                if normalize_time(ingestion_time) <= creation_time:
                     # This is to check that the file was completely downloaded
                     # without interruptions.
                     # The reason this works:

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -880,8 +880,15 @@ def skip_existing(output, search_result):
                 creation_time = str(
                     datetime.utcfromtimestamp(os.path.getctime(scene_file))
                 )
-                ingestion_time = scene.properties.get("modificationDate")
-                if normalize_time(ingestion_time) <= creation_time:
+                ingestion_time = scene.properties.get(
+                    "modificationDate",
+                    scene.properties.get(
+                        "publicationDate", scene.properties.get("creationDate")
+                    ),
+                )
+                if ingestion_time and normalize_time(ingestion_time) <= normalize_time(
+                    creation_time
+                ):
                     # This is to check that the file was completely downloaded
                     # without interruptions.
                     # The reason this works:

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -877,7 +877,9 @@ def skip_existing(output, search_result):
         for suffix in SUFFIXES:
             scene_file = output / (scene.properties["title"] + suffix)
             if scene_file.exists():
-                creation_time = datetime.utcfromtimestamp(os.path.getctime(scene_file))
+                creation_time = str(
+                    datetime.utcfromtimestamp(os.path.getctime(scene_file))
+                )
                 ingestion_time = scene.properties.get("modificationDate")
                 if normalize_time(ingestion_time) <= creation_time:
                     # This is to check that the file was completely downloaded

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -898,7 +898,7 @@ def skip_existing(output, search_result):
                     # the scenes remote location
                     # so here we are checking for the existance of that file.
                     hashed_file = (
-                        downloaded_dir / md5(scene.remote_location.encode()).hexdigest()
+                        downloaded_dir / md5((scene.product_type+"-"+scene.properties['id']).encode()).hexdigest()
                     )
                     if not hashed_file.exists():
                         continue

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -898,7 +898,10 @@ def skip_existing(output, search_result):
                     # the scenes remote location
                     # so here we are checking for the existance of that file.
                     hashed_file = (
-                        downloaded_dir / md5((scene.product_type+"-"+scene.properties['id']).encode()).hexdigest()
+                        downloaded_dir
+                        / md5(
+                            (scene.product_type + "-" + scene.properties["id"]).encode()
+                        ).hexdigest()
                     )
                     if not hashed_file.exists():
                         continue

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -1316,7 +1316,7 @@ def main():
             if not search_result:
                 gs.message(_("Nothing to download.\nExiting..."))
             if options["output"]:
-                custom_config["outputs_prefix"] = options["output"]
+                custom_config["output_dir"] = options["output"]
             dag.download_all(search_result, **custom_config)
         except MisconfiguredError as e:
             gs.fatal(_(e))


### PR DESCRIPTION
In EODAG 3.0, kwarg for download _outputs_prefix_ has been renamed to _output_dir_. See: https://eodag.readthedocs.io/en/stable/breaking_changes.html#b3

In consequence, the _output_ parameter of the module is not respected, and downloaded files end up in a local tempdir.
 
This PR adjust the kwarg name according to the changes in EODAG.