### PR TITLE
docs: fix HTML errors in r.hand.html

### DIFF
--- a/src/raster/r.hand/r.hand.html
+++ b/src/raster/r.hand/r.hand.html
@@ -18,7 +18,7 @@ Additionally, the HAND raster map can be returned as an output if desired by set
     r.hand elevation=elevation hand=hand depth=2 inundation_raster=inundation
 </pre></div>
 
-<div align="center" style="margin: 10px"></div>
+<div align="center" style="margin: 10px">
     <a href="r_hand.png">
         <img
         src="r_hand.png"
@@ -26,8 +26,8 @@ Additionally, the HAND raster map can be returned as an output if desired by set
         height="600"
         alt="r.hand example"
         border="0"
-        />
-    </a><br/>
+        >
+    </a><br>
     <i>Figure: Inundation event 2 m.</i>
 </div>
 
@@ -53,7 +53,7 @@ The HAND raster is classified according to Nobre et al (2011) where:
     <li>HAND &gt; 15 m = Deep Water Table</li>
 </ul>
 
-<div align="center" style="margin: 10px"></div>
+<div align="center" style="margin: 10px">
     <a href="r_hand_color.png">
         <img
         src="r_hand_color.png"
@@ -61,8 +61,8 @@ The HAND raster is classified according to Nobre et al (2011) where:
         height="600"
         alt="r.hand HAND example"
         border="0"
-        />
-    </a><br/>
+        >
+    </a><br>
     <i>Figure: Height Above Nearest Drainage (HAND)</i>
 </div>
 
@@ -85,7 +85,7 @@ The HAND raster is classified according to Nobre et al (2011) where:
     EOF
 </pre></div>
 
-<div align="center" style="margin: 10px"></div>
+<div align="center" style="margin: 10px">
     <a href="r_hand_class.png">
         <img
         src="r_hand_class.png"
@@ -93,8 +93,8 @@ The HAND raster is classified according to Nobre et al (2011) where:
         height="600"
         alt="r.hand HAND example"
         border="0"
-        />
-    </a><br/>
+        >
+    </a><br>
     <i>Figure: Height Above Nearest Drainage (HAND) water table classification.</i>
 </div>
 
@@ -102,8 +102,8 @@ The HAND raster is classified according to Nobre et al (2011) where:
 [1] Nobre, A.D., Cuartas, L.A., Hodnett, M., Rennó, C.D., Rodrigues, G., Silveira, A., Waterloo, M., Saleska, S., 2011. Height Above the Nearest Drainage – a hydrologically relevant new terrain model. Journal of Hydrology 404, 13–29. https://doi.org/10.1016/j.jhydrol.2011.03.051
 
 <h2>AUTHORS</h2>
-Corey White, <a href="https://openplains.com">OpenPlains Inc.</a> &amp; <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll Lab</a>,<br/>
-Maris Nartiss (author of <em><a href="https://grass.osgeo.org/grass-stable/manuals/r.lake.html">r.lake</a></em>),<br/>
+Corey White, <a href="https://openplains.com">OpenPlains Inc.</a> &amp; <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll Lab</a>,<br>
+Maris Nartiss (author of <em><a href="https://grass.osgeo.org/grass-stable/manuals/r.lake.html">r.lake</a></em>),<br>
 Vaclav Petras, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll Lab</a>(author of <em><a href="https://grass.osgeo.org/grass-stable/manuals/r.lake.series.html">r.lake.series</a></em>)
 
 <h2>SEE ALSO</h2>


### PR DESCRIPTION
At time `r.hand` cannot be compiled ([log](https://grass.osgeo.org/addons/grass8/logs/r.hand.log)) against GRASS GIS 8.4 (which is the version to build the addon HTML pages).

This PR fixes some HTML tags (as understood by the build system) in the manual page.