### PR TITLE
CI: silence confusing --help output in workflows/test.sh

### DIFF
--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -4,14 +4,16 @@
 set -e
 
 # Install module from addons if not available (in v7).
-if ! grass --tmp-project XY --exec g.download.location --help; then
+if ! grass --tmp-project XY --exec g.download.location --help 2>1; then
     grass --tmp-project XY --exec \
         g.extension g.download.location
 fi
+
+# note: g.download.location is a wrapper around g.download.project
 grass --tmp-project XY --exec \
-    g.download.location url=https://grass.osgeo.org/sampledata/north_carolina/nc_spm_full_v2alpha2.tar.gz path=$HOME
+    g.download.location url=https://grass.osgeo.org/sampledata/north_carolina/nc_spm_full_v2alpha2.tar.gz path=$TMP
 
 grass --tmp-project XY --exec \
     python3 -m grass.gunittest.main \
-        --grassdata $HOME --location nc_spm_full_v2alpha2 --location-type nc \
+        --grassdata $TMP --location nc_spm_full_v2alpha2 --location-type nc \
         --min-success 60

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -11,9 +11,9 @@ fi
 
 # note: g.download.location is a wrapper around g.download.project
 grass --tmp-project XY --exec \
-    g.download.location url=https://grass.osgeo.org/sampledata/north_carolina/nc_spm_full_v2alpha2.tar.gz path=$TMP
+    g.download.location url=https://grass.osgeo.org/sampledata/north_carolina/nc_spm_full_v2alpha2.tar.gz path=$HOME
 
 grass --tmp-project XY --exec \
     python3 -m grass.gunittest.main \
-        --grassdata $TMP --location nc_spm_full_v2alpha2 --location-type nc \
+        --grassdata $HOME --location nc_spm_full_v2alpha2 --location-type nc \
         --min-success 60


### PR DESCRIPTION
This PR silences some confusing help text output during data installation by `g.download.location`:

For the error, see
https://github.com/neteler/grass-addons/actions/runs/12647834206/job/35240965201

Additionally: comment added.