### PR TITLE
r.maxent.train: Prevent use of scientific notation for precision number

### DIFF
--- a/src/raster/r.maxent.predict/r.maxent.predict.html
+++ b/src/raster/r.maxent.predict/r.maxent.predict.html
@@ -244,11 +244,9 @@ allow GRASS to use Maxent.</li> </ul>
 
 <h2>AUTHOR</h2>
 
-Paulo van Breugel, <a href="https://ecodiv.earth">https://ecodiv.earth</a><br>
-
-<p>
-HAS green academy University of Applied Sciences<br>
-<a href="https://www.has.nl/en/research/professorships/innovative-bio-monitoring-professorship/">Innovative
-Biomonitoring research group</a><br>
-<a href="https://www.has.nl/en/research/professorships/climate-robust-landscapes-professorship/">Climate-robust
+<a href="https:ecodiv.earth">Paulo van Breugel</a>, <a 
+href="https://has.nl">HAS green academy</a>, <a 
+href="https://www.has.nl/en/research/professorships/innovative-bio-monitoring-professorship/">Innovative 
+Biomonitoring research group</a>, <a 
+href="https://www.has.nl/en/research/professorships/climate-robust-landscapes-professorship/">Climate-robust 
 Landscapes research group</a>

--- a/src/raster/r.maxent.setup/r.maxent.setup.html
+++ b/src/raster/r.maxent.setup/r.maxent.setup.html
@@ -85,11 +85,9 @@ that you may need administrator rightrs to edit the osgeo4w.bat file.
 
 <h2>AUTHOR</h2>
 
-Paulo van Breugel, <a href="https://ecodiv.earth">https://ecodiv.earth</a><br>
-
-<p>
-HAS green academy University of Applied Sciences<br> <a 
+<a href="https:ecodiv.earth">Paulo van Breugel</a>, <a 
+href="https://has.nl">HAS green academy</a>, <a 
 href="https://www.has.nl/en/research/professorships/innovative-bio-monitoring-professorship/">Innovative 
-Biomonitoring research group</a><br> <a 
+Biomonitoring research group</a>, <a 
 href="https://www.has.nl/en/research/professorships/climate-robust-landscapes-professorship/">Climate-robust 
 Landscapes research group</a>

--- a/src/raster/r.maxent.train/r.maxent.train.html
+++ b/src/raster/r.maxent.train/r.maxent.train.html
@@ -271,11 +271,9 @@ allow GRASS to use Maxent.</li>
 
 <h2>AUTHOR</h2>
 
-Paulo van Breugel, <a href="https://ecodiv.earth">https://ecodiv.earth</a><br>
-
-<p>
-HAS green academy University of Applied Sciences<br>
-<a href="https://www.has.nl/en/research/professorships/innovative-bio-monitoring-professorship/">Innovative
-Biomonitoring research group</a><br>
-<a href="https://www.has.nl/en/research/professorships/climate-robust-landscapes-professorship/">Climate-robust
+<a href="https:ecodiv.earth">Paulo van Breugel</a>, <a 
+href="https://has.nl">HAS green academy</a>, <a 
+href="https://www.has.nl/en/research/professorships/innovative-bio-monitoring-professorship/">Innovative 
+Biomonitoring research group</a>, <a 
+href="https://www.has.nl/en/research/professorships/climate-robust-landscapes-professorship/">Climate-robust 
 Landscapes research group</a>

--- a/src/raster/r.maxent.train/r.maxent.train.py
+++ b/src/raster/r.maxent.train/r.maxent.train.py
@@ -1280,6 +1280,7 @@ def main(options, flags):
             precision = options["precision"]
             if precision.isdigit():
                 prec = 10 ** -int(precision)
+                prec = f"{prec:.{precision}f}"
                 gs.run_command(
                     "r.mapcalc",
                     expression=f"{grasslayers[idx]} = round({grasslayers[idx]}, {prec})",

--- a/src/vector/v.maxent.swd/v.maxent.swd.html
+++ b/src/vector/v.maxent.swd/v.maxent.swd.html
@@ -146,13 +146,9 @@ software.
 
 <h2>AUTHOR</h2>
 
-Paulo van Breugel, paulo at ecodiv.earth
-
-<p>
-HAS green academy University of Applied Sciences<br>
-<a
-href="https://www.has.nl/en/research/professorships/innovative-bio-monitoring-professorship/">Innovative
-Biomonitoring research group</a><br>
-<a
-href="https://www.has.nl/en/research/professorships/climate-robust-landscapes-professorship/">Climate-robust
+<a href="https:ecodiv.earth">Paulo van Breugel</a>, <a 
+href="https://has.nl">HAS green academy</a>, <a 
+href="https://www.has.nl/en/research/professorships/innovative-bio-monitoring-professorship/">Innovative 
+Biomonitoring research group</a>, <a 
+href="https://www.has.nl/en/research/professorships/climate-robust-landscapes-professorship/">Climate-robust 
 Landscapes research group</a>


### PR DESCRIPTION
Prevent use of scientific notation for precision number Fix author details to make sure g.citation yields the correct results (for r.maxent.train, r.maxent.setup, r.maxent.predict, v.maxent.swd.