### PR TITLE
docs: Use meta page info from HTML in Markdown

### DIFF
--- a/src/imagery/i.ann.maskrcnn/i.ann.maskrcnn.md
+++ b/src/imagery/i.ann.maskrcnn/i.ann.maskrcnn.md
@@ -1,3 +1,10 @@
+---
+name: i.ann.maskrcnn
+description: Mask R-CNN toolset
+---
+
+# Mask R-CNN toolset
+
 ## DESCRIPTION
 
 Mask R-CNN tools allow the user to train his own model and use it for a

--- a/src/imagery/i.landsat/i.landsat.md
+++ b/src/imagery/i.landsat/i.landsat.md
@@ -1,3 +1,10 @@
+---
+name: i.landsat
+description: Toolset for downloading and importing of Landsat products
+---
+
+# Toolset for downloading and importing of Landsat products
+
 ## DESCRIPTION
 
 The *i.landsat* toolset consists of three modules:

--- a/src/imagery/i.modis/i.modis.md
+++ b/src/imagery/i.modis/i.modis.md
@@ -1,3 +1,10 @@
+---
+name: i.modis
+description: Toolset for download and processing of MODIS products using pyModis
+---
+
+# Toolset for download and processing of MODIS products using pyModis
+
 ## DESCRIPTION
 
 The *i.modis* suite is a toolset to import MODIS (Moderate Resolution

--- a/src/imagery/i.sentinel/i.sentinel.md
+++ b/src/imagery/i.sentinel/i.sentinel.md
@@ -1,3 +1,10 @@
+---
+name: i.sentinel
+description: Toolset for download and processing of Copernicus Sentinel products
+---
+
+# Toolset for download and processing of Copernicus Sentinel products
+
 ## DESCRIPTION
 
 The *i.sentinel* toolset consists of currently six modules:

--- a/src/misc/m.eigensystem/m.eigensystem.md
+++ b/src/misc/m.eigensystem/m.eigensystem.md
@@ -1,3 +1,10 @@
+---
+name: m.eigensystem
+description: Computes eigenvalues and eigenvectors for an NxN matrix
+---
+
+# Computes eigenvalues and eigenvectors for an NxN matrix
+
 ## DESCRIPTION
 
 *m.eigensystem* determines the eigen values and eigen vectors for square

--- a/src/raster/r.agent/r.agent.md
+++ b/src/raster/r.agent/r.agent.md
@@ -1,3 +1,10 @@
+---
+name: r.agent
+description: Toolset for agent based modeling
+---
+
+# Toolset for agent based modeling
+
 ## DESCRIPTION
 
 *r.agent* consists of a library *libagent* and some submodules which use

--- a/src/raster/r.connectivity/r.connectivity.md
+++ b/src/raster/r.connectivity/r.connectivity.md
@@ -1,3 +1,10 @@
+---
+name: r.connectivity
+description: Toolset for conducting connectivity analysis of ecological networks
+---
+
+# Toolset for conducting connectivity analysis of ecological networks
+
 ## DESCRIPTION
 
 *r.connectivity* is a toolset for conducting connectivity analysis of

--- a/src/raster/r.futures/r.futures.md
+++ b/src/raster/r.futures/r.futures.md
@@ -1,3 +1,10 @@
+---
+name: r.futures
+description: FUTure Urban-Regional Environment Simulation (FUTURES)
+---
+
+# FUTure Urban-Regional Environment Simulation (FUTURES)
+
 ## DESCRIPTION
 
 *r.futures.\** is an implementation of FUTure Urban-Regional Environment

--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.md
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.md
@@ -1,3 +1,9 @@
+---
+description: Computes the residual energy potential of different renewable energies like biomass or hydropower
+---
+
+# Computes the residual energy potential of different renewable energies like biomass or hydropower
+
 [![image-alt](grass_logo.png)](https://grass.osgeo.org/grass-stable/manuals/index.html)
 
 -----

--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.md
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.md
@@ -1,24 +1,10 @@
 ---
-description: Computes the residual energy potential of different renewable energies like biomass or hydropower
+name: r.green.biomassfor
+description: Toolset for computing the energy potential of biomass from the forestry residues, considering different limits and constraints
+keywords: raster, biomass, forestry
 ---
 
-# Computes the residual energy potential of different renewable energies like biomass or hydropower
-
-[![image-alt](grass_logo.png)](https://grass.osgeo.org/grass-stable/manuals/index.html)
-
------
-
-## NAME
-
-***r.green.biomassfor*** - Toolset for computing the energy potential of
-biomass from the forestry residues, considering different limits and
-constraints.
-
-## KEYWORDS
-
-[raster](https://grass.osgeo.org/grass-stable/manuals/raster.html),
-[biomass
-topic](https://grass.osgeo.org/grass-stable/manuals/topic_biomass.html)
+# Toolset for Computing the Energy Potential of Biomass
 
 ## DESCRIPTION
 
@@ -38,7 +24,7 @@ parts:
 - [r.green.biomassfor.legal](r.green.biomassfor.legal.md) - Estimates
     potential bioenergy depending on forest increment, forest management
     and forest treatment
-- [r.green.biomassfor.tecnical](r.green.biomassfor.technical.md) -
+- [r.green.biomassfor.technical](r.green.biomassfor.technical.md) -
     Estimates the quantity of woody biomass obtained from a forest
     surface where extraction is possible given a particular level of
     mechanisation

--- a/src/raster/r.green/r.green.gshp/r.green.gshp.md
+++ b/src/raster/r.green/r.green.gshp/r.green.gshp.md
@@ -1,23 +1,10 @@
 ---
-description: Computes the residual energy potential of different renewable energies like biomass or hydropower
+name: r.green.gshp
+description: Toolset for computing the Ground Source Heat Pump
+keywords: raster, geothermal, renewable energy
 ---
 
-# Computes the residual energy potential of different renewable energies like biomass or hydropower
-
-[![image-alt](grass_logo.png)](https://grass.osgeo.org/grass-stable/manuals/index.html)
-
------
-
-## NAME
-
-The *r.green.gshp* - Toolset for computing the Ground Source Heat Pump
-potential.
-
-## KEYWORDS
-
-[raster](https://grass.osgeo.org/grass-stable/manuals/raster.html),
-[biomass
-topic](https://grass.osgeo.org/grass-stable/manuals/topic_biomass.html)
+# Toolset for Computing the Ground Source Heat Pump
 
 ## DESCRIPTION
 

--- a/src/raster/r.green/r.green.gshp/r.green.gshp.md
+++ b/src/raster/r.green/r.green.gshp/r.green.gshp.md
@@ -1,3 +1,9 @@
+---
+description: Computes the residual energy potential of different renewable energies like biomass or hydropower
+---
+
+# Computes the residual energy potential of different renewable energies like biomass or hydropower
+
 [![image-alt](grass_logo.png)](https://grass.osgeo.org/grass-stable/manuals/index.html)
 
 -----

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.md
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.md
@@ -1,3 +1,9 @@
+---
+description: Computes the residual energy potential of different renewable energies like biomass or hydropower
+---
+
+# Computes the residual energy potential of different renewable energies like biomass or hydropower
+
 ## NAME
 
 The *r.green.hydro* - Toolset for computing the hydropower potential.

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.md
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.md
@@ -1,18 +1,10 @@
 ---
+name: r.green.hydro
 description: Computes the residual energy potential of different renewable energies like biomass or hydropower
+keywords: raster, biomass
 ---
 
-# Computes the residual energy potential of different renewable energies like biomass or hydropower
-
-## NAME
-
-The *r.green.hydro* - Toolset for computing the hydropower potential.
-
-## KEYWORDS
-
-[raster](https://grass.osgeo.org/grass-stable/manuals/raster.html),
-[biomass
-topic](https://grass.osgeo.org/grass-stable/manuals/topic_biomass.html)
+# Computes the residual energy potential of different renewable energies
 
 ## DESCRIPTION
 

--- a/src/raster/r.green/r.green.install/r.green.install.md
+++ b/src/raster/r.green/r.green.install/r.green.install.md
@@ -1,29 +1,7 @@
----
-description: Computes the residual energy potential of different renewable energies like biomass or hydropower
----
-
-# Computes the residual energy potential of different renewable energies like biomass or hydropower
-
-[![image-alt](grass_logo.png)](https://grass.osgeo.org/grass-stable/manuals/index.html)
-
------
-
-## NAME
-
-*r.green.install* - Toolset to check that all the necessary Python
-libraries like scipy and numexpr are present in the python path. The
-module also check post-installation troubles that sometimes may occur.
-
-## KEYWORDS
-
-[raster](https://grass.osgeo.org/grass-stable/manuals/raster.html),
-[biomass
-topic](https://grass.osgeo.org/grass-stable/manuals/topic_biomass.html)
-
 ## DESCRIPTION
 
-The module installs the missing Python libraries for different operating
-systems and provide a general menu in the GRASS GUI.
+The tool checks and installs the missing Python libraries for different
+operating systems and provide a general menu in the GRASS GUI.
 
 ## NOTES
 

--- a/src/raster/r.green/r.green.install/r.green.install.md
+++ b/src/raster/r.green/r.green.install/r.green.install.md
@@ -1,3 +1,9 @@
+---
+description: Computes the residual energy potential of different renewable energies like biomass or hydropower
+---
+
+# Computes the residual energy potential of different renewable energies like biomass or hydropower
+
 [![image-alt](grass_logo.png)](https://grass.osgeo.org/grass-stable/manuals/index.html)
 
 -----

--- a/src/raster/r.green/r.green.md
+++ b/src/raster/r.green/r.green.md
@@ -1,9 +1,9 @@
 ---
 name: r.green
-description: Toolset for computing the residual energy potential of different renewable energies like biomass or hydropower
+description: Toolset for computing the residual energy potential of different renewable energies
 ---
 
-# Toolset for computing the residual energy potential of different renewable energies like biomass or hydropower
+# Toolset for computing the residual energy potential of different renewable energies
 
 ## DESCRIPTION
 

--- a/src/raster/r.green/r.green.md
+++ b/src/raster/r.green/r.green.md
@@ -1,3 +1,10 @@
+---
+name: r.green
+description: Toolset for computing the residual energy potential of different renewable energies like biomass or hydropower
+---
+
+# Toolset for computing the residual energy potential of different renewable energies like biomass or hydropower
+
 ## DESCRIPTION
 
 The *r.green* suite computes the residual energy potential of different

--- a/src/raster/r.in.ogc/r.in.ogc.md
+++ b/src/raster/r.in.ogc/r.in.ogc.md
@@ -1,3 +1,10 @@
+---
+name: r.in.ogc
+description: Toolset for import of raster data from several OGC API standards
+---
+
+# Toolset for import of raster data from several OGC API standards
+
 ## DESCRIPTION
 
 The *r.in.ogc* suite is able to import raster data from several OGC API

--- a/src/raster/r.learn.ml2/r.learn.ml2.md
+++ b/src/raster/r.learn.ml2/r.learn.ml2.md
@@ -1,3 +1,10 @@
+---
+name: r.learn.ml2
+description: Supervised classification and regression with scikit-learn
+---
+
+# Supervised classification and regression with scikit-learn
+
 ## DESCRIPTION
 
 *r.learn.ml2* represents a front-end to the scikit learn python package.

--- a/src/raster/r.pi/r.pi.md
+++ b/src/raster/r.pi/r.pi.md
@@ -1,3 +1,10 @@
+---
+name: r.pi
+description: Toolset for multiscale analysis of landscape patch structure
+---
+
+# Toolset for multiscale analysis of landscape patch structure
+
 ## KEYWORDS
 
 [raster](raster.md), [landscape structure

--- a/src/raster/r.slopeunits/r.slopeunits.md
+++ b/src/raster/r.slopeunits/r.slopeunits.md
@@ -1,3 +1,10 @@
+---
+name: r.slopeunits
+description: Toolset for calculating metrics for slope units
+---
+
+# Toolset for calculating metrics for slope units
+
 ## DESCRIPTION
 
 *r.slopeunits* is a GRASS GIS addon toolset that creates, cleans and

--- a/src/temporal/t.stac/t.stac.md
+++ b/src/temporal/t.stac/t.stac.md
@@ -1,3 +1,10 @@
+---
+name: t.stac
+description: Toolset for working with SpatioTemporal Asset Catalogs
+---
+
+# Toolset for working with SpatioTemporal Asset Catalogs
+
 ## DESCRIPTION
 
 The *t.stac* toolset allows the user to explore metadata and ingest

--- a/src/vector/v.feature.algebra/v.feature.algebra.md
+++ b/src/vector/v.feature.algebra/v.feature.algebra.md
@@ -1,3 +1,10 @@
+---
+name: v.feature.algebra
+description: A vector calculator program
+---
+
+# A vector calculator program
+
 ## DESCRIPTION
 
 *v.feature.algebra* is a vector calculator program inspired by

--- a/src/vector/v.in.ogc/v.in.ogc.md
+++ b/src/vector/v.in.ogc/v.in.ogc.md
@@ -1,3 +1,10 @@
+---
+name: v.in.ogc
+description: Toolset for import of vector data from several OGC API standards
+---
+
+# Toolset for import of vector data from several OGC API standards
+
 ## DESCRIPTION
 
 The *v.in.ogc* suite is able to import vector data from several OGC API


### PR DESCRIPTION
Transfers meta page from HTML to Markdown as YAML header. Transfers meta page description to a Markdown level-1 heading if description is present.

Additionally, it fixes one heading and description to not contain period to conform with all the others and Markdown heading linting (r.pi).
