### PR TITLE
gitignore: Ignore Python virtual environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@ config.log
 config.status*
 error.log
 
+# Ingore Python virtual environment
+venv/
+env/
+.venv/
+.env/
 
 # notebook helper files
 .ipynb_checkpoints


### PR DESCRIPTION
I've added common Python virtual directories to the `.gitignore` file. 