### PR TITLE
CI: Install extra requirements from addons requirement files

### DIFF
--- a/.github/workflows/extra_requirements.txt
+++ b/.github/workflows/extra_requirements.txt
@@ -1,8 +1,11 @@
+-r ./requirements.txt
 scipy
 eodag
 pandas
 scikit-learn
 GDAL==${GDAL_VERSION}
 pygbif
-cf_units @ git+https://github.com/SciTools/cf-units@f57a7f1fdba4e9424e4dbbc01b614e521a88086c
+cf_units
 thredds_crawler
+-r ../../src/temporal/t.stac/requirements.txt
+-r ../../src/raster/r.estimap.recreation/requirements-dev.txt


### PR DESCRIPTION
When preparing to make the pytest test collection successful on the grass-addons repo, some dependencies were missing, but were listed in other requirement files. This PR refers to them, so the required packages are installed.

For cf_units, since the time the pin was added, they published a release with support for newer python versions. So it is now unneeded.