### PR TITLE
r.slopeunits: fix import of grass.scripts

### DIFF
--- a/src/raster/r.slopeunits/r.slopeunits.clean/r.slopeunits.clean.py
+++ b/src/raster/r.slopeunits/r.slopeunits.clean/r.slopeunits.clean.py
@@ -79,7 +79,7 @@
 import atexit
 import os
 
-import gs.script as gs
+import grass.script as gs
 
 # initialize global vars
 rm_rasters = []

--- a/src/raster/r.slopeunits/r.slopeunits.create/r.slopeunits.create.py
+++ b/src/raster/r.slopeunits/r.slopeunits.create/r.slopeunits.create.py
@@ -138,7 +138,7 @@ import os
 
 # import sys
 
-import gs.script as gs
+import grass.script as gs
 
 # initialize global vars
 rm_rasters = []

--- a/src/raster/r.slopeunits/r.slopeunits.metrics/r.slopeunits.metrics.py
+++ b/src/raster/r.slopeunits/r.slopeunits.metrics/r.slopeunits.metrics.py
@@ -78,7 +78,7 @@ import atexit
 import os
 import sys
 
-import gs.script as gs
+import grass.script as gs
 
 # initialize global vars
 rm_rasters = []

--- a/src/raster/r.slopeunits/r.slopeunits.optimize/r.slopeunits.optimize.py
+++ b/src/raster/r.slopeunits/r.slopeunits.optimize/r.slopeunits.optimize.py
@@ -145,7 +145,7 @@ import atexit
 import math
 import os
 
-import gs.script as gs
+import grass.script as gs
 
 # initialize global vars
 rm_rasters = []


### PR DESCRIPTION
Fixes

```
Traceback (most recent call last):
  File "/home/neteler/.grass8/addons/r.slopeunits/scripts/r.slopeunits.clean", line 82, in <module>
    import gs.script as gs
ModuleNotFoundError: No module named 'gs'
```

(and related)

Discovered in https://grass.osgeo.org/addons/grass8/logs/r.slopeunits.log