### PR TITLE
r.viewshed.exposure: Change nproc to 4 to speed up CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
           ../.github/workflows/test.sh
 
       - name: Make HTML test report available
+        if: ${{ always() }}
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: testreport-grass-${{ matrix.grass-version }}-python-${{ matrix.python-version }}

--- a/src/raster/r.viewshed.exposure/testsuite/test_r_viewshed_exposure.py
+++ b/src/raster/r.viewshed.exposure/testsuite/test_r_viewshed_exposure.py
@@ -138,16 +138,6 @@ class TestFunctions(TestCase):
             "variance": 0.308511,
             "coeff_var": 131.549853569661,
             "sum": 31834.1480130134,  # midpoint of 1 and 10 core x64
-            # "sum": 31834.1480232505,  # average 1, 2, 4 and 10 core
-            # "sum": 31834.1480175955,  # average 1, 4 and 10 core
-            # "sum": 31834.1480048643,  # average 4 and 10 core
-            # "sum": 31834.1480430579,  # 1 core x64
-            # "sum": 31834.1480402155,  # 2 core x64
-            # "sum": 31834.1480267597,  # 4 core x64
-            # "sum": 31834.1480075223,  # 8 core x64
-            # "sum": 31834.1479829689,  # 10 core x64
-            # "sum": 31834.1479833564,  # 12 core x64
-            # "sum": 31834.1479394501,  # 20 core x64
         },
         "test_points": {
             "n": 97340,

--- a/src/raster/r.viewshed.exposure/testsuite/test_r_viewshed_exposure.py
+++ b/src/raster/r.viewshed.exposure/testsuite/test_r_viewshed_exposure.py
@@ -137,11 +137,17 @@ class TestFunctions(TestCase):
             "stddev": 0.555438,
             "variance": 0.308511,
             "coeff_var": 131.549853569661,
-            "sum": 31834.1480175955,  # average 1, 4 and 10 core
-            # "sum": 31834.1480048643, # average 4 and 10 core
-            # "sum": 31834.1480430579, # 1 core x64
-            # "sum": 31834.1480267597, # 4 core x64
-            # "sum": 31834.1479829689, # 10 core x64
+            "sum": 31834.1480130134,  # midpoint of 1 and 10 core x64
+            # "sum": 31834.1480232505,  # average 1, 2, 4 and 10 core
+            # "sum": 31834.1480175955,  # average 1, 4 and 10 core
+            # "sum": 31834.1480048643,  # average 4 and 10 core
+            # "sum": 31834.1480430579,  # 1 core x64
+            # "sum": 31834.1480402155,  # 2 core x64
+            # "sum": 31834.1480267597,  # 4 core x64
+            # "sum": 31834.1480075223,  # 8 core x64
+            # "sum": 31834.1479829689,  # 10 core x64
+            # "sum": 31834.1479833564,  # 12 core x64
+            # "sum": 31834.1479394501,  # 20 core x64
         },
         "test_points": {
             "n": 97340,
@@ -245,7 +251,7 @@ class TestFunctions(TestCase):
         self.assertRasterFitsUnivar(
             raster=output,
             reference=self.test_results_stats[output],
-            precision=1e-5,
+            precision=4e-5,
         )
 
     def test_points(self):

--- a/src/raster/r.viewshed.exposure/testsuite/test_r_viewshed_exposure.py
+++ b/src/raster/r.viewshed.exposure/testsuite/test_r_viewshed_exposure.py
@@ -49,7 +49,7 @@ class TestFunctions(TestCase):
         sample_density=5,
         seed=50,
         memory=5000,
-        nprocs=10,
+        nprocs=4,
         quiet=True,
         overwrite=True,
     )

--- a/src/raster/r.viewshed.exposure/testsuite/test_r_viewshed_exposure.py
+++ b/src/raster/r.viewshed.exposure/testsuite/test_r_viewshed_exposure.py
@@ -137,7 +137,11 @@ class TestFunctions(TestCase):
             "stddev": 0.555438,
             "variance": 0.308511,
             "coeff_var": 131.549853569661,
-            "sum": 31834.1479829689,
+            "sum": 31834.1480175955,  # average 1, 4 and 10 core
+            # "sum": 31834.1480048643, # average 4 and 10 core
+            # "sum": 31834.1480430579, # 1 core x64
+            # "sum": 31834.1480267597, # 4 core x64
+            # "sum": 31834.1479829689, # 10 core x64
         },
         "test_points": {
             "n": 97340,


### PR DESCRIPTION
I measured about a 30sec time reduction by not using 10 cores, while the runners have 4 cores available. However, the r.univar stats didn't match exactly for the sum of test_lakes, at least not with a precision of 1E-5. So I measured multiple points, with different nproc values, to see what would be a good choice.

![image](https://github.com/user-attachments/assets/b09438ce-642f-4bff-918a-314111a01dba)

I chose midpoint of 1 and 10 core (on x64), they were the min and max before the 20 core that was further off. With a 4E-5 precision, all of the nproc values would be included.

Here is a bit of the commented code before I removed it through the last commit. Let me know if it should be kept, or having the info in the PR is enough.
```
            "sum": 31834.1480130134,  # midpoint of 1 and 10 core x64
            # "sum": 31834.1480232505,  # average 1, 2, 4 and 10 core
            # "sum": 31834.1480175955,  # average 1, 4 and 10 core
            # "sum": 31834.1480048643,  # average 4 and 10 core
            # "sum": 31834.1480430579,  # 1 core x64
            # "sum": 31834.1480402155,  # 2 core x64
            # "sum": 31834.1480267597,  # 4 core x64
            # "sum": 31834.1480075223,  # 8 core x64
            # "sum": 31834.1479829689,  # 10 core x64
            # "sum": 31834.1479833564,  # 12 core x64
            # "sum": 31834.1479394501,  # 20 core x64
``` 

