### PR TITLE
i.hyper: fix Makefile

### DIFF
--- a/src/imagery/i.hyper/Makefile
+++ b/src/imagery/i.hyper/Makefile
@@ -1,15 +1,17 @@
 MODULE_TOPDIR = ../..
 
-SUBDIRS = i_hyper_lib \
-        i.hyper.import \
-        i.hyper.preproc \
-        i.hyper.explore \
-        i.hyper.export \
-        i.hyper.composite
+PGM = i.hyper
+
+# note: to deactivate a module, just place a file "DEPRECATED" into the subdir
+ALL_SUBDIRS := ${sort ${dir ${wildcard */.}}}
+DEPRECATED_SUBDIRS := ${sort ${dir ${wildcard */DEPRECATED}}}
+RM_SUBDIRS := bin/ docs/ etc/ scripts/
+SUBDIRS_1 := $(filter-out $(DEPRECATED_SUBDIRS), $(ALL_SUBDIRS))
+SUBDIRS := $(filter-out $(RM_SUBDIRS), $(SUBDIRS_1))
 
 include $(MODULE_TOPDIR)/include/Make/Dir.make
 
-default: parsubdirs
+default: parsubdirs htmldir
 
 install: installsubdirs
-	$(INSTALL_DATA) i.hyper.html $(INST_DIR)/docs/html/
+	$(INSTALL_DATA) $(PGM).html $(INST_DIR)/docs/html/


### PR DESCRIPTION
Fix `Makefile` ("gold standard" is the [Makefile of i.sentinel](https://github.com/OSGeo/grass-addons/blob/grass8/src/imagery/i.sentinel/Makefile)):

- to avoid missing `i.hyper.html`/`i.hyper.md` in list at <https://grass.osgeo.org/grass8/manuals/addons/>
- to minimize hardcoded addon names

(@mazingaro)