### PR TITLE
r.maxent.train: change how naming suitability layer is handled

### DIFF
--- a/src/raster/r.maxent.train/r.maxent.train.py
+++ b/src/raster/r.maxent.train/r.maxent.train.py
@@ -1251,9 +1251,9 @@ def main(options, flags):
         predlays = options["predictionlayer"]
         asciilayers = [asc for asc in all_files if asc.endswith(".asc")]
         grasslayers = [gr.replace(".asc", f"{options['suffix']}") for gr in asciilayers]
-        result = {Path(f).stem.removesuffix("_clamping") for f in grasslayers}
+        result = [Path(f).stem.removesuffix("_clamping") for f in grasslayers]
         if bool(predlays):
-            grasslayers = [x.replace(result, predlays) for x in grasslayers]
+            grasslayers = [x.replace(result[0], predlays) for x in grasslayers]
         for idx, asci in enumerate(asciilayers):
             gs.info(_("Importing layer {0} of {1}").format(idx + 1, len(grasslayers)))
             asciifile = os.path.join(options["outputdirectory"], asci)

--- a/src/raster/r.maxent.train/r.maxent.train.py
+++ b/src/raster/r.maxent.train/r.maxent.train.py
@@ -445,6 +445,7 @@ import subprocess
 import sys
 import uuid
 import grass.script as gs
+from pathlib import Path
 
 
 CLEAN_LAY = []
@@ -1250,8 +1251,7 @@ def main(options, flags):
         predlays = options["predictionlayer"]
         asciilayers = [asc for asc in all_files if asc.endswith(".asc")]
         grasslayers = [gr.replace(".asc", f"{options['suffix']}") for gr in asciilayers]
-        pattern = re.compile(r"_([^_]+\.asc)$")
-        result = re.sub(pattern, "", asciilayers[0])
+        result = {Path(f).stem.removesuffix("_clamping") for f in grasslayers}
         if bool(predlays):
             grasslayers = [x.replace(result, predlays) for x in grasslayers]
         for idx, asci in enumerate(asciilayers):


### PR DESCRIPTION
When the user provides an output name for the suitability layer, this is now respected. I.e., no suffix based on the name of the folder that stored the ascii layers used as input for r.maxent.train.