### PR TITLE
cronjonb: simplify hugo cronjob by using rsync

### DIFF
--- a/utils/cronjobs_osgeo_lxd/README.md
+++ b/utils/cronjobs_osgeo_lxd/README.md
@@ -80,11 +80,13 @@ programmer's manual.
 
 ## Web site organisation
 
-Important: there are two web related directories on the server:
+Important: there are two web related directories on the server. The content
+of source code/data is blended via symlinks into the html directory which
+is served as grass.osgeo.org:
 
 - `/var/www/code_and_data/`: contains source code, sample data, etc.
 - `/var/www/html/`: contains the hugo generated files. The relevant
-  subdirectories of `/var/www/code_and_data/` are linked here.
+  subdirectories of `/var/www/code_and_data/` are linked into `/var/www/html/`.
 
 ## Infrastructure
 

--- a/utils/cronjobs_osgeo_lxd/hugo_clean_and_update_job.sh
+++ b/utils/cronjobs_osgeo_lxd/hugo_clean_and_update_job.sh
@@ -23,5 +23,4 @@ cd /home/neteler/grass-website/ && \
    nice /home/neteler/go/bin/hugo && \
    rsync -a --delete /home/neteler/grass-website/public/ /var/www/html/ && \
    ln -s /var/www/code_and_data/* /var/www/html/ && \
-   (cd /var/www/html/ ; /home/neteler/bin/fix_link_timestamp.sh .) && \
-   exit 0
+   (cd /var/www/html/ ; /home/neteler/bin/fix_link_timestamp.sh .)

--- a/utils/cronjobs_osgeo_lxd/hugo_clean_and_update_job.sh
+++ b/utils/cronjobs_osgeo_lxd/hugo_clean_and_update_job.sh
@@ -26,10 +26,29 @@
 #  6. restore timestamps of links from their original time stamps in src directory
 ####
 
+# function to update timestamp of link to the source timestamp
+fix_link_timestamp()
+{
+ if [ -z "$1" ] ; then
+   echo 'ERROR: Parameter missing. Specify the folder (. for current)!'
+   exit
+ fi
+
+ for mylink in $(find . -type l) ; do
+  LINK="$(namei ${mylink} | grep '^ l ' | tr -s ' ' ' ' | cut -d' ' -f3)"
+  ORIG="$(namei ${mylink} | grep '^ l ' | tr -s ' ' ' ' | cut -d' ' -f5-)"
+
+  echo "Updating timestamp of link <$ORIG> ---> <$LINK> timestamp"
+
+  # transfer timestamp
+  touch -h -m -r "$ORIG" "$LINK"
+ done
+}
+
 cd /home/neteler/grass-website/ && \
    git pull origin master && \
    rm -rf /home/neteler/grass-website/public/* && \
    nice /home/neteler/go/bin/hugo && \
    rsync -a --delete /home/neteler/grass-website/public/ /var/www/html/ && \
    ln -s /var/www/code_and_data/* /var/www/html/ && \
-   (cd /var/www/html/ && /home/neteler/bin/fix_link_timestamp.sh .)
+   (cd /var/www/html/ && fix_link_timestamp .)

--- a/utils/cronjobs_osgeo_lxd/hugo_clean_and_update_job.sh
+++ b/utils/cronjobs_osgeo_lxd/hugo_clean_and_update_job.sh
@@ -1,21 +1,30 @@
 #!/bin/sh
 
-# 2020-2024, Markus Neteler
-# deploy updated web site from github repo
+############################################################################
+#
+# TOOL:         hugo_clean_and_update_job.sh
+# AUTHOR(s):    Markus Neteler
+# PURPOSE:      Deploy updated web site from github repo
+# COPYRIGHT:    (c) 2020-2025  Markus Netelerand the GRASS Development Team
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+#############################################################################
 
-# preparations:
+# Preparations:
 #  sudo chown -R neteler.users /var/www
 # get grass-website repo
 #  cd ~/
 #  git clone https://github.com/OSGeo/grass-website.git
 ####
-
-# 1. change into local git repo copy
-# 2. update local repo from github
-# 3. build updated pages with hugo into clean directory
-# 4. rsync over updated pages to target web directory, deleting leftover files
-# 5. generate links from src code directory content into web directory
-# 6. restore timestamps of links from their original time stamps in src directory
+# Procedure:
+#  1. change into local git repo copy
+#  2. update local repo from github
+#  3. build updated pages with hugo into clean directory
+#  4. rsync over updated pages to target web directory, deleting leftover files
+#  5. generate links from src code directory content into web directory
+#  6. restore timestamps of links from their original time stamps in src directory
+####
 
 cd /home/neteler/grass-website/ && \
    git pull origin master && \
@@ -23,4 +32,4 @@ cd /home/neteler/grass-website/ && \
    nice /home/neteler/go/bin/hugo && \
    rsync -a --delete /home/neteler/grass-website/public/ /var/www/html/ && \
    ln -s /var/www/code_and_data/* /var/www/html/ && \
-   (cd /var/www/html/ ; /home/neteler/bin/fix_link_timestamp.sh .)
+   (cd /var/www/html/ && /home/neteler/bin/fix_link_timestamp.sh .)

--- a/utils/cronjobs_osgeo_lxd/hugo_clean_and_update_job.sh
+++ b/utils/cronjobs_osgeo_lxd/hugo_clean_and_update_job.sh
@@ -3,31 +3,25 @@
 # 2020-2024, Markus Neteler
 # deploy updated web site from github repo
 
-# preparation
+# preparations:
 #  sudo chown -R neteler.users /var/www
+# get grass-website repo
+#  cd ~/
+#  git clone https://github.com/OSGeo/grass-website.git
+####
 
-# 0.  change into local git repo copy
-#     cd ~ ; git clone https://github.com/OSGeo/grass-website.git
-#     cd grass-website
-# 1.  update local repo from github
-# 2.  rm previously built pages in local git repo copy
-# 3.  build updated pages with hugo
-# 4.  create tmp target web directory
-# 5.  copy over updated pages to tmp target web directory
-# 6.  rm previously deployed web pages while not deleting src code files in their adjacent directory (careful!)
-# 7.  copy over updated pages from tmp target web directory to server target web directory
-# 8.  links src code dir content into now deployed web directory
-# 9.  rm tmp target web directory
-# 10. restore linked src file timestamps from their original source time stamps
+# 1. change into local git repo copy
+# 2. update local repo from github
+# 3. build updated pages with hugo into clean directory
+# 4. rsync over updated pages to target web directory, deleting leftover files
+# 5. generate links from src code directory content into web directory
+# 6. restore timestamps of links from their original time stamps in src directory
 
 cd /home/neteler/grass-website/ && \
    git pull origin master && \
    rm -rf /home/neteler/grass-website/public/* && \
    nice /home/neteler/go/bin/hugo && \
-   mkdir /var/www/html_new && \
-   \cp -rp /home/neteler/grass-website/public/* /var/www/html_new/ && \
-   rm -fr /var/www/html/* && \
-   \mv /var/www/html_new/* /var/www/html/ && \
+   rsync -a --delete /home/neteler/grass-website/public/ /var/www/html/ && \
    ln -s /var/www/code_and_data/* /var/www/html/ && \
-   rmdir /var/www/html_new && \
-   (cd /var/www/html/ ; /home/neteler/bin/fix_link_timestamp.sh .)
+   (cd /var/www/html/ ; /home/neteler/bin/fix_link_timestamp.sh .) && \
+   exit 0


### PR DESCRIPTION
This PR simplifies the hugo cronjob by using rsync:

- avoids need of tmp-dir
- reduces rm/cp operations to single rsync call
- include header

In tests on grass.osgeo.org this modified script needs approx 80% of the time the original script required.