### PR TITLE
cronjobs: fix G84 patch version

### DIFF
--- a/utils/cronjobs_osgeo_lxd/cron_grass_current_stable_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_current_stable_build_binaries.sh
@@ -36,7 +36,7 @@ PATH=$MAINDIR/bin:/bin:/usr/bin:/usr/local/bin
 # https://github.com/OSGeo/grass/tags
 GMAJOR=8
 GMINOR=4
-GPATCH="0dev"  # required by grass-addons-index.sh
+GPATCH=1  # required by grass-addons-index.sh
 BRANCH=releasebranch_${GMAJOR}_${GMINOR}
 DOTVERSION=$GMAJOR.$GMINOR
 VERSION=$GMAJOR$GMINOR


### PR DESCRIPTION
The GRASS 8.4 binary compilation was still pointing to the previous patch release, now fixed.