### PR TITLE
CI: Configure ccache for speeding up grass, addons, and R packages by up to 3.5min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@a1209f81afb8c005c13b4296c32e363431bffea5 # v1.2.17
         with:
           create-symlink: true
-          verbose: 1
+          verbose: 2
           evict-old-files: 7d
           key: ${{ github.job }}-${{ matrix.grass-version }}-${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,12 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: grass-addons
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.17
+        with:
+          create-symlink: true
+          verbose: 1
+          evict-old-files: 7d
 
       - name: Get dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
         uses: r-lib/actions/setup-r@473c68190595b311a74f208fba61a8d8c0d4c247 # v2.11.1
         with:
           r-version: 4.2.1
+          Ncpus: 4
 
       - name: Get R dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,12 @@ jobs:
         with:
           r-version: 4.2.1
           Ncpus: 4
-
+      - name: Configure ccache for R package builds
+        run: |
+          # R package sources are extracted as newly created files
+          echo "CCACHE_SLOPPINESS=include_file_ctime" >> "${GITHUB_ENV}"
+          # R temp directory name differs
+          echo "CCACHE_NOHASHDIR=true" >> "${GITHUB_ENV}"
       - name: Get R dependencies
         run: |
           grass-addons/.github/workflows/install_r_packages.R

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
           create-symlink: true
           verbose: 1
           evict-old-files: 7d
+          key: ${{ github.job }}-${{ matrix.grass-version }}-${{ matrix.python-version }}
 
       - name: Get dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           path: grass-addons
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.17
+        uses: hendrikmuhs/ccache-action@a1209f81afb8c005c13b4296c32e363431bffea5 # v1.2.17
         with:
           create-symlink: true
           verbose: 1

--- a/.github/workflows/install_r_packages.R
+++ b/.github/workflows/install_r_packages.R
@@ -1,2 +1,3 @@
 #!/usr/bin/env Rscript
+getOption("Ncpus", 1L)
 install.packages(c("MuMIn", "lme4", "optparse", "snow"))


### PR DESCRIPTION
Since grass-addons constantly rebuilds a current and old grass version, plus all addons including the ones that don't change often, plus builds from source the R packages that don't change often, using ccache is a great fit to cache the compilation step (returns the .o files skipping the compiler if it would have returned the same thing).

After playing around to get the R packages to work as I wished, I observe improvements in the three build steps that it is used:
- GRASS (core): About 1min 15s to 1min 30s less
  - Before, usually takes 3min40 to almost 4 minutes.
  - After: 2min 8s to 2min 15s
 - GRASS addons: about 30+s less
   - Before: 1min 50s to 2min 10s
   - After: 1min 24s - 1min 30+s
 - Building R packages: 1min to 1min 30s less
   - Before: 1min 53s to  2min 11s+
   - After: 44 secs (kind of constant)

So, roughly, we can say roughly 3min to 3min 30s less time before the first test starts to run, for both grass version combinations tested.


In addition to the normal rules and expiration of github action caches, I also set ccache to evict after 7 days the files that didn't change. Since the ci.yml workflow runs once a day, the main branch will often have a very fresh cache to use in PRs.

For R packages, I added ccache settings as env vars later so that they would only apply later on in the workflow. It is needed to relax a bit the requirements, as the temporary build folder is always different, and when the source files are extracted, they have newer time stamps. There's a good blog post here: https://dirk.eddelbuettel.com/blog/2017/11/27/ and here:  https://www.jumpingrivers.com/blog/speeding-up-package-installation/
Setting the number of cpus options didn't impact as much as hoped (before adding ccache), probably because there are some dependencies between packages. But it is kept for now.