### PR TITLE
i.gravity: Fix function signature for free_air

### DIFF
--- a/src/imagery/i.gravity/gravity.c
+++ b/src/imagery/i.gravity/gravity.c
@@ -21,7 +21,7 @@ double delta_g_eotvos(double alpha, double lambda, double v)
 }
 
 /*# Free air Correction*/
-double free_air(h)
+double free_air(double h)
 {
     /* Free air Correction (mGal)
     h=height (m)*/

--- a/src/imagery/i.gravity/main.c
+++ b/src/imagery/i.gravity/main.c
@@ -24,7 +24,7 @@ double g_lambda(double lambda);
 /* Eotvos Correction*/
 double delta_g_eotvos(double alpha, double lambda, double v);
 /* Free air Correction*/
-double free_air(h);
+double free_air(double h);
 /* Bouguer Correction*/
 double delta_g_bouguer(double rho, double h);
 /* bouguer anomaly */


### PR DESCRIPTION
I was looking at the page https://grass.osgeo.org/grass-devel/manuals/addons/, noticed the last time the page was updated was on 2025-05-24, so I looked at the build logs. For windows, the page https://wingrass.fsv.cvut.cz/grass85/addons/grass-8.5.0dev/logs/ has some failures, so I opened one at random, and the problem was quite obvious: there’s no type to the function’s argument. Gcc says it will default to int.

The variable that is uses with this function is DCELL, and by reading what it is, I suppose that a double-cell would work as intended for a double argument.
