### PR TITLE
Added longitude and latitude to params dictonary

### DIFF
--- a/src/raster/r.sun.daily/r.sun.daily.py
+++ b/src/raster/r.sun.daily/r.sun.daily.py
@@ -385,7 +385,6 @@ def run_r_sun(
         params.update({"horizon_step": horizon_step})
     if solar_constant is not None:
         params.update({"solar_constant": solar_constant})
-        
     if latitude:
         params.update({"lat": latitude})
     if longitude:

--- a/src/raster/r.sun.daily/r.sun.daily.py
+++ b/src/raster/r.sun.daily/r.sun.daily.py
@@ -385,6 +385,11 @@ def run_r_sun(
         params.update({"horizon_step": horizon_step})
     if solar_constant is not None:
         params.update({"solar_constant": solar_constant})
+        
+    if latitude:
+        params.update({"lat": latitude})
+    if longitude:
+        params.update({"long": longitude})
 
     if flags:
         params.update({"flags": flags})


### PR DESCRIPTION
This change resolves #1288 by adding the longitude and latitude to params dictionary in r.sun.daily.py, making it compatible with other methods that index into longitude and latitude in params. Please let me know if anything needs to be fixed!