### PR TITLE
r.subdayprecip.design: do not limit raster names by return periods

### DIFF
--- a/src/raster/r.subdayprecip.design/r.subdayprecip.design.py
+++ b/src/raster/r.subdayprecip.design/r.subdayprecip.design.py
@@ -252,9 +252,7 @@ def main():
         # calculate output values, update attribute table
         coef = a * rl ** (1 - c)
         expression = "{}_average * {}".format(rast_name, coef)
-        Module(
-            "v.db.update", map=opt["map"], column=rast_name, query_column=expression
-        )
+        Module("v.db.update", map=opt["map"], column=rast_name, query_column=expression)
 
         if check_area_size:
             Module(
@@ -266,7 +264,9 @@ def main():
             )
 
         # remove unused column
-        Module("v.db.dropcolumn", map=opt["map"], columns="{}_average".format(rast_name))
+        Module(
+            "v.db.dropcolumn", map=opt["map"], columns="{}_average".format(rast_name)
+        )
 
     if check_area_size:
         # remove unused column

--- a/src/raster/r.subdayprecip.design/r.subdayprecip.design.py
+++ b/src/raster/r.subdayprecip.design/r.subdayprecip.design.py
@@ -242,8 +242,12 @@ def main():
         if a is None or c is None:
             allowed_return_period = ("N2", "N5", "N10", "N20", "N50", "N100")
             if not any(n in rast for n in allowed_return_period):
-                grass.error("Unable to determine return period from raster name: <{}>. "
-                            "Allowed return periods: {}".format(rast, ','.join(allowed_return_period)))
+                grass.error(
+                    "Unable to determine return period from raster name: <{}>. "
+                    "Allowed return periods: {}".format(
+                        rast, ",".join(allowed_return_period)
+                    )
+                )
             grass.fatal("Unable to calculate coefficients")
 
         # calculate output values, update attribute table

--- a/src/raster/r.subdayprecip.design/r.subdayprecip.design.py
+++ b/src/raster/r.subdayprecip.design/r.subdayprecip.design.py
@@ -30,7 +30,6 @@
 # %option G_OPT_R_INPUTS
 # % key: return_period
 # % description: Rainfall raster maps of required return period
-# % options: N2,N5,N10,N20,N50,N100
 # %end
 
 # %option
@@ -58,7 +57,7 @@ from grass.exceptions import CalledModuleError
 
 def coeff(name, rl):
     a = c = None
-    if name == "N2":
+    if "N2" in name:
         if rl < 40:
             a = 0.166
             c = 0.701
@@ -68,7 +67,7 @@ def coeff(name, rl):
         elif rl < 1440:
             a = 0.235
             c = 0.801
-    elif name == "N5":
+    elif "N5" in name:
         if rl < 40:
             a = 0.171
             c = 0.688
@@ -78,7 +77,7 @@ def coeff(name, rl):
         elif rl < 1440:
             a = 0.324
             c = 0.845
-    elif name == "N10":
+    elif "N10" in name:
         if rl < 40:
             a = 0.163
             c = 0.656
@@ -88,7 +87,7 @@ def coeff(name, rl):
         elif rl < 1440:
             a = 0.380
             c = 0.867
-    elif name == "N20":
+    elif "N20" in name:
         if rl < 40:
             a = 0.169
             c = 0.648
@@ -98,7 +97,7 @@ def coeff(name, rl):
         elif rl < 1440:
             a = 0.463
             c = 0.894
-    elif name == "N50":
+    elif "N50" in name:
         if rl < 40:
             a = 0.174
             c = 0.638
@@ -108,7 +107,7 @@ def coeff(name, rl):
         elif rl < 1440:
             a = 0.580
             c = 0.925
-    elif name == "N100":
+    elif "N100" in name:
         if rl < 40:
             a = 0.173
             c = 0.625
@@ -135,8 +134,6 @@ def main():
         columns = grass.vector_columns(opt["map"]).keys()
     except CalledModuleError as e:
         return 1
-
-    allowed_rasters = ("N2", "N5", "N10", "N20", "N50", "N100")
 
     # test input feature type
     vinfo = grass.vector_info_topo(opt["map"])
@@ -179,11 +176,6 @@ def main():
         name = grass.find_file(rast, element="cell")["name"]
         if not name:
             grass.warning("Raster map <{}> not found. Skipped.".format(rast))
-            continue
-        if name not in allowed_rasters:
-            grass.warning(
-                "Raster map <{}> skipped. Allowed: {}".format(rast, allowed_rasters)
-            )
             continue
 
         # perform zonal statistics
@@ -248,6 +240,10 @@ def main():
         # determine coefficient for calculation
         a, c = coeff(rast, rl)
         if a is None or c is None:
+            allowed_return_period = ("N2", "N5", "N10", "N20", "N50", "N100")
+            if not any(n in rast for n in allowed_return_period):
+                grass.error("Unable to determine return period from raster name: <{}>. "
+                            "Allowed return periods: {}".format(rast, ','.join(allowed_return_period)))
             grass.fatal("Unable to calculate coefficients")
 
         # calculate output values, update attribute table

--- a/src/raster/r.subdayprecip.design/r.subdayprecip.design.py
+++ b/src/raster/r.subdayprecip.design/r.subdayprecip.design.py
@@ -173,21 +173,21 @@ def main():
     # extract multi values to points
     for rast in opt["return_period"].split(","):
         # check valid rasters
-        name = grass.find_file(rast, element="cell")["name"]
-        if not name:
+        rast_name = grass.find_file(rast, element="cell")["name"]
+        if not rast_name:
             grass.warning("Raster map <{}> not found. Skipped.".format(rast))
             continue
 
         # perform zonal statistics
         grass.message("Processing <{}>...".format(rast))
-        table = "{}_table".format(name)
+        table = "{}_table".format(rast_name)
         if vinfo["areas"] > 0:
             Module(
                 "v.rast.stats",
                 flags="c",
                 map=opt["map"],
                 raster=rast,
-                column_prefix=name,
+                column_prefix=rast_name,
                 method="average",
                 quiet=True,
             )
@@ -197,7 +197,7 @@ def main():
                 map=opt["map"],
                 columns="cat",
                 flags="c",
-                where="{}_average is NULL".format(name),
+                where="{}_average is NULL".format(rast_name),
                 stdout_=grass.PIPE,
             )
             cats = null_values.outputs.stdout.splitlines()
@@ -214,8 +214,8 @@ def main():
                     map=opt["map"],
                     raster=rast,
                     type="centroid",
-                    column="{}_average".format(name),
-                    where="{}_average is NULL".format(name),
+                    column="{}_average".format(rast_name),
+                    where="{}_average is NULL".format(rast_name),
                     quiet=True,
                 )
         else:  # -> points
@@ -223,18 +223,17 @@ def main():
                 "v.what.rast",
                 map=opt["map"],
                 raster=rast,
-                column="{}_average".format(name),
+                column="{}_average".format(rast_name),
                 quiet=True,
             )
 
         # add column to the attribute table if not exists
         rl = float(opt["rainlength"])
-        field_name = "H_{}T{}".format(name, opt["rainlength"])
-        if field_name not in columns:
+        if rast_name not in columns:
             Module(
                 "v.db.addcolumn",
                 map=opt["map"],
-                columns="{} double precision".format(field_name),
+                columns="{} double precision".format(rast_name),
             )
 
         # determine coefficient for calculation
@@ -252,22 +251,22 @@ def main():
 
         # calculate output values, update attribute table
         coef = a * rl ** (1 - c)
-        expression = "{}_average * {}".format(name, coef)
+        expression = "{}_average * {}".format(rast_name, coef)
         Module(
-            "v.db.update", map=opt["map"], column=field_name, query_column=expression
+            "v.db.update", map=opt["map"], column=rast_name, query_column=expression
         )
 
         if check_area_size:
             Module(
                 "v.db.update",
                 map=opt["map"],
-                column=field_name,
+                column=rast_name,
                 value="-1",
                 where="{} > {}".format(area_col_name, opt["area_size"]),
             )
 
         # remove unused column
-        Module("v.db.dropcolumn", map=opt["map"], columns="{}_average".format(name))
+        Module("v.db.dropcolumn", map=opt["map"], columns="{}_average".format(rast_name))
 
     if check_area_size:
         # remove unused column


### PR DESCRIPTION
Currently r.subdayprecip.design requires raster names with the same name given by return_period option:

```
r.subdayprecip.design.py map=point return_period=N2,N25 rainlength=360
WARNING: Raster map <N2> not found. Skipped.
WARNING: Raster map <N5> not found. Skipped.
```

This PR relaxes this rule:

```
r.subdayprecip.design.py map=point return_period=H_N2T360@rain6h,H_N5T360@rain6h rainlength=360
Processing <H_N2T360@rain6h>...
Processing <H_N5T360@rain6h>...
```

The module ends with error in the case that return period cannot be determined from raster name:

```
r.subdayprecip.design.py map=point return_period=H_N1T360 rainlength=360
Processing <H_N1T360>...
ERROR: Unable to determine return period from raster name: <H_N1T360>.
       Allowed return periods: N2,N5,N10,N20,N50,N100
ERROR: Unable to calculate coefficients
```
