### PR TITLE
r.windfetch: add compass directions, fixes

### DIFF
--- a/src/raster/r.windfetch/r.windfetch.py
+++ b/src/raster/r.windfetch/r.windfetch.py
@@ -87,6 +87,10 @@ for details.
 # % descriptions: csv;CSV (Comma Separated Values);json;JSON (JavaScript Object Notation);
 # % answer: csv
 # %end
+# %flag
+# % key: c
+# % description: Use compass directions (0 is North, clockwise) for input direction and output
+# %end
 # %rules
 # % exclusive: coordinates, points
 # %end
@@ -98,6 +102,7 @@ import sys
 import atexit
 import json
 import csv
+from math import gcd
 from io import StringIO
 
 import grass.script as gs
@@ -113,23 +118,47 @@ def clean(name):
     gs.run_command("g.remove", type="raster", name=name, flags="f", superquiet=True)
 
 
-def point_fetch(land, coordinates, direction, step, minor_directions, minor_step):
+def point_fetch(
+    land, coordinates, direction, step, minor_directions, minor_step, compass
+):
     gs.verbose(_("Computing distances..."))
-    data = gs.read_command(
-        "r.horizon",
-        elevation=land,
-        direction=0,
-        coordinates=coordinates,
-        step=1,
-        format="json",
-    )
+    if minor_directions > 1:
+        # horizon step is the greatest common divisor of step and minor_step
+        gcd_step = gcd(step, minor_step)
+    else:
+        gcd_step = step
+    if compass:
+        data = gs.read_command(
+            "r.horizon",
+            elevation=land,
+            direction=(90 - direction) % 360,
+            coordinates=coordinates,
+            step=gcd_step,
+            format="json",
+            flags="c",
+        )
+    else:
+        data = gs.read_command(
+            "r.horizon",
+            elevation=land,
+            direction=0,
+            coordinates=coordinates,
+            step=gcd_step,
+            format="json",
+        )
     gs.verbose(_("Computing wind fetch..."))
     offset = minor_step * (minor_directions - 1) / 2
     output = []
     for point in json.loads(data):
-        distances_dict = {
-            horizons["azimuth"]: horizons["distance"] for horizons in point["horizons"]
-        }
+        distances_dict = dict(
+            sorted(
+                (
+                    (horizons["azimuth"], horizons["distance"])
+                    for horizons in point["horizons"]
+                ),
+                key=lambda x: x[0],
+            )
+        )
         output.append({"x": point["x"], "y": point["y"], "directions": [], "fetch": []})
         i = 0
         while i < 360:
@@ -164,6 +193,7 @@ def main():
     minor_step = int(options["minor_step"])
     output_file = options["output_file"]
     output_format = options["format"]
+    compass = flags["c"]
 
     if minor_directions % 2 == 0:
         gs.fatal(_("Number of minor directions should be odd, not even."))
@@ -171,10 +201,12 @@ def main():
     atexit.register(clean, temporary_raster)
     info = gs.raster_info(input_raster)
     height = int((info["north"] - info["south"]) / 10) + 1
-    rules = f"1 = {height}\n* = 0"
-    gs.write_command(
-        "r.reclass", input=input_raster, output=temporary_raster, stdin=rules, rules="-"
+    # set border cells to zero to force computing horizons
+    condition = "row() == 1 || row() == nrows() || col() == 1 || col() == ncols()"
+    gs.mapcalc(
+        f"{temporary_raster} = if ({input_raster} == 1, {height}, if ({condition}, {height}, 0))"
     )
+
     if points_map:
         point_data = gs.read_command(
             "v.out.ascii",
@@ -194,6 +226,7 @@ def main():
         step=step,
         minor_directions=minor_directions,
         minor_step=minor_step,
+        compass=compass,
     )
     if output_format == "csv":
         text_output = []

--- a/src/raster/r.windfetch/testsuite/test_r_windfetch.py
+++ b/src/raster/r.windfetch/testsuite/test_r_windfetch.py
@@ -7,6 +7,7 @@ from grass.gunittest.gmodules import SimpleModule
 
 class TestRWindfetch(TestCase):
     input = "test_input"
+    input2 = "test_input2"
     input_points = "test_input_points"
     output = "test_output"
 
@@ -24,12 +25,17 @@ class TestRWindfetch(TestCase):
         )
         cls.runModule("r.null", map=cls.input, null=0)
         cls.runModule(
+            "r.mapcalc", expression=f"{cls.input2} = if (y() < 5, 1, {cls.input})"
+        )
+        cls.runModule(
             "v.in.ascii", input="-", output=cls.input_points, stdin="5.5|5.5\n5.5|5.5"
         )
 
     @classmethod
     def tearDownClass(cls):
-        cls.runModule("g.remove", flags="f", type="raster", name=cls.input)
+        cls.runModule(
+            "g.remove", flags="f", type="raster", name=[cls.input, cls.input2]
+        )
         cls.runModule("g.remove", flags="f", type="vector", name=cls.input_points)
         cls.del_temp_region()
 
@@ -69,6 +75,69 @@ class TestRWindfetch(TestCase):
         self.assertListEqual(reference_directions, stdout_json[0]["directions"])
         reference_fetch = [5.0] * len(reference_directions)
         self.assertListEqual(reference_fetch, stdout_json[0]["fetch"])
+
+    def test_json_multiple_minor_directions_different_step(self):
+        """Test json output with multiple minor directions and different steps"""
+        module = SimpleModule(
+            "r.windfetch",
+            input=self.input,
+            coordinates=(5.5, 5.5),
+            step=90,
+            direction=0,
+            minor_directions=3,
+            minor_step=10,
+            format="json",
+        )
+        self.assertModule(module)
+        stdout_json = json.loads(module.outputs.stdout)
+        reference_directions = list(range(0, 360, 90))
+        self.assertListEqual(reference_directions, stdout_json[0]["directions"])
+        reference_fetch = [5.066] * len(reference_directions)
+        self.assertListEqual(
+            reference_fetch, [round(f, 3) for f in stdout_json[0]["fetch"]]
+        )
+
+    def test_json_compass(self):
+        """Test json output with compass flag"""
+        module = SimpleModule(
+            "r.windfetch",
+            input=self.input2,
+            coordinates=(5.5, 5.5),
+            step=90,
+            direction=90,
+            minor_directions=3,
+            minor_step=10,
+            format="json",
+        )
+        self.assertModule(module)
+        stdout_json = json.loads(module.outputs.stdout)
+        default = dict(zip(stdout_json[0]["directions"], stdout_json[0]["fetch"]))
+
+        module = SimpleModule(
+            "r.windfetch",
+            input=self.input2,
+            coordinates=(5.5, 5.5),
+            step=90,
+            direction=90,
+            minor_directions=3,
+            minor_step=10,
+            format="json",
+            flags="c",
+        )
+        self.assertModule(module)
+        stdout_json_compass = json.loads(module.outputs.stdout)
+        compass = dict(
+            zip(stdout_json_compass[0]["directions"], stdout_json_compass[0]["fetch"])
+        )
+
+        # E direction
+        self.assertAlmostEqual(default[0], compass[90], places=6)
+        # N direction
+        self.assertAlmostEqual(default[90], compass[0], places=6)
+        # W direction
+        self.assertAlmostEqual(default[180], compass[270], places=6)
+        # S direction
+        self.assertAlmostEqual(default[270], compass[180], places=6)
 
     def test_csv_single_minor_direction(self):
         """Test csv output with single minor direction"""


### PR DESCRIPTION
This PR adds a feature and fixes:

* Added -c flag to return the directions clockwise from N (useful for wind roses), tests added
* Fix minor directions - previously certain combinations of step and minor_step resulted in error, now the step for r.horizon is computed correctly. This should not influence previous results. I added tests.
* Currently underlying tool r.horizon returns 0 distance when no horizon is found (e.g. no land along the direction). This doesn't work well for this tool, so this PR is adding internally a one-cell boundary to the input raster to ensure distance is always returned. This potentially changes (corrects) the results depending on the specific position of land and the coordinate.
* Added documentation for compass flag, add note about points falling on water vs land.