### PR TITLE
CI: add wxpython-tools

### DIFF
--- a/.github/workflows/apt.txt
+++ b/.github/workflows/apt.txt
@@ -20,4 +20,5 @@ pdal
 sqlite3
 subversion
 udunits-bin
+wxpython-tools
 zlib1g-dev


### PR DESCRIPTION
Add `wxpython-tools` package to fix `ModuleNotFoundError: No module named 'wx'`.

The lack of it leads to addon compilation errors (see for example: [log](https://github.com/neteler/grass-addons/actions/runs/19500297112/job/55812445167), section "Run tests"):

```python
Running ./general/g.citation/testsuite/test_g_citation.py...
========================================================================
..FFFF..FAILED (failures=4)

======================================================================
FAIL: test_core_modules (__main__.CiteAllCase.test_core_modules)
Test that citation information is collected for all core modules
----------------------------------------------------------------------
Traceback (most recent call last):
  File "etc/python/grass/gunittest/case.py", line 1392, in assertModule
    module.run()
  File "etc/python/grass/pygrass/modules/interface/module.py", line 849, in run
    self.wait()
  File "etc/python/grass/pygrass/modules/interface/module.py", line 868, in wait
    raise CalledModuleError(
grass.exceptions.CalledModuleError: Module run `g.citation format=bibtex style=harvard1 -a -d` ended with an error.
The subprocess ended with a non-zero return code: 1. See the following errors:
ERROR: Module g.gui.cswbrowser: No HTML manual page entry for 'g.gui.cswbrowser'
```

which is caused by (see [log](https://github.com/neteler/grass-addons/actions/runs/19500297112/job/55812445167), section "Build addons"):

```python
make[4]: [/home/runner/install/grass85/include/Make/ScriptRules.make:28: /home/runner/install/grass85/locale/scriptstrings/g.gui.cswbrowser_to_translate.c] Error 2 (ignored)
if [ "/home/runner/install/grass85/scripts/g.gui.cswbrowser" != "" ] ; then GISRC=/home/runner/install/grass85/demolocation/.grassrc85 GISBASE=/home/runner/install/grass85 PATH="/home/runner/install/grass85/bin:/home/runner/install/grass85/bin:/home/runner/install/grass85/scripts:$PATH" PYTHONPATH="/home/runner/install/grass85/etc/python:/home/runner/install/grass85/gui/wxpython:$PYTHONPATH" LD_LIBRARY_PATH="/home/runner/install/grass85/bin:/home/runner/install/grass85/bin:/home/runner/install/grass85/scripts:/home/runner/install/grass85/lib:/home/runner/install/grass85/lib:/home/runner/install/lib" LC_ALL=C LANG=C LANGUAGE=C /home/runner/install/grass85/scripts/g.gui.cswbrowser --html-description < /dev/null | grep -v '</body>\|</html>\|</div> <!-- end container -->' > g.gui.cswbrowser.tmp.html ; fi
VERSION_NUMBER=8.5.0dev VERSION_DATE=2025 MODULE_TOPDIR=/home/runner/install/grass85 \
        python3 /home/runner/install/grass85/utils/mkmarkdown.py db.csw.harvest > /home/runner/install/grass85/docs/mkdocs/source/db.csw.harvest.md
if [ "/home/runner/install/grass85/scripts/m.crawl.thredds" != "" ] ; then GISRC=/home/runner/install/grass85/demolocation/.grassrc85 GISBASE=/home/runner/install/grass85 PATH="/home/runner/install/grass85/bin:/home/runner/install/grass85/bin:/home/runner/install/grass85/scripts:$PATH" PYTHONPATH="/home/runner/install/grass85/etc/python:/home/runner/install/grass85/gui/wxpython:$PYTHONPATH" LD_LIBRARY_PATH="/home/runner/install/grass85/bin:/home/runner/install/grass85/bin:/home/runner/install/grass85/scripts:/home/runner/install/grass85/lib:/home/runner/install/grass85/lib:/home/runner/install/lib" LC_ALL=C LANG=C LANGUAGE=C /home/runner/install/grass85/scripts/m.crawl.thredds --md-description < /dev/null > m.crawl.thredds.tmp.md ; fi
Traceback (most recent call last):
  File "/home/runner/install/grass85/scripts/g.gui.cswbrowser", line 26, in <module>
    from mdlib.cswlib import CSWBrowserPanel, CSWConnectionPanel
  File "/home/runner/work/grass-addons/grass-addons/grass-addons/src/gui/wxpython/wx.metadata/mdlib/cswlib.py", line 30, in <module>
    import wx
ModuleNotFoundError: No module named 'wx'
make[4]: *** [/home/runner/install/grass85/include/Make/Html.make:18: g.gui.cswbrowser.tmp.html] Error 1
rm g.gui.cswbrowser.tmp.html
make[4]: Leaving directory '/home/runner/work/grass-addons/grass-addons/grass-addons/src/gui/wxpython/wx.metadata/g.gui.cswbrowser'
```