### PR TITLE
tests: Add timeout to .gunittest.cfg file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
         timeout-minutes: 45
         run: |
           cd grass-addons/src
-          ../.github/workflows/test.sh
+          ../.github/workflows/test.sh --config ../.gunittest.cfg
 
       - name: Make HTML test report available
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -16,4 +16,4 @@ grass --tmp-project XY --exec \
 grass --tmp-project XY --exec \
     python3 -m grass.gunittest.main \
         --grassdata $HOME --location nc_spm_full_v2alpha2 --location-type nc \
-        --min-success 60
+        --min-success 60 $@

--- a/.gunittest.cfg
+++ b/.gunittest.cfg
@@ -8,6 +8,6 @@
 # Maximum time for execution of one test file (not a test function)
 # after which test is terminated (which may not terminate child processes
 # from that test).
-# Using 5 minutes as maximum (average test time should be much shorter,
+# Using 6 minutes as maximum (average test time should be much shorter,
 # couple seconds per file, median should be around one second).
-timeout = 300
+timeout = 360

--- a/.gunittest.cfg
+++ b/.gunittest.cfg
@@ -1,0 +1,13 @@
+[gunittest]
+
+# Files (or wildcard patterns) to exclude from testing separated by newline or
+# space. This would be ideally empty or it would include just special cases,
+# but it includes mainly tests which can (and should) be fixed.
+# exclude =
+
+# Maximum time for execution of one test file (not a test function)
+# after which test is terminated (which may not terminate child processes
+# from that test).
+# Using 5 minutes as maximum (average test time should be much shorter,
+# couple seconds per file, median should be around one second).
+timeout = 300


### PR DESCRIPTION
Also to address a part of #1312.

Adding a default timeout value to .gunittest.cfg in grass-addons too, like for the main repo.

5 minutes is probably not enough because some tests are really long, but I want to see which ones are timing out on the CI runners speed first.

Even though #1314 limited the test step to 45 minutes, the r.futures.calib apparent hang already happens after 7 minutes, so there's almost 40 minutes spent waiting on timing out.