### PR TITLE
cronjobs: Add Markdown and generalize addon build

### DIFF
--- a/utils/cronjobs_osgeo_lxd/compile_addons_git.sh
+++ b/utils/cronjobs_osgeo_lxd/compile_addons_git.sh
@@ -31,10 +31,10 @@ fi
 if [ -z "$3" ]; then
     echo "Usage: $0 grass_major_version grass_minor_version git_path \
 topdir addons_path grass_startup_program [separate]"
-    echo "eg. $0 8 0 ~/src/grass_addons/grass${GMAJOR}/ \
-~/src/releasebranch_${GMAJOR}_${GMINOR}/dist.${PLATFORM}-pc-linux-gnu \
-~/.grass${GMAJOR}/addons \
-~/src/releasebranch_${GMAJOR}_${GMINOR}/bin.${PLATFORM}-pc-linux-gnu/grass${GMAJOR}"
+    echo "eg. $0 8 0 ${HOME}/src/grass_addons/grass${GMAJOR}/ \
+${HOME}/src/releasebranch_${GMAJOR}_${GMINOR}/dist.${PLATFORM}-pc-linux-gnu \
+${HOME}/.grass${GMAJOR}/addons \
+${HOME}/src/releasebranch_${GMAJOR}_${GMINOR}/bin.${PLATFORM}-pc-linux-gnu/grass${GMAJOR}"
     exit 1
 fi
 
@@ -51,7 +51,7 @@ if [ ! -d "$5" ] ; then
 fi
 
 if [ -z "$6" ] ; then
-    echo "ERROR: Set GRASS GIS startup program with full path (e.g., ~/src/releasebranch_${GMAJOR}_${GMINOR}/bin.${PLATFORM}-pc-linux-gnu/grass${GMAJOR})"
+    echo "ERROR: Set GRASS GIS startup program with full path (e.g., ${HOME}/src/releasebranch_${GMAJOR}_${GMINOR}/bin.${PLATFORM}-pc-linux-gnu/grass${GMAJOR})"
     exit 1
 fi
 
@@ -129,7 +129,7 @@ for c in "db" "display" "general" "gui/wxpython" "imagery" "misc" "raster" "rast
     export GRASS_ADDON_BASE=$path
     if [ ! -d $GRASS_ADDON_BASE ]; then
         # Create addon dir first for download addons_paths.json file if
-        # addon has own dir e.g. ~/.grass8/addons/db.join/ with bin/ docs/
+        # addon has own dir e.g. ${HOME}/.grass8/addons/db.join/ with bin/ docs/
         # etc/ scripts/ subdir (check condition $SEP -eq 1)
         mkdir $GRASS_ADDON_BASE
     fi
@@ -143,7 +143,7 @@ for c in "db" "display" "general" "gui/wxpython" "imagery" "misc" "raster" "rast
         if [ ! -f "$GRASS_ADDON_BASE/$ADDONS_PATHS_JSON_FILE" ] && [ ! -f "$(dirname $GRASS_ADDON_BASE)/$ADDONS_PATHS_JSON_FILE" ]; then
             $GRASS_STARTUP_PROGRAM --tmp-location EPSG:4326 --exec g.extension -j
             # Prevent download addons_paths.json file for every addon compilation if
-            # addon has own dir e.g. ~/.grass8/addons/db.join/ with bin/ docs/
+            # addon has own dir e.g. ${HOME}/.grass8/addons/db.join/ with bin/ docs/
             # etc/ scripts/ subdir (check condition $SEP -eq 1)
             if [ ! -f "$(dirname $GRASS_ADDON_BASE)/$ADDONS_PATHS_JSON_FILE" ]; then
                 mv "$GRASS_ADDON_BASE/$ADDONS_PATHS_JSON_FILE" "$(dirname $GRASS_ADDON_BASE)/$ADDONS_PATHS_JSON_FILE"
@@ -191,7 +191,7 @@ echo "</table><hr />
 </body></html>" >> "$ADDON_PATH/logs/${INDEX_FILE}.html"
 
 # If the script is available, run it. Otherwise just print the command.
-URL_CHECK_SCRIPT="~/cronjobs/check_addons_urls.sh"
+URL_CHECK_SCRIPT="${HOME}/cronjobs/check_addons_urls.sh"
 URL_CHECK_INDEX_LOG="$ADDON_PATH/logs/${INDEX_MANUAL_PAGES_FILE}.log"
 URL_CHECK_INDEX_HTML="$ADDON_PATH/logs/${INDEX_MANUAL_PAGES_FILE}.html"
 if [ -f $URL_CHECK_SCRIPT ]; then

--- a/utils/cronjobs_osgeo_lxd/compile_addons_git.sh
+++ b/utils/cronjobs_osgeo_lxd/compile_addons_git.sh
@@ -29,7 +29,7 @@ else
 fi
 
 if [ -z "$3" ]; then
-    echo "Usage: $0 grass_major_version grass_minor_version git_patch \
+    echo "Usage: $0 grass_major_version grass_minor_version git_path \
 topdir addons_path grass_startup_program [separate]"
     echo "eg. $0 8 0 ~/src/grass_addons/grass${GMAJOR}/ \
 ~/src/releasebranch_${GMAJOR}_${GMINOR}/dist.${PLATFORM}-pc-linux-gnu \
@@ -155,6 +155,7 @@ for c in "db" "display" "general" "gui/wxpython" "imagery" "misc" "raster" "rast
     make -j2 MODULE_TOPDIR="$TOPDIR" \
         BIN="$path/bin" \
         HTMLDIR="$path/docs/html" \
+        MDDIR="$path/docs/md" \
         MANBASEDIR="$path/docs/man" \
         SCRIPTDIR="$path/scripts" \
         ETC="$path/etc" \
@@ -189,10 +190,23 @@ echo "</table><hr />
 <div style=\"text-align: right\">Valid: <a href=\"https://validator.w3.org/check/referer\">XHTML</a></div>
 </body></html>" >> "$ADDON_PATH/logs/${INDEX_FILE}.html"
 
-echo ""
-bash ~/cronjobs/check_addons_urls.sh "$ADDON_PATH" \
-   "$ADDON_PATH/logs/${INDEX_MANUAL_PAGES_FILE}.log" \
-   "$ADDON_PATH/logs/${INDEX_MANUAL_PAGES_FILE}.html"
+# If the script is available, run it. Otherwise just print the command.
+URL_CHECK_SCRIPT="~/cronjobs/check_addons_urls.sh"
+URL_CHECK_INDEX_LOG="$ADDON_PATH/logs/${INDEX_MANUAL_PAGES_FILE}.log"
+URL_CHECK_INDEX_HTML="$ADDON_PATH/logs/${INDEX_MANUAL_PAGES_FILE}.html"
+if [ -f $URL_CHECK_SCRIPT ]; then
+    echo ""
+    bash $URL_CHECK_SCRIPT \
+        "$ADDON_PATH" \
+        "$URL_CHECK_INDEX_LOG" \
+        "$URL_CHECK_INDEX_HTML"
+else
+    echo ""
+    echo bash $URL_CHECK_SCRIPT \
+        "$ADDON_PATH" \
+        "$URL_CHECK_INDEX_LOG" \
+        "$URL_CHECK_INDEX_HTML"
+fi
 echo ""
 
 echo "</table><hr />

--- a/utils/cronjobs_osgeo_lxd/compile_addons_git.sh
+++ b/utils/cronjobs_osgeo_lxd/compile_addons_git.sh
@@ -201,7 +201,7 @@ if [ -f $URL_CHECK_SCRIPT ]; then
         "$URL_CHECK_INDEX_LOG" \
         "$URL_CHECK_INDEX_HTML"
 else
-    echo ""
+    echo "Run (modify script path as needed):"
     echo bash $URL_CHECK_SCRIPT \
         "$ADDON_PATH" \
         "$URL_CHECK_INDEX_LOG" \


### PR DESCRIPTION
- Add Markdown path to compilation.
- Make running of the URL check script optional, so the build does not fail if the script is not available (local server path is currently hardcoded, so that's tricky or maybe even impossible to change for me).
- Fix the misleading typo in the usage info.
