### PR TITLE
i.landsat.qa: default to Collection 2 dataset

### DIFF
--- a/src/imagery/i.landsat/i.landsat.qa/i.landsat.qa.py
+++ b/src/imagery/i.landsat/i.landsat.qa/i.landsat.qa.py
@@ -37,7 +37,7 @@ COPYRIGHT:  (C) 2016-2021 by the GRASS Development Team
 # % description: Landsat dataset to search for
 # % required: no
 # % options: landsat_tm_c1, landsat_etm_c1, landsat_8_c1, landsat_tm_c2_l1, landsat_tm_c2_l2, landsat_etm_c2_l1, landsat_etm_c2_l2, landsat_ot_c2_l1, landsat_ot_c2_l2
-# % answer: landsat_8_c1
+# % answer: landsat_ot_c2_l2
 # % guisection: Filter
 # %end
 


### PR DESCRIPTION
This PR changes the default value of the `dataset` option in i.landsat.qa
from a Landsat Collection 1 dataset (`landsat_8_c1`) to a Collection 2 dataset (`landsat_ot_c2_l2`).

This keeps support for Collection 1 datasets in the options list but encourages
new usage of Collection 2, in line with USGS deprecating Collection 1 products.

Related to #830.
