### PR TITLE
config: Port over some .gitignore patterns from main grass repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,105 @@ OBJ.*
 *.pyc
 *.o
 *.tmp.html
+bin.*/*
+dist.*/*
+config.log
+config.status*
+error.log
+
+
+# notebook helper files
+.ipynb_checkpoints
+
+# ignore gunittest helper and result files
+testreport/*
+testsuite/examples/testreports/
+test_keyvalue_result.txt
+
+# Ignore code coverage files
+*.gcov
+*.gcno
+*.gcda
+.coverage
+.coverage.*
+coverage.xml
+
+
+# Created by https://www.toptal.com/developers/gitignore/api/windows,linux,macos
+# Edit at https://www.toptal.com/developers/gitignore?templates=windows,linux,macos
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/windows,linux,macos


### PR DESCRIPTION
Updates the .gitignore file a little, especially since https://github.com/OSGeo/grass/pull/4995 was merged. It is even more important here I think, where occasional developers might contribute and prevent accidental committing of files