### PR TITLE
CI: Always upload the test report, even on failure and when cancelling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,7 @@ jobs:
           ../.github/workflows/test.sh --config ../.gunittest.cfg
 
       - name: Make HTML test report available
+        if: ${{ always() }}
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: testreport-grass-${{ matrix.grass-version }}-python-${{ matrix.python-version }}


### PR DESCRIPTION
Mirrors behaviour on main grass repo, useful to see what worked before a job gets cancelled, failed, or times out.