### PR TITLE
r.stream.snap: Fix output category for correct points with accumulation

### DIFF
--- a/src/raster/r.stream.snap/points_io.c
+++ b/src/raster/r.stream.snap/points_io.c
@@ -52,10 +52,9 @@ int read_points(char *in_point, SEGMENT *streams, SEGMENT *accum)
             Segment_get(accum, &absaccum, points[i].r, points[i].c);
             points[i].accum = fabs(absaccum);
         }
-        else {
+        else
             points[i].accum = 0;
-            points[i].status = 4; /* default status is 'correct' */
-        }
+        points[i].status = 4; /* default status is 'correct' */
         // dodać skip category
 
         i++;


### PR DESCRIPTION
This PR fixes #1517 (random output cat for correct points with accumulation) by assigning the default status `4`. It was missing for cases with accumulation.