### PR TITLE
style: Replace `black .` with `ruff format` for improved user experience to match grass repo

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,5 +1,5 @@
 ---
-name: Python Black Formatting
+name: Linting & formatting
 on:
   push:
     branches:
@@ -13,20 +13,20 @@ concurrency:
     ${{ github.ref_protected != true }}
 env:
   # renovate: datasource=python-version depName=python
-  PYTHON_VERSION: "3.12"
-  # renovate: datasource=pypi depName=black
-  BLACK_VERSION: "25.1.0"
+  PYTHON_VERSION: "3.13"
+  # renovate: datasource=pypi depName=ruff
+  RUFF_VERSION: "0.9.4"
 permissions: {}
 jobs:
-  run-black:
-    name: Black formatting
+  run-ruff:
+    name: Ruff formatting
 
     # Using matrix just to get variables which are not environmental variables
     # and also to sync with other workflows which use matrix.
     strategy:
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -42,15 +42,15 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          pip install black[jupyter]==${{ env.BLACK_VERSION }}
+          pip install ruff==${{ env.RUFF_VERSION }}
 
-      - name: Run Black
+      - name: Run ruff formatter
         run: |
-          black .
+          ruff format
       - name: Create and uploads code suggestions to apply
         id: diff
         uses: OSGeo/grass/.github/actions/create-upload-suggestions@main
         with:
-          tool-name: black
+          tool-name: ruff
           # To keep repo's file structure in formatted changes artifact
-          extra-upload-changes: .clang-format
+          extra-upload-changes: pyproject.toml

--- a/.github/workflows/post-pr-reviews.yml
+++ b/.github/workflows/post-pr-reviews.yml
@@ -3,7 +3,8 @@ name: Post PR code suggestions
 
 on:
   workflow_run:
-    workflows: ["ClangFormat Check", "Python Black Formatting"]
+    workflows:
+      ["ClangFormat Check", "Python Black Formatting", "Linting & formatting"]
     types:
       - completed
 permissions: {}

--- a/.github/workflows/post-pr-reviews.yml
+++ b/.github/workflows/post-pr-reviews.yml
@@ -34,12 +34,12 @@ jobs:
           for tool_name in $INPUT_TOOL_NAMES
           do
             INPUT_TOOL_NAME_FILE="diff-${tool_name}.patch"
-            echo "Checking if tool ${tool_name} left suggestions in ${INPUT_TOOL_NAME_FILE}"
+            echo "Checking if tool ${tool_name} left suggestions in ${INPUT_TOOL_NAME_FILE}..."
             if [[ -f "${INPUT_TOOL_NAME_FILE}" ]]; then
-              echo "${INPUT_TOOL_NAME_FILE} was found for tool ${tool_name}"
+              echo "   ${INPUT_TOOL_NAME_FILE} was found for tool ${tool_name}"
               echo "$tool_name=true" >> "${GITHUB_OUTPUT}"
             else
-              echo "${INPUT_TOOL_NAME_FILE} was not found for tool ${tool_name}"
+              echo "   ${INPUT_TOOL_NAME_FILE} was not found for tool ${tool_name}"
               echo "$tool_name=false" >> "${GITHUB_OUTPUT}"
             fi
           done
@@ -47,6 +47,7 @@ jobs:
           INPUT_TOOL_NAMES: >-
             black
             clang-format
+            ruff
       - name: Post Black suggestions
         if: ${{ steps.tools.outputs.black == 'true' }}
         run: |
@@ -65,7 +66,7 @@ jobs:
           CI_REPO_OWNER: ${{ github.event.workflow_run.repository.owner.login }}
           CI_REPO_NAME: ${{ github.event.workflow_run.repository.name }}
           # CI_PULL_REQUEST: "" # Populated from reviewdog's "-guess" flag since hard to get
-      - name: Post Clang-format suggestions
+      - name: Post ClangFormat suggestions
         if: ${{ steps.tools.outputs.clang-format == 'true' }}
         run: |
           TMPFILE="diff-${INPUT_TOOL_NAME}.patch"
@@ -78,6 +79,24 @@ jobs:
               -reporter="github-pr-review" < "${TMPFILE}"
         env:
           INPUT_TOOL_NAME: clang-format
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CI_COMMIT: ${{ github.event.workflow_run.head_sha }}
+          CI_REPO_OWNER: ${{ github.event.workflow_run.repository.owner.login }}
+          CI_REPO_NAME: ${{ github.event.workflow_run.repository.name }}
+          # CI_PULL_REQUEST: "" # Populated from reviewdog's "-guess" flag since hard to get
+      - name: Post Ruff suggestions
+        if: ${{ steps.tools.outputs.ruff == 'true' }}
+        run: |
+          TMPFILE="diff-${INPUT_TOOL_NAME}.patch"
+          GITHUB_ACTIONS="" reviewdog \
+              -name="${INPUT_TOOL_NAME:-reviewdog-suggester}" \
+              -f=diff \
+              -f.diff.strip=1 \
+              -filter-mode=nofilter \
+              -guess \
+              -reporter="github-pr-review" < "${TMPFILE}"
+        env:
+          INPUT_TOOL_NAME: ruff
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CI_COMMIT: ${{ github.event.workflow_run.head_sha }}
           CI_REPO_OWNER: ${{ github.event.workflow_run.repository.owner.login }}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -56,7 +56,7 @@ jobs:
           VALIDATE_MARKDOWN_PRETTIER: false # Until issues are fixed
           VALIDATE_NATURAL_LANGUAGE: false # Until issues are fixed, lots of valid suggestions
           VALIDATE_PERL: false # Until issues are fixed
-          VALIDATE_PYTHON_BLACK: false # Until code is upgraded to a newer black version
+          VALIDATE_PYTHON_BLACK: false # We are using ruff format
           VALIDATE_PYTHON_FLAKE8: false
           VALIDATE_PYTHON_ISORT: false # Until issues are fixed
           VALIDATE_PYTHON_MYPY: false # Issue with module name wx.wms

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,11 @@
 ---
 repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.9.4
+    hooks:
+      # Run the formatter.
+      - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
@@ -27,11 +33,6 @@ repos:
     rev: v0.44.0
     hooks:
       - id: markdownlint-fix
-  # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.1.0
-    hooks:
-      - id: black-jupyter
   - repo: https://github.com/pycqa/flake8
     rev: 7.1.1
     hooks:

--- a/src/gui/wxpython/wx.metadata/mdlib/cswlib.py
+++ b/src/gui/wxpython/wx.metadata/mdlib/cswlib.py
@@ -103,7 +103,20 @@ class CSWBrowserPanel(wx.Panel):
         wx.Panel.__init__(self, parent)
 
         try:
-            global BBox, CatalogueServiceWeb, Environment, ExceptionReport, FileSystemLoader, GError, GMessage, GUI, GWarning, HtmlFormatter, PropertyIsLike, XmlLexer, highlight
+            global \
+                BBox, \
+                CatalogueServiceWeb, \
+                Environment, \
+                ExceptionReport, \
+                FileSystemLoader, \
+                GError, \
+                GMessage, \
+                GUI, \
+                GWarning, \
+                HtmlFormatter, \
+                PropertyIsLike, \
+                XmlLexer, \
+                highlight
 
             from jinja2 import Environment, FileSystemLoader
 
@@ -1059,7 +1072,19 @@ class CSWConnectionPanel(wx.Panel):
     def __init__(self, parent, main, cswBrowser=True):
         wx.Panel.__init__(self, parent)
         try:
-            global BBox, CatalogueServiceWeb, Environment, ExceptionReport, FileSystemLoader, GError, GMessage, GWarning, HtmlFormatter, PropertyIsLike, XmlLexer, highlight
+            global \
+                BBox, \
+                CatalogueServiceWeb, \
+                Environment, \
+                ExceptionReport, \
+                FileSystemLoader, \
+                GError, \
+                GMessage, \
+                GWarning, \
+                HtmlFormatter, \
+                PropertyIsLike, \
+                XmlLexer, \
+                highlight
 
             from jinja2 import Environment, FileSystemLoader
 

--- a/src/gui/wxpython/wx.metadata/mdlib/mdeditorfactory.py
+++ b/src/gui/wxpython/wx.metadata/mdlib/mdeditorfactory.py
@@ -1170,7 +1170,16 @@ class MdMainEditor(wx.Panel):
         wx.Panel.__init__(self, parent=parent, id=wx.ID_ANY)
 
         try:
-            global CI_Date, CI_OnlineResource, CI_ResponsibleParty, DQ_DataQuality, EX_Extent, EX_GeographicBoundingBox, GError, MD_Distribution, MD_ReferenceSystem
+            global \
+                CI_Date, \
+                CI_OnlineResource, \
+                CI_ResponsibleParty, \
+                DQ_DataQuality, \
+                EX_Extent, \
+                EX_GeographicBoundingBox, \
+                GError, \
+                MD_Distribution, \
+                MD_ReferenceSystem
 
             from owslib.iso import (
                 CI_Date,

--- a/src/gui/wxpython/wx.metadata/mdlib/mdgrass.py
+++ b/src/gui/wxpython/wx.metadata/mdlib/mdgrass.py
@@ -42,7 +42,19 @@ class GrassMD:
 
     def __init__(self, map, type):
         try:
-            global CI_Date, CI_OnlineResource, CI_ResponsibleParty, DQ_DataQuality, Environment, etree, EX_Extent, EX_GeographicBoundingBox, FileSystemLoader, MD_Distribution, MD_ReferenceSystem, RunCommand
+            global \
+                CI_Date, \
+                CI_OnlineResource, \
+                CI_ResponsibleParty, \
+                DQ_DataQuality, \
+                Environment, \
+                etree, \
+                EX_Extent, \
+                EX_GeographicBoundingBox, \
+                FileSystemLoader, \
+                MD_Distribution, \
+                MD_ReferenceSystem, \
+                RunCommand
 
             from owslib.iso import (
                 CI_Date,

--- a/src/gui/wxpython/wx.metadata/mdlib/mdpdftheme.py
+++ b/src/gui/wxpython/wx.metadata/mdlib/mdpdftheme.py
@@ -23,7 +23,15 @@ class MySheet:
 
     def __init__(self):
         try:
-            global ParagraphStyle, TA_CENTER, _baseFontName, _baseFontNameB, _baseFontNameBI, _baseFontNameI, colors, inch
+            global \
+                ParagraphStyle, \
+                TA_CENTER, \
+                _baseFontName, \
+                _baseFontNameB, \
+                _baseFontNameBI, \
+                _baseFontNameI, \
+                colors, \
+                inch
 
             from reportlab.lib.styles import (
                 ParagraphStyle,
@@ -351,7 +359,14 @@ class Pdf(object):
 
     def __init__(self, title, author):
         try:
-            global Image, KeepTogether, LongTable, Paragraph, SimpleDocTemplate, Spacer, Table
+            global \
+                Image, \
+                KeepTogether, \
+                LongTable, \
+                Paragraph, \
+                SimpleDocTemplate, \
+                Spacer, \
+                Table
 
             from reportlab.platypus.doctemplate import SimpleDocTemplate
             from reportlab.platypus.flowables import Image

--- a/src/gui/wxpython/wx.mwprecip/mw3.py
+++ b/src/gui/wxpython/wx.mwprecip/mw3.py
@@ -1783,11 +1783,13 @@ class Database:
             self.connection.executeSql(sql, False, True)
 
             logger.info("Computing column lenght")
-            sql = "UPDATE link SET lenght = get_earth_distance1(n1.long,n1.lat,n2.long,n2.lat) \
+            sql = (
+                "UPDATE link SET lenght = get_earth_distance1(n1.long,n1.lat,n2.long,n2.lat) \
                     FROM node AS n1 JOIN \
                     link AS l ON n1.nodeid = fromnodeid \
                     JOIN node AS n2 ON n2.nodeid = tonodeid \
                     WHERE link.linkid = l.linkid; "
+            )
             self.connection.executeSql(sql, False, True)
 
             # logger.info("Add column precip")

--- a/src/imagery/i.ann.maskrcnn/maskrcnnlib/model.py
+++ b/src/imagery/i.ann.maskrcnn/maskrcnnlib/model.py
@@ -1527,10 +1527,10 @@ def build_detection_targets(rpn_rois, gt_class_ids, gt_boxes, gt_masks, config):
             # Fill the rest with repeated bg rois.
             keep_extra_ids = np.random.choice(keep_bg_ids, remaining, replace=True)
             keep = np.concatenate([keep, keep_extra_ids])
-    assert (
-        keep.shape[0] == config.TRAIN_ROIS_PER_IMAGE
-    ), "keep doesn't match ROI batch size {}, {}".format(
-        keep.shape[0], config.TRAIN_ROIS_PER_IMAGE
+    assert keep.shape[0] == config.TRAIN_ROIS_PER_IMAGE, (
+        "keep doesn't match ROI batch size {}, {}".format(
+            keep.shape[0], config.TRAIN_ROIS_PER_IMAGE
+        )
     )
 
     # Reset the gt boxes assigned to BG ROIs.
@@ -2876,9 +2876,9 @@ class MaskRCNN:
             verbose form in case of verbosity == 3, not 1
         """
         assert self.mode == "inference", "Create model in inference mode."
-        assert (
-            len(images) == self.config.BATCH_SIZE
-        ), "len(images) must be equal to BATCH_SIZE"
+        assert len(images) == self.config.BATCH_SIZE, (
+            "len(images) must be equal to BATCH_SIZE"
+        )
 
         if verbosity == 3:
             log("Processing {} images".format(len(images)))
@@ -2892,9 +2892,9 @@ class MaskRCNN:
         # All images in a batch MUST be of the same size
         image_shape = molded_images[0].shape
         for g in molded_images[1:]:
-            assert (
-                g.shape == image_shape
-            ), "After resizing, all images must have the same size. Check IMAGE_RESIZE_MODE and image sizes."
+            assert g.shape == image_shape, (
+                "After resizing, all images must have the same size. Check IMAGE_RESIZE_MODE and image sizes."
+            )
 
         # Anchors
         anchors = self.get_anchors(image_shape)
@@ -2950,9 +2950,9 @@ class MaskRCNN:
         masks: [H, W, N] instance binary masks
         """
         assert self.mode == "inference", "Create model in inference mode."
-        assert (
-            len(molded_images) == self.config.BATCH_SIZE
-        ), "Number of images must be equal to BATCH_SIZE"
+        assert len(molded_images) == self.config.BATCH_SIZE, (
+            "Number of images must be equal to BATCH_SIZE"
+        )
 
         if verbose:
             log("Processing {} images".format(len(molded_images)))

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -1313,9 +1313,9 @@ def main():
                         ]
                     )
                 else:
-                    dag.providers_config["creodias"].auth.credentials[
-                        "totp"
-                    ] = creodias_otp
+                    dag.providers_config["creodias"].auth.credentials["totp"] = (
+                        creodias_otp
+                    )
                     dag._plugins_manager.get_auth_plugin("creodias").authenticate()
             custom_config = {
                 "timeout": int(options["timeout"]),

--- a/src/imagery/i.landsat/i.landsat.qa/i.landsat.qa.py
+++ b/src/imagery/i.landsat/i.landsat.qa/i.landsat.qa.py
@@ -178,9 +178,7 @@ def check_user_input(user_input):
             grass.fatal(
                 _(
                     """All conditions for {} specified as
-            unacceptable, this will result in an empty map.""".format(
-                        o
-                    )
+            unacceptable, this will result in an empty map.""".format(o)
                 )
             )
         # Check if valid combination of options if provided

--- a/src/imagery/i.landsat8.swlst/split_window_lst.py
+++ b/src/imagery/i.landsat8.swlst/split_window_lst.py
@@ -128,9 +128,9 @@ class SplitWindowLST:
 
         if landcover in EMISSIVITIES.keys() or landcover == "Random":
             # a fixed land cover class requested
-            assert self._landcover_string_validity(
-                landcover_class
-            ), "Unknown land cover class name!"
+            assert self._landcover_string_validity(landcover_class), (
+                "Unknown land cover class name!"
+            )
             self.landcover_class = landcover
 
             # retrieve & set avg emissivities for channels t10, t11

--- a/src/imagery/i.pysptools.unmix/i.pysptools.unmix.py
+++ b/src/imagery/i.pysptools.unmix/i.pysptools.unmix.py
@@ -206,9 +206,7 @@ def main():
     if endmember_n > len(maps) + 1:
         gs.warning(
             "More endmembers ({}) requested than bands in \
-                   input imagery group ({})".format(
-                endmember_n, len(maps)
-            )
+                   input imagery group ({})".format(endmember_n, len(maps))
         )
         if extraction_method != "PPI":
             gs.fatal(
@@ -237,9 +235,7 @@ def main():
             gs.warning(
                 "{} is of type Float64.\
                         Float64 is currently not supported.\
-                        Reducing precision to Float32".format(
-                    raster
-                )
+                        Reducing precision to Float32".format(raster)
             )
 
         # Determine map type
@@ -343,9 +339,7 @@ def main():
             if len(idx[0]) == 0 or len(idx[1]) == 0:
                 gs.warning(
                     "Could not compute coordinated for endmember {}. \
-                            Please consider rescaling your data to integer".format(
-                        cat
-                    )
+                            Please consider rescaling your data to integer".format(cat)
                 )
                 cat = cat + 1
                 continue

--- a/src/raster/r.area.createweight/r.area.createweight.py
+++ b/src/raster/r.area.createweight/r.area.createweight.py
@@ -813,9 +813,7 @@ def RandomForest(weighting_layer_name, vector, id):
     message = (
         "Selected covariates for the random forest model (with "
         "feature importance upper than {value} %) : \n\
-        ".format(
-            value=min_fimportance * 100
-        )
+        ".format(value=min_fimportance * 100)
     )
     message += "\n".join(list_covar)
     log_text += message + "\n\n"
@@ -977,7 +975,31 @@ def main():
     gscript.use_temp_region()  # define use of temporary regions
 
     ## Create global variables
-    global TMP_MAPS, TMP_CSV, TMP_VECT, vector_map, allstatfile, min_fimportance, param_grid, kfold, basemap_a, basemap_b, distance_to, tile_size, n_jobs, id, response_variable, plot, log_f, log_text, log_text_extend, basemap_a_category_list, basemap_b_category_list, rasta_class_list, rastb_class_list, output_units_layer
+    global \
+        TMP_MAPS, \
+        TMP_CSV, \
+        TMP_VECT, \
+        vector_map, \
+        allstatfile, \
+        min_fimportance, \
+        param_grid, \
+        kfold, \
+        basemap_a, \
+        basemap_b, \
+        distance_to, \
+        tile_size, \
+        n_jobs, \
+        id, \
+        response_variable, \
+        plot, \
+        log_f, \
+        log_text, \
+        log_text_extend, \
+        basemap_a_category_list, \
+        basemap_b_category_list, \
+        rasta_class_list, \
+        rastb_class_list, \
+        output_units_layer
 
     ## Create empty variables
     raster_list = []  # List of the input rasters

--- a/src/raster/r.colors.out_sld/r.colors.out_sld.py
+++ b/src/raster/r.colors.out_sld/r.colors.out_sld.py
@@ -123,17 +123,13 @@ def main():
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NamedLayer>
-    <Name>{}</Name>""".format(
-        style_name
-    )
+    <Name>{}</Name>""".format(style_name)
     sld += """
     <UserStyle>
       <Title>{}</Title>
       <FeatureTypeStyle>
         <Rule>
-          <RasterSymbolizer>\n""".format(
-        name
-    )
+          <RasterSymbolizer>\n""".format(name)
 
     # Define type of ColorMap depending on data type of input map
     if use_categories:

--- a/src/raster/r.connectivity/r.connectivity.corridors/r.connectivity.corridors.py
+++ b/src/raster/r.connectivity/r.connectivity.corridors/r.connectivity.corridors.py
@@ -244,9 +244,7 @@ def main():
     if not con:
         grass.fatal(
             "Database connection for map {} \
-                    is not defined for layer {}.".format(
-                network, layer
-            )
+                    is not defined for layer {}.".format(network, layer)
         )
 
     # Check if required columns exist and are of required type
@@ -262,9 +260,7 @@ def main():
         grass.fatal(
             "Cannot find the following required/requested \
                     column(s) {} in vector map \
-                    {}.".format(
-                ", ".join(missing_columns), network
-            )
+                    {}.".format(", ".join(missing_columns), network)
         )
 
     #
@@ -276,9 +272,7 @@ def main():
                 "Column {} is of type {}. \
                          Only numeric types (integer, \
                          real or double precision) \
-                         allowed!".format(
-                    col, in_columns[col]["type"]
-                )
+                         allowed!".format(col, in_columns[col]["type"])
             )
 
         if col in weights:

--- a/src/raster/r.connectivity/r.connectivity.distance/r.connectivity.distance.py
+++ b/src/raster/r.connectivity/r.connectivity.distance/r.connectivity.distance.py
@@ -318,17 +318,13 @@ def main():
     if not grass.legal_name(prefix):
         grass.fatal(
             "{} is not a legal name for GRASS \
-                    maps.".format(
-                prefix
-            )
+                    maps.".format(prefix)
         )
 
     if prefix[0].isdigit():
         grass.fatal(
             "Tables names starting with a digit are not SQL \
-                    compliant.".format(
-                prefix
-            )
+                    compliant.".format(prefix)
         )
 
     # Check if output maps not already exists or could be overwritten
@@ -341,9 +337,7 @@ def main():
     if not int(layer) in in_db_connection.keys():
         grass.fatal(
             "No attribute table connected vector map {} at \
-                    layer {}.".format(
-                patches, layer
-            )
+                    layer {}.".format(patches, layer)
         )
 
     # Check if cat column exists
@@ -353,18 +347,14 @@ def main():
     if "cat" not in pcols.keys():
         grass.fatal(
             "Cannot find the reqired column cat in vector map \
-                    {}.".format(
-                patches
-            )
+                    {}.".format(patches)
         )
 
     # Check if pop_proxy column exists
     if pop_proxy not in pcols.keys():
         grass.fatal(
             "Cannot find column {} in vector map \
-                    {}".format(
-                pop_proxy, patches
-            )
+                    {}".format(pop_proxy, patches)
         )
 
     # Check if pop_proxy column is numeric type
@@ -372,9 +362,7 @@ def main():
         grass.fatal(
             "Column {} is of type {}. Only numeric types \
                     (integer or double precision) \
-                    allowed!".format(
-                pop_proxy, pcols[pop_proxy]["type"]
-            )
+                    allowed!".format(pop_proxy, pcols[pop_proxy]["type"])
         )
 
     # Check if pop_proxy column does not contain values <= 0
@@ -389,9 +377,7 @@ def main():
     if np.min(pop_vals) <= 0:
         grass.fatal(
             "Column {} contains values <= 0 or NULL. Neither \
-                    values <= 0 nor NULL allowed!}".format(
-                pop_proxy
-            )
+                    values <= 0 nor NULL allowed!}".format(pop_proxy)
         )
 
     ##############################################
@@ -504,9 +490,7 @@ def main():
     {p}_patches_pol[1,0]!={p}_patches_pol)||| \
     (isnull({p}_patches_pol[0,-1])||| \
     {p}_patches_pol[0,-1]!={p}_patches_pol)), \
-    {p}_patches_pol,null()), null())".format(
-            p=TMP_PREFIX
-        ),
+    {p}_patches_pol,null()), null())".format(p=TMP_PREFIX),
         quiet=True,
     )
 
@@ -583,17 +567,13 @@ def main():
                 "Patch {} has not been rasterized and will \
                           therefore not be treated as part of the \
                           network. Consider using t-flag or change \
-                          resolution.".format(
-                    cat
-                )
+                          resolution.".format(cat)
             )
 
             continue
         grass.verbose(
             "Calculating connectivity-distances for patch \
-                      number {}".format(
-                cat
-            )
+                      number {}".format(cat)
         )
 
         # Filter
@@ -842,9 +822,7 @@ def main():
         if p_flag:
             grass.verbose(
                 "Extracting shortest paths for patch number \
-                          {}...".format(
-                    cat
-                )
+                          {}...".format(cat)
             )
 
             points_n = len(to_cats)
@@ -1020,9 +998,7 @@ def main():
                  ELSE to_p END AS p_to,
                  dist
                  FROM {}) AS x
-                 GROUP BY p_from, p_to""".format(
-            edge_map
-        )
+                 GROUP BY p_from, p_to""".format(edge_map)
         with open(
             os.path.join(conefor_dir, "undirected_connection_file"), "w"
         ) as edges:

--- a/src/raster/r.connectivity/r.connectivity.network/r.connectivity.network.py
+++ b/src/raster/r.connectivity/r.connectivity.network/r.connectivity.network.py
@@ -322,32 +322,24 @@ def main():
         if grass.db.db_table_exist(table) and not overwrite:
             grass.fatal(
                 'Table "{}" already exists. \
-                         Use --o flag to overwrite'.format(
-                    table
-                )
+                         Use --o flag to overwrite'.format(table)
             )
 
     if qml_style_dir:
         if not os.path.exists(qml_style_dir):
             grass.fatal(
                 'QML output requested but directory "{}" \
-                        does not exists.'.format(
-                    qml_style_dir
-                )
+                        does not exists.'.format(qml_style_dir)
             )
         if not os.path.isdir(qml_style_dir):
             grass.fatal(
                 'QML output requested but "{}" is not a \
-                        directory.'.format(
-                    qml_style_dir
-                )
+                        directory.'.format(qml_style_dir)
             )
         if not os.access(qml_style_dir, os.R_OK):
             grass.fatal(
                 'Output directory "{}" for QML files is not \
-                        writable.'.format(
-                    qml_style_dir
-                )
+                        writable.'.format(qml_style_dir)
             )
 
     for plot in [kernel_plot, overview_plot]:
@@ -355,16 +347,12 @@ def main():
             if not os.path.exists(os.path.dirname(plot)):
                 grass.fatal(
                     'Directory for output "{}" does not \
-                            exists.'.format(
-                        plot
-                    )
+                            exists.'.format(plot)
                 )
             if not os.access(os.path.dirname(plot), os.R_OK):
                 grass.fatal(
                     'Output directory "{}" is not \
-                            writable.'.format(
-                        plot
-                    )
+                            writable.'.format(plot)
                 )
 
     # Visualise negative exponential decay kernel and exit
@@ -507,9 +495,7 @@ def main():
     if i_flag and missing_packages:
         grass.warning(
             "Installing required R-packages {} on \
-                      request.".format(
-                ",".join(missing_packages)
-            )
+                      request.".format(",".join(missing_packages))
         )
         utils = rpackages.importr("utils")
         utils.chooseCRANmirror(ind=1)
@@ -518,9 +504,7 @@ def main():
         grass.fatal(
             "The following required R-packages {} are issing \
                     on your system. Please install \
-                    them.".format(
-                ",".join(missing_packages)
-            )
+                    them.".format(",".join(missing_packages))
         )
 
     # Check igraph version
@@ -537,9 +521,7 @@ def main():
                 "The required igraph version is 0.6-2 or \
                           later, the installed version is {}. \
                           Installing latest version of igraph on \
-                          request.".format(
-                    igraph_version
-                )
+                          request.".format(igraph_version)
             )
             utils.install_packages("igraph")
         else:
@@ -547,9 +529,7 @@ def main():
                 "The required igraph version is 0.6-2 or \
                          later, the installed version is {}. \
                          Please download and install at least igraph \
-                         version 0.6-2".format(
-                    igraph_version
-                )
+                         version 0.6-2".format(igraph_version)
             )
 
     rscript = """
@@ -567,9 +547,7 @@ library(nlme)
 library(codetools)
 library(rgrass7)
 library(DBI)
-""".format(
-        "{}".format(verbose).upper()
-    )
+""".format("{}".format(verbose).upper())
 
     if cores > 1:
         rscript += """
@@ -580,9 +558,7 @@ library(doMC)
 
 registerDoMC()
 options(cores = {})
-""".format(
-            cores
-        )
+""".format(cores)
 
     rscript += """
 # Variables
@@ -1648,9 +1624,7 @@ close(con_qml)
 #Close R
 ########################################################################
 #q()
-""".format(
-        cores
-    )
+""".format(cores)
 
     if cores <= 1 or os_type == "Windows":
         rscript.replace("mclapply(mc.cores={}, ".format(cores), "lapply(")

--- a/src/raster/r.fidimo/r.fidimo.py
+++ b/src/raster/r.fidimo/r.fidimo.py
@@ -856,9 +856,7 @@ def main():
             "db.select",
             flags="c",
             sql="SELECT segment FROM source_points_%d" % os.getpid(),
-        ).split("\n")[
-            :-1
-        ]  # remove last (empty line)
+        ).split("\n")[:-1]  # remove last (empty line)
         segment_list = map(int, segment_list)
         segment_list = sorted(list(set(segment_list)))
 
@@ -875,9 +873,7 @@ def main():
                 flags="c",
                 sql="SELECT cat, X, Y, n_fish, prob_scalar, Strahler, habitat_attract, p FROM source_points_%d WHERE segment=%d"
                 % (os.getpid(), int(j)),
-            ).split("\n")[
-                :-1
-            ]  # remove last (empty line)
+            ).split("\n")[:-1]  # remove last (empty line)
             source_points_list = list(csv.reader(source_points_list, delimiter="|"))
 
             for k in source_points_list:
@@ -1138,9 +1134,7 @@ def main():
                         flags="c",
                         sql="SELECT cat, adj_X, adj_Y, dist, %s FROM barriers_%d WHERE dist > 0 ORDER BY dist"
                         % (passability_col, os.getpid()),
-                    ).split("\n")[
-                        :-1
-                    ]  # remove last (empty line)
+                    ).split("\n")[:-1]  # remove last (empty line)
                     barriers_list = list(csv.reader(barriers_list, delimiter="|"))
 
                     # if affected barriers then define the last loop (find the upstream most barrier)

--- a/src/raster/r.forestfrag/r.forestfrag.py
+++ b/src/raster/r.forestfrag/r.forestfrag.py
@@ -325,7 +325,8 @@ def main(options, flags):
     else:
         indexfin2 = opl
     mapcalc(
-        "eval(" "dpf = $pf - $pff,"
+        "eval("
+        "dpf = $pf - $pff,"
         # Individual classes
         "patch = if($pf < 0.4, 1, 0),"
         "transitional = if($pf >= 0.4 && $pf < 0.6, 2, 0),"

--- a/src/raster/r.green/r.green.install/r.green.install.py
+++ b/src/raster/r.green/r.green.install/r.green.install.py
@@ -158,9 +158,7 @@ XMLENERGYTOOLBOX = """<?xml version="1.0" encoding="UTF-8"?>
     </items>
   </toolbox>
 </toolboxes>
-""".format(
-    XMLMAINMENU=XMLMAINMENU
-)
+""".format(XMLMAINMENU=XMLMAINMENU)
 
 
 def value_not_none(method):

--- a/src/raster/r.slope.direction/r.slope.direction.py
+++ b/src/raster/r.slope.direction/r.slope.direction.py
@@ -238,9 +238,7 @@ if({{dir}} == {3}, if(isnull({{elev_in}}[0,-1]),{{elev_in}},{{elev_in}}[0,-1]), 
 if({{dir}} == {4}, if(isnull({{elev_in}}[1,-1]),{{elev_in}},{{elev_in}}[1,-1]), \
 if({{dir}} == {5}, if(isnull({{elev_in}}[1,0]),{{elev_in}},{{elev_in}}[1,0]), \
 if({{dir}} == {6}, if(isnull({{elev_in}}[1,1]),{{elev_in}},{{elev_in}}[1,1]), \
-if(isnull({{elev_in}}[0,1]),{{elev_in}},{{elev_in}}[0,1]))))))))""".format(
-        *dirs
-    )
+if(isnull({{elev_in}}[0,1]),{{elev_in}},{{elev_in}}[0,1]))))))))""".format(*dirs)
 
     kwargs = {
         "dir": direction,
@@ -258,9 +256,7 @@ if({{dir}} == {4}, if(isnull({{dist_in}}[1,-1]),{{dist_in}},{{dist_in}}[1,-1]), 
 if({{dir}} == {5}, if(isnull({{dist_in}}[1,0]),{{dist_in}},{{dist_in}}[1,0]), \
 if({{dir}} == {6}, if(isnull({{dist_in}}[1,1]),{{dist_in}},{{dist_in}}[1,1]), \
 if(isnull({{dist_in}}[0,1]),{{dist_in}},{{dist_in}}[0,1]))))))))
-{{dist_sum_out}}={{dist_sum_in}}+{{dist_in}}""".format(
-            *dirs
-        )
+{{dist_sum_out}}={{dist_sum_in}}+{{dist_in}}""".format(*dirs)
 
         kwargs["dist_in"] = "{}_dist_odd".format(tmpname)
         kwargs["dist_out"] = "{}_dist_even".format(tmpname)

--- a/src/raster/r.survey/r.survey.py
+++ b/src/raster/r.survey/r.survey.py
@@ -574,9 +574,7 @@ def compute(
                 Module(
                     "r.mapcalc",
                     expression="zzview{Q} = if(zzview{Q}>90 && zzview{Q}<180,\
-                    null(),zzview{Q})".format(
-                        Q=i
-                    ),
+                    null(),zzview{Q})".format(Q=i),
                     overwrite=True,
                     quiet=True,
                 )
@@ -609,9 +607,7 @@ def compute(
         Module(
             "r.mapcalc",
             expression="zzview{Q} =\
-            if(zzview{Q}==180,0,zzview{Q})".format(
-                Q=i
-            ),
+            if(zzview{Q}==180,0,zzview{Q})".format(Q=i),
             overwrite=True,
             quiet=True,
         )
@@ -628,9 +624,7 @@ def compute(
             if( y()<{py} && x()=={px}, 180, \
             if( y()=={py} && x()<{px}, 270, \
             if( y()>{py} && x()=={px}, 0 \
-            ) ) ) ) ) ) ) )".format(
-                A=f"zzview_angle{i}", py=y, px=x
-            ),
+            ) ) ) ) ) ) ) )".format(A=f"zzview_angle{i}", py=y, px=x),
             quiet=True,
         )
         # estimating the layer of the vertical angle between point and each
@@ -652,9 +646,7 @@ def compute(
         Module(
             "r.mapcalc",
             expression="zzb_view{Q} =\
-            cos(zzview90_{Q})*cos(zzview_angle{Q})".format(
-                Q=i
-            ),
+            cos(zzview90_{Q})*cos(zzview_angle{Q})".format(Q=i),
             quiet=True,
         )
         # evaluate the eastern component of the versor oriented along
@@ -662,9 +654,7 @@ def compute(
         Module(
             "r.mapcalc",
             expression="zza_view{Q} =\
-            cos(zzview90_{Q})*sin(zzview_angle{Q})".format(
-                Q=i
-            ),
+            cos(zzview90_{Q})*sin(zzview_angle{Q})".format(Q=i),
             quiet=True,
         )
         # estimate the three-dimensional distance between the point and
@@ -680,9 +670,7 @@ def compute(
                 Module(
                     "r.mapcalc",
                     expression="{D} = pow(pow(abs(y()-{py}),2)\
-                    +pow(abs(x()-{px}),2),0.5)".format(
-                        D=f"zzeuclidean{i}", py=y, px=x
-                    ),
+                    +pow(abs(x()-{px}),2),0.5)".format(D=f"zzeuclidean{i}", py=y, px=x),
                     quiet=True,
                 )  # Planar distance
                 Module(
@@ -727,9 +715,7 @@ def compute(
                 Module(
                     "r.mapcalc",
                     expression="{D} = pow(pow(abs(y()-{py}),2)+pow(abs(x()\
-                    -{px}),2),0.5)".format(
-                        D=f"zzeuclidean{i}", py=y, px=x
-                    ),
+                    -{px}),2),0.5)".format(D=f"zzeuclidean{i}", py=y, px=x),
                     quiet=True,
                 )  # Planar distance
                 Module(
@@ -793,9 +779,7 @@ def compute(
             Module(
                 "r.mapcalc",
                 expression="kkview_angle{Q} = if(y()>{py} && x()>={px},\
-                zzview_angle{Q}+270, zzview_angle{Q}-90)".format(
-                    Q=i, py=y, px=x
-                ),
+                zzview_angle{Q}+270, zzview_angle{Q}-90)".format(Q=i, py=y, px=x),
                 quiet=True,
             )
             # Calculating the 3 components of the K versor
@@ -816,9 +800,7 @@ def compute(
             Module(
                 "r.mapcalc",
                 expression="zz_dotproduct{Q} = kka_view{Q}*zza_dem +\
-                kkb_view{Q}*zzb_dem + kkc_view{Q}*zzc_dem".format(
-                    Q=i
-                ),
+                kkb_view{Q}*zzb_dem + kkc_view{Q}*zzc_dem".format(Q=i),
                 quiet=True,
             )
             # Calculating a, b and c components for the first part of the
@@ -826,25 +808,19 @@ def compute(
             Module(
                 "r.mapcalc",
                 expression="zzc_equation_first{Q} = kkc_view{Q}*\
-                zz_dotproduct{Q}*(1-cos({B}))".format(
-                    Q=i, B=f"zzarc{i}"
-                ),
+                zz_dotproduct{Q}*(1-cos({B}))".format(Q=i, B=f"zzarc{i}"),
                 quiet=True,
             )
             Module(
                 "r.mapcalc",
                 expression="zzb_equation_first{Q} = kkb_view{Q}*\
-                zz_dotproduct{Q}*(1-cos({B}))".format(
-                    Q=i, B=f"zzarc{i}"
-                ),
+                zz_dotproduct{Q}*(1-cos({B}))".format(Q=i, B=f"zzarc{i}"),
                 quiet=True,
             )
             Module(
                 "r.mapcalc",
                 expression="zza_equation_first{Q} = kka_view{Q}*\
-                zz_dotproduct{Q}*(1-cos({B}))".format(
-                    Q=i, B=f"zzarc{i}"
-                ),
+                zz_dotproduct{Q}*(1-cos({B}))".format(Q=i, B=f"zzarc{i}"),
                 quiet=True,
             )
             # Calculating a, b and c components for the second part of
@@ -875,25 +851,19 @@ def compute(
             Module(
                 "r.mapcalc",
                 expression="zzc_equation_third{Q} = sin({B})*(kka_view{Q}\
-                *zzb_dem - kkb_view{Q}*zza_dem)".format(
-                    Q=i, B=f"zzarc{i}"
-                ),
+                *zzb_dem - kkb_view{Q}*zza_dem)".format(Q=i, B=f"zzarc{i}"),
                 quiet=True,
             )
             Module(
                 "r.mapcalc",
                 expression="zzb_equation_third{Q} = sin({B})*(kkc_view{Q}\
-                *zza_dem - kka_view{Q}*zzc_dem)".format(
-                    Q=i, B=f"zzarc{i}"
-                ),
+                *zza_dem - kka_view{Q}*zzc_dem)".format(Q=i, B=f"zzarc{i}"),
                 quiet=True,
             )
             Module(
                 "r.mapcalc",
                 expression="zza_equation_third{Q} = sin({B})*(kkb_view{Q}\
-                *zzc_dem - kkc_view{Q}*zzb_dem)".format(
-                    Q=i, B=f"zzarc{i}"
-                ),
+                *zzc_dem - kkc_view{Q}*zzb_dem)".format(Q=i, B=f"zzarc{i}"),
                 quiet=True,
             )
 
@@ -902,25 +872,19 @@ def compute(
             Module(
                 "r.mapcalc",
                 expression="zzc_dem_curv{Q} = zzc_equation_first{Q}\
-                + zzc_equation_second{Q} + zzc_equation_third{Q}".format(
-                    Q=i
-                ),
+                + zzc_equation_second{Q} + zzc_equation_third{Q}".format(Q=i),
                 quiet=True,
             )
             Module(
                 "r.mapcalc",
                 expression="zzb_dem_curv{Q} = zzb_equation_first{Q}\
-                + zzb_equation_second{Q} + zzb_equation_third{Q}".format(
-                    Q=i
-                ),
+                + zzb_equation_second{Q} + zzb_equation_third{Q}".format(Q=i),
                 quiet=True,
             )
             Module(
                 "r.mapcalc",
                 expression="zza_dem_curv{Q} = zza_equation_first{Q}\
-                + zza_equation_second{Q} + zza_equation_third{Q}".format(
-                    Q=i
-                ),
+                + zza_equation_second{Q} + zza_equation_third{Q}".format(Q=i),
                 quiet=True,
             )
 
@@ -934,9 +898,7 @@ def compute(
                 (sqrt(zza_view{Q}*zza_view{Q}+zzb_view{Q}*zzb_view{Q}\
                 +zzc_view{Q}*zzc_view{Q})*sqrt(zza_dem_curv{Q}*zza_dem_curv{Q}\
                 +zzb_dem_curv{Q}*zzb_dem_curv{Q}+zzc_dem_curv{Q}\
-                *zzc_dem_curv{Q})))".format(
-                    Q=i
-                ),
+                *zzc_dem_curv{Q})))".format(Q=i),
                 quiet=True,
             )
         else:
@@ -946,9 +908,7 @@ def compute(
                 acos((zza_view{Q}*zza_dem+zzb_view{Q}*zzb_dem+zzc_view{Q}\
                 *zzc_dem)/(sqrt(zza_view{Q}*zza_view{Q}+zzb_view{Q}\
                 *zzb_view{Q}+zzc_view{Q}*zzc_view{Q})*sqrt(zza_dem*\
-                zza_dem+zzb_dem*zzb_dem+zzc_dem*zzc_dem)))".format(
-                    Q=i
-                ),
+                zza_dem+zzb_dem*zzb_dem+zzc_dem*zzc_dem)))".format(Q=i),
                 quiet=True,
             )
         # filtering 3d distance based on angle{Q} map
@@ -974,9 +934,7 @@ def compute(
         Module(
             "r.mapcalc",
             expression="zzH2_{Q} = pow(pow({r},2)+pow({d},2)-(2*{r}*{d}\
-            *cos(zzangle{Q}-90)),0.5)".format(
-                r=circle_radius, d=f"zzdistance{i}", Q=i
-            ),
+            *cos(zzangle{Q}-90)),0.5)".format(r=circle_radius, d=f"zzdistance{i}", Q=i),
             quiet=True,
         )
         # calculating B1 and B2 that are the angles between the line passing
@@ -1019,9 +977,7 @@ def compute(
         Module(
             "r.mapcalc",
             expression="zzsangle{Q} = if(zzsangle{Q}>2*{pi} || \
-            zzB2_{Q}>=90,2*{pi},zzsangle{Q})".format(
-                Q=i, pi=pi
-            ),
+            zzB2_{Q}>=90,2*{pi},zzsangle{Q})".format(Q=i, pi=pi),
             overwrite=True,
             quiet=True,
         )
@@ -1045,9 +1001,7 @@ def collectresults(task, proc):
         Module(
             "r.mapcalc",
             expression="{A} = if(isnull({Q}) ||| \
-            {Q}==0,{A},max({A},{Q}))".format(
-                A=f"xxtemp_a_{proc}", Q=f"zzangle{i}"
-            ),
+            {Q}==0,{A},max({A},{Q}))".format(A=f"xxtemp_a_{proc}", Q=f"zzangle{i}"),
             overwrite=True,
             quiet=True,
         )

--- a/src/raster/r.terrain.texture/r.terrain.texture.py
+++ b/src/raster/r.terrain.texture/r.terrain.texture.py
@@ -155,9 +155,7 @@ def parse_tiles(tiles):
 def laplacian_matrix(w):
     s = """TITLE Laplacian filter
     MATRIX {w}
-    """.format(
-        w=w
-    )
+    """.format(w=w)
 
     x = np.zeros((w, w))
     x[:] = -1

--- a/src/raster/r.zonal.classes/r.zonal.classes.py
+++ b/src/raster/r.zonal.classes/r.zonal.classes.py
@@ -214,9 +214,9 @@ def main():
         if (
             row[0] not in totals_dict
         ):  # Will pass the condition only if the current zone ID does not exists yet in the dictionary
-            totals_dict[row[0]] = (
-                {}
-            )  # Declare a new embedded dictionnary for the current zone ID
+            totals_dict[
+                row[0]
+            ] = {}  # Declare a new embedded dictionnary for the current zone ID
         if (
             flags["l"] and row[1] in classes_list
         ):  # Will pass only if flag -l is active and if the current class is in the 'classes_list'

--- a/src/vector/v.rast.bufferstats/v.rast.bufferstats.py
+++ b/src/vector/v.rast.bufferstats/v.rast.bufferstats.py
@@ -374,9 +374,7 @@ def main():
     if in_mapset and unicode(in_mapset) != unicode(Mapset()):
         grass.fatal(
             "Input vector map is not in current mapset and cannot be modified. \
-                    Please consider copying it to current mapset.".format(
-                output
-            )
+                    Please consider copying it to current mapset.".format(output)
         )
 
     buffers = []

--- a/src/vector/v.what.strds.timestamp/v.what.strds.timestamp.py
+++ b/src/vector/v.what.strds.timestamp/v.what.strds.timestamp.py
@@ -102,9 +102,7 @@ def sample_relative(input, layer, timestamp_column, column, t_raster, where, i_f
     end = t_raster["end_time"]
     raster_map = "{}@{}".format(t_raster["name"], t_raster["mapset"])
     where += """(julianday({0}) >= date('{1}') AND \
-                julianday({0}) < date('{2}'))""".format(
-        timestamp_column, start, end
-    )
+                julianday({0}) < date('{2}'))""".format(timestamp_column, start, end)
 
 
 def sample_absolute(input, layer, timestamp_column, column, t_raster, where, i_flag):
@@ -113,9 +111,7 @@ def sample_absolute(input, layer, timestamp_column, column, t_raster, where, i_f
     end = t_raster["end_time"]
     raster_map = "{}@{}".format(t_raster["name"], t_raster["mapset"])
     where += """({0} >= date('{1}') AND \
-                {0} < date('{2}'))""".format(
-        timestamp_column, start, end
-    )
+                {0} < date('{2}'))""".format(timestamp_column, start, end)
 
     grass.verbose(_("Sampling points between {} and {}".format(start, end)))
 
@@ -190,9 +186,7 @@ def main():
             _(
                 "Could not find column {} \
                     in table connected to vector map {} \
-                    at layer {}".format(
-                    timestamp_column, input, layer
-                )
+                    at layer {}".format(timestamp_column, input, layer)
             )
         )
     if cols[timestamp_column]["type"] != "DATE":
@@ -204,9 +198,7 @@ def main():
                 _(
                     "Timestamp column is of type {}. \
                             It is recommended to use DATE type with an index. \
-                            ".format(
-                        cols[timestamp_column]["type"]
-                    )
+                            ".format(cols[timestamp_column]["type"])
                 )
             )
 
@@ -228,9 +220,7 @@ def main():
         grass.verbose(
             _(
                 "Temporal extent of vector points map is \
-                      {} to {}".format(
-                    extent[0], extent[1]
-                )
+                      {} to {}".format(extent[0], extent[1])
             )
         )
     else:

--- a/utils/std_dataset_display.py
+++ b/utils/std_dataset_display.py
@@ -38,9 +38,7 @@ def legend_item(color, text, x, y):
         {x1} {y1}
         {x2} {y1}
         {x2} {y2}
-    """.format(
-            color=color, x1=x, y1=y, x2=x + 2, y2=y + 2
-        ),
+    """.format(color=color, x1=x, y1=y, x2=x + 2, y2=y + 2),
     )
     gscript.run_command("d.text", text=text, at=(x + 3, y + 0.5), size=2, color="black")
 


### PR DESCRIPTION
Equivalent PR of https://github.com/OSGeo/grass/pull/5023.

Applied here to help keep both repos contributing workflows similar.

For the post-pr-reviews workflow, it is intended to keep the old name of the workflow, so it can still continue to send review comments for PRs that aren't updated yet. The old workflow name could be removed from the list of triggers later on (like once all currently open PRs are either closed, merged, or updated from main. That file now only has the list of workflow names to run against that differs from the file in the main repo (that's why we see a bit more changes than the strict minimum).
I intend to group other tools in that workflow, thus the generic tile and file name, but for now, flake8 (running in its own workflow file) is a required check, so the name of the job+workflow cannot be changed unless the repo's settings are changed.
