### PR TITLE
r.ml.learn2: remove deprecated parameter to fix tests

### DIFF
--- a/src/raster/r.learn.ml2/rlearnlib/utils.py
+++ b/src/raster/r.learn.ml2/rlearnlib/utils.py
@@ -127,7 +127,6 @@ def predefined_estimators(estimator, random_state, n_jobs, p):
             C=p["C"],
             solver="liblinear",
             random_state=random_state,
-            multi_class="auto",
             n_jobs=1,
             fit_intercept=True,
         ),


### PR DESCRIPTION
The tests fail now with:
```
2025-12-12T03:56:50.8723431Z Traceback (most recent call last):
2025-12-12T03:56:50.8723802Z   File "scripts/r.learn.train", line 890, in <module>
2025-12-12T03:56:50.8724095Z     main()
2025-12-12T03:56:50.8724375Z   File "scripts/r.learn.train", line 500, in main
2025-12-12T03:56:50.8724729Z     estimator, mode = predefined_estimators(
2025-12-12T03:56:50.8725035Z                       ^^^^^^^^^^^^^^^^^^^^^^
2025-12-12T03:56:50.8725505Z   File "etc/r.learn.ml2/rlearnlib/utils.py", line 126, in predefined_estimators
2025-12-12T03:56:50.8725943Z     "LogisticRegression": LogisticRegression(
2025-12-12T03:56:50.8726496Z                           ^^^^^^^^^^^^^^^^^^^
2025-12-12T03:56:50.8726988Z TypeError: LogisticRegression.__init__() got an unexpected keyword argument 'multi_class'
```

This PR removes the deprecated parameter:
> Deprecated since version 1.5: multi_class was deprecated in version 1.5 and will be removed in 1.8. From then on, the recommended ‘multinomial’ will always be used for n_classes >= 3. Solvers that do not support ‘multinomial’ will raise an error. Use sklearn.multiclass.OneVsRestClassifier(LogisticRegression()) if you still want to use OvR.
