### PR TITLE
i.sam2: use lazy import for torch

### DIFF
--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -1325,7 +1325,7 @@ if __name__ == "__main__":
         from eodag.utils.exceptions import MisconfiguredError
         import eodag
     except ImportError:
-        gs.fatal(_("Cannot import eodag. Please intall the library first."))
+        gs.fatal(_("Cannot import eodag. Please install the library first."))
 
     # To disable eodag logs, set DEBUG to 0
     # with " g.gisenv 'set=DEBUG=0' "

--- a/src/imagery/i.sam2/i.sam2.html
+++ b/src/imagery/i.sam2/i.sam2.html
@@ -27,15 +27,15 @@ Segment orthoimagery using SamGeo2:
     </pre>
 </div>
 
-<img src="./i_sam2_trees.jpg" height="600" alt="i.sam2 example" />
+<img src="i_sam2_trees.jpg" height="600" alt="i.sam2 example">
 
 <h2>NOTES</h2>
 The first time use will be longer as the model needs to be downloaded. Subsequent runs will be faster.
-Additionally, Cuda is required for GPU acceleration. If you do not have a GPU, you can use the CPU by setting the environment variable `CUDA_VISIBLE_DEVICES` to `-1`.
+Additionally, CUDA is required for GPU acceleration. If you do not have a GPU, you can use the CPU by setting the environment variable `CUDA_VISIBLE_DEVICES` to `-1`.
 
 <h2>REFERENCES</h2>
 <ul>
-<li>Wu, Q., & Osco, L. (2023). samgeo: A Python package for segmenting geospatial data with the Segment Anything Model (SAM). Journal of Open Source Software, 8(89), 5663. <a href="https://doi.org/10.21105/joss.05663">https://doi.org/10.21105/joss.05663</a></li>
+<li>Wu, Q., &amp; Osco, L. (2023). samgeo: A Python package for segmenting geospatial data with the Segment Anything Model (SAM). Journal of Open Source Software, 8(89), 5663. <a href="https://doi.org/10.21105/joss.05663">https://doi.org/10.21105/joss.05663</a></li>
 <li>Osco, L. P., Wu, Q., de Lemos, E. L., Gonçalves, W. N., Ramos, A. P. M., Li, J., & Junior, J. M. (2023). The Segment Anything Model (SAM) for remote sensing applications: From zero to one shot. International Journal of Applied Earth Observation and Geoinformation, 124, 103540. <a href="https://doi.org/10.1016/j.jag.2023.103540">https://doi.org/10.1016/j.jag.2023.103540</a></li>
 </ul>
 
@@ -47,4 +47,4 @@ Additionally, Cuda is required for GPU acceleration. If you do not have a GPU, y
 </em>
 
 <h2>AUTHOR</h2>
-Corey T. White (NCSU GeoForAll Lab & OpenPlains Inc.)
+Corey T. White (NCSU GeoForAll Lab &amp; OpenPlains Inc.)

--- a/src/imagery/i.sam2/i.sam2.md
+++ b/src/imagery/i.sam2/i.sam2.md
@@ -24,7 +24,7 @@ Segment orthoimagery using SamGeo2:
     
 ```
 
-![image-alt](./i_sam2_trees.jpg)
+![i.sam2: trees detected in an aerial image with samgeo](i_sam2_trees.jpg)
 
 ## NOTES
 

--- a/src/imagery/i.sam2/i.sam2.md
+++ b/src/imagery/i.sam2/i.sam2.md
@@ -29,7 +29,7 @@ Segment orthoimagery using SamGeo2:
 ## NOTES
 
 The first time use will be longer as the model needs to be downloaded.
-Subsequent runs will be faster. Additionally, Cuda is required for GPU
+Subsequent runs will be faster. Additionally, CUDA is required for GPU
 acceleration. If you do not have a GPU, you can use the CPU by setting
 the environment variable \`CUDA\_VISIBLE\_DEVICES\` to \`-1\`.
 

--- a/src/imagery/i.sam2/i.sam2.py
+++ b/src/imagery/i.sam2/i.sam2.py
@@ -66,7 +66,6 @@
 import os
 import sys
 import grass.script as gs
-import torch
 import numpy as np
 from PIL import Image
 from grass.script import array as garray
@@ -228,6 +227,11 @@ def main():
     text_prompt = options.get("text_prompt")
     text_threshold = float(options.get("text_threshold"))
     box_threshold = float(options.get("box_threshold"))
+
+    try:
+        import torch
+    except ImportError:
+        gs.fatal(_("Cannot import torch. Please install python3-torch first."))
 
     input_image_np = read_raster_group(group)
     rgb_array = normalize_rgb_array(np.stack(input_image_np, axis=-1))

--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -530,6 +530,6 @@ if __name__ == "__main__":
 
         gs.find_program("i.eodag", "--help")
     except ImportError:
-        gs.fatal(_("Addon i.eodag not found. Please intall it with g.extension."))
+        gs.fatal(_("Addon i.eodag not found. Please install it with g.extension."))
 
     sys.exit(main())

--- a/src/raster/r.green/r.green.install/r.green.install.html
+++ b/src/raster/r.green/r.green.install/r.green.install.html
@@ -37,7 +37,7 @@ may occur.
 <h3>Installation on Microsoft Windows</h3>
 You should install <a href="https://grass.osgeo.org/download/windows/">GRASS GIS</a> with administrator
 rights; either the stand-alone installer or via OSGeo4W package, in a directory with full control of
-permissions, to be able to intall the <em>r.green</em> modules.
+permissions, to be able to install the <em>r.green</em> modules.
 
 <center>
 <img src="r_green_install_permissions.png" alt="Microsoft Windows Permissions"><br>

--- a/src/raster/r.green/r.green.install/r.green.install.md
+++ b/src/raster/r.green/r.green.install/r.green.install.md
@@ -30,7 +30,7 @@ post-installation troubles that sometimes may occur.
 You should install [GRASS
 GIS](https://grass.osgeo.org/download/windows/) with administrator
 rights; either the stand-alone installer or via OSGeo4W package, in a
-directory with full control of permissions, to be able to intall the
+directory with full control of permissions, to be able to install the
 *r.green* modules.
 
 ![image-alt](r_green_install_permissions.png)  


### PR DESCRIPTION
i.sam2: use lazy import for torch to avoid Python error:

```
Traceback (most recent call last):
  File "/home/neteler/.grass8/addons/i.sam2/scripts/i.sam2", line 69, in <module>
    import torch
ModuleNotFoundError: No module named 'torch'
```

Also 
- fix HTML error (img)
- add HTML alt tag
- fix typos in several manual pages