### PR TITLE
r.agent: Fix tests to run on Python 3 without unittest2

### DIFF
--- a/src/raster/r.agent/libagent/grassland.py
+++ b/src/raster/r.agent/libagent/grassland.py
@@ -139,5 +139,5 @@ class Grassland(playground.Playground):
             # TODO find out why 'filename' is lost - numpy vs. garray..
         # TODO think about moving 'minimum' to a predifined matrix in anthill
         if minimum > 0:
-            mask = garray.numpy.ones_like(self.layers[layername]) - 1 + minimum
-            self.layers[layername] = garray.numpy.maximum(self.layers[layername], mask)
+            mask = garray.np.ones_like(self.layers[layername]) - 1 + minimum
+            self.layers[layername] = garray.np.maximum(self.layers[layername], mask)

--- a/src/raster/r.agent/tests/README
+++ b/src/raster/r.agent/tests/README
@@ -1,15 +1,17 @@
-README file for libagent's test suite
+# libagent's test suite
 
 These test cases are intended to contain all the tests for
-libagent and to be usable with python 2.7 and higher, it
-should however run resp. via the separate unittest2 available
-as backport for python 2.3-2.6 too.
+libagent and to be usable with Python 3 and higher.
 
 To invoke e.g. the error tests only, from the topmost directory
 level issue
- user@host:~/path/r.agent.aco$ unit2 discover -v -p "test*.py"
+```console
+user@host:~/grass-addons/src/raster/r.agent$ python -m unittest -v
+```
 
-All tests except for tests.test_grassland should run without
-the GRASS environment. For tests.test_grassland you must start
+All tests except for testsuite.test_grassland should run without
+the GRASS environment. For testsuite.test_grassland you must start
 the tests inside the GRASS console respectively:
- GRASS 6.4.4 (foobar):~/path/r.agent.aco > unit2 discover -v -p "test*.py"
+```console
+GRASS 8.4.0 (foobar):~/grass-addons/src/raster/r.agent > python -m unittest discover -v -s "testsuite"
+```

--- a/src/raster/r.agent/tests/test_agent.py
+++ b/src/raster/r.agent/tests/test_agent.py
@@ -1,6 +1,4 @@
-import unittest2 as unittest
-
-# import unittest
+import unittest
 
 from libagent import playground, world, agent
 

--- a/src/raster/r.agent/tests/test_ant.py
+++ b/src/raster/r.agent/tests/test_ant.py
@@ -1,6 +1,4 @@
-import unittest2 as unittest
-
-# import unittest
+import unittest
 
 from libagent import playground, anthill, ant
 

--- a/src/raster/r.agent/tests/test_anthill.py
+++ b/src/raster/r.agent/tests/test_anthill.py
@@ -1,6 +1,4 @@
-import unittest2 as unittest
-
-# import unittest
+import unittest
 
 from libagent import playground, anthill
 

--- a/src/raster/r.agent/tests/test_error.py
+++ b/src/raster/r.agent/tests/test_error.py
@@ -1,6 +1,4 @@
-import unittest2 as unittest
-
-# import unittest
+import unittest
 
 from libagent import error
 

--- a/src/raster/r.agent/tests/test_playground.py
+++ b/src/raster/r.agent/tests/test_playground.py
@@ -1,7 +1,7 @@
-import unittest2 as unittest
+import unittest
 
-# import unittest
 from math import sqrt
+
 from libagent import playground, error
 
 
@@ -109,9 +109,9 @@ class TestPlayground(unittest.TestCase):
         self.pg.setregion(3, 3)
         positions = []
         ps = positions[:]
-        self.assertItemsEqual(ps, self.pg.addneighbourposition(positions, [9, 9]))
+        self.assertCountEqual(ps, self.pg.addneighbourposition(positions, [9, 9]))
         ps.append([1, 1])
-        self.assertItemsEqual(ps, self.pg.addneighbourposition(positions, [1, 1]))
+        self.assertCountEqual(ps, self.pg.addneighbourposition(positions, [1, 1]))
 
     def test_getorderedneighbourpositions(self):
         self.pg.setregion(3, 3)

--- a/src/raster/r.agent/tests/test_world.py
+++ b/src/raster/r.agent/tests/test_world.py
@@ -1,6 +1,4 @@
-import unittest2 as unittest
-
-# import unittest
+import unittest
 
 from libagent import world, error
 

--- a/src/raster/r.agent/testsuite/test_grassland.py
+++ b/src/raster/r.agent/testsuite/test_grassland.py
@@ -1,10 +1,9 @@
-import unittest2 as unittest
+import unittest
 
-# import unittest
-
-from libagent import error, playground, grassland
 import grass.script as grass
 from grass.script import array as garray
+
+from libagent import error, grassland, playground
 
 
 class TestGrassland(unittest.TestCase):

--- a/src/raster/r.agent/testsuite/test_grassland.py
+++ b/src/raster/r.agent/testsuite/test_grassland.py
@@ -2,7 +2,9 @@ import unittest
 
 import grass.script as grass
 from grass.script import array as garray
+from grass.script.utils import set_path
 
+set_path("r.agent", "libagent", "..")
 from libagent import error, grassland, playground
 
 


### PR DESCRIPTION
- Adjusted the test's README file accordingly
- Changed unittest2 to unittest
- `self.assertItemsEqual` was renamed to `self.assertCountEqual` in Python 3.0.
- Moved `test_grassland.py` to a testsuite folder, so it can be collected by its own. It is the only file that needs to be run inside a GRASS session. The other ones can be run outside of GRASS. Pure unittest cannot exclude a pattern, only include a pattern, so there was no way of running all the others outside a GRASS session.