### PR TITLE
v.in.osm: fix passing -o flag

### DIFF
--- a/src/vector/v.in.osm/v.in.osm.py
+++ b/src/vector/v.in.osm/v.in.osm.py
@@ -113,7 +113,7 @@ class OsmImporter:
                 layer=options["table"],
                 where=options["where"],
                 type=options["type"],
-                flags=flags["o"],
+                flags="o" if flags["o"] else None,
             )
         except CalledModuleError:
             gs.fatal(_("%s failed") % "v.in.ogr")


### PR DESCRIPTION
The -o flag was not passed correctly.