### PR TITLE
CI: Update the actions to be able to run grass7 workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,14 @@ jobs:
     steps:
 
     - name: Checkout addons
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: OSGeo/grass
         ref: ${{ matrix.grass-version }}
         path: grass
 
     - name: Checkout core
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         path: grass-addons
 
@@ -43,7 +43,7 @@ jobs:
             sudo apt-get install -y --no-install-recommends --no-install-suggests
 
     - name: Set up Python ${{ matrix.python-version }} as default Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -89,7 +89,7 @@ jobs:
         pip install -r grass-addons/.github/workflows/extra_requirements.txt
 
     - name: Set up R
-      uses: r-lib/actions/setup-r@v1
+      uses: r-lib/actions/setup-r@v2
       with:
         r-version: "4.0.4"
 
@@ -103,7 +103,7 @@ jobs:
         ../.github/workflows/test.sh
 
     - name: Make HTML test report available
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: testreport-grass-${{ matrix.grass-version }}-python-${{ matrix.python-version }}
         path: grass-addons/src/testreport


### PR DESCRIPTION
I hope it will be just enough to allow the jobs to not automatically error out. If it works, it will unblock https://github.com/OSGeo/grass-addons/pull/1203