### PR TITLE
t.stac: Updated python dependencies

### DIFF
--- a/src/temporal/t.stac/requirements.txt
+++ b/src/temporal/t.stac/requirements.txt
@@ -1,3 +1,3 @@
-pystac==1.11.0
-pystac_client==0.8.3
-tqdm==4.67.1
+pystac==1.12.*
+pystac_client==0.8.*
+tqdm==4.67.*

--- a/src/temporal/t.stac/requirements.txt
+++ b/src/temporal/t.stac/requirements.txt
@@ -1,3 +1,3 @@
-pystac>=1.12,<2.0
-pystac_client>=0.8,<1.0
-tqdm>=4.67,<5.0
+pystac>=1.12
+pystac_client>=0.8
+tqdm>=4.67

--- a/src/temporal/t.stac/requirements.txt
+++ b/src/temporal/t.stac/requirements.txt
@@ -1,3 +1,3 @@
-pystac==1.12.*
-pystac_client==0.8.*
-tqdm==4.67.*
+pystac>=1.12,<2.0
+pystac_client>=0.8,<1.0
+tqdm>=4.67,<5.0


### PR DESCRIPTION
This PR addresses loosening t.stac dependencies to ignore minor version changes:

- PR #1286
- PR #1226 
