### PR TITLE
tests: Bump gunittest min-success threshold to 81%

### DIFF
--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -16,4 +16,4 @@ grass --tmp-project XY --exec \
 grass --tmp-project XY --exec \
     python3 -m grass.gunittest.main \
         --grassdata $HOME --location nc_spm_full_v2alpha2 --location-type nc \
-        --min-success 70 $@
+        --min-success 81 $@


### PR DESCRIPTION
Tests against release branch 8.4 have 57/69 test files passing (82.6%), and against main branch they have 56/69 test files passing (81.159%).

Bumping the threshold from 70% to 81%, in order to catch a bit of failures/regressions again