### PR TITLE
r.hants: Fix link to GRASS GIS location in HTML example

### DIFF
--- a/src/raster/r.hants/r.hants.html
+++ b/src/raster/r.hants/r.hants.html
@@ -123,7 +123,7 @@ the other is very important.
 This small example is based on a climatic dataset for North Carolina which
 was from publicly available data (monthly temperature averages and monthly
 precipitation sums from 2000 to 2012, downloadable as
-<a href="http://courses.ncsu.edu/mea592/common/media/02/nc_climate_spm_2000_2012.zip">GRASS GIS 7 location</a>):
+<a href="https://grass.osgeo.org/sampledata/north_carolina/nc_climate_spm_2000_2012.zip">GRASS GIS location</a>):
 
 
 <div class="code"><pre>


### PR DESCRIPTION
Updated the link to the GRASS GIS location for the climatic dataset, using the climate dataset on the data download page.