### PR TITLE
r.in.usgs: print info to stdout only with -i flag, otherwise verbose message

### DIFF
--- a/src/raster/r.in.usgs/r.in.usgs.py
+++ b/src/raster/r.in.usgs/r.in.usgs.py
@@ -711,7 +711,10 @@ def main():
             srs=product_srs,
             tile=TNM_file_titles_info,
         )
-    print(data_info)
+    if gui_i_flag:
+        print(data_info)
+    else:
+        gs.verbose(data_info)
 
     if gui_i_flag:
         gs.message(_("To download USGS data, remove <i> flag, and rerun r.in.usgs."))


### PR DESCRIPTION
Print info to stdout only with -i flag, otherwise use verbose message.