### PR TITLE
cronjobs: script to retrieve and unpack manual artifacts from GitHub

### DIFF
--- a/utils/cronjobs_osgeo_lxd/cron_job_list_grass
+++ b/utils/cronjobs_osgeo_lxd/cron_job_list_grass
@@ -23,13 +23,13 @@
 # run at 00:30:00 and 12:30:00 each day: fetches code from GitHub and builds it with hugo (target dir: /var/www/html/)
 30 */12 * * * nice bash /home/neteler/cronjobs/hugo_clean_and_update_job.sh
 # run at 00:40:00 and 12:40:00 each day:
-40 */12 * * * nice bash /home/neteler/fetch_unpack_manual_GHA.sh > /home/neteler/fetch_unpack_manual_GHA.log  2>&1
+40 */12 * * * nice bash /home/neteler/cronjobs/fetch_unpack_manual_GHA.sh > /home/neteler/fetch_unpack_manual_GHA.log  2>&1
 
 # weekly source snapshots (target dir: /var/www/code_and_data/)
 # legacy
 20 02 * * 6 nice bash /home/neteler/cronjobs/cron_grass_legacy_src_snapshot.sh
-# old (former stable)
-30 02 * * 6 nice bash /home/neteler/cronjobs/cron_grass_old_src_snapshot.sh
+## old (former stable, 8.3 src-tarball disabled on May 6th, 2025)
+#30 02 * * 6 nice bash /home/neteler/cronjobs/cron_grass_old_src_snapshot.sh
 # current stable
 40 02 * * 6 nice bash /home/neteler/cronjobs/cron_grass_current_stable_src_snapshot.sh
 # preview
@@ -39,8 +39,8 @@
 # daily Linux binary snapshots, also creates main manuals, addon manuals, and prog-manual (target dir: /var/www/code_and_data/)
 # legacy
 00 05 * * * nice bash /home/neteler/cronjobs/cron_grass_legacy_build_binaries.sh      > /var/www/code_and_data/grass78/binary/linux/snapshot/build.log.txt 2>&1
-# old stable (no more releases planned)
-35 05 * * * nice bash /home/neteler/cronjobs/cron_grass_old_build_binaries.sh > /var/www/code_and_data/grass83/binary/linux/snapshot/build.log.txt 2>&1
+## old stable (no more releases planned, 8.3 compilation disabled on May 6th, 2025)
+#35 05 * * * nice bash /home/neteler/cronjobs/cron_grass_old_build_binaries.sh > /var/www/code_and_data/grass83/binary/linux/snapshot/build.log.txt 2>&1
 # new stable
 10 06 * * * nice bash /home/neteler/cronjobs/cron_grass_current_stable_build_binaries.sh > /var/www/code_and_data/grass84/binary/linux/snapshot/build.log.txt 2>&1
 # preview

--- a/utils/cronjobs_osgeo_lxd/cron_job_list_grass
+++ b/utils/cronjobs_osgeo_lxd/cron_job_list_grass
@@ -22,6 +22,8 @@
 
 # run at 00:30:00 and 12:30:00 each day: fetches code from GitHub and builds it with hugo (target dir: /var/www/html/)
 30 */12 * * * nice bash /home/neteler/cronjobs/hugo_clean_and_update_job.sh
+# run at 00:40:00 and 12:40:00 each day:
+40 */12 * * * nice bash /home/neteler/fetch_unpack_manual_GHA.sh > /home/neteler/fetch_unpack_manual_GHA.log  2>&1
 
 # weekly source snapshots (target dir: /var/www/code_and_data/)
 # legacy

--- a/utils/cronjobs_osgeo_lxd/fetch_unpack_manual_GHA.sh
+++ b/utils/cronjobs_osgeo_lxd/fetch_unpack_manual_GHA.sh
@@ -20,7 +20,7 @@
 cd $HOME
 
 # fetch artifact
-bash gh_cli_download_artifact.sh
+bash /home/neteler/cronjobs/gh_cli_download_artifact.sh
 
 # update twice: version and devel
 cd /var/www/code_and_data/grass85/manuals/ && rm -rf * && unzip -q /tmp/mkdocs-site.zip

--- a/utils/cronjobs_osgeo_lxd/fetch_unpack_manual_GHA.sh
+++ b/utils/cronjobs_osgeo_lxd/fetch_unpack_manual_GHA.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Purpose: Script to download GRASS "Documentation" artifact from GitHub (produced by GitHub action workflow) and unpack
+#
+# (c) 2025, GPL 2+ Markus Neteler <neteler@osgeo.org>
+#
+# GRASS GIS github, https://github.com/OSGeo/grass
+#
+# requires: jq, gh cli and login via gh auth login
+#
+###################################################################
+#
+# How this script works:
+# GRASS 8.5 `main` mkdocs documentation update
+#
+# to be run on grass.osgeo.org, in "neteler" or "grassbot" userspace
+# - executes gh_cli_download_artifact.sh
+# - unpacks the Documentation artifact both in grass85 and grass-devel dirs on the server
+
+cd $HOME
+
+# fetch artifact
+bash gh_cli_download_artifact.sh
+
+# update twice: version and devel
+cd /var/www/code_and_data/grass85/manuals/ && rm -rf * && unzip -q /tmp/mkdocs-site.zip
+cd /var/www/code_and_data/grass-devel/manuals/ && rm -rf * && unzip -q /tmp/mkdocs-site.zip
+
+# if run as "neteler", let the grassbot user also write therein
+chmod -R g+rw /var/www/code_and_data/grass85/manuals/* /var/www/code_and_data/grass-devel/manuals/*
+
+# cleanup the artifact file
+rm -f /tmp/mkdocs-site.zip

--- a/utils/cronjobs_osgeo_lxd/gh_cli_download_artifact.sh
+++ b/utils/cronjobs_osgeo_lxd/gh_cli_download_artifact.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# Download "mkdocs-site" from the "documentation.yml" workflow runs
+# Script to be run on grass.osgeo.org
+#
+# (c) 2025, GPL 2+ Markus Neteler <neteler@osgeo.org>
+#
+# GRASS GIS github, https://github.com/OSGeo/grass
+#
+# requires: jq, gh cli and login via gh auth login
+###################################################################
+# How this script works:
+# - generate a new read-only token: https://github.com/settings/personal-access-tokens
+# - cd to repo; login via gh auth login using the token
+# - CAVEAT: these tokens expire after three months!
+# - the last successful workflow run is identified via GH CLI
+# - artifacts for this run are looked up
+# - the artifact is downloaded as ZIP file (takes a moment)
+#
+# Useful GitHub CLI commands for debugging:
+# - to find workflow names/IDs: gh workflow list
+# - to preview runs: gh run list --workflow your-workflow.yml
+# - to see artifact names: manually inspect a run on GitHub or use gh run view <run-id> --log
+#
+# Related docs:
+# - GitHub CLI installation: https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+# - GitHub CLI api: https://cli.github.com/manual/gh_api
+# - GitHub workflow runs: https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-workflow
+
+# Configuration
+OWNER="OSGeo"
+REPO="grass"
+REPO_LOCAL="$HOME/software/grass_main/"
+WORKFLOW_NAME="documentation.yml"  # or the workflow filename/id
+ARTIFACT_NAME="mkdocs-site" # the name of the artifact
+ZIP_OUTPUT="$ARTIFACT_NAME.zip"
+OUTPUT_DIR="/tmp"
+
+# cleanup from previous run
+cd $OUTPUT_DIR && rm -f $ZIP_OUTPUT
+
+# this script must be run within the `grass` GH repo
+echo "Changing into <$REPO_LOCAL>..."
+cd $REPO_LOCAL
+
+# use e.g. (read-only) TOKEN
+# gh auth login
+
+echo "Identifying last successful workflow run for '$WORKFLOW_NAME'..."
+
+RUN_ID=$(gh run list \
+  --branch main \
+  --repo "$OWNER/$REPO" \
+  --workflow "$WORKFLOW_NAME" \
+  --status success \
+  --limit 1 \
+  --json databaseId \
+  --jq '.[0].databaseId')
+
+if [ -z "$RUN_ID" ]; then
+  echo "ERROR: No successful workflow run found."
+  exit 1
+fi
+
+echo "Found last successful run: $RUN_ID"
+echo "Looking up artifacts for run $RUN_ID..."
+
+ARTIFACT_ID=$(gh api \
+  -H "Accept: application/vnd.github+json" \
+  "/repos/$OWNER/$REPO/actions/runs/$RUN_ID/artifacts" \
+  --jq ".artifacts[] | select(.name == \"$ARTIFACT_NAME\") | .id")
+
+if [ -z "$ARTIFACT_ID" ]; then
+  echo "Artifact '$ARTIFACT_NAME' not found in run $RUN_ID."
+  exit 1
+fi
+
+echo "Found artifact ID: $ARTIFACT_ID"
+
+echo "Downloading the artifact as ZIP (takes a moment)..."
+
+gh api \
+  -H "Accept: application/vnd.github+json" \
+  -H "Accept: application/zip" \
+  "/repos/$OWNER/$REPO/actions/artifacts/$ARTIFACT_ID/zip" \
+  > "$OUTPUT_DIR/$ZIP_OUTPUT"
+
+echo "Artifact saved as: $OUTPUT_DIR/$ZIP_OUTPUT"

--- a/utils/cronjobs_osgeo_lxd/gh_cli_download_artifact.sh
+++ b/utils/cronjobs_osgeo_lxd/gh_cli_download_artifact.sh
@@ -27,15 +27,16 @@
 # - GitHub CLI api: https://cli.github.com/manual/gh_api
 # - GitHub workflow runs: https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-workflow
 
-# Configuration
+# === Configuration ===
 OWNER="OSGeo"
 REPO="grass"
-REPO_LOCAL="$HOME/software/grass_main/"
+REPO_LOCAL="$HOME/src/main/"
 WORKFLOW_NAME="documentation.yml"  # or the workflow filename/id
 ARTIFACT_NAME="mkdocs-site" # the name of the artifact
 ZIP_OUTPUT="$ARTIFACT_NAME.zip"
 OUTPUT_DIR="/tmp"
 
+# === Script ===
 # cleanup from previous run
 cd $OUTPUT_DIR && rm -f $ZIP_OUTPUT
 


### PR DESCRIPTION
The mkdocs based manual pages (currently the GRASS 8.5 main branch) are generated as a ZIP file through the GitHub Actions. This ZIP file needs then to be transferred and unpacked in the related directories on grass.osgeo.org/ and download.osgeo.org/grass/.

The `gh_cli_download_artifact.sh` script downloads the latest "mkdocs-site" ZIP artifact from the "documentation.yml" workflow runs. It is executed by the `fetch_unpack_manual_GHA.sh` script.

How `gh_cli_download_artifact.sh` works:
- the user to execute this script needs to generate a new read-only token: https://github.com/settings/personal-access-tokens
- the user to execute this script on the GRASS/OSGeo servers needs to `cd` to the repo; login via gh auth login using the token
- CAVEAT: these tokens expire after three months! - unsolved problem at time
- in this script:
  - the last successful workflow run is identified via GH CLI
  - artifacts for this run are looked up
  - the artifact is downloaded as ZIP file (takes a moment)

Eventually the ZIP archive needs to be unpacked in the right server directory. This is done by the script `fetch_unpack_manual_GHA.sh` which itself executes `gh_cli_download_artifact.sh`.

Addresses https://github.com/OSGeo/grass/issues/5794

A typical run looks like this:

```bash
neteler@grasslxd:~$ sh fetch_unpack_manual_GHA.sh
Changing into </home/neteler/src/main/>...
Identifying last successful workflow run for 'documentation.yml'...
Found last successful run: 16642929867
Looking up artifacts for run 16642929867...
Found artifact ID: 3655903688
Downloading the artifact as ZIP (takes a moment)...
Artifact saved as: /tmp/mkdocs-site.zip
```