### PR TITLE
style: Fix format-in-get-text-func-call (INT002) in r.estimap.recreation

### DIFF
--- a/src/raster/r.estimap.recreation/estimap_recreation/components.py
+++ b/src/raster/r.estimap.recreation/estimap_recreation/components.py
@@ -34,8 +34,7 @@ def append_map_to_component(raster, component_name, component_list):
     """
     component_list.append(raster)
     msg = "Map {name} included in the '{component}' component"
-    msg = msg.format(name=raster, component=component_name)
-    grass.verbose(_(msg))
+    grass.verbose(_(msg).format(name=raster, component=component_name))
 
 
 def smooth_component(component, method, size):
@@ -47,8 +46,7 @@ def smooth_component(component, method, size):
     size:
     """
     try:
-        msg = "Smoothing component '{c}'"
-        grass.verbose(_(msg.format(c=component)))
+        grass.verbose(_("Smoothing component '{c}'").format(c=component))
         if len(component) > 1:
             for item in component:
                 smooth_map(item, method=method, size=size)

--- a/src/raster/r.estimap.recreation/estimap_recreation/demand.py
+++ b/src/raster/r.estimap.recreation/estimap_recreation/demand.py
@@ -91,8 +91,7 @@ def build_unmet_demand_expression(
     # build_distance_function().
 
     msg = "Expression for distance category '{d}': {e}"
-    msg = msg.format(d=distance_category, e=unmet_demand_expression)
-    grass.debug(_(msg))
+    grass.debug(_(msg).format(d=distance_category, e=unmet_demand_expression))
 
     # build expressions -- explicit: use the 'score' kwarg!
     expression = (
@@ -103,7 +102,7 @@ def build_unmet_demand_expression(
     )
     if not real_numbers:
         expression = "round(" + expression + ")"
-    grass.debug(_("Mapcalc expression: {e}".format(e=expression)))
+    grass.debug(_("Mapcalc expression: {e}").format(e=expression))
 
     # replace keywords appropriately
     unmet_demand_expression = expression.format(
@@ -112,8 +111,8 @@ def build_unmet_demand_expression(
         distance_category=distance_category,
     )
 
-    msg = "Big expression (after formatting): {e}".format(e=unmet_demand_expression)
-    grass.debug(_(msg))
+    msg = "Big expression (after formatting): {e}"
+    grass.debug(_(msg).format(e=unmet_demand_expression))
 
     return unmet_demand_expression
 
@@ -188,7 +187,7 @@ def compute_unmet_demand(
     # integration to build_distance_function().
 
     msg = "*** Unmet demand function: {f}"
-    grass.debug(_(msg.format(f=unmet_demand_expression)))
+    grass.debug(_(msg).format(f=unmet_demand_expression))
 
     unmet_demand_equation = EQUATION.format(
         result=output_unmet_demand, expression=unmet_demand_expression

--- a/src/raster/r.estimap.recreation/estimap_recreation/distance.py
+++ b/src/raster/r.estimap.recreation/estimap_recreation/distance.py
@@ -71,19 +71,19 @@ def build_distance_function(
 
     function = " ( {numerator} ) / ( {denominator} )"
     function = function.format(numerator=numerator, denominator=denominator)
-    grass.debug("Function without score: {f}".format(f=function))
+    grass.debug("Function without score: {f}").format(f=function)
 
     if score:
         function += " * {score}"  # need for float()?
         function = function.format(score=score)
-    grass.debug(_("*** Function after adding 'score': {f}".format(f=function)))
+    grass.debug(_("*** Function after adding 'score': {f}").format(f=function))
 
     # -------------------------------------------------------------------------
     # if suitability:
     #     function += " * {suitability}"  # FIXME : Confirm Correctness
     #     function = function.format(suitability=suitability)
-    # msg = "Function after adding 'suitability': {f}".format(f=function)
-    # grass.debug(_(msg))
+    # msg = "Function after adding 'suitability': {f}"
+    # grass.debug(_(msg).format(f=function))
     # -------------------------------------------------------------------------
 
     return function
@@ -141,7 +141,7 @@ def compute_attractiveness(
     ]
 
     if score:
-        grass.debug(_("Score for attractiveness equation: {s}".format(s=score)))
+        grass.debug(_("Score for attractiveness equation: {s}").format(s=score))
         distance_terms += str(score)
 
     # tmp_distance = temporary_filename('_'.join(distance_terms))
@@ -153,8 +153,7 @@ def compute_attractiveness(
     if mask:
         msg = "Inverted masking to exclude non-NULL cells "
         msg += "from distance related computations based on '{mask}'"
-        msg = msg.format(mask=mask)
-        grass.verbose(_(msg))
+        grass.verbose(_(msg).format(mask=mask))
         r.mask(raster=mask, flags="i", overwrite=True, quiet=True)
 
     # FIXME: use a parameters dictionary, avoid conditionals
@@ -183,14 +182,13 @@ def compute_attractiveness(
     distance_function = EQUATION.format(
         result=tmp_distance_map, expression=distance_function
     )
-    msg = "* Distance function: {f}".format(f=distance_function)
-    grass.verbose(_(msg))
+    grass.verbose(_("* Distance function: {f}").format(f=distance_function))
     grass.mapcalc(distance_function, overwrite=True)
 
     r.null(map=tmp_distance_map, null=0)  # Set NULLs to 0
 
     compress_status = grass.read_command("r.compress", flags="g", map=tmp_distance_map)
-    grass.verbose(_("* Compress status: {s}".format(s=compress_status)))  # REMOVEME
+    grass.verbose(_("* Compress status: {s}").format(s=compress_status))  # REMOVEME
 
     return tmp_distance_map
 
@@ -224,8 +222,7 @@ def neighborhood_function(raster, method, size, distance_map):
 
     neighborhood_output = distance_map + "_" + method
     msg = "* Neighborhood operator '{method}' and size '{size}' for map '{name}'"
-    msg = msg.format(method=method, size=size, name=neighborhood_output)
-    grass.verbose(_(msg))
+    grass.verbose(_(msg).format(method=method, size=size, name=neighborhood_output))
 
     r.neighbors(
         input=raster,
@@ -247,7 +244,7 @@ def neighborhood_function(raster, method, size, distance_map):
         result=filtered_output, expression=scoring_function
     )
     # ---------------------------------------------------------------
-    grass.debug(_("*** Expression: {e}".format(e=neighborhood_function)))
+    grass.debug(_("*** Expression: {e}").format(e=neighborhood_function))
     # ---------------------------------------------------------------
     grass.mapcalc(neighborhood_function, overwrite=True)
 
@@ -299,17 +296,16 @@ def compute_artificial_proximity(raster, distance_categories, output_name=None):
     # temporary maps will be removed
     if output_name:
         tmp_output = temporary_filename(filename=output_name)
-        grass.debug(_("*** Pre-defined output map name {name}".format(name=tmp_output)))
+        grass.debug(_("*** Pre-defined output map name {name}").format(name=tmp_output))
 
     else:
         tmp_output = temporary_filename(filename="artificial_proximity")
         grass.debug(
-            _("*** Hardcoded temporary map name {name}".format(name=tmp_output))
+            _("*** Hardcoded temporary map name {name}").format(name=tmp_output)
         )
 
     msg = "* Computing proximity to '{mapname}'"
-    msg = msg.format(mapname=raster)
-    grass.verbose(_(msg))
+    grass.verbose(_(msg).format(mapname=raster))
     grass.run_command(
         "r.recode",
         input=artificial_distances,
@@ -322,6 +318,6 @@ def compute_artificial_proximity(raster, distance_categories, output_name=None):
     if not output["file"]:
         grass.fatal("\n***Proximity map {name} not created!".format(name=raster))
     #     else:
-    #         g.message(_("Output map {name}:".format(name=tmp_output)))
+    #         g.message(_("Output map {name}:").format(name=tmp_output))
 
     return tmp_output

--- a/src/raster/r.estimap.recreation/estimap_recreation/grassy_utilities.py
+++ b/src/raster/r.estimap.recreation/estimap_recreation/grassy_utilities.py
@@ -42,14 +42,14 @@ def remove_map(map_name):
 def remove_map_at_exit(map_name):
     """Remove the provided map when the program exits"""
     msg = "*** Add '{map}' to list of maps to remove when program exits"
-    grass.debug(_(msg.format(map=map_name)))
+    grass.debug(_(msg).format(map=map_name))
     atexit.register(lambda: remove_map(map_name))
 
 
 def remove_files_at_exit(filename):
     """Remove the specified file when the program exits"""
     msg = "*** Add '{file}' to list of files to remove when program exits"
-    grass.debug(_(msg.format(file=filename)))
+    grass.debug(_(msg).format(file=filename))
     atexit.register(lambda: os.unlink(filename))
 
 
@@ -121,8 +121,7 @@ def string_to_file(string, filename=None):
     string = string.split(",")
     string = "\n".join(string)
     # string = string.splitlines()
-    msg = "String split in lines: {s}".format(s=string)
-    grass.debug(_(msg))
+    grass.debug(_("String split in lines: {s}").format(s=string))
 
     # # Use a file-like object instead?
     # import tempfile
@@ -173,10 +172,11 @@ def get_univariate_statistics(raster):
     mean = round(float(univariate["mean"]), 3)
     maximum = univariate["max"]
     variance = round(float(univariate["variance"]), 3)
-    msg = " * Univariate statistics for '{raster}'".format(raster=raster)
+    msg = " * Univariate statistics for '{raster}'"
     msg += "\n  min {mn} | mean {avg} | max {mx} | variance {v}"
-    msg = msg.format(mn=minimum, avg=mean, mx=maximum, v=variance)
-    grass.verbose(_(msg))
+    grass.verbose(
+        _(msg).format(raster=raster, mn=minimum, avg=mean, mx=maximum, v=variance)
+    )
     return univariate
 
 
@@ -207,19 +207,16 @@ def recode_map(raster, rules, colors, output):
     --------
     ...
     """
-    msg = "*** Setting NULL cells in {name} map to 0"
-    msg = msg.format(name=raster)
-    grass.debug(_(msg))
+    grass.debug(_("*** Setting NULL cells in {name} map to 0").format(name=raster))
 
     # ------------------------------------------
     r.null(map=raster, null=0)  # Set NULLs to 0
     msg = "*** To Do: confirm if setting the '{raster}' map's NULL cells to 0 is right"
-    msg = msg.format(raster=raster)
-    grass.debug(_(msg))
+    grass.debug(_(msg).format(raster=raster))
     # Is this right?
     # ------------------------------------------
 
-    grass.verbose(_("* Scoring map {name}:".format(name=raster)))
+    grass.verbose(_("* Scoring map {name}:").format(name=raster))
     r.recode(input=raster, rules=rules, output=output)
     r.colors(map=output, rules="-", stdin=SCORE_COLORS, quiet=True)
 
@@ -330,9 +327,7 @@ def export_map(input_name, title, categories, colors, output_name, timestamp):
         )  # Maybe use 'finding'?
 
     # inform
-    msg = "* Outputting '{raster}' map\n"
-    msg = msg.format(raster=output_name)
-    grass.verbose(_(msg))
+    grass.verbose(_("* Outputting '{raster}' map\n").format(raster=output_name))
 
     # get categories and labels
     temporary_raster_categories_map = temporary_filename("categories_of_" + input_name)
@@ -448,8 +443,7 @@ def smooth_map(raster, method, size):
     --------
     """
     # Build MASK for current category & high quality recreation areas
-    msg = "Smoothing map '{m}'"
-    grass.verbose(_(msg.format(m=raster)))
+    grass.verbose(_("Smoothing map '{m}'").format(m=raster))
     r.neighbors(
         input=raster,
         output=raster,
@@ -496,7 +490,7 @@ def update_vector(vector, raster, methods, column_prefix):
         column_prefix=column_prefix,
         overwrite=True,
     )
-    grass.verbose(_("* Updating vector map '{v}'".format(v=vector)))
+    grass.verbose(_("* Updating vector map '{v}'").format(v=vector))
 
 
 def raster_to_vector(
@@ -525,12 +519,10 @@ def raster_to_vector(
     """
     msg = " * Vectorising raster map '{r}'"
     grass.verbose(
-        _(
-            msg.format(
-                c=category,
-                r=raster_category_flow,
-                v=vector_category_flow,
-            )
+        _(msg).format(
+            c=category,
+            r=raster_category_flow,
+            v=vector_category_flow,
         )
     )
     r.to_vect(

--- a/src/raster/r.estimap.recreation/estimap_recreation/land_component.py
+++ b/src/raster/r.estimap.recreation/estimap_recreation/land_component.py
@@ -79,17 +79,17 @@ def build_land_component(
         # Check datatype: a land use map should be categorical, i.e. of type CELL
         landuse_datatype = grass.raster.raster_info(landuse)["datatype"]
         if landuse_datatype != "CELL":
-            grass.fatal(_(FATAL_MESSAGE_LAND_USE_DATATYPE.format(landuse=landuse)))
+            grass.fatal(_(FATAL_MESSAGE_LAND_USE_DATATYPE).format(landuse=landuse))
 
     if landuse and suitability_scores and ":" not in suitability_scores:
-        msg = USING_SUITABILITY_SCORES_FROM_FILE.format(scores=suitability_scores)
-        grass.verbose(_(msg))
+        msg = USING_SUITABILITY_SCORES_FROM_FILE
+        grass.verbose(_(msg).format(scores=suitability_scores))
 
     suitability_map_name = temporary_filename(filename="suitability")
 
     if landuse and not suitability_scores:
-        msg = USING_SUITABILITY_SCORES_FROM_INTERNAL_RULES.format(map=landuse)
-        grass.warning(_(msg))
+        msg = USING_SUITABILITY_SCORES_FROM_INTERNAL_RULES
+        grass.warning(_(msg).format(map=landuse))
 
         temporary_suitability_map_name = temporary_filename(
             filename=suitability_map_name
@@ -100,8 +100,8 @@ def build_land_component(
         remove_files_at_exit(suitability_scores)
 
     if landuse and suitability_scores and ":" in suitability_scores:
-        msg = USING_SUITABILITY_SCORES_FROM_STRING.format(map=landuse)
-        grass.verbose(_(msg))
+        msg = USING_SUITABILITY_SCORES_FROM_STRING
+        grass.verbose(_(msg).format(map=landuse))
         temporary_suitability_map_name = temporary_filename(
             filename=suitability_map_name
         )
@@ -117,8 +117,8 @@ def build_land_component(
 
     if not landcover and landuse:
         landcover = landuse
-        msg = ATTEMPT_TO_USE_LAND_USE_FOR_AREAL_STATISTICS.format(landuse=landuse)
-        grass.warning(_(msg))
+        msg = ATTEMPT_TO_USE_LAND_USE_FOR_AREAL_STATISTICS
+        grass.warning(_(msg).format(landuse=landuse))
 
     # if 'land_classes' is a file
     if (
@@ -127,8 +127,7 @@ def build_land_component(
         and ":" not in landcover_reclassification_rules
     ):
         msg = USING_LAND_COVER_RECLASSIFICATION_RULES_FROM_FILE
-        msg = msg.format(rules=landcover_reclassification_rules)
-        grass.verbose(_(msg))
+        grass.verbose(_(msg).format(rules=landcover_reclassification_rules))
 
     # if 'land_classes' not given
     if landcover and not landcover_reclassification_rules:
@@ -138,8 +137,8 @@ def build_land_component(
         # 1. landcover is not a "MAES" land cover
         # 2. landcover is an Urban Atlas one?
 
-        msg = USING_INTERNAL_LAND_COVER_RECLASSIFICATION_RULES.format(map=landcover)
-        grass.verbose(_(msg))
+        msg = USING_INTERNAL_LAND_COVER_RECLASSIFICATION_RULES
+        grass.verbose(_(msg).format(map=landcover))
 
         temporary_maes_ecosystem_types = temporary_filename(
             filename=maes_ecosystem_types
@@ -156,8 +155,8 @@ def build_land_component(
         and landcover_reclassification_rules
         and ":" in landcover_reclassification_rules
     ):
-        msg = USING_LAND_COVER_RECLASSIFICATION_RULES_FROM_STRING.format(map=landcover)
-        grass.verbose(_(msg))
+        msg = USING_LAND_COVER_RECLASSIFICATION_RULES_FROM_STRING
+        grass.verbose(_(msg).format(map=landcover))
         temporary_maes_land_classes = temporary_filename(filename=maes_land_classes)
         landcover_reclassification_rules = string_to_file(
             landcover_reclassification_rules, filename=maes_land_classes

--- a/src/raster/r.estimap.recreation/estimap_recreation/main.py
+++ b/src/raster/r.estimap.recreation/estimap_recreation/main.py
@@ -253,12 +253,12 @@ def main(options, flags):
     """ First, care about the computational region"""
 
     if mask:
-        msg = " * Masking NULL cells based on '{mask}'".format(mask=mask)
-        grass.verbose(_(msg))
+        msg = " * Masking NULL cells based on '{mask}'"
+        grass.verbose(_(msg).format(mask=mask))
         r.mask(raster=mask, overwrite=True, quiet=True)
 
     if landuse_extent:
-        g.message(_(MATCHING_COMPUTATIONAL_RESOLUTION.format(raster=landuse)))
+        g.message(_(MATCHING_COMPUTATIONAL_RESOLUTION).format(raster=landuse))
         grass.use_temp_region()  # modify the region safely
         g.region(flags="p", raster=landuse)  # set region to 'landuse'
 
@@ -309,7 +309,7 @@ def main(options, flags):
 
     """Water"""
     if len(water_component) > 1:
-        grass.verbose(_(MESSAGE_NORMALISING.format(component=WATER_COMPONENT)))
+        grass.verbose(_(MESSAGE_NORMALISING).format(component=WATER_COMPONENT))
         zerofy_and_normalise_component(
             water_component,
             THRESHHOLD_ZERO,
@@ -323,7 +323,7 @@ def main(options, flags):
 
     """Natural"""
     if len(natural_component) > 1:
-        grass.verbose(_(MESSAGE_NORMALISING.format(component=NATURAL_COMPONENT)))
+        grass.verbose(_(MESSAGE_NORMALISING).format(component=NATURAL_COMPONENT))
         zerofy_and_normalise_component(
             components=natural_component,
             threshhold=THRESHHOLD_ZERO,
@@ -344,8 +344,8 @@ def main(options, flags):
     )
 
     msg = COMPUTING_INTERMEDIATE_POTENTIAL_MAP
-    grass.verbose(_(msg.format(potential=tmp_recreation_potential)))
-    grass.debug(_("*** Maps: {maps}".format(maps=recreation_potential_component)))
+    grass.verbose(_(msg).format(potential=tmp_recreation_potential))
+    grass.debug(_("*** Maps: {maps}").format(maps=recreation_potential_component))
 
     zerofy_and_normalise_component(
         components=recreation_potential_component,
@@ -358,8 +358,8 @@ def main(options, flags):
         filename=recreation_potential
     )
 
-    msg = CLASSIFYING_POTENTIAL_MAP.format(potential=tmp_recreation_potential)
-    grass.verbose(_(msg))
+    msg = CLASSIFYING_POTENTIAL_MAP
+    grass.verbose(_(msg).format(potential=tmp_recreation_potential))
 
     classify_recreation_component(
         component=tmp_recreation_potential,
@@ -437,12 +437,12 @@ def main(options, flags):
             filename=recreation_opportunity_map_name
         )
         msg = COMPUTING_INTERMEDIATE_OPPORTUNITY_MAP
-        grass.debug(_(msg.format(opportunity=tmp_recreation_opportunity)))
+        grass.debug(_(msg).format(opportunity=tmp_recreation_opportunity))
 
         grass.verbose(
-            _(MESSAGE_NORMALISING.format(component=RECREATION_OPPORTUNITY_COMPONENT))
+            _(MESSAGE_NORMALISING).format(component=RECREATION_OPPORTUNITY_COMPONENT)
         )
-        grass.debug(_("*** Maps: {maps}".format(maps=recreation_opportunity_component)))
+        grass.debug(_("*** Maps: {maps}").format(maps=recreation_opportunity_component))
 
         zerofy_and_normalise_component(
             components=recreation_opportunity_component,
@@ -492,8 +492,8 @@ def main(options, flags):
             spectrum=recreation_spectrum,
         )
 
-        msg = WRITING_SPECTRUM_MAP.format(spectrum=recreation_spectrum)
-        grass.verbose(_(msg))
+        msg = WRITING_SPECTRUM_MAP
+        grass.verbose(_(msg).format(spectrum=recreation_spectrum))
         get_univariate_statistics(recreation_spectrum)
 
         # get category labels
@@ -595,8 +595,8 @@ def main(options, flags):
             quiet=True,
         )
 
-        msg = MATCHING_COMPUTATIONAL_RESOLUTION.format(raster=population)
-        grass.verbose(_(msg))
+        msg = MATCHING_COMPUTATIONAL_RESOLUTION
+        grass.verbose(_(msg).format(raster=population))
         grass.use_temp_region()  # to safely modify the region
         g.region(
             nsres=population_ns_resolution,
@@ -607,8 +607,7 @@ def main(options, flags):
         if info:
             population_statistics = get_univariate_statistics(population)
             population_total = population_statistics["sum"]
-            msg = POPULATION_STATISTICS.format(s=population_total)
-            grass.verbose(_(msg))
+            grass.verbose(_(POPULATION_STATISTICS).format(s=population_total))
 
         """Demand Distribution"""
 
@@ -660,7 +659,7 @@ def main(options, flags):
             # Maybe it can, though, after successfully testing its
             # integration to build_distance_function().
 
-            grass.debug(_(MOBILITY_FUNCTION.format(f=mobility_expression)))
+            grass.debug(_(MOBILITY_FUNCTION).format(f=mobility_expression))
 
             """Flow map"""
 

--- a/src/raster/r.estimap.recreation/estimap_recreation/mobility.py
+++ b/src/raster/r.estimap.recreation/estimap_recreation/mobility.py
@@ -116,11 +116,11 @@ def mobility_function(
         # Maybe it can, though, after successfully testing its
         # integration to build_distance_function().
 
-        grass.debug(_("For distance '{d}':".format(d=distance)))
+        grass.debug(_("For distance '{d}':").format(d=distance))
         grass.debug(_(expressions[distance_category]))
 
-    msg = "Expressions per distance category: {e}".format(e=expressions)
-    grass.debug(_(msg))
+    msg = "Expressions per distance category: {e}"
+    grass.debug(_(msg).format(e=expressions))
 
     # build expressions -- explicit: use the'score' kwarg!
     expression = (
@@ -140,7 +140,7 @@ def mobility_function(
     )
     if not real_numbers:
         expression = "round(" + expression + ")"
-    grass.debug(_("Mapcalc expression: {e}".format(e=expression)))
+    grass.debug(_("Mapcalc expression: {e}").format(e=expression))
 
     # replace keywords appropriately
     # 'distance' is a map
@@ -159,7 +159,7 @@ def mobility_function(
     )
     # FIXME Make the above more elegant?
 
-    msg = "Big expression (after formatting): {e}".format(e=expression)
-    grass.debug(_(msg))
+    msg = "Big expression (after formatting): {e}"
+    grass.debug(_(msg).format(e=expression))
 
     return mobility_expression

--- a/src/raster/r.estimap.recreation/estimap_recreation/natural_component.py
+++ b/src/raster/r.estimap.recreation/estimap_recreation/natural_component.py
@@ -47,7 +47,7 @@ def build_natural_component(
 
     if protected:
         msg = SCORING_PROTECTED_AREAS
-        grass.verbose(_(msg.format(protected=protected, rules=protected_scores)))
+        grass.verbose(_(msg).format(protected=protected, rules=protected_scores))
 
         recode_map(
             raster=protected,

--- a/src/raster/r.estimap.recreation/estimap_recreation/normalisation.py
+++ b/src/raster/r.estimap.recreation/estimap_recreation/normalisation.py
@@ -81,10 +81,10 @@ def normalize_map(raster, output_name):
     # msg = "Univariate statistics: {us}".format(us=univar_string)
 
     minimum = grass.raster_info(raster)["min"]
-    grass.debug(_("Minimum: {m}".format(m=minimum)))
+    grass.debug(_("Minimum: {m}").format(m=minimum))
 
     maximum = grass.raster_info(raster)["max"]
-    grass.debug(_("Maximum: {m}".format(m=maximum)))
+    grass.debug(_("Maximum: {m}").format(m=maximum))
 
     if minimum is None or maximum is None:
         msg = "Minimum and maximum values of the <{raster}> map are 'None'.\n"
@@ -94,7 +94,7 @@ def normalize_map(raster, output_name):
         msg += "\n  - the MASK opacifies all non-NULL cells "
         msg += "\n  - the region is not correctly set\n"
         msg += "=========================================== "
-        grass.fatal(_(msg.format(raster=raster)))
+        grass.fatal(_(msg).format(raster=raster))
 
     normalisation = "float(({raster} - {minimum}) / ({maximum} - {minimum}))"
     normalisation = normalisation.format(
@@ -181,7 +181,7 @@ def zerofy_and_normalise_component(components, threshhold, output_name):
         tmp_output = tmp_intermediate
 
     # grass.verbose(_("Temporary map name: {name}".format(name=tmp_output)))
-    grass.debug(_("Output map name: {name}".format(name=output_name)))
+    grass.debug(_("Output map name: {name}").format(name=output_name))
     # r.info(map=tmp_output, flags='gre')
 
     ### FIXME

--- a/src/raster/r.estimap.recreation/estimap_recreation/normalise_land.py
+++ b/src/raster/r.estimap.recreation/estimap_recreation/normalise_land.py
@@ -56,11 +56,12 @@ def zerofy_component_null_cells(component):
     for dummy_index in component:
         land_map = component.pop(0)  # remove 'map' from 'land_component'
         suitability_map = zerofy_null_cells(land_map)  # process it
-        msg = ADDING_MAP_TO_COMPONENT.format(
-            raster=suitability_map,
-            component=RECREATION_POTENTIAL_COMPONENT,
+        grass.verbose(
+            _(ADDING_MAP_TO_COMPONENT).format(
+                raster=suitability_map,
+                component=RECREATION_POTENTIAL_COMPONENT,
+            )
         )
-        grass.verbose(_(msg))
         component.append(suitability_map)  # add back to 'land_component'
     return component
 
@@ -85,7 +86,7 @@ def normalise_land_component(land_component):
     remove_map_at_exit(land_component)
     zerofy_component_null_cells(land_component)
     if len(land_component) > 1:
-        grass.verbose(_(MESSAGE_NORMALISING.format(component=LAND_COMPONENT)))
+        grass.verbose(_(MESSAGE_NORMALISING).format(component=LAND_COMPONENT))
         land_component_map_name = temporary_filename(filename=LAND_COMPONENT_MAP_NAME)
         zerofy_and_normalise_component(
             land_component,

--- a/src/raster/r.estimap.recreation/estimap_recreation/supply_and_use.py
+++ b/src/raster/r.estimap.recreation/estimap_recreation/supply_and_use.py
@@ -206,7 +206,7 @@ def compute_supply(
 
     for category in categories:
         msg = "\n>>> Processing category '{c}' of aggregation map '{a}'"
-        grass.verbose(_(msg.format(c=category, a=aggregation)))
+        grass.verbose(_(msg).format(c=category, a=aggregation))
 
         # Intermediate names
 
@@ -234,8 +234,7 @@ def compute_supply(
         # Output names
 
         msg = "*** Processing aggregation raster category: {r}"
-        msg = msg.format(r=category)
-        grass.debug(_(msg))
+        grass.debug(_(msg).format(r=category))
         # g.message(_(msg))
 
         # First, set region to extent of the aggregation map
@@ -251,12 +250,11 @@ def compute_supply(
         )
 
         msg = "!!! Computational resolution matched to {raster}"
-        msg = msg.format(raster=aggregation)
-        grass.debug(_(msg))
+        grass.debug(_(msg).format(raster=aggregation))
 
         # Build MASK for current category & high quality recreation areas
         msg = " * Setting category '{c}' as a MASK"
-        grass.verbose(_(msg.format(c=category, a=aggregation)))
+        grass.verbose(_(msg).format(c=category, a=aggregation))
 
         masking = "if( {spectrum} == {highest_quality_category} && "
         masking += "{aggregation} == {category}, "
@@ -284,7 +282,7 @@ def compute_supply(
             quiet=True,
         )
         cells_categories = grass.parse_command("r.category", map=cells, delimiter="\t")
-        grass.debug(_("*** Cells: {c}".format(c=cells_categories)))
+        grass.debug(_("*** Cells: {c}").format(c=cells_categories))
 
         # Build cell category and label rules for `r.category`
         cells_rules = "\n".join(
@@ -432,8 +430,8 @@ def compute_supply(
                 for x in fraction_categories.values()
             ]
         )
-        msg = "*** Fractions: {f}".format(f=fraction_categories)
-        grass.debug(_(msg))
+        msg = "*** Fractions: {f}"
+        grass.debug(_(msg).format(f=fraction_categories))
 
         # g.message(_("Sum: {:.17g}".format(fractions_sum)))
         assert abs(fractions_sum - 1) < 1.0e-6, "Sum of fractions is != 1"
@@ -463,7 +461,7 @@ def compute_supply(
             delimiter="\t",
             quiet=True,
         )
-        grass.debug(_("*** Flow: {c}".format(c=flow_categories)))
+        grass.debug(_("*** Flow: {c}").format(c=flow_categories))
 
         # Build flow category and label rules for `r.category`
         flow_rules = "\n".join(


### PR DESCRIPTION
Fixes: `format` method argument is resolved before function call; consider `_("string %s") % arg`

Ruff rule: https://docs.astral.sh/ruff/rules/format-in-get-text-func-call/

I made a separate PR, as multiple changes were from the same module, and there were lots of the similar errors

Equivalent of the following PR: https://github.com/OSGeo/grass/pull/4052/