### PR TITLE
checks: Add Ruff per-file-file-ignores section in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,6 @@ name = "grass-addons"
 requires-python = ">=3.8"
 
 [tool.black]
-required-version = '25'
-line-length = 88
-target-version = ['py38', 'py39', 'py310', 'py311', 'py312', 'py313']
 extend-exclude = '''
 (
     # exclude directories in the root of the project
@@ -24,6 +21,9 @@ extend-exclude = '''
     )/
 )
 '''
+line-length = 88
+required-version = '25'
+target-version = ['py38', 'py39', 'py310', 'py311', 'py312', 'py313']
 
 [tool.ruff]
 builtins = ["_"]
@@ -430,3 +430,7 @@ ignore = [
     "UP035",   # deprecated-import
     "UP036",   # outdated-version-block
 ]
+
+[tool.ruff.lint.per-file-ignores]
+# See https://docs.astral.sh/ruff/settings/#lint_per-file-ignores
+"src/imagery/i.sam2/i.sam2.py" = ["DOC502"]


### PR DESCRIPTION
Ignoring DOC502 in i.sam2, as it wasn't discussed what convention to use in docstrings (list the exceptions that the function explicitly raises itself, or include exceptions that can be thrown by all called functions). We should let the grass-addons be more free to accept existing code (even though this is new code), whatever the convention was, in order to lower the barrier of entry. It was the first introduction of that error yet.

The pyproject.toml file was also reformatted (including sorting of keys), that I was constantly reverting since configuring ruff here, except this time where I let it through.