### PR TITLE
r.slopeunits.clean: fix input option

### DIFF
--- a/src/raster/r.slopeunits/r.slopeunits.clean/r.slopeunits.clean.py
+++ b/src/raster/r.slopeunits/r.slopeunits.clean/r.slopeunits.clean.py
@@ -34,9 +34,9 @@
 # % required: no
 # %end
 
-# %option G_OPT_R_OUTPUT
+# %option G_OPT_R_INPUT
 # % key: slumap
-# % description: Output Slope Units layer (the main output)
+# % description: Input Slope Units layer (the main input)
 # % required: yes
 # %end
 


### PR DESCRIPTION
The `slumap` option is an input raster, not an output raster