### PR TITLE
chore(deps): Update R version to 4.5.1 and use Renovate-tagged R_VERSION env var to keep updated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
           - grass-version: releasebranch_8_4
             python-version: "3.10"
       fail-fast: false
+    env:
+      # renovate: datasource=github-tags depName=r-hub/R
+      R_VERSION: "4.5.1"
 
     steps:
       - name: Checkout core
@@ -116,7 +119,7 @@ jobs:
       - name: Set up R
         uses: r-lib/actions/setup-r@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 # v2.11.3
         with:
-          r-version: 4.5.1
+          r-version: ${{ env.R_VERSION }}
           Ncpus: 4
       - name: Configure ccache for R package builds
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Set up R
         uses: r-lib/actions/setup-r@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 # v2.11.3
         with:
-          r-version: 4.2.1
+          r-version: 4.5.1
           Ncpus: 4
       - name: Configure ccache for R package builds
         run: |


### PR DESCRIPTION
Even though the action we use in CI could use "latest" or versions relative to the newest release, for posterity, still write the R version in the repo.
After testing with the exact 4.5.1, MuMIn was correctly installed and allowed more test files to pass.
