### PR TITLE
r.futures.demand: fix incorrect flag combination

### DIFF
--- a/src/raster/r.futures/r.futures.demand/r.futures.demand.py
+++ b/src/raster/r.futures/r.futures.demand/r.futures.demand.py
@@ -163,7 +163,7 @@ def main():
     for i in range(len(observed_times)):
         gcore.percent(i, len(observed_times), 1)
         data = gcore.read_command(
-            "r.univar", flags="gt", zones=subregions, map=developments[i]
+            "r.univar", flags="t", zones=subregions, map=developments[i]
         )
         for line in data.splitlines():
             stats = line.split("|")


### PR DESCRIPTION
It's using r.univar with "-gt" which is incorrect combination, but it was ignored (using -t) in the past, now with revising the formats there is a check for that enforcing it.