### PR TITLE
raster: Fix unconventional-import-alias (ICN001) (part 2)

### DIFF
--- a/src/raster/r.maxent.lambdas/r.maxent.lambdas.py
+++ b/src/raster/r.maxent.lambdas/r.maxent.lambdas.py
@@ -148,13 +148,13 @@ COPYRIGHT:    (C) 2019-2022 by the Norwegian Institute for Nature Research
 import os
 
 from grass.pygrass.raster import RasterRow
-import grass.script as gscript
+import grass.script as gs
 from grass.script.raster import mapcalc, raster_history
 from functools import partial
 
 
 def tiled_mapcalc(expression=None, width=None, height=None, nprocs=None):
-    gscript.run_command(
+    gs.run_command(
         "r.mapcalc.tiled",
         expression=expression,
         width=width,
@@ -168,12 +168,10 @@ def parse_alias(alias_file):
     """Parse alias file if provided"""
     if alias_file:
         if not os.access(alias_file, os.R_OK):
-            gscript.fatal(
-                _("Alias file <{}> not found or not readable").format(alias_file)
-            )
+            gs.fatal(_("Alias file <{}> not found or not readable").format(alias_file))
 
         with open(alias_file, "r") as a_f:
-            alias_dict = gscript.parse_key_val(a_f.read(), sep=",")
+            alias_dict = gs.parse_key_val(a_f.read(), sep=",")
     else:
         alias_dict = None
 
@@ -190,7 +188,7 @@ def parse_alias(alias_file):
             raster_map = RasterRow(full_name)  # raster, mapset)
             mapset = "." if not mapset else mapset
             if not raster_map.exist():
-                gscript.fatal(
+                gs.fatal(
                     _(
                         "Could not find environmental parameter raster map <{0}> in mapset <{1}>."
                     ).format(raster, mapset)
@@ -268,7 +266,7 @@ def parse_lambdas_row(row, coeff, alias_dict, clamp):
     if alias_dict:
         for rmap in mc_row[0]:
             if rmap not in alias_dict:
-                gscript.fatal(
+                gs.fatal(
                     _("Invalid input: Variable {} not found in alias file").format(rmap)
                 )
             mc_row[1] = mc_row[1].replace(rmap, alias_dict[rmap])
@@ -283,12 +281,12 @@ def main():
     alias_file = options["alias_file"]
 
     if not options["ndigits"].isdigit():
-        gscript.fatal(_("The ndigits option needs to be given as integer."))
+        gs.fatal(_("The ndigits option needs to be given as integer."))
 
     ndigits = int(options["ndigits"])
 
     if ndigits > 5 or ndigits < 0:
-        gscript.warning(
+        gs.warning(
             _(
                 "Valid range for ndigits is 0 to 5. \
         Setting to closest bound."
@@ -302,8 +300,8 @@ def main():
     logistic = options["logistic"]
 
     if int(options["nprocs"]) > 1:
-        if not gscript.find_program("r.mapcalc.tiled"):
-            gscript.fatal(
+        if not gs.find_program("r.mapcalc.tiled"):
+            gs.fatal(
                 _(
                     "Cannot find r.mapcalc.tiled for parallel processing.\n"
                     "Please install it with 'g.extension r.mapcalc.tiled'"
@@ -320,7 +318,7 @@ def main():
 
     # Check if input file exists and is readable
     if not os.access(lambdas_file, os.R_OK):
-        gscript.fatal(_("MaxEnt lambdas-file could not be found or is not readable."))
+        gs.fatal(_("MaxEnt lambdas-file could not be found or is not readable."))
 
     # Parse alias_file if provided
     alias_dict = parse_alias(alias_file)
@@ -387,11 +385,11 @@ def main():
             return 0
         rmapcalc(log_expr)
         if flags["N"]:
-            gscript.run_command("r.null", map=logistic, setnull=0)
+            gs.run_command("r.null", map=logistic, setnull=0)
         raster_history(logistic, overwrite=True)
     return 0
 
 
 if __name__ == "__main__":
-    options, flags = gscript.parser()
+    options, flags = gs.parser()
     main()

--- a/src/raster/r.mblend/r.mblend.py
+++ b/src/raster/r.mblend/r.mblend.py
@@ -62,7 +62,7 @@ import os
 import atexit
 import math
 from time import gmtime, strftime
-import grass.script as gscript
+import grass.script as gs
 
 index = 0
 far_edge_value = "0"
@@ -84,7 +84,7 @@ def getTemporaryIdentifier():
 
 def cleanup():
     while len(TMP_MAPS) > 0:
-        gscript.run_command(
+        gs.run_command(
             "g.remove", type="all", name=TMP_MAPS.pop(), flags="f", quiet=True
         )
 
@@ -105,7 +105,7 @@ def main():
     global far_edge_value
     global d_max
 
-    options, flags = gscript.parser()
+    options, flags = gs.parser()
     high = options["high"]
     low = options["low"]
     output = options["output"]
@@ -114,33 +114,31 @@ def main():
     use_average_differences = flags["a"]
 
     if high is None or high == "":
-        gscript.error(_("[r.mblend] ERROR: high is a mandatory parameter."))
+        gs.error(_("[r.mblend] ERROR: high is a mandatory parameter."))
         exit()
 
     if low is None or low == "":
-        gscript.error(_("[r.mblend] ERROR: low is a mandatory parameter."))
+        gs.error(_("[r.mblend] ERROR: low is a mandatory parameter."))
         exit()
 
     if output is None or output == "":
-        gscript.error(_("[r.mblend] ERROR: output is a mandatory parameter."))
+        gs.error(_("[r.mblend] ERROR: output is a mandatory parameter."))
         exit()
 
     if far_edge < 0 or far_edge > 100:
-        gscript.error(
+        gs.error(
             _("[r.mblend] ERROR: far_edge must be a percentage", " between 0 and 100.")
         )
         exit()
 
     if inter_points < 0:
-        gscript.error(
-            _("[r.mblend] ERROR: inter_points must be a positive", " integer.")
-        )
+        gs.error(_("[r.mblend] ERROR: inter_points must be a positive", " integer."))
         exit()
 
     # Set the region to the two input rasters
-    gscript.run_command("g.region", raster=high + "," + low)
+    gs.run_command("g.region", raster=high + "," + low)
     # Determine cell side
-    region = gscript.region()
+    region = gs.region()
     if region["nsres"] > region["ewres"]:
         cell_side = region["nsres"]
     else:
@@ -150,12 +148,10 @@ def main():
 
     # Make cell size compatible
     low_res_inter = getTemporaryIdentifier()
-    gscript.message(
+    gs.message(
         _("[r.mblend] Resampling low resolution raster to higher" + " resolution")
     )
-    gscript.run_command(
-        "r.resamp.interp", input=low, output=low_res_inter, method="nearest"
-    )
+    gs.run_command("r.resamp.interp", input=low, output=low_res_inter, method="nearest")
 
     # Obtain extent to interpolate
     low_extent_rast = getTemporaryIdentifier()
@@ -163,20 +159,16 @@ def main():
     low_extent = getTemporaryIdentifier()
     high_extent = getTemporaryIdentifier()
     interpol_area = getTemporaryIdentifier()
-    gscript.message(_("[r.mblend] Multiplying low resolution by zero"))
-    gscript.mapcalc(low_extent_rast + " = " + low + " * 0")
-    gscript.message(_("[r.mblend] Multiplying high resolution by zero"))
-    gscript.mapcalc(high_extent_rast + " = " + high + " * 0")
-    gscript.message(_("[r.mblend] Computing extent of low resolution"))
-    gscript.run_command(
-        "r.to.vect", input=low_extent_rast, output=low_extent, type="area"
-    )
-    gscript.message(_("[r.mblend] Computing extent of high resolution"))
-    gscript.run_command(
-        "r.to.vect", input=high_extent_rast, output=high_extent, type="area"
-    )
-    gscript.message(_("[r.mblend] Computing area to interpolate"))
-    gscript.run_command(
+    gs.message(_("[r.mblend] Multiplying low resolution by zero"))
+    gs.mapcalc(low_extent_rast + " = " + low + " * 0")
+    gs.message(_("[r.mblend] Multiplying high resolution by zero"))
+    gs.mapcalc(high_extent_rast + " = " + high + " * 0")
+    gs.message(_("[r.mblend] Computing extent of low resolution"))
+    gs.run_command("r.to.vect", input=low_extent_rast, output=low_extent, type="area")
+    gs.message(_("[r.mblend] Computing extent of high resolution"))
+    gs.run_command("r.to.vect", input=high_extent_rast, output=high_extent, type="area")
+    gs.message(_("[r.mblend] Computing area to interpolate"))
+    gs.run_command(
         "v.overlay",
         ainput=low_extent,
         binput=high_extent,
@@ -188,23 +180,23 @@ def main():
     interpol_area_buff = getTemporaryIdentifier()
     diff = getTemporaryIdentifier()
     diff_points_edge = getTemporaryIdentifier()
-    gscript.mapcalc(diff + " = " + high + " - " + low_res_inter)
-    gscript.message(_("[r.mblend] Computing buffer around interpolation area"))
-    gscript.run_command(
+    gs.mapcalc(diff + " = " + high + " - " + low_res_inter)
+    gs.message(_("[r.mblend] Computing buffer around interpolation area"))
+    gs.run_command(
         "v.buffer",
         input=interpol_area,
         output=interpol_area_buff,
         type="area",
         distance=cell_side,
     )
-    gscript.message(_("[r.mblend] Vectorising differences between input" + " rasters"))
-    gscript.run_command("r.mask", vector=interpol_area_buff)
-    gscript.run_command("r.to.vect", input=diff, output=diff_points_edge, type="point")
-    gscript.run_command("r.mask", flags="r")
+    gs.message(_("[r.mblend] Vectorising differences between input" + " rasters"))
+    gs.run_command("r.mask", vector=interpol_area_buff)
+    gs.run_command("r.to.vect", input=diff, output=diff_points_edge, type="point")
+    gs.run_command("r.mask", flags="r")
 
     # Compute average of the differences if flag -a was passed
     if use_average_differences:
-        p = gscript.pipe_command("r.univar", map=diff)
+        p = gs.pipe_command("r.univar", map=diff)
         result = {}
         for line in p.stdout:
             vector = line.split(": ")
@@ -224,26 +216,24 @@ def main():
     weight_points_all_edges = getTemporaryIdentifier()
     weight_points_edge = getTemporaryIdentifier()
     # 1. Distance to High resolution raster
-    gscript.message(_("[r.mblend] Computing distance to high resolution" + " raster"))
-    gscript.run_command("r.grow.distance", input=high, distance=dist_high)
+    gs.message(_("[r.mblend] Computing distance to high resolution" + " raster"))
+    gs.run_command("r.grow.distance", input=high, distance=dist_high)
     # 2. Rescale to the interval [0,10000]: these are the weights
-    gscript.message(_("[r.mblend] Rescaling distance to [0,10000] interval"))
-    gscript.run_command(
+    gs.message(_("[r.mblend] Rescaling distance to [0,10000] interval"))
+    gs.run_command(
         "r.rescale", input=dist_high, output=weights, to="0," + str(WEIGHT_MAX)
     )
     # 3. Extract points from interpolation area border
-    gscript.message(
-        _("[r.mblend] Extract points from interpolation area " + "boundary")
-    )
+    gs.message(_("[r.mblend] Extract points from interpolation area " + "boundary"))
     inner_buff = -cell_side / 2
-    gscript.run_command(
+    gs.run_command(
         "v.buffer",
         input=interpol_area,
         output=interpol_area_inner_buff,
         type="area",
         distance=inner_buff,
     )
-    gscript.run_command(
+    gs.run_command(
         "v.to.points",
         input=interpol_area_inner_buff,
         output=pre_interpol_area_points,
@@ -251,16 +241,16 @@ def main():
         dmax=d_max,
         layer="-1",
     )
-    gscript.message(_("[r.mblend] Copying features to layer 1"))
-    gscript.run_command(
+    gs.message(_("[r.mblend] Copying features to layer 1"))
+    gs.run_command(
         "v.category",
         input=pre_interpol_area_points,
         output=interpol_area_points,
         option="chlayer",
         layer="2,1",
     )
-    gscript.message(_("[r.mblend] Linking attribute table to layer 1"))
-    gscript.run_command(
+    gs.message(_("[r.mblend] Linking attribute table to layer 1"))
+    gs.run_command(
         "v.db.connect",
         map=interpol_area_points,
         table=interpol_area_points,
@@ -268,16 +258,16 @@ def main():
         flags="o",
     )
     # 4. Query distances to interpolation area points
-    gscript.message(_("[r.mblend] Querying distances raster"))
-    gscript.run_command(
+    gs.message(_("[r.mblend] Querying distances raster"))
+    gs.run_command(
         "v.what.rast", map=interpol_area_points, raster=weights, column=COL_VALUE
     )
     # 5. Select those with higher weights
     cut_off = str(far_edge / 100 * WEIGHT_MAX)
-    gscript.message(
+    gs.message(
         _("[r.mblend] Selecting far edge points (using cut-off" + " percentage)")
     )
-    gscript.run_command(
+    gs.run_command(
         "v.extract",
         input=interpol_area_points,
         output=weight_points_edge,
@@ -286,16 +276,16 @@ def main():
 
     # Merge the two point edges and set low res edge to zero
     points_edges = getTemporaryIdentifier()
-    gscript.message(_("[r.mblend] Dropping extra column from far edge"))
-    gscript.run_command(
+    gs.message(_("[r.mblend] Dropping extra column from far edge"))
+    gs.run_command(
         "v.db.dropcolumn", map=weight_points_edge, layer="1", columns="along"
     )
-    gscript.message(_("[r.mblend] Setting far edge weights to zero"))
-    gscript.run_command(
+    gs.message(_("[r.mblend] Setting far edge weights to zero"))
+    gs.run_command(
         "v.db.update", map=weight_points_edge, column=COL_VALUE, value=far_edge_value
     )
-    gscript.message(_("[r.mblend] Patching the two edges"))
-    gscript.run_command(
+    gs.message(_("[r.mblend] Patching the two edges"))
+    gs.run_command(
         "v.patch",
         input=diff_points_edge + "," + weight_points_edge,
         output=points_edges,
@@ -306,11 +296,11 @@ def main():
     smoothing = getTemporaryIdentifier()
     interpol_area_rst = getTemporaryIdentifier()
     # Consign region to interpolation area
-    gscript.run_command("g.region", vector=interpol_area_buff)
-    gscript.message(
+    gs.run_command("g.region", vector=interpol_area_buff)
+    gs.message(
         _("[r.mblend] Interpolating smoothing surface. This" + " might take a while...")
     )
-    gscript.run_command(
+    gs.run_command(
         "v.surf.idw",
         input=points_edges,
         column=COL_VALUE,
@@ -319,25 +309,25 @@ def main():
         npoints=inter_points,
     )
     # Reset region to full extent
-    gscript.run_command("g.region", raster=high + "," + low)
+    gs.run_command("g.region", raster=high + "," + low)
 
     # Apply stitching
     smooth_low_res = getTemporaryIdentifier()
     # Sum to low res
-    gscript.message(_("[r.mblend] Applying smoothing surface"))
-    gscript.mapcalc(smooth_low_res + " = " + low_res_inter + " + " + smoothing)
+    gs.message(_("[r.mblend] Applying smoothing surface"))
+    gs.mapcalc(smooth_low_res + " = " + low_res_inter + " + " + smoothing)
     # Add both rasters
     try:
-        gscript.message(_("[r.mblend] Joining result into a single raster"))
-        gscript.run_command("r.patch", input=high + "," + smooth_low_res, output=output)
+        gs.message(_("[r.mblend] Joining result into a single raster"))
+        gs.run_command("r.patch", input=high + "," + smooth_low_res, output=output)
     except Exception as ex:
-        gscript.error(_("[r.mblend] ERROR: Failed to create smoothed raster."))
+        gs.error(_("[r.mblend] ERROR: Failed to create smoothed raster."))
         exit()
 
-    gscript.message(_("[r.mblend] SUCCESS: smoothed raster created."))
+    gs.message(_("[r.mblend] SUCCESS: smoothed raster created."))
 
 
 if __name__ == "__main__":
     atexit.register(cleanup)
-    gscript.use_temp_region()
+    gs.use_temp_region()
     main()

--- a/src/raster/r.mcda.ahp/r.mcda.ahp.py
+++ b/src/raster/r.mcda.ahp/r.mcda.ahp.py
@@ -47,7 +47,7 @@
 # %end
 
 import sys
-import grass.script as grass
+import grass.script as gs
 import numpy as np
 import warnings
 
@@ -74,7 +74,7 @@ def calculateMap(criteria, weight, outputMap):
     for i in range(len(criteria) - 1):
         formula += "%s*%s + " % (criteria[i], weight[i])
     formula += "%s*%s " % (criteria[len(criteria) - 1], weight[len(criteria) - 1])
-    grass.mapcalc(outputMap + "=" + formula)
+    gs.mapcalc(outputMap + "=" + formula)
     return 0
 
 
@@ -112,7 +112,7 @@ def main():
     criteria = options["criteria"].split(",")
     pairwise = options["pairwise"]
     outputMap = options["output"]
-    gregion = grass.region()
+    gregion = gs.region()
     nrows = gregion["rows"]
     ncols = gregion["cols"]
     ewres = int(gregion["ewres"])
@@ -124,5 +124,5 @@ def main():
 
 
 if __name__ == "__main__":
-    options, flags = grass.parser()
+    options, flags = gs.parser()
     sys.exit(main())

--- a/src/raster/r.mcda.input/r.mcda.input.py
+++ b/src/raster/r.mcda.input/r.mcda.input.py
@@ -49,7 +49,7 @@
 
 
 import sys
-import grass.script as grass
+import grass.script as gs
 import pdb
 import string
 
@@ -128,33 +128,33 @@ def patch_georules(maps, outputMap):
             if l == "_".join(m.split("_")[1:]):
                 map_synth.append(m)
         if len(map_synth) > 1:
-            grass.run_command(
+            gs.run_command(
                 "r.patch", overwrite="True", input=(",".join(map_synth)), output=l
             )
         else:
-            grass.run_command("g.copy", raster=(str(map_synth), l))
+            gs.run_command("g.copy", raster=(str(map_synth), l))
 
-        grass.run_command(
+        gs.run_command(
             "r.to.vect", overwrite="True", flags="s", input=l, output=l, feature="area"
         )
-        grass.run_command("v.db.addcol", map=l, columns="rule varchar(25)")
-        grass.run_command("v.db.update", map=l, column="rule", value=l)
-        grass.run_command("v.db.update", map=l, column="label", value=l)
+        gs.run_command("v.db.addcol", map=l, columns="rule varchar(25)")
+        gs.run_command("v.db.update", map=l, column="rule", value=l)
+        gs.run_command("v.db.update", map=l, column="label", value=l)
     mapstring = ",".join(labels)
 
     if len(maps) > 1:
-        grass.run_command(
+        gs.run_command(
             "v.patch", overwrite="True", flags="e", input=mapstring, output=outputMap
         )
     else:
-        grass.run_command("g.copy", vector=(mapstring, outputMap))
+        gs.run_command("g.copy", vector=(mapstring, outputMap))
 
 
 def main():
     input_rules = options["input"]
     outputMap = options["output"]
 
-    gregion = grass.region()
+    gregion = gs.region()
     nrows = gregion["rows"]
     ncols = gregion["cols"]
     ewres = int(gregion["ewres"])
@@ -170,7 +170,7 @@ def main():
     for i in range(len(rules)):
         mappa = "r" + rules[i]["id_rule"] + "_" + rules[i]["class"]
         formula = parser_mapcalc(rules, i)
-        grass.mapcalc(mappa + "=" + formula)
+        gs.mapcalc(mappa + "=" + formula)
         maps.append(mappa)
 
     maplist = ",".join(maps)
@@ -178,17 +178,13 @@ def main():
     patch_georules(maps, outputMap)
 
     if not flags["l"]:
-        grass.run_command(
-            "g.remove", flags="f", quiet=True, type="raster", name=maplist
-        )
-        grass.run_command(
-            "g.remove", flags="f", quiet=True, type="vector", name=maplist
-        )
+        gs.run_command("g.remove", flags="f", quiet=True, type="raster", name=maplist)
+        gs.run_command("g.remove", flags="f", quiet=True, type="vector", name=maplist)
 
     input_rules.close()
     return 0
 
 
 if __name__ == "__main__":
-    options, flags = grass.parser()
+    options, flags = gs.parser()
     sys.exit(main())

--- a/src/raster/r.mcda.output/r.mcda.output.py
+++ b/src/raster/r.mcda.output/r.mcda.output.py
@@ -57,7 +57,7 @@
 import sys
 
 ##from grass.script import core as grass
-import grass.script as grass
+import grass.script as gs
 
 
 def main():
@@ -66,7 +66,7 @@ def main():
     decision = options["decision"]
     output = options["output"]
 
-    gregion = grass.region()
+    gregion = gs.region()
     nrows = gregion["rows"]
     ncols = gregion["cols"]
     ewres = int(gregion["ewres"])
@@ -79,7 +79,7 @@ def main():
         outf.write("+ %s: (continuous)\n" % attributes[i])
     outf.write("+ %s: [" % decision)
     value = []
-    value = grass.read_command("r.describe", flags="1n", map=decision)
+    value = gs.read_command("r.describe", flags="1n", map=decision)
     v = value.split()
 
     for i in range(len(v) - 1):
@@ -98,16 +98,16 @@ def main():
     examples = []
     MATRIX = []
     for i in range(len(attributes)):
-        grass.mapcalc(
+        gs.mapcalc(
             "rast=if(isnull(${decision})==0,${attribute},null())",
             rast="rast",
             decision=decision,
             attribute=attributes[i],
         )
-        tmp = grass.read_command("r.stats", flags="1n", nv="?", input="rast")
+        tmp = gs.read_command("r.stats", flags="1n", nv="?", input="rast")
         example = tmp.split()
         examples.append(example)
-    tmp = grass.read_command("r.stats", flags="1n", nv="?", input=decision)
+    tmp = gs.read_command("r.stats", flags="1n", nv="?", input=decision)
     example = tmp.split()
 
     examples.append(example)
@@ -129,5 +129,5 @@ def main():
 
 
 if __name__ == "__main__":
-    options, flags = grass.parser()
+    options, flags = gs.parser()
     sys.exit(main())

--- a/src/raster/r.mcda.roughset/r.mcda.roughset.py
+++ b/src/raster/r.mcda.roughset/r.mcda.roughset.py
@@ -71,7 +71,7 @@ import sys
 import copy
 import numpy as np
 from time import time, ctime
-import grass.script as grass
+import grass.script as gs
 import grass.script.array as garray
 from functools import reduce
 
@@ -84,7 +84,7 @@ def BuildFileISF(attributes, preferences, decision, outputMap, outputTxt):
         outf.write("+ %s: (continuous)\n" % attributes[i])
     outf.write("+ %s: [" % decision)
     value = []
-    value = grass.read_command("r.describe", flags="1n", map=decision)
+    value = gs.read_command("r.describe", flags="1n", map=decision)
     v = value.split()
 
     for i in range(len(v) - 1):
@@ -102,23 +102,23 @@ def BuildFileISF(attributes, preferences, decision, outputMap, outputTxt):
     if flags["n"]:
         for i in range(len(attributes)):
             print("%s - convert null to 0" % str(attributes[i]))
-            grass.run_command("r.null", map=attributes[i], null=0)
+            gs.run_command("r.null", map=attributes[i], null=0)
 
     outf.write("\n**EXAMPLES\n")
     examples = []
     MATRIX = []
 
     for i in range(len(attributes)):
-        grass.mapcalc(
+        gs.mapcalc(
             "rast=if(isnull(${decision})==0,${attribute},null())",
             rast="rast",
             decision=decision,
             attribute=attributes[i],
         )
-        tmp = grass.read_command("r.stats", flags="1n", nv="?", input="rast")
+        tmp = gs.read_command("r.stats", flags="1n", nv="?", input="rast")
         example = tmp.split()
         examples.append(example)
-    tmp = grass.read_command("r.stats", flags="1n", nv="?", input=decision)
+    tmp = gs.read_command("r.stats", flags="1n", nv="?", input=decision)
     example = tmp.split()
     examples.append(example)
 
@@ -632,7 +632,7 @@ def Parser_mapcalc(RULES, outputMap):
             {"id": i, "type": R[0]["type"], "class": R[0]["class"]}
         )  # extract category name
         maps.append(mappa)  # extract maps name
-        grass.mapcalc(mappa + "=" + formula)
+        gs.mapcalc(mappa + "=" + formula)
         i += 1
     mapstring = ",".join(maps)
 
@@ -646,30 +646,30 @@ def Parser_mapcalc(RULES, outputMap):
             if l == "_".join(m.split("_")[1:]):
                 map_synth.append(m)
         if len(map_synth) > 1:
-            grass.run_command(
+            gs.run_command(
                 "r.patch", overwrite="True", input=(",".join(map_synth)), output=l
             )
         else:
-            grass.run_command("g.copy", raster=(str(map_synth), l))
+            gs.run_command("g.copy", raster=(str(map_synth), l))
         print("__", str(map_synth), l)
-        grass.run_command(
+        gs.run_command(
             "r.to.vect", overwrite="True", flags="s", input=l, output=l, feature="area"
         )
-        grass.run_command("v.db.addcol", map=l, columns="rule varchar(25)")
-        grass.run_command("v.db.update", map=l, column="rule", value=l)
-        grass.run_command("v.db.update", map=l, column="label", value=l)
+        gs.run_command("v.db.addcol", map=l, columns="rule varchar(25)")
+        gs.run_command("v.db.update", map=l, column="rule", value=l)
+        gs.run_command("v.db.update", map=l, column="label", value=l)
     mapslabels = ",".join(labels)
 
     if len(maps) > 1:
-        grass.run_command(
+        gs.run_command(
             "v.patch", overwrite="True", flags="e", input=mapslabels, output=outputMap
         )
     else:
-        grass.run_command("g.copy", vector=(mapslabels, outputMap))
+        gs.run_command("g.copy", vector=(mapslabels, outputMap))
 
     if not flags["l"]:
-        grass.run_command("g.remove", flags="f", type="raster", name=mapstring)
-        grass.run_command("g.remove", flags="f", type="vector", name=mapstring)
+        gs.run_command("g.remove", flags="f", type="raster", name=mapstring)
+        gs.run_command("g.remove", flags="f", type="vector", name=mapstring)
 
     return 0
 
@@ -723,5 +723,5 @@ def main():
 
 
 if __name__ == "__main__":
-    options, flags = grass.parser()
+    options, flags = gs.parser()
     sys.exit(main())

--- a/src/raster/r.mcda.topsis/r.mcda.topsis.py
+++ b/src/raster/r.mcda.topsis/r.mcda.topsis.py
@@ -52,19 +52,17 @@
 
 
 import sys
-import grass.script as gscript
+import grass.script as gs
 from time import time
 
 
 def standardizedNormalizedMatrix(attributes, weights):  # step1 and step2
     criteria = []
     for criterion, weight in zip(attributes, weights):
-        gscript.mapcalc(
-            "critPow=pow(${criterion},2)", criterion=criterion, overwrite="True"
-        )
-        stats = gscript.parse_command("r.univar", map="critPow", flags="g")
+        gs.mapcalc("critPow=pow(${criterion},2)", criterion=criterion, overwrite="True")
+        stats = gs.parse_command("r.univar", map="critPow", flags="g")
         nameMap = "_%s" % criterion
-        gscript.mapcalc(
+        gs.mapcalc(
             "${nameMap}=(${criterion}/sqrt(${sum}))*${weight}",
             nameMap=nameMap,
             criterion=criterion,
@@ -79,7 +77,7 @@ def standardizedNormalizedMatrix(attributes, weights):  # step1 and step2
 def idealPoints(criteria, preference):  # step3
     idelaPointsList = []
     for c, p in zip(criteria, preference):
-        stats = gscript.parse_command("r.univar", map=c, flags="g")
+        stats = gs.parse_command("r.univar", map=c, flags="g")
         if p == "gain":
             ip = float(stats["max"])
         elif p == "cost":
@@ -94,7 +92,7 @@ def idealPoints(criteria, preference):  # step3
 def worstPoints(criteria, preference):
     worstPointsList = []
     for c, p in zip(criteria, preference):
-        stats = gscript.parse_command("r.univar", map=c, flags="g")
+        stats = gs.parse_command("r.univar", map=c, flags="g")
         if p == "gain":
             wp = float(stats["min"])
         elif p == "cost":
@@ -111,7 +109,7 @@ def idealPointDistance(idelaPointsList, criteria):  # step4a
     i = 0
     for c, ip in zip(criteria, idelaPointsList):
         mapname = "tmap_%s" % i
-        gscript.mapcalc(
+        gs.mapcalc(
             "${mapname}=pow((${c}-${ip}),2)",
             mapname=mapname,
             c=c,
@@ -121,8 +119,8 @@ def idealPointDistance(idelaPointsList, criteria):  # step4a
         distance.append(mapname)
         i = i + 1
     mapalgebra2 = "IdealPointDistance=sqrt(%s)" % ("+".join(distance))
-    gscript.mapcalc(mapalgebra2, overwrite="True")
-    gscript.run_command("g.remove", flags="f", type="raster", name=",".join(distance))
+    gs.mapcalc(mapalgebra2, overwrite="True")
+    gs.run_command("g.remove", flags="f", type="raster", name=",".join(distance))
     return 0
 
 
@@ -131,7 +129,7 @@ def worstPointDistance(worstPointsList, criteria):  # step4b
     i = 0
     for c, wp in zip(criteria, worstPointsList):
         mapname = "tmap_%s" % i
-        gscript.mapcalc(
+        gs.mapcalc(
             "${mapname}=pow((${c}-${wp}),2)",
             mapname=mapname,
             c=c,
@@ -141,12 +139,12 @@ def worstPointDistance(worstPointsList, criteria):  # step4b
         distance.append(mapname)
         i = i + 1
     mapalgebra2 = "WorstPointDistance=sqrt(%s)" % ("+".join(distance))
-    gscript.mapcalc(mapalgebra2, overwrite="True")
-    gscript.run_command("g.remove", flags="f", type="raster", name=",".join(distance))
+    gs.mapcalc(mapalgebra2, overwrite="True")
+    gs.run_command("g.remove", flags="f", type="raster", name=",".join(distance))
 
 
 def relativeCloseness(topsismap):  # step5
-    gscript.mapcalc(
+    gs.mapcalc(
         "${topsismap}=WorstPointDistance/(WorstPointDistance+IdealPointDistance)",
         topsismap=topsismap,
         overwrite="True",
@@ -169,8 +167,8 @@ def main():
     idealPointDistance(idelaPointsList, criteria)
     worstPointDistance(worstPointsList, criteria)
     relativeCloseness(topsismap)
-    gscript.run_command("g.remove", flags="f", type="raster", name=",".join(criteria))
-    gscript.run_command(
+    gs.run_command("g.remove", flags="f", type="raster", name=",".join(criteria))
+    gs.run_command(
         "g.remove",
         flags="f",
         type="raster",
@@ -181,5 +179,5 @@ def main():
 
 
 if __name__ == "__main__":
-    options, flags = gscript.parser()
+    options, flags = gs.parser()
     main()

--- a/src/raster/r.mregression.series/r.mregression.series.py
+++ b/src/raster/r.mregression.series/r.mregression.series.py
@@ -64,7 +64,7 @@ if "GISBASE" not in os.environ:
     sys.stderr.write("You must be in GRASS GIS to run this program.\n")
     sys.exit(1)
 
-import grass.script as grass
+import grass.script as gs
 from grass.pygrass import raster
 from grass.pygrass.gis.region import Region
 
@@ -149,7 +149,7 @@ class DataModel(object):
             prefix+variable_name (see header)
         """
         if len(set(headers)) != len(headers):
-            grass.error("The names of the variables are not unique!")
+            gs.error("The names of the variables are not unique!")
 
         self.mtype = restype
 
@@ -266,18 +266,18 @@ def main(options, flags):
     headers, outputs, inputs = get_sample_names(samples)
 
     model = DataModel(headers, outputs, inputs, res_pref)
-    model.fit(model=model_type, overwrite=grass.overwrite())
+    model.fit(model=model_type, overwrite=gs.overwrite())
     sys.exit(0)
 
 
 if __name__ == "__main__":
-    options, flags = grass.parser()
+    options, flags = gs.parser()
 
     # lazy import (global to avoid import in a loop)
     try:
         import statsmodels.api as sm
     except ImportError:
-        grass.fatal(
+        gs.fatal(
             _("Cannot import statsmodels. Install python-statmodels package first")
         )
 

--- a/src/raster/r.northerness.easterness/r.northerness.easterness.py
+++ b/src/raster/r.northerness.easterness/r.northerness.easterness.py
@@ -31,7 +31,7 @@ COPYRIGHT: (C) 2014 by the GRASS Development Team
 
 import sys
 import os
-import grass.script as grass
+import grass.script as gs
 import math
 
 
@@ -45,89 +45,89 @@ def main():
     r_northerness_slope = r_elevation + "_northerness_slope"
 
     # Calculation of slope and aspect maps
-    grass.message("----")
-    grass.message("Calculation of slope and aspect by r.slope.aspect ...")
-    grass.run_command(
+    gs.message("----")
+    gs.message("Calculation of slope and aspect by r.slope.aspect ...")
+    gs.run_command(
         "r.slope.aspect",
         elevation=r_elevation,
         slope=r_slope,
         aspect=r_aspect,
         overwrite=True,
     )
-    grass.message("Calculation of slope and aspect done.")
-    grass.message("----")
+    gs.message("Calculation of slope and aspect done.")
+    gs.message("----")
 
     # Correction aspect angles from cartesian (GRASS default) to compass angles
     #   if((A < 90, 90-A, 360+90-A))
-    grass.message(
+    gs.message(
         "Convert aspect angles from cartesian (GRASS GIS default) to compass angles ..."
     )
-    grass.mapcalc(
+    gs.mapcalc(
         "$outmap = if( $cartesian == 0, 0, if( $cartesian < 90, 90 - $cartesian, 360 + 90 - $cartesian) )",
         outmap=r_aspect_compass,
         cartesian=r_aspect,
     )
-    grass.message("...")
-    grass.run_command("r.info", map=r_aspect_compass)
-    grass.message("Aspect conversion done.")
-    grass.message("----")
+    gs.message("...")
+    gs.run_command("r.info", map=r_aspect_compass)
+    gs.message("Aspect conversion done.")
+    gs.message("----")
 
     # Calculation of northerness
-    grass.message("Calculate northerness ...")
-    grass.mapcalc(
+    gs.message("Calculate northerness ...")
+    gs.mapcalc(
         "$outmap = cos( $compass )", outmap=r_northerness, compass=r_aspect_compass
     )
-    grass.message("...")
-    grass.run_command("r.info", map=r_northerness)
-    grass.message("Northerness calculation done.")
-    grass.message("----")
+    gs.message("...")
+    gs.run_command("r.info", map=r_northerness)
+    gs.message("Northerness calculation done.")
+    gs.message("----")
 
     # Calculation of easterness
-    grass.message("Calculate easterness ...")
-    grass.mapcalc(
+    gs.message("Calculate easterness ...")
+    gs.mapcalc(
         "$outmap = sin( $compass )", outmap=r_easterness, compass=r_aspect_compass
     )
-    grass.message("...")
-    grass.run_command("r.info", map=r_easterness)
-    grass.message("Easterness calculation done.")
-    grass.message("----")
+    gs.message("...")
+    gs.run_command("r.info", map=r_easterness)
+    gs.message("Easterness calculation done.")
+    gs.message("----")
 
     # Calculation of northerness*slope
-    grass.message("Calculate northerness*slope ...")
-    grass.mapcalc(
+    gs.message("Calculate northerness*slope ...")
+    gs.mapcalc(
         "$outmap = $northerness * $slope",
         outmap=r_northerness_slope,
         northerness=r_northerness,
         slope=r_slope,
     )
-    grass.message("...")
-    grass.run_command("r.info", map=r_northerness_slope)
-    grass.message("Northerness*slope calculation done.")
-    grass.message("----")
+    gs.message("...")
+    gs.run_command("r.info", map=r_northerness_slope)
+    gs.message("Northerness*slope calculation done.")
+    gs.message("----")
 
     # adjust color
-    grass.message("Adjust color ...")
-    grass.run_command("r.colors", map=r_northerness, color="grey")
-    grass.run_command("r.colors", map=r_easterness, color="grey")
-    grass.run_command("r.colors", map=r_northerness_slope, color="grey")
+    gs.message("Adjust color ...")
+    gs.run_command("r.colors", map=r_northerness, color="grey")
+    gs.run_command("r.colors", map=r_easterness, color="grey")
+    gs.run_command("r.colors", map=r_northerness_slope, color="grey")
 
-    grass.message("Color adjustment done.")
-    grass.message("----")
+    gs.message("Color adjustment done.")
+    gs.message("----")
 
     # clean up some temporay files and maps
-    grass.message("Some clean up ...")
-    grass.run_command("g.remove", flags="f", type="raster", name=r_slope, quiet=True)
-    grass.run_command("g.remove", flags="f", type="raster", name=r_aspect, quiet=True)
-    grass.run_command(
+    gs.message("Some clean up ...")
+    gs.run_command("g.remove", flags="f", type="raster", name=r_slope, quiet=True)
+    gs.run_command("g.remove", flags="f", type="raster", name=r_aspect, quiet=True)
+    gs.run_command(
         "g.remove", flags="f", type="raster", name=r_aspect_compass, quiet=True
     )
-    grass.message("Clean up done.")
-    grass.message("----")
+    gs.message("Clean up done.")
+    gs.message("----")
 
     # r.northerness.easterness done!
-    grass.message("r.northerness.easterness done!")
+    gs.message("r.northerness.easterness done!")
 
 
 if __name__ == "__main__":
-    options, flags = grass.parser()
+    options, flags = gs.parser()
     sys.exit(main())

--- a/src/raster/r.object.activelearning/r.object.activelearning.py
+++ b/src/raster/r.object.activelearning/r.object.activelearning.py
@@ -97,7 +97,7 @@
 
 try:  # You can run the tests outside of grass where those imports are not available
     import grass as grass
-    import grass.script as gcore
+    import grass.script as gs
 except ImportError:
     pass
 
@@ -193,7 +193,7 @@ def update(update_file, X_train, ID_train, y_train, X_unlabeled, ID_unlabeled):
             ID_train = np.append(ID_train, [ID], axis=0)
             y_train = np.append(y_train, [label], axis=0)
         else:
-            gcore.warning("The following sample could not be found :{}".format(row[0]))
+            gs.warning("The following sample could not be found :{}".format(row[0]))
 
     return X_train, ID_train, y_train
 
@@ -243,7 +243,7 @@ def write_update(
             unlabeled = np.delete(unlabeled, index[0][0], axis=0)
             successful_updates.append(index_update)
         else:
-            gcore.warning(
+            gs.warning(
                 "Unable to update completely: the following sample could not be found in the unlabeled set:{}".format(
                     row[0]
                 )
@@ -259,10 +259,10 @@ def write_update(
     # Save files
     if new_training_filename != "":
         write_updated_file(new_training_filename, training)
-        gcore.message("New training file written to {}".format(new_training_filename))
+        gs.message("New training file written to {}".format(new_training_filename))
     if new_unlabeled_filename != "":
         write_updated_file(new_unlabeled_filename, unlabeled)
-        gcore.message("New unlabeled file written to {}".format(new_unlabeled_filename))
+        gs.message("New unlabeled file written to {}".format(new_unlabeled_filename))
 
 
 def write_updated_file(file_path, data):
@@ -517,7 +517,7 @@ def learning(
     c_svm, gamma_parameter = SVM_parameters(
         options["c_svm"], options["gamma_parameter"], X_train, y_train, search_iter
     )
-    gcore.message(
+    gs.message(
         "Parameters used : C={}, gamma={}, lambda={}".format(
             c_svm, gamma_parameter, diversity_lambda
         )
@@ -592,7 +592,7 @@ def main():
         from sklearn.model_selection import StratifiedKFold
         from sklearn.metrics.pairwise import rbf_kernel
     except ImportError:
-        gcore.fatal(
+        gs.fatal(
             "This module requires the scikit-learn python package. Please install it."
         )
 
@@ -602,7 +602,7 @@ def main():
         import numpy as np
     except ModuleNotFoundError as e:
         msg = e.msg
-        gcore.fatal(
+        gs.fatal(
             _(
                 "Unable to load python <{0}> lib (requires lib <{0}> being installed)."
             ).format(msg.split("'")[-2])
@@ -650,7 +650,7 @@ def main():
     elif options["update"] == "" and (
         options["training_updated"] != "" or options["unlabeled_updated"] != ""
     ):
-        gcore.warning("No update file specified : could not write the updated files.")
+        gs.warning("No update file specified : could not write the updated files.")
     nbr_new_train = ID_train.shape[0]
 
     samples_to_label_IDs, score, predictions = learning(
@@ -675,14 +675,14 @@ def main():
         write_result_file(
             ID_unlabeled, X_unlabeled, predictions, header_unlabeled, predictions_file
         )
-        gcore.message("Class predictions written to {}".format(predictions_file))
+        gs.message("Class predictions written to {}".format(predictions_file))
 
-    gcore.message("Training set : {}".format(X_train.shape[0]))
-    gcore.message("Test set : {}".format(X_test.shape[0]))
-    gcore.message(
+    gs.message("Training set : {}".format(X_train.shape[0]))
+    gs.message("Test set : {}".format(X_test.shape[0]))
+    gs.message(
         "Unlabeled set : {}".format(X_unlabeled.shape[0] - (nbr_new_train - nbr_train))
     )
-    gcore.message("Score : {}".format(score))
+    gs.message("Score : {}".format(score))
 
     for ID in samples_to_label_IDs:
         print((int(ID)))

--- a/src/raster/r.object.spatialautocor/r.object.spatialautocor.py
+++ b/src/raster/r.object.spatialautocor/r.object.spatialautocor.py
@@ -58,28 +58,28 @@
 
 from __future__ import print_function
 import sys
-import grass.script as gscript
+import grass.script as gs
 
 
 # check requirements
 def check_progs():
     found_missing = False
     for prog in ["r.neighborhoodmatrix"]:
-        if not gscript.find_program(prog, "--help"):
+        if not gs.find_program(prog, "--help"):
             found_missing = True
-            gscript.warning(
+            gs.warning(
                 _("'%s' required. Please install '%s' first using 'g.extension %s'")
                 % (prog, prog, prog)
             )
     if found_missing:
-        gscript.fatal(_("An ERROR occurred running i.segment.uspo"))
+        gs.fatal(_("An ERROR occurred running i.segment.uspo"))
 
 
 def get_nb_matrix(mapname, diagonal):
     """Create a dictionary with neighbors per segment"""
 
     if diagonal:
-        res = gscript.read_command(
+        res = gs.read_command(
             "r.neighborhoodmatrix",
             input_=mapname,
             output="-",
@@ -88,7 +88,7 @@ def get_nb_matrix(mapname, diagonal):
             quiet=True,
         )
     else:
-        res = gscript.read_command(
+        res = gs.read_command(
             "r.neighborhoodmatrix", input_=mapname, output="-", sep="comma", quiet=True
         )
 
@@ -107,10 +107,10 @@ def get_nb_matrix(mapname, diagonal):
 def get_autocorrelation(mapname, raster, neighbordict, method):
     """Calculate either Moran's I or Geary's C for values of the given raster"""
 
-    raster_vars = gscript.parse_command("r.univar", map_=raster, flags="g", quiet=True)
+    raster_vars = gs.parse_command("r.univar", map_=raster, flags="g", quiet=True)
     global_mean = float(raster_vars["mean"])
 
-    univar_res = gscript.read_command(
+    univar_res = gs.read_command(
         "r.univar",
         flags="t",
         map_=raster,
@@ -176,5 +176,5 @@ def main():
 
 
 if __name__ == "__main__":
-    options, flags = gscript.parser()
+    options, flags = gs.parser()
     sys.exit(main())

--- a/src/raster/r.out.legend/r.out.legend.py
+++ b/src/raster/r.out.legend/r.out.legend.py
@@ -179,7 +179,7 @@
 import os
 import sys
 import math
-import grass.script as grass
+import grass.script as gs
 from grass.pygrass.modules import Module
 from grass.script.utils import parse_key_val
 import importlib.util
@@ -198,20 +198,20 @@ def main():
     outputfile = options["file"]
     ext = outputfile.split(".")
     if len(ext) == 1:
-        grass.fatal("Please provide the file extension of the output file")
+        gs.fatal("Please provide the file extension of the output file")
     filetype = options["filetype"]
     if filetype == "cairo":
         allowed = (".png", ".bmp", "ppm", "pdf", "ps", "svg")
         if not outputfile.lower().endswith(allowed):
-            grass.fatal("Unknown display driver <{}>".format(ext[1]))
+            gs.fatal("Unknown display driver <{}>".format(ext[1]))
     if filetype == "ps" and not ext[1] == "ps":
-        grass.fatal(
+        gs.fatal(
             "The file type <{}> does not match the file extension <{}>".format(
                 filetype, ext[1]
             )
         )
     if filetype == "png" and not ext[1] == "png":
-        grass.fatal(
+        gs.fatal(
             "The file type <{}> does not match the file extension <{}>".format(
                 filetype, ext[1]
             )
@@ -262,7 +262,7 @@ def main():
         bw = float(width)
         bh = float(height)
     else:
-        grass.error("Unit must be inch, cm, mm or px")
+        gs.error("Unit must be inch, cm, mm or px")
 
     # Add size of legend to w or h, if flag_d is set
     # Add size of tics
@@ -285,7 +285,7 @@ def main():
 
     # Determine space at left and right (or top and bottom)
     # based on fontsize (fz) and number of digits
-    maprange = grass.raster_info(inmap)
+    maprange = gs.raster_info(inmap)
     maxval = round(maprange["max"], digits)
     minval = round(maprange["min"], digits)
     if maxval < 1:
@@ -375,10 +375,10 @@ def main():
         im.save(outputfile, dpi=(resol, resol))
 
     # Provide informatie about image on standard output
-    grass.message("----------------------------\n")
-    grass.message("File saved as {}".format(outputfile))
-    grass.message("The image dimensions are:\n")
-    grass.message("{} px wide and {} px heigh\n".format(str(int(iw)), str(int(ih))))
+    gs.message("----------------------------\n")
+    gs.message("File saved as {}".format(outputfile))
+    gs.message("The image dimensions are:\n")
+    gs.message("{} px wide and {} px heigh\n".format(str(int(iw)), str(int(ih))))
     if unit == "inch":
         wr = round(iw / resol, 3)
         hr = round(ih / resol, 3)
@@ -391,11 +391,11 @@ def main():
     else:
         wr = "same"
     if wr != "same":
-        grass.message("at a resolution of {} ppi this is:".format(str(resol)))
-        grass.message("{0} {2} x {1} {2}\n".format(str(wr), str(hr), unit))
-    grass.message("----------------------------\n")
+        gs.message("at a resolution of {} ppi this is:".format(str(resol)))
+        gs.message("{0} {2} x {1} {2}\n".format(str(wr), str(hr), unit))
+    gs.message("----------------------------\n")
 
 
 if __name__ == "__main__":
-    options, flags = grass.parser()
+    options, flags = gs.parser()
     sys.exit(main())

--- a/src/raster/r.popgrowth/r.popgrowth.py
+++ b/src/raster/r.popgrowth/r.popgrowth.py
@@ -126,7 +126,7 @@ import atexit
 import math  # for function sqrt()
 
 # import required grass modules
-import grass.script as grass
+import grass.script as gs
 import grass.script.array as garray
 
 
@@ -135,16 +135,16 @@ import numpy as np
 
 
 def cleanup():
-    grass.debug(_("This is the cleanup part"))
+    gs.debug(_("This is the cleanup part"))
     if tmp_map_rast or tmp_map_vect:
-        grass.run_command(
+        gs.run_command(
             "g.remove",
             flags="fb",
             type="raster",
             name=[f + str(os.getpid()) for f in tmp_map_rast],
             quiet=True,
         )
-        grass.run_command(
+        gs.run_command(
             "g.remove",
             flags="f",
             type="vector",
@@ -165,14 +165,14 @@ def main():
     ############ PARAMETER INPUT ##############
     # Check for correct input
     if str(options["exponential_output"]) == "" and str(options["ricker_output"]) == "":
-        grass.fatal(_("Output name for a model is missing"))
+        gs.fatal(_("Output name for a model is missing"))
 
     # Model parameters input
     t = int(options["timesteps"])
 
     # If populations patches are provided, otherwise single cell populations are used
     if options["population_patches"]:
-        grass.run_command(
+        gs.run_command(
             "r.statistics2",
             base=options["population_patches"],
             cover=options["n_initial"],
@@ -180,7 +180,7 @@ def main():
             output="n0_tmp_%d" % os.getpid(),
         )
     else:
-        grass.run_command(
+        gs.run_command(
             "g.copy", raster=options["n_initial"] + "," + "n0_tmp_%d" % os.getpid()
         )
 
@@ -225,14 +225,14 @@ def main():
     if options["exponential_output"]:
         # Check for correct input
         if options["r_exp_value"] and options["r_exp_map"]:
-            grass.fatal(_("Provide either fixed value for r or raster map"))
+            gs.fatal(_("Provide either fixed value for r or raster map"))
 
         # Define r
         if options["r_exp_map"]:
-            grass.debug(_("r_exp_map provided"))
+            gs.debug(_("r_exp_map provided"))
 
             if options["population_patches"]:
-                grass.run_command(
+                gs.run_command(
                     "r.statistics2",
                     base=options["population_patches"],
                     cover=options["r_exp_map"],
@@ -240,7 +240,7 @@ def main():
                     output="r_exp_tmp_%d" % os.getpid(),
                 )
             else:
-                grass.run_command(
+                gs.run_command(
                     "g.copy",
                     raster=options["r_exp_map"] + "," + "r_exp_tmp_%d" % os.getpid(),
                 )
@@ -252,7 +252,7 @@ def main():
         elif options["r_exp_value"]:
             r = float(options["r_exp_value"])
         else:
-            grass.fatal(_("No r value/map provided for exponential model"))
+            gs.fatal(_("No r value/map provided for exponential model"))
 
         # run model
         n0_map = garray.array("n0_tmp_%d" % os.getpid())
@@ -263,7 +263,7 @@ def main():
 
         # Retransform in case of patches
         if options["population_patches"]:
-            grass.mapcalc(
+            gs.mapcalc(
                 "$exponential_output = if($n0,(round(($n0*1.0/$n0_tmp)*$exponential_output_tmp)),null())",
                 ricker_output=options["exponential_output"],
                 n0=options["n_initial"],
@@ -272,7 +272,7 @@ def main():
             )
 
         else:
-            grass.mapcalc(
+            gs.mapcalc(
                 "$exponential_output = if($n0,$exponential_output_tmp,null())",
                 exponential_output=options["exponential_output"],
                 n0=options["n_initial"],
@@ -283,16 +283,16 @@ def main():
     if options["ricker_output"]:
         # Check for correct input
         if options["r_rick_value"] and options["r_rick_map"]:
-            grass.fatal(_("Provide either fixed value for r or raster map"))
+            gs.fatal(_("Provide either fixed value for r or raster map"))
         if options["k_value"] and options["k_map"]:
-            grass.fatal(
+            gs.fatal(
                 _("Provide either fixed value for carrying capacity (K) or raster map")
             )
 
         # Define r
         if options["r_rick_map"]:
             if options["population_patches"]:
-                grass.run_command(
+                gs.run_command(
                     "r.statistics2",
                     base=options["population_patches"],
                     cover=options["r_rick_map"],
@@ -300,7 +300,7 @@ def main():
                     output="r_rick_tmp_%d" % os.getpid(),
                 )
             else:
-                grass.run_command(
+                gs.run_command(
                     "g.copy",
                     raster=options["r_rick_map"] + "," + "r_rick_tmp_%d" % os.getpid(),
                 )
@@ -312,12 +312,12 @@ def main():
         elif options["r_rick_value"]:
             r = float(options["r_rick_value"])
         else:
-            grass.fatal(_("No r value/map for Ricker model provided"))
+            gs.fatal(_("No r value/map for Ricker model provided"))
 
         # Define k
         if options["k_map"]:
             if options["population_patches"]:
-                grass.run_command(
+                gs.run_command(
                     "r.statistics2",
                     base=options["population_patches"],
                     cover=options["k_map"],
@@ -325,7 +325,7 @@ def main():
                     output="k_tmp_%d" % os.getpid(),
                 )
             else:
-                grass.run_command(
+                gs.run_command(
                     "g.copy", raster=options["k_map"] + "," + "k_tmp_%d" % os.getpid()
                 )
 
@@ -336,7 +336,7 @@ def main():
         elif options["k_value"]:
             k = float(options["k_value"])
         else:
-            grass.fatal(_("No value/map for carrying capacity (k) provided"))
+            gs.fatal(_("No value/map for carrying capacity (k) provided"))
 
         # run model
         n0_map = garray.array("n0_tmp_%d" % os.getpid())
@@ -347,7 +347,7 @@ def main():
 
         # Retransform in case of patches
         if options["population_patches"]:
-            grass.mapcalc(
+            gs.mapcalc(
                 "$ricker_output = if($n0,(round(($n0*1.0/$n0_tmp)*$ricker_output_tmp)),null())",
                 ricker_output=options["ricker_output"],
                 n0=options["n_initial"],
@@ -356,7 +356,7 @@ def main():
             )
 
         else:
-            grass.mapcalc(
+            gs.mapcalc(
                 "$ricker_output = if($n0,$ricker_output_tmp,null())",
                 ricker_output=options["ricker_output"],
                 n0=options["n_initial"],
@@ -367,6 +367,6 @@ def main():
 
 
 if __name__ == "__main__":
-    options, flags = grass.parser()
+    options, flags = gs.parser()
     atexit.register(cleanup)
     sys.exit(main())

--- a/src/raster/r.richdem.breachdepressions/r.richdem.breachdepressions.py
+++ b/src/raster/r.richdem.breachdepressions/r.richdem.breachdepressions.py
@@ -55,7 +55,7 @@
 import numpy as np
 
 # GRASS
-from grass import script as gscript
+from grass import script as gs
 from grass.script import array as garray
 from grass.pygrass.modules.shortcuts import general as g
 
@@ -91,9 +91,9 @@ def main():
     rd.BreachDepressions(dem=rd_inout, in_place=True, topology=_topology)
 
     dem[:] = rd_inout[:]
-    dem.write(_output, overwrite=gscript.overwrite())
+    dem.write(_output, overwrite=gs.overwrite())
 
 
 if __name__ == "__main__":
-    options, flags = gscript.parser()
+    options, flags = gs.parser()
     main()

--- a/src/raster/r.richdem.filldepressions/r.richdem.filldepressions.py
+++ b/src/raster/r.richdem.filldepressions/r.richdem.filldepressions.py
@@ -67,7 +67,7 @@
 import numpy as np
 
 # GRASS
-from grass import script as gscript
+from grass import script as gs
 from grass.script import array as garray
 from grass.pygrass.modules.shortcuts import general as g
 
@@ -109,9 +109,9 @@ def main():
     rd.FillDepressions(dem=rd_inout, epsilon=epsilon, in_place=True, topology=_topology)
 
     dem[:] = rd_inout[:]
-    dem.write(_output, overwrite=gscript.overwrite())
+    dem.write(_output, overwrite=gs.overwrite())
 
 
 if __name__ == "__main__":
-    options, flags = gscript.parser()
+    options, flags = gs.parser()
     main()

--- a/src/raster/r.richdem.flowaccumulation/r.richdem.flowaccumulation.py
+++ b/src/raster/r.richdem.flowaccumulation/r.richdem.flowaccumulation.py
@@ -68,7 +68,7 @@
 import numpy as np
 
 # GRASS
-from grass import script as gscript
+from grass import script as gs
 from grass.script import array as garray
 from grass.pygrass.modules.shortcuts import general as g
 
@@ -140,9 +140,9 @@ def main():
 
     accum = garray.array()
     accum[:] = rd_output[:]
-    accum.write(_output, overwrite=gscript.overwrite())
+    accum.write(_output, overwrite=gs.overwrite())
 
 
 if __name__ == "__main__":
-    options, flags = gscript.parser()
+    options, flags = gs.parser()
     main()

--- a/src/raster/r.richdem.resolveflats/r.richdem.resolveflats.py
+++ b/src/raster/r.richdem.resolveflats/r.richdem.resolveflats.py
@@ -45,7 +45,7 @@
 import numpy as np
 
 # GRASS
-from grass import script as gscript
+from grass import script as gs
 from grass.script import array as garray
 from grass.pygrass.modules.shortcuts import general as g
 
@@ -75,7 +75,7 @@ def main():
     _output = options["output"]
 
     # Check for overwrite
-    _rasters = np.array(gscript.parse_command("g.list", type="raster").keys())
+    _rasters = np.array(gs.parse_command("g.list", type="raster").keys())
     if (_rasters == _output).any():
         g.message(flags="e", message="output would overwrite " + _output)
 
@@ -85,9 +85,9 @@ def main():
     rd_output = rd.ResolveFlats(rd_input)
 
     dem[:] = rd_output[:]
-    dem.write(_output, overwrite=gscript.overwrite())
+    dem.write(_output, overwrite=gs.overwrite())
 
 
 if __name__ == "__main__":
-    options, flags = gscript.parser()
+    options, flags = gs.parser()
     main()

--- a/src/raster/r.richdem.terrainattribute/r.richdem.terrainattribute.py
+++ b/src/raster/r.richdem.terrainattribute/r.richdem.terrainattribute.py
@@ -62,7 +62,7 @@
 import numpy as np
 
 # GRASS
-from grass import script as gscript
+from grass import script as gs
 from grass.script import array as garray
 from grass.pygrass.modules.shortcuts import general as g
 
@@ -102,9 +102,9 @@ def main():
 
     outarray = garray.array()
     outarray[:] = rd_output[:]
-    outarray.write(_output, overwrite=gscript.overwrite())
+    outarray.write(_output, overwrite=gs.overwrite())
 
 
 if __name__ == "__main__":
-    options, flags = gscript.parser()
+    options, flags = gs.parser()
     main()

--- a/src/raster/r.rock.stability/r.rock.stability.py
+++ b/src/raster/r.rock.stability/r.rock.stability.py
@@ -92,12 +92,11 @@ import os
 import sys
 
 try:
-    import grass.script as grass
+    import grass.script as gs
 except:
     try:
-        from grass.script import core as grass
+        from grass.script import core as gs
 
-        # from grass.script import core as gcore
     except:
         sys.exit("grass.script can't be imported.")
 
@@ -121,11 +120,11 @@ def main():
     RMR = options["rmr"]
     prefix = options["prefix"]
     # SMRrib = options['SMRtoppling']
-    grass.message("Starting to calculate SMR index")
-    grass.message("Waiting...")
+    gs.message("Starting to calculate SMR index")
+    gs.message("Waiting...")
     # calcolo slope ed aspect
 
-    grass.run_command(
+    gs.run_command(
         "r.slope.aspect",
         elevation=r_elevation,
         slope="slopes_",
@@ -140,7 +139,7 @@ def main():
 
     # Correggi aspect per avere: N=0 E=90 S=180 W=270
 
-    grass.mapcalc(
+    gs.mapcalc(
         "aspects_1 = if (aspects_ > 90, 450 - aspects_, 90 - aspects_)",
         overwrite=True,
         quiet=True,
@@ -148,40 +147,38 @@ def main():
 
     # calcolo A (valore assoluto)che vale SCIVOL=abs(immersdelgiunto-aspect1); RIBAL=abs(immersdelgiunto-aspect1-180)
 
-    grass.mapcalc(
-        "Asci = abs($imme - aspects_1)", imme=imme, overwrite=True, quiet=True
-    )
-    grass.mapcalc("Arib = abs(Asci - 180)", overwrite=True, quiet=True)
+    gs.mapcalc("Asci = abs($imme - aspects_1)", imme=imme, overwrite=True, quiet=True)
+    gs.mapcalc("Arib = abs(Asci - 180)", overwrite=True, quiet=True)
 
     # calcolo F1
     # la formula originale e' stata in parte modificata per tener conto dei valori di A compresi tra 270 e 360 sfavorevoli x la stabilita'
 
-    grass.mapcalc(
+    gs.mapcalc(
         "F1sci1 = if(Asci > 270, 0.64 - 0.006*atan(0.1*(abs(Asci - 360) - 17)), 0)",
         overwrite=True,
         quiet=True,
     )
-    grass.mapcalc(
+    gs.mapcalc(
         "F1sci2 = if(Asci < 270, 0.64 - 0.006*atan(0.1*(Asci - 17)), 0)",
         overwrite=True,
         quiet=True,
     )
-    grass.mapcalc("F1sci = F1sci1 + F1sci2", overwrite=True, quiet=True)
-    grass.mapcalc(
+    gs.mapcalc("F1sci = F1sci1 + F1sci2", overwrite=True, quiet=True)
+    gs.mapcalc(
         "F1rib1 = if(Arib > 270, 0.64 - 0.006*atan(0.1*(abs(Arib - 360) - 17)), 0)",
         overwrite=True,
         quiet=True,
     )
-    grass.mapcalc(
+    gs.mapcalc(
         "F1rib2 = if(Arib < 270, 0.64 - 0.006*atan(0.1*(Arib - 17)), 0)",
         overwrite=True,
         quiet=True,
     )
-    grass.mapcalc("F1rib = F1rib1 + F1rib2", overwrite=True, quiet=True)
+    gs.mapcalc("F1rib = F1rib1 + F1rib2", overwrite=True, quiet=True)
 
     # calcolo F2 (per il toppling vale sempre 1)
 
-    grass.mapcalc(
+    gs.mapcalc(
         "F2sci = 0.56 + 0.005*(atan(0.17*abs($incl) - 5))",
         incl=incl,
         overwrite=True,
@@ -190,13 +187,13 @@ def main():
 
     # calcolo F3
 
-    grass.mapcalc(
+    gs.mapcalc(
         "F3sci = -30 + 0.33*atan($incl - slopes_)",
         incl=incl,
         overwrite=True,
         quiet=True,
     )
-    grass.mapcalc(
+    gs.mapcalc(
         "F3rib = -13 - 0.143*atan($incl + slopes_ - 120)",
         incl=incl,
         overwrite=True,
@@ -205,12 +202,12 @@ def main():
 
     # moltiplica F1xF2XF3
 
-    grass.mapcalc("Isciv = F1sci * F2sci * F3sci", overwrite=True, quiet=True)
-    grass.mapcalc("Irib = F1rib * F3rib * 1", overwrite=True, quiet=True)
+    gs.mapcalc("Isciv = F1sci * F2sci * F3sci", overwrite=True, quiet=True)
+    gs.mapcalc("Irib = F1rib * F3rib * 1", overwrite=True, quiet=True)
 
     # Calcola l'indice SMR
 
-    grass.mapcalc(
+    gs.mapcalc(
         "$SMRsciv = Isciv + $RMR + $F4",
         SMRsciv=prefix + "_planar",
         RMR=RMR,
@@ -218,7 +215,7 @@ def main():
         quiet=True,
     )
 
-    grass.mapcalc(
+    gs.mapcalc(
         "$SMRrib = Irib + $RMR + $F4",
         SMRrib=prefix + "_toppling",
         RMR=RMR,
@@ -230,13 +227,13 @@ def main():
     ########################################################
     imme2 = options["imme2"]
     incl2 = options["incl2"]
-    grass.message("SMR index done!")
+    gs.message("SMR index done!")
     if imme2 != "" and incl2 != "":
         # calcola trend del cuneo
-        grass.message("Parameter set for SMR_wedge")
-        grass.message("Starting to calculate SMR_wedge index")
-        grass.message("Waiting...")
-        grass.mapcalc(
+        gs.message("Parameter set for SMR_wedge")
+        gs.message("Starting to calculate SMR_wedge index")
+        gs.message("Waiting...")
+        gs.mapcalc(
             "T = (-tan($incl) * cos($imme)+tan($incl2)*cos($imme2))/(tan($incl)*sin($imme)-tan($incl2)*sin($imme2))",
             imme=imme,
             imme2=imme2,
@@ -246,9 +243,9 @@ def main():
             quiet=True,
         )
 
-        grass.mapcalc("T1 = atan(T)", overwrite=True, quiet=True)
+        gs.mapcalc("T1 = atan(T)", overwrite=True, quiet=True)
         # calcola plunge del cuneo P2 (sarebbe inclinazione)
-        grass.mapcalc(
+        gs.mapcalc(
             "P=((sin($incl)*sin($imme)*sin($imme2-$imme))/(sin($incl)*cos($imme)*cos($incl2)-sin($incl2)*cos($imme2)*cos($incl)))*sin(T1)",
             imme=imme,
             imme2=imme2,
@@ -257,16 +254,16 @@ def main():
             overwrite=True,
             quiet=True,
         )
-        grass.mapcalc("P1=atan(P)", overwrite=True, quiet=True)
-        grass.mapcalc("P2=abs(P1)", overwrite=True, quiet=True)
+        gs.mapcalc("P1=atan(P)", overwrite=True, quiet=True)
+        gs.mapcalc("P2=abs(P1)", overwrite=True, quiet=True)
         # calcola trend del cuneo corretto (TB) sarebbe immersione
-        grass.mapcalc("TA=if(P1<0,T1+180,T1)", overwrite=True, quiet=True)
-        grass.mapcalc("TB=if(TA<0,TA+360,TA)", overwrite=True, quiet=True)
+        gs.mapcalc("TA=if(P1<0,T1+180,T1)", overwrite=True, quiet=True)
+        gs.mapcalc("TB=if(TA<0,TA+360,TA)", overwrite=True, quiet=True)
         # calcola slope e aspect
         # ...calcolo A (valore assoluto)che vale SCIVOL=abs(immersdelgiunto-aspect1); RIBAL=abs(immersdelgiunto-aspect1-180)
-        grass.mapcalc("Asci=abs(TB-aspects_1)", overwrite=True, quiet=True)
+        gs.mapcalc("Asci=abs(TB-aspects_1)", overwrite=True, quiet=True)
         reclass_rules = "-360 thru 5 = 1\n5.1 thru 10 = 0.085\n10.1 thru 20 = 0.7\n20.1 thru 30 = 0.4\n30.1 thru 320 = 0.15"
-        grass.write_command(
+        gs.write_command(
             "r.reclass",
             input="Asci",
             output="F1sci_",
@@ -276,10 +273,10 @@ def main():
             quiet=True,
         )
         # creo una mappa con valore dell'inclinazione
-        grass.mapcalc("mappa=P2+slopes_*0", overwrite=True, quiet=True)
+        gs.mapcalc("mappa=P2+slopes_*0", overwrite=True, quiet=True)
         # calcolo di F2
         reclass_rules2 = "0 thru 20 = 0.15\n20.1 thru 30 = 0.4\n30.1 thru 35 = 0.7\n35.1 thru 45 = 0.85\n45.1 thru 90 = 1"
-        grass.write_command(
+        gs.write_command(
             "r.reclass",
             input="mappa",
             output="F2",
@@ -290,10 +287,10 @@ def main():
         )
         # Calcolo di F3
         # Calcolo C che vale SCIVOL=inclgiunto - slopes;
-        grass.mapcalc("Csci=P2-slopes_", overwrite=True, quiet=True)
+        gs.mapcalc("Csci=P2-slopes_", overwrite=True, quiet=True)
         # Reclass per F3 scivolamento
         reclass_rules3 = "180 thru 9 = 0\n10 thru 0.1 = -6\n0 = -25\n-0.1 thru -9 = -50\n-10 thru -180 = -60"
-        grass.write_command(
+        gs.write_command(
             "r.reclass",
             input="Csci",
             output="F3sci_",
@@ -301,8 +298,8 @@ def main():
             overwrite=True,
             stdin=reclass_rules3,
         )
-        grass.mapcalc("Isciv_=F1sci_*F3sci_*F2", quiet=True)
-        grass.mapcalc(
+        gs.mapcalc("Isciv_=F1sci_*F3sci_*F2", quiet=True)
+        gs.mapcalc(
             "$SMRsciv=Isciv_+$RMR+$F4",
             SMRsciv=prefix + "_wedge",
             RMR=RMR,
@@ -310,7 +307,7 @@ def main():
             overwrite=True,
             quiet=True,
         )
-        grass.run_command(
+        gs.run_command(
             "g.remove",
             flags="f",
             type="raster",
@@ -332,9 +329,9 @@ def main():
             ),
             quiet=True,
         )
-        grass.message("SMR_wedge index done!")
+        gs.message("SMR_wedge index done!")
     else:
-        grass.message("No parameter set for SMR_wedge")
+        gs.message("No parameter set for SMR_wedge")
 
     #####################################################
     ############################SSPC#####################
@@ -343,61 +340,59 @@ def main():
     TC = options["tc"]
     if TC != "":
         # calcolo DELTA=aspect-immersione
-        grass.mapcalc(
-            "delta = aspects_1 - $imme", imme=imme, overwrite=True, quiet=True
-        )
+        gs.mapcalc("delta = aspects_1 - $imme", imme=imme, overwrite=True, quiet=True)
         # calcola A=cosenoDELTA
-        grass.mapcalc("A = cos(delta)", overwrite=True, quiet=True)
+        gs.mapcalc("A = cos(delta)", overwrite=True, quiet=True)
         # calcola B=tan(inclinazione)
-        grass.mapcalc("B = tan($incl)", incl=incl, overwrite=True, quiet=True)
+        gs.mapcalc("B = tan($incl)", incl=incl, overwrite=True, quiet=True)
         # calcola C=A*B
-        grass.mapcalc("C = A * B", overwrite=True, quiet=True)
+        gs.mapcalc("C = A * B", overwrite=True, quiet=True)
         # calcola AP
-        grass.mapcalc("AP = atan(C)", overwrite=True, quiet=True)
+        gs.mapcalc("AP = atan(C)", overwrite=True, quiet=True)
         # additional condition per scivolamento (dip del pendio deve essere < di AP+5), AP deve essere < di 85
-        grass.mapcalc("AP1 = slopes_ - AP - 5", overwrite=True, quiet=True)
-        grass.mapcalc("consci1 = if(AP1 > 0, 0, null())", overwrite=True, quiet=True)
-        grass.mapcalc("consci2 = if(AP < 85, 0, null())", overwrite=True, quiet=True)
+        gs.mapcalc("AP1 = slopes_ - AP - 5", overwrite=True, quiet=True)
+        gs.mapcalc("consci1 = if(AP1 > 0, 0, null())", overwrite=True, quiet=True)
+        gs.mapcalc("consci2 = if(AP < 85, 0, null())", overwrite=True, quiet=True)
         # additional condition per ribaltamento (AP deve essere> di 85)
-        grass.mapcalc("conrib = if(AP > (-85), 0, null())", overwrite=True, quiet=True)
+        gs.mapcalc("conrib = if(AP > (-85), 0, null())", overwrite=True, quiet=True)
         # ANALISI SCIVOLAMENTO PLANARE AP * 0.0113
-        grass.mapcalc("membro_sci = 0.0113 * AP", overwrite=True, quiet=True)
-        grass.mapcalc("sci = membro_sci - $TC", TC=TC, overwrite=True, quiet=True)
+        gs.mapcalc("membro_sci = 0.0113 * AP", overwrite=True, quiet=True)
+        gs.mapcalc("sci = membro_sci - $TC", TC=TC, overwrite=True, quiet=True)
         # se il risultato ottenuto e' minore di zero non ho cinematismo, maggiore e' il valore piu' alta sara' la propensione al distacco
-        grass.mapcalc(
+        gs.mapcalc(
             "cinem_sci = if(sci >= 0, 1, null())", TC=TC, overwrite=True, quiet=True
         )
-        grass.mapcalc(
+        gs.mapcalc(
             "$SSPCsciv = cinem_sci * sci + consci1 + consci2",
             SSPCsciv=prefix + "_SSPC_planar",
             overwrite=True,
             quiet=True,
         )
         # ANALISI RIBALTAMENTO 0.0087*(-90-AP+INCLINAZIONE)
-        grass.mapcalc(
+        gs.mapcalc(
             "membro_RIB = 0.0087 * ((-90) - AP + $incl)",
             incl=incl,
             overwrite=True,
             quiet=True,
         )
-        grass.mapcalc("rib = membro_RIB - $TC", TC=TC, overwrite=True, quiet=True)
+        gs.mapcalc("rib = membro_RIB - $TC", TC=TC, overwrite=True, quiet=True)
         # se il risultato ottenuto e' minore di zero non ho cinematismo, maggiore e' il valore piu' alta sara' la propensione al distacco
-        grass.mapcalc("cinem_rib = if(rib >= 0, 1, null())", overwrite=True, quiet=True)
-        grass.mapcalc(
+        gs.mapcalc("cinem_rib = if(rib >= 0, 1, null())", overwrite=True, quiet=True)
+        gs.mapcalc(
             "$SSPCrib = cinem_rib * rib + conrib",
             SSPCrib=prefix + "_SSPC_toppling",
             overwrite=True,
             quiet=True,
         )
         # processo per sostituire i valori di cella nulli con 0 (passaggio importante per trovare poi il minimo
-        grass.run_command(
+        gs.run_command(
             "r.null", map=prefix + "_SSPC_planar", null=0, overwrite=True, quiet=True
         )
-        grass.run_command(
+        gs.run_command(
             "r.null", map=prefix + "_SSPC_toppling", null=0, overwrite=True, quiet=True
         )
         # elimino mappe
-        grass.run_command(
+        gs.run_command(
             "g.remove",
             flags="f",
             type="raster",
@@ -437,7 +432,7 @@ def main():
             quiet=True,
         )
     else:
-        grass.run_command(
+        gs.run_command(
             "g.remove",
             flags="f",
             type="raster",
@@ -462,9 +457,9 @@ def main():
             quiet=True,
         )
 
-    grass.message("Done!")
+    gs.message("Done!")
 
 
 if __name__ == "__main__":
-    options, flags = grass.parser()
+    options, flags = gs.parser()
     sys.exit(main())

--- a/src/raster/r.series.decompose/r.series.decompose.py
+++ b/src/raster/r.series.decompose/r.series.decompose.py
@@ -79,7 +79,7 @@ if "GISBASE" not in os.environ:
     sys.stderr.write("You must be in GRASS GIS to run this program.\n")
     sys.exit(1)
 
-import grass.script as grass
+import grass.script as gs
 
 
 def get_time(N, t, deg=True):
@@ -117,8 +117,8 @@ def _generate_time(N, prefix):
     for i in range(N):
         output = prefix + _time_to_name(i)
         t = get_time(N, i, deg=True)
-        grass.mapcalc(
-            "${out} = ${t}", out=output, t=t, quiet=True, overwrite=grass.overwrite()
+        gs.mapcalc(
+            "${out} = ${t}", out=output, t=t, quiet=True, overwrite=gs.overwrite()
         )
         names[i] = output
 
@@ -141,23 +141,23 @@ def _generate_harmonics(time_names, freq, prefix):
         t = get_time(len(time_names), i)
         for f in freq:
             sin_output = prefix + "sin" + _time_to_name(i) + _freq_to_name(f)
-            grass.mapcalc(
+            gs.mapcalc(
                 "${out} = sin(${f} * ${t})",
                 out=sin_output,
                 t=t,
                 f=f,
                 quiet=True,
-                overwrite=grass.overwrite(),
+                overwrite=gs.overwrite(),
             )
 
             cos_output = prefix + "cos" + _time_to_name(i) + _freq_to_name(f)
-            grass.mapcalc(
+            gs.mapcalc(
                 "${out} = cos(${f} * ${t})",
                 out=cos_output,
                 t=t,
                 f=f,
                 quiet=True,
-                overwrite=grass.overwrite(),
+                overwrite=gs.overwrite(),
             )
             harm[f] = dict(sin=sin_output, cos=cos_output)
 
@@ -168,7 +168,7 @@ def _generate_harmonics(time_names, freq, prefix):
 
 def _generate_const(prefix):
     output = prefix + "const"
-    grass.mapcalc("${out} = 1.0", out=output, quiet=True, overwrite=grass.overwrite())
+    gs.mapcalc("${out} = 1.0", out=output, quiet=True, overwrite=gs.overwrite())
     return output
 
 
@@ -205,11 +205,11 @@ def _generate_sample_descr(fileobj, freq, xnames, const_name, time_names, harm_n
 
 
 def regression(settings_name, coef_prefix):
-    grass.run_command(
+    gs.run_command(
         "r.mregression.series",
         samples=settings_name,
         result_prefix=coef_prefix,
-        overwrite=grass.overwrite(),
+        overwrite=gs.overwrite(),
     )
 
 
@@ -226,7 +226,7 @@ def inverse_transform(settings_name, coef_prefix, result_prefix="res."):
             sums.append("%s*%s" % (data_names[i], row[i + 1]))
         s += " + ".join(sums)
 
-        grass.mapcalc(s, overwrite=grass.overwrite(), quite=True)
+        gs.mapcalc(s, overwrite=gs.overwrite(), quite=True)
 
 
 def main(options, flags):
@@ -241,7 +241,7 @@ def main(options, flags):
 
     N = len(xnames)
     if len(freq) >= (N - 1) / 2:
-        grass.error("Count of used harmonics is to large. Reduce the paramether.")
+        gs.error("Count of used harmonics is to large. Reduce the paramether.")
         sys.exit(1)
 
     const_name, time_names, harm_names = generate_vars(N, freq, timevar_pref)
@@ -256,5 +256,5 @@ def main(options, flags):
 
 
 if __name__ == "__main__":
-    options, flags = grass.parser()
+    options, flags = gs.parser()
     main(options, flags)

--- a/src/raster/r.shalstab/r.shalstab.py
+++ b/src/raster/r.shalstab/r.shalstab.py
@@ -101,10 +101,10 @@ import sys
 import os
 
 try:
-    import grass.script as grass
+    import grass.script as gs
 except:
     try:
-        from grass.script import core as grass
+        from grass.script import core as gs
     except:
         sys.exit("grass.script can't be imported.")
 
@@ -129,7 +129,7 @@ def main():
     # if gamma_wet == '':
     #    gamma_wet = 2100
     # calculate slope
-    grass.run_command(
+    gs.run_command(
         "r.slope.aspect",
         elevation=r_elevation,
         slope="slopes",
@@ -137,11 +137,11 @@ def main():
         overwrite="True",
     )
     # zero value = null
-    grass.run_command("r.null", map="slopes", setnull=0)
+    gs.run_command("r.null", map="slopes", setnull=0)
     # calculate soil transmissivity T (m^2/day)
-    grass.mapcalc("T=$k*24*$z*cos(slopes)", k=k, z=z)
+    gs.mapcalc("T=$k*24*$z*cos(slopes)", k=k, z=z)
     # calculate dimensionless
-    grass.mapcalc(
+    gs.mapcalc(
         "C=($root+$c_soil)/($z*cos(slopes)*9.81*$gamma)",
         root=root,
         c_soil=c_soil,
@@ -149,27 +149,27 @@ def main():
         gamma=gamma,
     )
     # calculate contribution area
-    grass.run_command("r.watershed", elevation=r_elevation, accumulation="accum")
+    gs.run_command("r.watershed", elevation=r_elevation, accumulation="accum")
 
-    grass.mapcalc("A=abs(accum*((ewres()+nsres())/2)*((ewres()+nsres())/2))")
+    gs.mapcalc("A=abs(accum*((ewres()+nsres())/2)*((ewres()+nsres())/2))")
     # stable condition
-    grass.mapcalc("assoluta_stab=(1-1000/($gamma))*tan($phy)", gamma=gamma, phy=phy)
-    grass.mapcalc("assoluta_cond=if(assoluta_stab>tan(slopes),9999,0)")
+    gs.mapcalc("assoluta_stab=(1-1000/($gamma))*tan($phy)", gamma=gamma, phy=phy)
+    gs.mapcalc("assoluta_cond=if(assoluta_stab>tan(slopes),9999,0)")
     # unstable condition
-    grass.mapcalc("assoluta_instab=C/cos(slopes)+(tan($phy))", phy=phy)
-    grass.mapcalc("cond_instab=if(assoluta_instab<tan(slopes),-9999,0)")
+    gs.mapcalc("assoluta_instab=C/cos(slopes)+(tan($phy))", phy=phy)
+    gs.mapcalc("cond_instab=if(assoluta_instab<tan(slopes),-9999,0)")
     # calculate 1(m/day)
-    grass.mapcalc(
+    gs.mapcalc(
         "i_crit_m=T*sin(slopes)*(((ewres()+nsres())/2)/A)*($gamma/1000*(1-(1-(C/(sin(slopes))))*(tan(slopes)/tan($phy))))+(assoluta_cond)+(cond_instab)",
         phy=phy,
         gamma=gamma,
     )
     # Calculation of critical rain (mm / hr) and riclassification
-    grass.mapcalc("i_cri_mm=i_crit_m*1000")
+    gs.mapcalc("i_cri_mm=i_crit_m*1000")
     # grass.mapcalc("i_cri_mm_reclass=if(i_cri_mm<0, 0, if(i_cri_mm>))")
-    grass.run_command("r.colors", map="i_cri_mm", color="precipitation")
+    gs.run_command("r.colors", map="i_cri_mm", color="precipitation")
     reclass_rules = "0 thru 30 = 2\n31 thru 100 = 3\n101 thru 150 = 4\n151 thru 200 = 5\n201 thru 999 = 6"
-    grass.write_command(
+    gs.write_command(
         "r.reclass",
         input="i_cri_mm",
         output="i_recl",
@@ -177,20 +177,20 @@ def main():
         rules="-",
         stdin=reclass_rules,
     )
-    grass.mapcalc("copia_reclass=i_recl+0")
-    grass.run_command("r.null", map="copia_reclass", null=0)
-    grass.mapcalc("Stable=if(i_cri_mm>1000,7,0)")
-    grass.mapcalc("Unstable=if(i_cri_mm<0,1,0)")
-    grass.mapcalc("Icritica=copia_reclass+Unstable+Stable")
+    gs.mapcalc("copia_reclass=i_recl+0")
+    gs.run_command("r.null", map="copia_reclass", null=0)
+    gs.mapcalc("Stable=if(i_cri_mm>1000,7,0)")
+    gs.mapcalc("Unstable=if(i_cri_mm<0,1,0)")
+    gs.mapcalc("Icritica=copia_reclass+Unstable+Stable")
     colors_rules = (
         "1 255:85:255\n2 255:0:0\n3 255:170:0\n4 255:255:0\n"
         "5 85:255:0\n6 170:255:255\n7 255:255:255"
     )
-    grass.write_command(
+    gs.write_command(
         "r.colors", map="Icritica", rules="-", stdin=colors_rules, quiet=True
     )
 
-    grass.run_command(
+    gs.run_command(
         "r.neighbors",
         input="Icritica",
         method="average",
@@ -198,10 +198,10 @@ def main():
         output="I_cri_average",
     )
     # rename maps
-    grass.run_command("g.rename", raster=("I_cri_average", susceptibility))
-    grass.run_command("g.rename", raster=("i_cri_mm", critic_rain))
+    gs.run_command("g.rename", raster=("I_cri_average", susceptibility))
+    gs.run_command("g.rename", raster=("i_cri_mm", critic_rain))
     # remove temporary map
-    grass.run_command(
+    gs.run_command(
         "g.remove",
         flags="f",
         type="raster",
@@ -227,5 +227,5 @@ def main():
 
 
 if __name__ == "__main__":
-    options, flags = grass.parser()
+    options, flags = gs.parser()
     sys.exit(main())

--- a/src/raster/r.surf.nnbathy/r.surf.nnbathy.py
+++ b/src/raster/r.surf.nnbathy/r.surf.nnbathy.py
@@ -58,7 +58,7 @@
 import os
 import sys
 
-import grass.script as grass
+import grass.script as gs
 
 
 def main():
@@ -68,13 +68,13 @@ def main():
     try:
         from nnbathy import Nnbathy_raster
     except ImportError:
-        grass.fatal(
+        gs.fatal(
             "r.surf.nnbathy requires 'v.surf.nnbathy'. "
             "Please install this module by running:\ng.extension v.surf.nnbathy"
         )
 
-    if not grass.find_file(options["input"], element="cell")["fullname"]:
-        grass.fatal("Raster map <%s> not found" % options["input"])
+    if not gs.find_file(options["input"], element="cell")["fullname"]:
+        gs.fatal("Raster map <%s> not found" % options["input"])
 
     obj = Nnbathy_raster(options)
     obj.compute()
@@ -82,5 +82,5 @@ def main():
 
 
 if __name__ == "__main__":
-    options, flags = grass.parser()
+    options, flags = gs.parser()
     main()

--- a/src/raster/r.texture.tiled/r.texture.tiled.py
+++ b/src/raster/r.texture.tiled/r.texture.tiled.py
@@ -88,7 +88,7 @@
 
 
 import math
-import grass.script as gscript
+import grass.script as gs
 from grass.pygrass.modules.grid.grid import *
 
 
@@ -171,5 +171,5 @@ def main():
 
 
 if __name__ == "__main__":
-    options, flags = gscript.parser()
+    options, flags = gs.parser()
     main()

--- a/src/raster/r.threshold/r.threshold.py
+++ b/src/raster/r.threshold/r.threshold.py
@@ -43,11 +43,11 @@ import sys
 import math
 import numpy as np
 
-import grass.script as grass
+import grass.script as gs
 
 
 def main():
-    stats = grass.read_command(
+    stats = gs.read_command(
         "r.stats",
         input=options["acc"],
         separator="space",
@@ -74,18 +74,18 @@ def main():
     th = area[index]
 
     if th < 0:
-        grass.warning("Flow accumulation contains negative values")
+        gs.warning("Flow accumulation contains negative values")
         if flags["g"]:
             print("threshold=%d" % th)
     else:
         if flags["g"]:
             print("threshold=%d" % th)
         else:
-            grass.message("Suggested threshold is %d" % th)
+            gs.message("Suggested threshold is %d" % th)
 
     return 0
 
 
 if __name__ == "__main__":
-    options, flags = grass.parser()
+    options, flags = gs.parser()
     sys.exit(main())

--- a/src/raster/r.to.vect.tiled/r.to.vect.tiled.py
+++ b/src/raster/r.to.vect.tiled/r.to.vect.tiled.py
@@ -105,7 +105,7 @@
 
 import sys
 
-import grass.script as grass
+import grass.script as gs
 
 
 def main():
@@ -123,20 +123,20 @@ def main():
 
     # check options
     if xtiles <= 0:
-        grass.fatal(_("Number of tiles in x direction must be > 0"))
+        gs.fatal(_("Number of tiles in x direction must be > 0"))
     if ytiles < 0:
-        grass.fatal(_("Number of tiles in y direction must be > 0"))
-    if grass.find_file(name=input)["name"] == "":
-        grass.fatal(_("Input raster %s not found") % input)
+        gs.fatal(_("Number of tiles in y direction must be > 0"))
+    if gs.find_file(name=input)["name"] == "":
+        gs.fatal(_("Input raster %s not found") % input)
 
-    grass.use_temp_region()
-    curr = grass.region()
+    gs.use_temp_region()
+    curr = gs.region()
     width = int(curr["cols"] / xtiles)
     if width <= 1:
-        grass.fatal("The requested number of tiles in x direction is too large")
+        gs.fatal("The requested number of tiles in x direction is too large")
     height = int(curr["rows"] / ytiles)
     if height <= 1:
-        grass.fatal("The requested number of tiles in y direction is too large")
+        gs.fatal("The requested number of tiles in y direction is too large")
 
     do_clip = False
     overlap = 0
@@ -154,13 +154,13 @@ def main():
     e = curr["e"]
     w = curr["w"] + xoverlap
     if w >= e:
-        grass.fatal(_("Overlap is too large"))
+        gs.fatal(_("Overlap is too large"))
     n = curr["n"] - yoverlap
     s = curr["s"]
     if s >= n:
-        grass.fatal(_("Overlap is too large"))
+        gs.fatal(_("Overlap is too large"))
 
-    datatype = grass.raster_info(input)["datatype"]
+    datatype = gs.raster_info(input)["datatype"]
     vtiles = None
 
     # north to south
@@ -177,7 +177,7 @@ def main():
             if xtile == xtiles - 1:
                 e = curr["e"]
 
-            grass.run_command("g.region", n=n, s=s, e=e, w=w, nsres=nsres, ewres=ewres)
+            gs.run_command("g.region", n=n, s=s, e=e, w=w, nsres=nsres, ewres=ewres)
 
             if do_clip:
                 tilename = output + "_stile_" + str(ytile) + str(xtile)
@@ -186,7 +186,7 @@ def main():
 
             outname = output + "_tile_" + str(ytile) + str(xtile)
 
-            grass.run_command(
+            gs.run_command(
                 "r.to.vect",
                 input=input,
                 output=tilename,
@@ -213,15 +213,15 @@ def main():
                     e2 = curr["e"]
 
                 tilename = output + "_stile_" + str(ytile) + str(xtile)
-                if grass.vector_info_topo(tilename)["areas"] > 0:
-                    grass.run_command(
+                if gs.vector_info_topo(tilename)["areas"] > 0:
+                    gs.run_command(
                         "g.region", n=n2, s=s2, e=e2, w=w2, nsres=nsres, ewres=ewres
                     )
 
                     extname = "extent_tile_" + str(ytile) + str(xtile)
-                    grass.run_command("v.in.region", output=extname, flags="d")
+                    gs.run_command("v.in.region", output=extname, flags="d")
                     outname = output + "_tile_" + str(ytile) + str(xtile)
-                    grass.run_command(
+                    gs.run_command(
                         "v.overlay",
                         ainput=tilename,
                         binput=extname,
@@ -229,7 +229,7 @@ def main():
                         operator="and",
                         olayer="0,1,0",
                     )
-                    grass.run_command(
+                    gs.run_command(
                         "g.remove", flags="f", type="vector", name=extname, quiet=True
                     )
 
@@ -238,36 +238,36 @@ def main():
                     else:
                         vtiles = vtiles + "," + outname
 
-                grass.run_command(
+                gs.run_command(
                     "g.remove", flags="f", type="vector", name=tilename, quiet=True
                 )
 
             else:
                 # write cmd history:
-                grass.vector_history(outname)
+                gs.vector_history(outname)
                 if vtiles is None:
                     vtiles = outname
                 else:
                     vtiles = vtiles + "," + outname
 
     if flags["p"]:
-        grass.run_command("v.patch", input=vtiles, output=output, flags="e")
+        gs.run_command("v.patch", input=vtiles, output=output, flags="e")
 
-        grass.run_command("g.remove", flags="f", type="vector", name=vtiles, quiet=True)
+        gs.run_command("g.remove", flags="f", type="vector", name=vtiles, quiet=True)
 
-        if grass.vector_info_topo(output)["boundaries"] > 0:
+        if gs.vector_info_topo(output)["boundaries"] > 0:
             outpatch = output + "_patch"
-            grass.run_command("g.rename", vector=(output, outpatch))
-            grass.run_command(
+            gs.run_command("g.rename", vector=(output, outpatch))
+            gs.run_command(
                 "v.clean", input=outpatch, output=output, tool="break", flags="c"
             )
-            grass.run_command("g.remove", flags="f", type="vector", name=outpatch)
+            gs.run_command("g.remove", flags="f", type="vector", name=outpatch)
 
-    grass.message(_("%s complete") % "r.to.vect.tiled")
+    gs.message(_("%s complete") % "r.to.vect.tiled")
 
     return 0
 
 
 if __name__ == "__main__":
-    options, flags = grass.parser()
+    options, flags = gs.parser()
     sys.exit(main())

--- a/src/raster/r.viewshed.cva/r.viewshed.cva.py
+++ b/src/raster/r.viewshed.cva/r.viewshed.cva.py
@@ -113,7 +113,7 @@
 
 import sys
 import os
-import grass.script as grass
+import grass.script as gs
 
 
 # main block of code starts here
@@ -143,14 +143,14 @@ def main():
         flagstring += "e"
 
     # check if vector map exists
-    gfile = grass.find_file(vect, element="vector")
+    gfile = gs.find_file(vect, element="vector")
     if not gfile["name"]:
-        grass.fatal(_("Vector map <%s> not found") % vect)
+        gs.fatal(_("Vector map <%s> not found") % vect)
 
     # get the coords from the vector map, and check if we want to name them
     if flags["k"] and options["name_column"] != "":
         # note that the "r" flag will constrain to points in the current geographic region.
-        output_points = grass.read_command(
+        output_points = gs.read_command(
             "v.out.ascii",
             flags="r",
             input=vect,
@@ -161,7 +161,7 @@ def main():
         ).strip()
     else:
         # note that the "r" flag will constrain to points in the current geographic region.
-        output_points = grass.read_command(
+        output_points = gs.read_command(
             "v.out.ascii",
             flags="r",
             input=vect,
@@ -169,7 +169,7 @@ def main():
             format="point",
             separator=",",
         ).strip()
-    grass.message(
+    gs.message(
         _(
             "Note that the routine is constrained to points in the current geographic region."
         )
@@ -188,7 +188,7 @@ def main():
             ptname = site[3]
         else:
             ptname = site[2]
-        grass.verbose(
+        gs.verbose(
             _("Calculating viewshed for location %s,%s (point name = %s)")
             % (site[0], site[1], ptname)
         )
@@ -196,10 +196,10 @@ def main():
         tempry = "vshed_{ptname}_{c}".format(ptname=ptname, c=counter)
         counter += 1
         vshed_list.append(tempry)
-        grass.run_command(
+        gs.run_command(
             "r.viewshed",
             quiet=True,
-            overwrite=grass.overwrite(),
+            overwrite=gs.overwrite(),
             flags=flagstring,
             input=elev,
             output=tempry,
@@ -207,25 +207,25 @@ def main():
             **viewshed_options,
         )
     # now make a mapcalc statement to add all the viewsheds together to make the outout cumulative viewsheds map
-    grass.message(_("Calculating cumulative viewshed map <%s>") % out)
+    gs.message(_("Calculating cumulative viewshed map <%s>") % out)
     # when binary viewshed, r.series has to use sum instead of count
     rseries_method = "sum" if "b" in flagstring else "count"
-    grass.run_command(
+    gs.run_command(
         "r.series",
         quiet=True,
-        overwrite=grass.overwrite(),
+        overwrite=gs.overwrite(),
         input=(",").join(vshed_list),
         output=out,
         method=rseries_method,
     )
     if flags["e"]:
-        grass.run_command("r.null", quiet=True, map=out, setnull="0")
+        gs.run_command("r.null", quiet=True, map=out, setnull="0")
     # Clean up temporary maps, if requested
     if flags["k"]:
-        grass.message(_("Temporary viewshed maps will not removed"))
+        gs.message(_("Temporary viewshed maps will not removed"))
     else:
-        grass.message(_("Removing temporary viewshed maps"))
-        grass.run_command(
+        gs.message(_("Removing temporary viewshed maps"))
+        gs.run_command(
             "g.remove",
             quiet=True,
             flags="f",
@@ -237,5 +237,5 @@ def main():
 
 # here is where the code in "main" actually gets executed. This way of programming is neccessary for the way g.parser needs to run.
 if __name__ == "__main__":
-    options, flags = grass.parser()
+    options, flags = gs.parser()
     main()

--- a/src/raster/r.viewshed.exposure/validation/validate_r_viewshed_exposure.py
+++ b/src/raster/r.viewshed.exposure/validation/validate_r_viewshed_exposure.py
@@ -17,7 +17,7 @@ from subprocess import Popen, PIPE
 
 
 from grass.pygrass.vector import VectorTopo
-import grass.script as grass
+import grass.script as gs
 
 
 def run_test_A(
@@ -36,8 +36,8 @@ def run_test_A(
     :param val_file: File to store the validation results
     """
 
-    nsres = grass.raster_info(dsm)["nsres"]
-    ewres = grass.raster_info(dsm)["ewres"]
+    nsres = gs.raster_info(dsm)["nsres"]
+    ewres = gs.raster_info(dsm)["ewres"]
 
     # new VectorTopo object
     val_pts_topo = VectorTopo(val_pts)
@@ -66,7 +66,7 @@ def run_test_A(
 
         # iterate over points
         for pt in val_pts_topo.viter("points"):
-            grass.percent(counter, no_points, 1)
+            gs.percent(counter, no_points, 1)
             counter += 1
 
             pt_id = pt.attrs["img_no"]
@@ -76,7 +76,7 @@ def run_test_A(
             # iterate over radii
             for r in radii:
                 # set region around processed point
-                grass.run_command(
+                gs.run_command(
                     "g.region",
                     align=dsm,
                     n=pt_y + (r + nsres / 2.0),
@@ -130,7 +130,7 @@ def run_test_A(
                     if r_viewshed_profile["Exit status"] == "0":
                         # extract GVI value at point
                         gvi = float(
-                            grass.read_command(
+                            gs.read_command(
                                 "r.what",
                                 map=r_GVI,
                                 coordinates="{},{}".format(pt_x, pt_y),
@@ -173,7 +173,7 @@ def run_test_A(
                             "exit": r_viewshed_profile["Exit status"],
                         }
                     )
-                    grass.message(
+                    gs.message(
                         "{},{},{},{},{},{},{},{},{},{},{}".format(
                             pt_id,
                             m,
@@ -211,8 +211,8 @@ def run_test_A_no_viewshed(
     :param val_file: File to store the validation results
     """
 
-    nsres = grass.raster_info(dsm)["nsres"]
-    ewres = grass.raster_info(dsm)["ewres"]
+    nsres = gs.raster_info(dsm)["nsres"]
+    ewres = gs.raster_info(dsm)["ewres"]
 
     # new VectorTopo object
     val_pts_topo = VectorTopo(val_pts)
@@ -241,7 +241,7 @@ def run_test_A_no_viewshed(
 
         # iterate over points
         for pt in val_pts_topo.viter("points"):
-            grass.percent(counter, no_points, 1)
+            gs.percent(counter, no_points, 1)
             counter += 1
 
             pt_id = pt.attrs["img_no"]
@@ -251,7 +251,7 @@ def run_test_A_no_viewshed(
             # iterate over radii
             for r in radii:
                 # set region around processed point
-                grass.run_command(
+                gs.run_command(
                     "g.region",
                     align=dsm,
                     n=pt_y + (r + nsres / 2.0),
@@ -304,7 +304,7 @@ def run_test_A_no_viewshed(
                     if r_viewshed_profile["Exit status"] == "0":
                         # extract GVI value at point
                         gvi = float(
-                            grass.read_command(
+                            gs.read_command(
                                 "r.what",
                                 map=r_GVI,
                                 coordinates="{},{}".format(pt_x, pt_y),
@@ -347,7 +347,7 @@ def run_test_A_no_viewshed(
                             "exit": r_viewshed_profile["Exit status"],
                         }
                     )
-                    grass.message(
+                    gs.message(
                         "{},{},{},{},{},{},{},{},{},{},{}".format(
                             pt_id,
                             m,
@@ -384,8 +384,8 @@ def run_test_B(
     :param elev: Observer elevation
     :param val_file: File to store the validation results
     """
-    nsres = grass.raster_info(dsm)["nsres"]
-    ewres = grass.raster_info(dsm)["ewres"]
+    nsres = gs.raster_info(dsm)["nsres"]
+    ewres = gs.raster_info(dsm)["ewres"]
 
     # new VectorTopo object
     val_pts_topo = VectorTopo(val_pts)
@@ -420,7 +420,7 @@ def run_test_B(
 
             # iterate over points
             for pt in val_pts_topo.viter("points"):
-                grass.percent(counter, no_points, 1)
+                gs.percent(counter, no_points, 1)
                 counter += 1
 
                 pt_id = pt.attrs["img_no"]
@@ -435,7 +435,7 @@ def run_test_B(
                 # iterate over radii
                 for radius in radii:
                     # set region around processed point
-                    grass.run_command(
+                    gs.run_command(
                         "g.region",
                         align=dsm,
                         n=pt_y + (radius + nsres / 2.0),
@@ -491,7 +491,7 @@ def run_test_B(
                         # check if r.viewshed.exposure finished sucessfuly
                         if r_viewshed_profile["Exit status"] == "0":
                             # extract GVI value at point
-                            gvi = grass.read_command(
+                            gvi = gs.read_command(
                                 "r.what",
                                 map=r_GVI,
                                 coordinates="{},{}".format(pt_x, pt_y),
@@ -534,7 +534,7 @@ def run_test_B(
                                 "exit": r_viewshed_profile["Exit status"],
                             }
                         )
-                        grass.message(
+                        gs.message(
                             "{},{},{},{},{},{},{},{},{},{},{},{}".format(
                                 pt_id,
                                 rep,
@@ -574,8 +574,8 @@ def run_test_C(
     :param elev: Observer elevation
     :param val_file: File to store the validation results
     """
-    nsres = grass.raster_info(dsm)["nsres"]
-    ewres = grass.raster_info(dsm)["ewres"]
+    nsres = gs.raster_info(dsm)["nsres"]
+    ewres = gs.raster_info(dsm)["ewres"]
 
     # new VectorTopo object
     val_pts_topo = VectorTopo(val_pts)
@@ -604,7 +604,7 @@ def run_test_C(
 
         # iterate over points
         for pt in val_pts_topo.viter("points"):
-            grass.percent(counter, no_points, 1)
+            gs.percent(counter, no_points, 1)
             counter += 1
 
             pt_id = pt.attrs["img_no"]
@@ -612,7 +612,7 @@ def run_test_C(
             pt_y = pt.y
 
             # set region around processed point
-            grass.run_command(
+            gs.run_command(
                 "g.region",
                 align=dsm,
                 n=pt_y + (radius + nsres / 2.0),
@@ -663,7 +663,7 @@ def run_test_C(
             # check if r.viewshed.exposure finished sucessfuly
             if r_viewshed_profile["Exit status"] == "0":
                 # extract GVI value at point
-                gvi = grass.read_command(
+                gvi = gs.read_command(
                     "r.what", map=r_GVI, coordinates="{},{}".format(pt_x, pt_y)
                 ).split("|")[3]
             else:
@@ -695,7 +695,7 @@ def run_test_C(
                     "exit": r_viewshed_profile["Exit status"],
                 }
             )
-            grass.message(
+            gs.message(
                 "{},{},{},{},{},{},{},{},{},{},{}".format(
                     pt_id,
                     method,
@@ -723,7 +723,7 @@ def main():
 
     # Validation points
     v_points = "validation_points_update_20210326"
-    grass.run_command("v.build", map=v_points, quiet=True)
+    gs.run_command("v.build", map=v_points, quiet=True)
 
     # Constant viewshed settings
     observer_elevation = 1.5
@@ -873,5 +873,5 @@ def main():
 
 
 if __name__ == "__main__":
-    options, flags = grass.parser()
+    options, flags = gs.parser()
     sys.exit(main())

--- a/src/raster/r.width.funct/r.width.funct.py
+++ b/src/raster/r.width.funct/r.width.funct.py
@@ -42,17 +42,17 @@
 
 import sys
 import os
-import grass.script as grass
+import grass.script as gs
 import numpy as np
 
 
 def main():
-    stats = grass.read_command(
+    stats = gs.read_command(
         "r.stats", input=options["map"], sep="space", nv="*", nsteps="255", flags="Anc"
     ).split("\n")[:-1]
 
     # res = cellsize
-    res = grass.region()["nsres"]
+    res = gs.region()["nsres"]
 
     zn = np.zeros((len(stats), 4), float)
     kl = np.zeros((len(stats), 2), float)
@@ -148,5 +148,5 @@ def findint(kl, f):
 
 
 if __name__ == "__main__":
-    options, flags = grass.parser()
+    options, flags = gs.parser()
     sys.exit(main())


### PR DESCRIPTION
Continuation of #1319

- `grass.script` should be imported as `gs`

Ruff rule: https://docs.astral.sh/ruff/rules/unconventional-import-alias/

Applies the same import convention as on the main grass repo. The full set of changes concerns over 240 files, so it is chunked in multiple PRs.