### PR TITLE
docs: Fix typos, broken links, old parameter names in examples

### DIFF
--- a/src/gui/wxpython/wx.stream/gui_modules/ImageViewer.py
+++ b/src/gui/wxpython/wx.stream/gui_modules/ImageViewer.py
@@ -6,7 +6,7 @@
 
 @brief GUI for r.stream.* modules
 
-See https://grass.osgeo.org/wiki/Wx.stream_GSoC_2011
+See https://grasswiki.osgeo.org/wiki/Wx.stream_GSoC_2011
 
 Classes:
  - ImgFrame

--- a/src/gui/wxpython/wx.stream/gui_modules/rstream.py
+++ b/src/gui/wxpython/wx.stream/gui_modules/rstream.py
@@ -6,7 +6,7 @@
 
 @brief GUI for r.stream.* modules
 
-See https://grass.osgeo.org/wiki/Wx.stream_GSoC_2011
+See https://grasswiki.osgeo.org/wiki/Wx.stream_GSoC_2011
 
 Classes:
  - RStreamFrame

--- a/src/gui/wxpython/wx.stream/gui_modules/rstream_ImageViewer.py
+++ b/src/gui/wxpython/wx.stream/gui_modules/rstream_ImageViewer.py
@@ -6,7 +6,7 @@
 
 @brief GUI for r.stream.* modules
 
-See https://grass.osgeo.org/wiki/Wx.stream_GSoC_2011
+See https://grasswiki.osgeo.org/wiki/Wx.stream_GSoC_2011
 
 Classes:
  - ImgFrame

--- a/src/gui/wxpython/wx.stream/gui_modules/rstream_panelOne.py
+++ b/src/gui/wxpython/wx.stream/gui_modules/rstream_panelOne.py
@@ -6,7 +6,7 @@
 
 @brief GUI for r.stream.* modules
 
-See https://grass.osgeo.org/wiki/Wx.stream_GSoC_2011
+See https://grasswiki.osgeo.org/wiki/Wx.stream_GSoC_2011
 
 Classes:
  - CoorWindow

--- a/src/imagery/i.segment.gsoc/i.segment.gsoc.html
+++ b/src/imagery/i.segment.gsoc/i.segment.gsoc.html
@@ -201,11 +201,11 @@ after the seed map has been processed.)
 This project was first developed during GSoC 2012.  Project
 documentation, Image Segmentation references, and other information
 is at the <a href=
-"https://grass.osgeo.org/wiki/GRASS_GSoC_2012_Image_Segmentation">
+"https://grasswiki.osgeo.org/wiki/GRASS_GSoC_2012_Image_Segmentation">
 project wiki</a>.
 <p>
 Information about <a href=
-"https://grass.osgeo.org/wiki/Image_classification">classification in
+"https://grasswiki.osgeo.org/wiki/Image_classification">classification in
 GRASS GIS</a> is also available on the wiki.
 
 <h2>SEE ALSO</h2>

--- a/src/imagery/i.segment.gsoc/i.segment.gsoc.md
+++ b/src/imagery/i.segment.gsoc/i.segment.gsoc.md
@@ -213,10 +213,10 @@ after the seed map has been processed.)
 This project was first developed during GSoC 2012. Project
 documentation, Image Segmentation references, and other information is
 at the [project
-wiki](https://grass.osgeo.org/wiki/GRASS_GSoC_2012_Image_Segmentation).
+wiki](https://grasswiki.osgeo.org/wiki/GRASS_GSoC_2012_Image_Segmentation).
 
 Information about [classification in GRASS
-GIS](https://grass.osgeo.org/wiki/Image_classification) is also
+GIS](https://grasswiki.osgeo.org/wiki/Image_classification) is also
 available on the wiki.
 
 ## SEE ALSO

--- a/src/raster/r.connectivity/r.connectivity.network/r.connectivity.network.py
+++ b/src/raster/r.connectivity/r.connectivity.network/r.connectivity.network.py
@@ -412,7 +412,7 @@ def main():
             "R is required, but cannot be found on the system.\n \
                     Please make sure that R is installed and the path \
                     to R is added to the environment variables \
-                    (see: https://grass.osgeo.org/wiki/R_statistics#MS_Windows). \
+                    (see: https://grasswiki.osgeo.org/wiki/R_statistics#Installation). \
                     After that a restart of GRASS GIS is required."
         )
 

--- a/src/raster/r.pi/TODO.txt
+++ b/src/raster/r.pi/TODO.txt
@@ -42,7 +42,7 @@ bt full
 
 This will generate a full backtrace if GRASS was compiled with "-g",
 i.e. debugging. See
-https://grass.osgeo.org/wiki/GRASS_Debugging#Using_GDB
+https://grasswiki.osgeo.org/wiki/GRASS_Debugging#Using_GDB
 
 Got it, too:
 

--- a/src/raster/r.stream.basins/r.stream.basins.html
+++ b/src/raster/r.stream.basins/r.stream.basins.html
@@ -93,7 +93,7 @@ differ, the module informs about it and stops. Region boundary and
 maps boundaries may differ but it may lead to unexpected results.
 </dd>
 
-<dt><b>coors</b></dt>
+<dt><b>coordinates</b></dt>
 <dd>East and north coordinates for the basin outlet. Using this option, it is possible
 to delineate only one basin at a time, similarly to <em>r.water.outlet</em>.
 </dd>
@@ -152,7 +152,7 @@ subbasins, use -l flag. This flag ignores all nodes and uses only real outlets
 <div class="code"><pre>
 r.stream.basins -l direction=direction stream_rast=streams basins=bas_basins_last
 
-r.stream.basins direction=direction coors=639936.623832,216939.836449
+r.stream.basins direction=direction coordinates=639936.623832,216939.836449
 </pre></div>
 
 <p>
@@ -180,7 +180,7 @@ with <em>v.digit</em>:
 
 <div class="code"><pre>
 r.circle -b output=circle coordinate=639936.623832,216939.836449 max=200
-r.stream.basins -c direction=direction streams=circle basins=bas_simul
+r.stream.basins -c direction=direction stream_rast=circle basins=bas_simul
 </pre></div>
 
 <p>
@@ -206,7 +206,7 @@ r.stream.basins direction=direction streams=lake8056 basins=bas_basin_lake
 </pre></div>
 
 <p>
-See also the tutorial: <a href="https://grass.osgeo.org/wiki/R.stream.*">https://grass.osgeo.org/wiki/R.stream.*</a>
+See also the tutorial: <a href="https://grasswiki.osgeo.org/wiki/R.stream.*_modules">https://grasswiki.osgeo.org/wiki/R.stream.*_modules</a>
 
 <h2>SEE ALSO</h2>
 

--- a/src/raster/r.stream.basins/r.stream.basins.md
+++ b/src/raster/r.stream.basins/r.stream.basins.md
@@ -53,7 +53,7 @@ create a collective basin for all the outlets with common category.
     resolutions differ, the module informs about it and stops. Region
     boundary and maps boundaries may differ but it may lead to
     unexpected results.
-- **coors**  
+- **coordinates**  
     East and north coordinates for the basin outlet. Using this option,
     it is possible to delineate only one basin at a time, similarly to
     *r.water.outlet*.
@@ -105,7 +105,7 @@ outlets (in most cases that on map border):
 ```sh
 r.stream.basins -l direction=direction stream_rast=streams basins=bas_basins_last
 
-r.stream.basins direction=direction coors=639936.623832,216939.836449
+r.stream.basins direction=direction coordinates=639936.623832,216939.836449
 ```
 
 To delineate one or more particular basins defined by given streams, add
@@ -131,7 +131,7 @@ substituted by any polygon created for example with *v.digit*:
 
 ```sh
 r.circle -b output=circle coordinate=639936.623832,216939.836449 max=200
-r.stream.basins -c direction=direction streams=circle basins=bas_simul
+r.stream.basins -c direction=direction stream_rast=circle basins=bas_simul
 ```
 
 To determine areas of contribution to streams of particular order use as
@@ -152,10 +152,10 @@ v.extract -d input=lakes@PERMANENT output=lake8056 type=area layer=1 \
 
 v.to.rast input=lake8056 output=lake8056 use=val type=area layer=1 value=1
 
-r.stream.basins direction=direction streams=lake8056 basins=bas_basin_lake
+r.stream.basins direction=direction stream_rast=lake8056 basins=bas_basin_lake
 ```
 
-See also the tutorial: <https://grass.osgeo.org/wiki/R.stream.*>
+See also the tutorial: <https://grasswiki.osgeo.org/wiki/R.stream.*_modules>
 
 ## SEE ALSO
 

--- a/src/temporal/t.stac/t.stac.html
+++ b/src/temporal/t.stac/t.stac.html
@@ -24,9 +24,9 @@ that is interoperable across software and data services. The
 
 <p>
 <ul>
-  <li><a href="https://pystac.readthedocs.io/en/stable/installation.html">pystac (1.9.x)</a></li>
-  <li><a href="https://pystac-client.readthedocs.io/en/stable/">pystac_client (0.7.x)</a></li>
-  <li><a href="https://pypi.org/project/tqdm/"></a>tqdm (4.66.x)</li>
+  <li><a href="https://pystac.readthedocs.io/en/stable/installation.html">pystac (>=1.12)</a></li>
+  <li><a href="https://pystac-client.readthedocs.io/en/stable/">pystac_client (>=0.8)</a></li>
+  <li><a href="https://pypi.org/project/tqdm/">tqdm (>=4.67)</a></li>
 </ul>
 
 <p>
@@ -39,7 +39,7 @@ g.extension extension=t.stac
 <h2>MODULES</h2>
 
 <em>
-<a href="t.stac.catalog">t.stac.catalog.html</a>
+<a href="t.stac.catalog.html">t.stac.catalog.html</a>
 <a href="t.stac.collection.html">t.stac.collection.html</a>
 <a href="t.stac.item.html">t.stac.item.html</a>
 </em>

--- a/src/temporal/t.stac/t.stac.md
+++ b/src/temporal/t.stac/t.stac.md
@@ -13,11 +13,9 @@ interact with STAC APIs.
 
 ## REQUIREMENTS
 
-- [pystac
-    (1.9.x)](https://pystac.readthedocs.io/en/stable/installation.html)
-- [pystac\_client
-    (0.7.x)](https://pystac-client.readthedocs.io/en/stable/)
-- [](https://pypi.org/project/tqdm/)tqdm (4.66.x)
+- [pystac (>=1.12)](https://pystac.readthedocs.io/en/stable/installation.html)
+- [pystac\_client (>=0.8)](https://pystac-client.readthedocs.io/en/stable/)
+- [tqdm (>=4.67)](https://pypi.org/project/tqdm/)
 
 After dependencies are fulfilled, the toolset can be installed using the
 *g.extension* tool:
@@ -28,7 +26,7 @@ g.extension extension=t.stac
 
 ## MODULES
 
-*[t.stac.catalog.html](t.stac.catalog)
+*[t.stac.catalog.html](t.stac.catalog.md)
 [t.stac.collection.html](t.stac.collection.md)
 [t.stac.item.html](t.stac.item.md)*
 


### PR DESCRIPTION
Fixes typos, broken links, including many old GRASS wiki links, and old parameter names used in the examples, esp. in *t.stac* and *r.stream.basins* tools. Updates *t.stac* dependencies.