### PR TITLE
CI(tests): Limit test step duration with timeout-minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
           grass-addons/.github/workflows/install_r_packages.R
 
       - name: Run tests
+        timeout-minutes: 45
         run: |
           cd grass-addons/src
           ../.github/workflows/test.sh


### PR DESCRIPTION
Following https://github.com/OSGeo/grass-addons/issues/1312#issuecomment-2660148588, limit the tests step to 45 minutes to avoid timeouts after 6h+ (normally, tests finish under 30 minutes).

This doesn't really fix the issue, but addresses the consequences of it.