### PR TITLE
g.citation.py: bugfix

### DIFF
--- a/src/general/g.citation/g.citation.py
+++ b/src/general/g.citation/g.citation.py
@@ -693,7 +693,7 @@ def print_bibtex(citation, output):
         sep="",
         file=output,
     )
-    print("  year = {", citation["year"], "}", sep="", file=output)
+    print("  year = {", citation["year"], "},", sep="", file=output)
     print(
         "  note = {Accessed: ",
         citation["access"],


### PR DESCRIPTION
Added missing comma between year and note in the BibTeX output.