### PR TITLE
CI: Configure and fix all remaining GitHub Action issues found by zizmor

### DIFF
--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -16,6 +16,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   additional-checks:
     name: Additional checks
@@ -23,6 +25,8 @@ jobs:
     env:
       # renovate: datasource=python-version depName=python
       PYTHON_VERSION: "3.13"
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository contents

--- a/.github/workflows/post-pr-reviews.yml
+++ b/.github/workflows/post-pr-reviews.yml
@@ -2,6 +2,7 @@
 name: Post PR code suggestions
 
 on:
+  # zizmor: ignore[dangerous-triggers] Only selected branches, and whitelisted input values are used
   workflow_run:
     workflows:
       ["ClangFormat Check", "Python Black Formatting", "Linting & formatting"]

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,3 +1,4 @@
+---
 rules:
   unpinned-uses:
     config:

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        OSGeo/grass/.github/actions/create-upload-suggestions: any


### PR DESCRIPTION
This PR will unblock the super-linter 8.1.0 update PR https://github.com/OSGeo/grass-addons/pull/1467 that adds zizmor as a linter.
The issues reported were mostly legitimate, so they are addressed. This is a follow-up of the other issue type fixed in https://github.com/OSGeo/grass-addons/pull/1473