### PR TITLE
CI: Make renovate also update the biome config schema version

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,5 +5,6 @@
 
         // Use config file from upstream GRASS repo
         "github>OSGeo/grass:renovate.json5",
+        "customManagers:biomeVersions",
     ],
 }


### PR DESCRIPTION
The mismatch was found when running pre-commit with verbose output