### PR TITLE
r.viewshed.cva: minor bugfix for memory error with r.series

### DIFF
--- a/src/raster/r.viewshed.cva/r.viewshed.cva.py
+++ b/src/raster/r.viewshed.cva/r.viewshed.cva.py
@@ -212,6 +212,7 @@ def main():
     rseries_method = "sum" if "b" in flagstring else "count"
     gs.run_command(
         "r.series",
+        flags="z",
         quiet=True,
         overwrite=gs.overwrite(),
         input=(",").join(vshed_list),


### PR DESCRIPTION
 Add flag -z to r.series call to avoid memory error when many viewpoints are input.