### PR TITLE
Fixed modules: removed six dependency

### DIFF
--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,3 +1,2 @@
 matplotlib
 numpy
-six

--- a/src/raster/r.in.nasadem/r.in.nasadem.py
+++ b/src/raster/r.in.nasadem/r.in.nasadem.py
@@ -116,7 +116,7 @@ import time
 import zipfile as zfile
 import subprocess
 import urllib
-from six.moves.urllib import request as urllib2
+import urllib.request as urllib2
 
 try:
     from http.cookiejar import CookieJar

--- a/src/raster/r.in.srtm.region/r.in.srtm.region.py
+++ b/src/raster/r.in.srtm.region/r.in.srtm.region.py
@@ -122,7 +122,7 @@ import os
 import atexit
 import numpy as np
 import subprocess
-from six.moves.urllib import request as urllib2
+import urllib.request as urllib2
 
 try:
     from http.cookiejar import CookieJar

--- a/src/raster/r.in.usgs/r.in.usgs.py
+++ b/src/raster/r.in.usgs/r.in.usgs.py
@@ -155,9 +155,9 @@
 import sys
 import os
 import zipfile
-from six.moves.urllib.request import urlopen
-from six.moves.urllib.error import URLError, HTTPError
-from six.moves.urllib.parse import quote_plus
+from urllib.request import urlopen
+from urllib.error import URLError, HTTPError
+from urllib.parse import quote_plus
 from multiprocessing import Process, Manager
 import json
 import atexit


### PR DESCRIPTION
This change resolves #1346 by removing outdated six.moves imports from r.in.srtm.region, r.in.nasadem, and r.in.usgs modules. Please let me know if I need to fix anything as this is my first contribution!