### PR TITLE
checks(Ruff): Configure ruff linter

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -44,11 +44,24 @@ jobs:
           python -m pip install --upgrade pip
           pip install ruff==${{ env.RUFF_VERSION }}
 
-      - name: Run ruff formatter
-        run: |
-          ruff format
-      - name: Create and uploads code suggestions to apply
-        id: diff
+      - name: Run Ruff (output annotations on fixable errors)
+        run: ruff check --output-format=github . --preview --unsafe-fixes
+        continue-on-error: true
+      - name: Run Ruff (apply fixes for suggestions)
+        run: ruff check . --preview --fix --unsafe-fixes
+      - name: Run `ruff format` showing diff without failing
+        continue-on-error: true
+        if: ${{ !cancelled() }}
+        run: ruff format --diff
+      - name: Run `ruff format` fixing files
+        # Run `ruff format` even when `ruff check` fixed files: fixes can require formatting
+        if: ${{ !cancelled() }}
+        run: ruff format
+      - name: Create and uploads code suggestions to apply for Ruff
+        # Will fail fast here if there are changes required
+        id: diff-ruff
+        # To run after ruff step exits with failure when rules don't have fixes available
+        if: ${{ !cancelled() }}
         uses: OSGeo/grass/.github/actions/create-upload-suggestions@main
         with:
           tool-name: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,8 @@ repos:
     # Ruff version.
     rev: v0.9.5
     hooks:
+      # Run the linter.
+      - id: ruff
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,5 +26,413 @@ extend-exclude = '''
 '''
 
 [tool.ruff]
-required-version = ">=0.9.4"
 builtins = ["_"]
+required-version = ">=0.9.5"
+
+[tool.ruff.lint]
+# See https://docs.astral.sh/ruff/rules/
+select = [
+    "A",     # flake8-builtins (A)
+    "AIR",   # Airflow (AIR)
+    "ANN",   # flake8-annotations (ANN)
+    "ARG",   # flake8-unused-arguments (ARG)
+    "ASYNC", # flake8-async (ASYNC)
+    "B",     # flake8-bugbear (B)
+    "BLE",   # flake8-blind-except (BLE)
+    "C4",    # flake8-comprehensions (C4)
+    "COM",   # flake8-commas (COM)
+    "D",     # pydocstyle (D)
+    "D202",  # pydocstyle (D) blank-line-after-function
+    "D209",  # pydocstyle (D) new-line-after-last-paragraph
+    "D211",  # pydocstyle (D) blank-line-before-class
+    "D212",  # pydocstyle (D) multi-line-summary-first-line
+    "DOC",   # pydoclint (DOC)
+    "DTZ",   # flake8-datetimez (DTZ)
+    "E",     # pycodestyle (E, W)
+    "EM",    # flake8-errmsg (EM)
+    "EXE",   # flake8-executable (EXE)
+    "F",     # Pyflakes (F)
+    "FA",    # flake8-future-annotations (FA)
+    "FBT",   # flake8-boolean-trap (FBT)
+    "FLY",   # flynt (FLY)
+    "FURB",  # refurb (FURB)
+    "G",     # flake8-logging-format (G)
+    "I",     # isort (I)
+    "ICN",   # flake8-import-conventions (ICN)
+    "INP",   # flake8-no-pep420 (INP)
+    "INT",   # flake8-gettext (INT)
+    "ISC",   # flake8-implicit-str-concat (ISC)
+    "LOG",   # flake8-logging (LOG)
+    "N",     # pep8-naming (N)
+    "NPY",   # NumPy-specific rules (NPY)
+    "PD",    # pandas-vet (PD)
+    "PERF",  # Perflint (PERF)
+    "PGH",   # pygrep-hooks (PGH)
+    "PIE",   # flake8-pie (PIE)
+    "PLC",   # Pylint (PL) Convention (C)
+    "PLE",   # Pylint (PL) Error (E)
+    "PLR",   # Pylint (PL) Refactor (R)
+    "PLW",   # Pylint (PL) Warning (W)
+    "PT",    # flake8-pytest-style (PT)
+    "PTH",   # flake8-use-pathlib (PTH)
+    "PYI",   # flake8-pyi (PYI)
+    "Q",     # flake8-quotes (Q)
+    "RET",   # flake8-return (RET)
+    "RSE",   # flake8-raise (RSE)
+    "RUF",   # Ruff-specific rules (RUF)
+    "S",     # flake8-bandit (S)
+    "SIM",   # flake8-simplify (SIM)
+    "SLF",   # flake8-self (SLF)
+    "SLOT",  # flake8-slots (SLOT)
+    "T10",   # flake8-debugger (T10)
+    "TC",    # flake8-type-checking (TC)
+    "TID",   # flake8-tidy-imports (TID)
+    "TRY",   # tryceratops (TRY)
+    "UP",    # pyupgrade (UP)
+    "W",     # pycodestyle (E, W)
+    "YTT",   # flake8-2020 (YTT)
+]
+
+ignore = [
+    # See https://docs.astral.sh/ruff/rules/
+    # *GRASS TODO: fix the issues, or use https://docs.astral.sh/ruff/settings/#lint_per-file-ignores
+    "A001",    # builtin-variable-shadowing
+    "A002",    # builtin-argument-shadowing
+    "A004",    # builtin-import-shadowing
+    "ANN",     # flake8-annotations (ANN)
+    "ARG001",  # unused-function-argument
+    "ARG002",  # unused-method-argument
+    "ARG005",  # unused-lambda-argument
+    "B005",    # strip-with-multi-characters
+    "B006",    # mutable-argument-default
+    "B007",    # unused-loop-control-variable
+    "B008",    # function-call-in-default-argument
+    "B009",    # get-attr-with-constant
+    "B012",    # jump-statement-in-finally
+    "B018",    # useless-expression
+    "B020",    # loop-variable-overrides-iterator
+    "B023",    # function-uses-loop-variable
+    "B034",    # re-sub-positional-args
+    "B904",    # raise-without-from-inside-except
+    "B909",    # loop-iterator-mutation
+    "BLE001",  # blind-except
+    "C401",    # unnecessary-generator-set
+    "C402",    # unnecessary-generator-dict
+    "C403",    # unnecessary-list-comprehension-set
+    "C404",    # unnecessary-list-comprehension-dict
+    "C405",    # unnecessary-literal-set
+    "C408",    # unnecessary-collection-call
+    "C409",    # unnecessary-literal-within-tuple-call
+    "C411",    # unnecessary-list-call
+    "C414",    # unnecessary-double-cast-or-process
+    "C416",    # unnecessary-comprehension
+    "C417",    # unnecessary-map
+    "C419",    # unnecessary-comprehension-in-call
+    "COM812",  # missing-trailing-comma
+    "D1",      # pydocstyle (D), undocumented-*
+    "D200",    # unnecessary-multiline-docstring
+    "D202",    # blank-line-after-function (selected)
+    "D203",    # incorrect-blank-line-before-class (ignored, use D211)
+    "D205",    # missing-blank-line-after-summary
+    "D208",    # over-indentation
+    "D209",    # new-line-after-last-paragraph (selected)
+    "D210",    # surrounding-whitespace
+    "D212",    # multi-line-summary-first-line (selected)
+    "D213",    # multi-line-summary-second-line (ignored, use D212)
+    "D214",    # overindented-section
+    "D215",    # overindented-section-underline
+    "D300",    # triple-single-quotes
+    "D301",    # escape-sequence-in-docstring
+    "D400",    # missing-trailing-period
+    "D401",    # non-imperative-mood
+    "D402",    # signature-in-docstring
+    "D403",    # first-word-uncapitalized
+    "D404",    # docstring-starts-with-this
+    "D405",    # non-capitalized-section-name
+    "D406",    # missing-new-line-after-section-name
+    "D407",    # missing-dashed-underline-after-section
+    "D409",    # mismatched-section-underline-length
+    "D410",    # no-blank-line-after-section
+    "D411",    # no-blank-line-before-section
+    "D412",    # blank-lines-between-header-and-content
+    "D413",    # missing-blank-line-after-last-section
+    "D414",    # empty-docstring-section
+    "D415",    # missing-terminal-punctuation
+    "D416",    # missing-section-name-colon
+    "D417",    # undocumented-param
+    "D419",    # empty-docstring
+    "DOC201",  # docstring-missing-returns
+    "DOC202",  # docstring-extraneous-returns
+    "DOC402",  # docstring-missing-yields
+    "DOC501",  # docstring-missing-exception
+    "DTZ001",  # call-datetime-without-tzinfo
+    "DTZ004",  # call-datetime-utcfromtimestamp
+    "DTZ005",  # call-datetime-now-without-tzinfo
+    "DTZ006",  # call-datetime-fromtimestamp
+    "DTZ007",  # call-datetime-strptime-without-zone
+    "DTZ011",  # call-date-today
+    "E265",    # no-space-after-block-comment
+    "E266",    # multiple-leading-hashes-for-block-comment
+    "E402",    # module-import-not-at-top-of-file
+    "E501",    # line-too-long
+    "E712",    # true-false-comparison
+    "E713",    # not-in-test
+    "E722",    # bare-except
+    "E741",    # ambiguous-variable-name
+    "EM101",   # raw-string-in-exception
+    "EM102",   # f-string-in-exception
+    "EM103",   # dot-format-in-exception
+    "EXE001",  # shebang-not-executable
+    "EXE002",  # shebang-missing-executable-file
+    "EXE003",  # shebang-missing-python
+    "EXE005",  # shebang-not-first-line
+    "F401",    # unused-import
+    "F402",    # import-shadowed-by-loop-var
+    "F403",    # undefined-local-with-import-star
+    "F405",    # undefined-local-with-import-star-usage
+    "F507",    # percent-format-positional-count-mismatch
+    "F509",    # percent-format-unsupported-format-character
+    "F521",    # string-dot-format-invalid-format
+    "F522",    # string-dot-format-extra-named-arguments
+    "F523",    # string-dot-format-extra-positional-arguments
+    "F632",    # is-literal
+    "F811",    # redefined-while-unused
+    "F821",    # undefined-name
+    "F823",    # undefined-local
+    "F841",    # unused-variable
+    "FBT002",  # boolean-default-value-positional-argument
+    "FBT003",  # boolean-positional-value-in-call
+    "FLY002",  # static-join-to-f-string
+    "FURB101", # read-whole-file
+    "FURB103", # write-whole-file
+    "FURB105", # print-empty-string
+    "FURB110", # if-exp-instead-of-or-operator
+    "FURB113", # repeated-append
+    "FURB118", # reimplemented-operator
+    "FURB122", # for-loop-writes
+    "FURB129", # readlines-in-for
+    "FURB136", # if-expr-min-max
+    "FURB140", # reimplemented-starmap
+    "FURB145", # slice-copy
+    "FURB148", # unnecessary-enumerate
+    "FURB152", # math-constant
+    "FURB154", # repeated-global
+    "FURB163", # redundant-log-base
+    "FURB171", # single-item-membership-test
+    "FURB187", # list-reverse-copy
+    "FURB192", # sorted-min-max
+    "G001",    # logging-string-format
+    "G002",    # logging-percent-format
+    "G003",    # logging-string-concat
+    "I001",    # unsorted-imports
+    "ICN001",  # unconventional-import-alias
+    "INP001",  # implicit-namespace-package
+    "INT001",  # f-string-in-get-text-func-call
+    "INT002",  # format-in-get-text-func-call
+    "INT003",  # printf-in-get-text-func-call
+    "ISC003",  # explicit-string-concatenation
+    "LOG015",  # root-logger-call
+    "N801",    # invalid-class-name
+    "N802",    # invalid-function-name
+    "N803",    # invalid-argument-name
+    "N804",    # invalid-first-argument-name-for-class-method
+    "N805",    # invalid-first-argument-name-for-method
+    "N806",    # non-lowercase-variable-in-function
+    "N811",    # constant-imported-as-non-constant
+    "N812",    # lowercase-imported-as-non-lowercase
+    "N813",    # camelcase-imported-as-lowercase
+    "N815",    # mixed-case-variable-in-class-scope
+    "N816",    # mixed-case-variable-in-global-scope
+    "N817",    # camelcase-imported-as-acronym
+    "N818",    # error-suffix-on-exception-name
+    "N999",    # invalid-module-name
+    "NPY001",  # numpy-deprecated-type-alias
+    "NPY002",  # numpy-legacy-random
+    "NPY201",  # numpy2-deprecation
+    "PD002",   # pandas-use-of-inplace-argument
+    "PD011",   # pandas-use-of-dot-values
+    "PD015",   # pandas-use-of-pd-merge
+    "PD901",   # pandas-df-variable-name
+    "PERF102", # incorrect-dict-iterator
+    "PERF203", # try-except-in-loop
+    "PERF401", # manual-list-comprehension
+    "PERF402", # manual-list-copy
+    "PERF403", # manual-dict-comprehension
+    "PGH004",  # blanket-noqa
+    "PIE790",  # unnecessary-placeholder
+    "PIE800",  # unnecessary-spread
+    "PIE808",  # unnecessary-range-start
+    "PIE810",  # multiple-starts-ends-with
+    "PLC0206", # dict-index-missing-items
+    "PLC0414", # useless-import-alias
+    "PLC0415", # import-outside-top-level
+    "PLC1901", # compare-to-empty-string
+    "PLC2701", # import-private-name
+    "PLC2801", # unnecessary-dunder-call
+    "PLE0704", # misplaced-bare-raise
+    "PLE1300", # bad-string-format-character
+    "PLR0124", # comparison-with-itself
+    "PLR0133", # comparison-of-constant
+    "PLR0402", # manual-from-import
+    "PLR0904", # too-many-public-methods
+    "PLR0911", # too-many-return-statements
+    "PLR0912", # too-many-branches
+    "PLR0913", # too-many-arguments
+    "PLR0914", # too-many-locals
+    "PLR0915", # too-many-statements
+    "PLR0916", # too-many-boolean-expressions
+    "PLR0917", # too-many-positional-arguments
+    "PLR1702", # too-many-nested-blocks
+    "PLR1704", # redefined-argument-from-local
+    "PLR1711", # useless-return
+    "PLR1714", # repeated-equality-comparison
+    "PLR1722", # sys-exit-alias
+    "PLR1730", # if-stmt-min-max
+    "PLR1736", # unnecessary-list-index-lookup
+    "PLR2004", # magic-value-comparison
+    "PLR2044", # empty-comment
+    "PLR5501", # collapsible-else-if
+    "PLR6104", # non-augmented-assignment
+    "PLR6201", # literal-membership
+    "PLR6301", # no-self-use
+    "PLW0108", # unnecessary-lambda
+    "PLW0127", # self-assigning-variable
+    "PLW0128", # redeclared-assigned-name
+    "PLW0133", # useless-exception-statement
+    "PLW0602", # global-variable-not-assigned
+    "PLW0603", # global-statement
+    "PLW0604", # global-at-module-level
+    "PLW1501", # bad-open-mode
+    "PLW1508", # invalid-envvar-default
+    "PLW1510", # subprocess-run-without-check
+    "PLW1514", # unspecified-encoding
+    "PLW2901", # redefined-loop-name
+    "PT009",   # pytest-unittest-assertion
+    "PT027",   # pytest-unittest-raises-assertion
+    "PT028",   # pytest-parameter-with-default-argument
+    "PTH100",  # os-path-abspath
+    "PTH101",  # os-chmod
+    "PTH102",  # os-mkdir
+    "PTH103",  # os-makedirs
+    "PTH104",  # os-rename
+    "PTH107",  # os-remove
+    "PTH108",  # os-unlink
+    "PTH109",  # os-getcwd
+    "PTH110",  # os-path-exists
+    "PTH111",  # os-path-expanduser
+    "PTH112",  # os-path-isdir
+    "PTH113",  # os-path-isfile
+    "PTH116",  # os-stat
+    "PTH117",  # os-path-isabs
+    "PTH118",  # os-path-join
+    "PTH119",  # os-path-basename
+    "PTH120",  # os-path-dirname
+    "PTH122",  # os-path-splitext
+    "PTH123",  # builtin-open
+    "PTH124",  # py-path
+    "PTH202",  # os-path-getsize
+    "PTH204",  # os-path-getmtime
+    "PTH205",  # os-path-getctime
+    "PTH207",  # glob
+    "PTH208",  # os-listdir
+    "PYI006",  # bad-version-info-comparison
+    "PYI024",  # collections-named-tuple
+    "RET50",   # flake8-return (RET)
+    "RSE102",  # unnecessary-paren-on-raise-exception
+    "RUF001",  # ambiguous-unicode-character-string
+    "RUF002",  # ambiguous-unicode-character-docstring
+    "RUF003",  # ambiguous-unicode-character-comment
+    "RUF005",  # collection-literal-concatenation
+    "RUF010",  # explicit-f-string-type-conversion
+    "RUF012",  # mutable-class-default
+    "RUF015",  # unnecessary-iterable-allocation-for-first-element
+    "RUF019",  # unnecessary-key-check
+    "RUF027",  # missing-f-string-syntax
+    "RUF039",  # unraw-re-pattern
+    "RUF046",  # unnecessary-cast-to-int
+    "RUF047",  # needless-else
+    "RUF051",  # if-key-in-dict-del
+    "RUF052",  # used-dummy-variable
+    "RUF055",  # unnecessary-regular-expression
+    "RUF100",  # unused-noqa
+    "S101",    # assert
+    "S102",    # exec-builtin
+    "S104",    # hardcoded-bind-all-interfaces
+    "S105",    # hardcoded-password-string
+    "S108",    # hardcoded-temp-file
+    "S110",    # try-except-pass
+    "S112",    # try-except-continue
+    "S113",    # request-without-timeout
+    "S202",    # tarfile-unsafe-members
+    "S307",    # suspicious-eval-usage
+    "S310",    # suspicious-url-open-usage
+    "S311",    # suspicious-non-cryptographic-random-usage
+    "S314",    # suspicious-xml-element-tree-usage
+    "S318",    # suspicious-xml-mini-dom-usage
+    "S320",    # suspicious-xmle-tree-usage
+    "S321",    # suspicious-ftp-lib-usage
+    "S324",    # hashlib-insecure-hash-function
+    "S402",    # suspicious-ftplib-import
+    "S403",    # suspicious-pickle-import
+    "S404",    # suspicious-subprocess-import
+    "S405",    # suspicious-xml-etree-import
+    "S408",    # suspicious-xml-minidom-import
+    "S602",    # subprocess-popen-with-shell-equals-true
+    "S603",    # subprocess-without-shell-equals-true
+    "S604",    # call-with-shell-equals-true
+    "S605",    # start-process-with-a-shell
+    "S607",    # start-process-with-partial-path
+    "S608",    # hardcoded-sql-expression
+    "SIM102",  # collapsible-if
+    "SIM103",  # needless-bool
+    "SIM105",  # suppressible-exception
+    "SIM107",  # return-in-try-except-finally
+    "SIM108",  # if-else-block-instead-of-if-exp
+    "SIM109",  # compare-with-tuple
+    "SIM110",  # reimplemented-builtin
+    "SIM112",  # uncapitalized-environment-variables
+    "SIM113",  # enumerate-for-loop
+    "SIM114",  # if-with-same-arms
+    "SIM115",  # open-file-with-context-handler
+    "SIM117",  # multiple-with-statements
+    "SIM118",  # in-dict-keys
+    "SIM201",  # negate-equal-op
+    "SIM210",  # if-expr-with-true-false
+    "SIM211",  # if-expr-with-false-true
+    "SIM212",  # if-expr-with-twisted-arms
+    "SIM222",  # expr-or-true
+    "SIM223",  # expr-and-false
+    "SIM300",  # yoda-conditions
+    "SIM401",  # if-else-block-instead-of-dict-get
+    "SIM910",  # dict-get-with-none-default
+    "SLF001",  # private-member-access
+    "T100",    # debugger
+    "TRY002",  # raise-vanilla-class
+    "TRY003",  # raise-vanilla-args
+    "TRY004",  # type-check-without-type-error
+    "TRY201",  # verbose-raise
+    "TRY300",  # try-consider-else
+    "TRY301",  # raise-within-try
+    "TRY400",  # error-instead-of-exception
+    "TRY401",  # verbose-log-message
+    "UP004",   # useless-object-inheritance
+    "UP008",   # super-call-with-parameters
+    "UP009",   # utf8-encoding-declaration
+    "UP010",   # unnecessary-future-import
+    "UP012",   # unnecessary-encode-utf8
+    "UP015",   # redundant-open-modes
+    "UP018",   # native-literals
+    "UP020",   # open-alias
+    "UP021",   # replace-universal-newlines
+    "UP022",   # replace-stdout-stderr
+    "UP023",   # deprecated-c-element-tree
+    "UP024",   # os-error-alias
+    "UP028",   # yield-in-for-loop
+    "UP029",   # unnecessary-builtin-import
+    "UP030",   # format-literals
+    "UP031",   # printf-string-formatting
+    "UP032",   # f-string
+    "UP034",   # extraneous-parentheses
+    "UP035",   # deprecated-import
+    "UP036",   # outdated-version-block
+]


### PR DESCRIPTION
Just like when ruff was introduced in the main GRASS repo in https://github.com/OSGeo/grass/pull/3972, this PR adds the ruff linter to grass-addons, but starts by excluding all rules that have errors. This sets the baseline, such as the code can't get worse than what it currently is.

This PR also configures ruff pre-commit like the main GRASS repo.
This PR also configures ruff in CI with suggestions, with the same patterns used in the main GRASS repo.

Following what is used in the grass repo helps to reduce maintenance, as the files can be directly compared.