### PR TITLE
r.windfetch: use the r.horizon JSON format in 8.4.0

### DIFF
--- a/src/raster/r.windfetch/r.windfetch.py
+++ b/src/raster/r.windfetch/r.windfetch.py
@@ -128,9 +128,7 @@ def point_fetch(land, coordinates, direction, step, minor_directions, minor_step
     offset = minor_step * (minor_directions - 1) / 2
     output = []
     for point in json.loads(data):
-        distances_dict = {
-            horizons["azimuth"]: horizons["distance"] for horizons in point["horizons"]
-        }
+        distances_dict = dict(zip(point["azimuth"], point["horizon_distance"]))
         output.append({"x": point["x"], "y": point["y"], "directions": [], "fetch": []})
         i = 0
         while i < 360:


### PR DESCRIPTION
Given the change in JSON format of r.horizon didn't make it into 8.4.0, it's reverting it to work with the released version.