### PR TITLE
docs: Use YAML list for keywords in front matter

### DIFF
--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.md
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.md
@@ -1,7 +1,7 @@
 ---
 name: r.green.biomassfor
 description: Toolset for computing the energy potential of biomass from the forestry residues, considering different limits and constraints
-keywords: raster, biomass, forestry
+keywords: [raster, biomass, forestry]
 ---
 
 # Toolset for Computing the Energy Potential of Biomass

--- a/src/raster/r.green/r.green.gshp/r.green.gshp.md
+++ b/src/raster/r.green/r.green.gshp/r.green.gshp.md
@@ -1,7 +1,7 @@
 ---
 name: r.green.gshp
 description: Toolset for computing the Ground Source Heat Pump
-keywords: raster, geothermal, renewable energy
+keywords: [raster, geothermal, renewable energy]
 ---
 
 # Toolset for Computing the Ground Source Heat Pump

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.md
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.md
@@ -1,7 +1,7 @@
 ---
 name: r.green.hydro
 description: Computes the residual energy potential of different renewable energies like biomass or hydropower
-keywords: raster, biomass
+keywords: [raster, biomass]
 ---
 
 # Computes the residual energy potential of different renewable energies

--- a/src/raster/r.pi/r.pi.md
+++ b/src/raster/r.pi/r.pi.md
@@ -1,16 +1,10 @@
 ---
 name: r.pi
 description: Toolset for multiscale analysis of landscape patch structure
+keywords: [raster, landscape structure analysis, neutral landscapes, patch index]
 ---
 
 # Toolset for multiscale analysis of landscape patch structure
-
-## KEYWORDS
-
-[raster](raster.md), [landscape structure
-analysis](topic_landscape_structure_analysis.md), [neutral
-landscapes](keywords.md#neutral-landscapes), [patch
-index](keywords.md#patch-index)
 
 ## DESCRIPTION
 


### PR DESCRIPTION
To support MkDocs reading the keywords property, use actual YAML syntax for inline list as opposed to string with comma-separated values for r.green. For r.pi, use keywords property and remove Keywords section.
