### PR TITLE
chore: Add *.tmp.md to .gitignore to exclude temporary markdown files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 OBJ.*
 *.o
 *.tmp.html
+*.tmp.md
 bin.*/*
 build
 /out/


### PR DESCRIPTION
Follow-up from https://github.com/OSGeo/grass-addons/pull/1441: I noticed when building that there are now (since a couple of months) `*.tmp.md` files used when generating markdown docs, just like html docs were doing before.

This PR adds this pattern too to the .gitignore file.