### PR TITLE
CI: remove CRLF checks and always run pre-commit checks

### DIFF
--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -30,21 +30,6 @@ jobs:
         with:
           fetch-depth: 31
 
-      - name: Check what files were changed
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: changes
-        with:
-          filters: |
-            precommit:
-              - '.pre-commit-config.yaml'
-              - '.github/workflows/additional_checks.yml'
-
-      - name: Check for CRLF endings
-        uses: erclu/check-crlf@94acb86c2a41b0a46bd8087b63a06f0457dd0c6c # v1.2.0
-        with:
-          # Ignore all test data, Windows-specific directories and scripts.
-          exclude: mswindows .*\.bat .*/testsuite/data/.*
-
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:

--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -36,4 +36,3 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - run: pip install pre-commit && pre-commit run -a
-        if: ${{ steps.changes.outputs.precommit == 'true' }}


### PR DESCRIPTION
This should unblock a little bit before applying more of OSGeo/grass#6070.