### PR TITLE
Update i.hyper.preproc.py

### DIFF
--- a/src/imagery/i.hyper/i.hyper.preproc/i.hyper.preproc.py
+++ b/src/imagery/i.hyper/i.hyper.preproc/i.hyper.preproc.py
@@ -10,7 +10,7 @@
 
 # %module
 # % description: General hyperspectral data preprocessing
-# % keyword: raster
+# % keyword: imagery
 # % keyword: hyperspectral
 # % keyword: preprocessing
 # %end


### PR DESCRIPTION
changed raster to imagery in keywords, so that the imagery menu can build the entry. Check with GUI team to create a hyperspectral default entry with i.spectral, or to find a default way of organizing the imagery menu for i.hyper add-ons