### PR TITLE
r.stream.snap: Fix snapping to immediate NW neighbor cell

### DIFF
--- a/src/raster/r.stream.snap/snap.c
+++ b/src/raster/r.stream.snap/snap.c
@@ -27,7 +27,8 @@ int snap_point(OUTLET *point, int radius, SEGMENT *streams, SEGMENT *accum,
                double accum_treshold)
 {
 
-    int i, j, di = -1, dj = -1;
+    int i, j, di = 0, dj = 0;
+    int snapped = 0;
     int status = 3;
     int teststream = 0;
     float cur_distance = radius;
@@ -72,6 +73,7 @@ int snap_point(OUTLET *point, int radius, SEGMENT *streams, SEGMENT *accum,
                             cur_distance = distance;
                             di = i;
                             dj = j;
+                            snapped = 1;
                         }
                 }
             }
@@ -130,15 +132,14 @@ int snap_point(OUTLET *point, int radius, SEGMENT *streams, SEGMENT *accum,
                         cur_distance = distance;
                         di = i;
                         dj = j;
+                        snapped = 1;
                     }
             }
     } /* end of non-streams version */
-    if (di == -1 && dj == -1) {
+    if (!snapped) {
         G_warning(_("Unable to snap point with cat %d, in a given radius. "
                     "Increase search radius."),
                   point->cat);
-        di = 0;
-        dj = 0;
         status = 2;
     }
     point->di = di;

--- a/src/raster/r.stream.snap/snap.c
+++ b/src/raster/r.stream.snap/snap.c
@@ -28,8 +28,7 @@ int snap_point(OUTLET *point, int radius, SEGMENT *streams, SEGMENT *accum,
 {
 
     int i, j, di = 0, dj = 0;
-    int snapped = 0;
-    int status = 3;
+    int status = 2;
     int teststream = 0;
     float cur_distance = radius;
     float distance = 0;
@@ -73,7 +72,7 @@ int snap_point(OUTLET *point, int radius, SEGMENT *streams, SEGMENT *accum,
                             cur_distance = distance;
                             di = i;
                             dj = j;
-                            snapped = 1;
+                            status = 3;
                         }
                 }
             }
@@ -132,16 +131,14 @@ int snap_point(OUTLET *point, int radius, SEGMENT *streams, SEGMENT *accum,
                         cur_distance = distance;
                         di = i;
                         dj = j;
-                        snapped = 1;
+                        status = 3;
                     }
             }
     } /* end of non-streams version */
-    if (!snapped) {
+    if (status == 2)
         G_warning(_("Unable to snap point with cat %d, in a given radius. "
                     "Increase search radius."),
                   point->cat);
-        status = 2;
-    }
     point->di = di;
     point->dj = dj;
     point->status = status;


### PR DESCRIPTION
This PR fixes snapping to the immediate NW neighbor cell. It was using `di=-1` and `dj=-1` to indicate the unsnapped status, but they are valid deltas for the NW cell. This PR uses the existing `status` variable to store this status.