### PR TITLE
Update r.hydro.flatten.py to change order of r.patch to create the optional filled DEM raster layer

### DIFF
--- a/src/raster/r.hydro.flatten/r.hydro.flatten.py
+++ b/src/raster/r.hydro.flatten/r.hydro.flatten.py
@@ -265,7 +265,7 @@ def main():
     if options["filled_elevation"]:
         gs.run_command(
             "r.patch",
-            input=[tmp_rfillstats, options["water_elevation"]],
+            input=[options["water_elevation"],tmp_rfillstats],
             output=options["filled_elevation"],
         )
         gs.run_command("r.colors", map=options["filled_elevation"], raster=ground)

--- a/src/raster/r.hydro.flatten/r.hydro.flatten.py
+++ b/src/raster/r.hydro.flatten/r.hydro.flatten.py
@@ -265,7 +265,7 @@ def main():
     if options["filled_elevation"]:
         gs.run_command(
             "r.patch",
-            input=[options["water_elevation"],tmp_rfillstats],
+            input=[options["water_elevation"], tmp_rfillstats],
             output=options["filled_elevation"],
         )
         gs.run_command("r.colors", map=options["filled_elevation"], raster=ground)


### PR DESCRIPTION
This changes the order of the input rater layers to r.patch . Previously the values from the r.fill.stats result were overwriting the calculated water level near the edges of the water.