### PR TITLE
i.points.auto: use either fftw3.h or dfftw.h; remove erroneous prototype

### DIFF
--- a/src/imagery/i.points.auto/find_points.c
+++ b/src/imagery/i.points.auto/find_points.c
@@ -6,10 +6,9 @@
 #include <signal.h>
 
 #include <grass/config.h>
-#ifdef HAVE_FFTW3_H
+#if defined(HAVE_FFTW3_H)
 #include <fftw3.h>
-#endif
-#ifdef HAVE_DFFTW_H
+#elif defined(HAVE_DFFTW_H)
 #include <dfftw.h>
 #endif
 

--- a/src/imagery/i.points.auto/globals.h
+++ b/src/imagery/i.points.auto/globals.h
@@ -24,8 +24,3 @@ GLOBAL char interrupt_char;
 GLOBAL char *tempfile1;
 GLOBAL char *tempfile2;
 GLOBAL char *tempfile3;
-
-double row_to_northing();
-double col_to_easting();
-double northing_to_row();
-double easting_to_col();


### PR DESCRIPTION
Fix some minor bugs in ´i.points.auto`:
- use either fftw3.h or dfftw.h
- remove erroneous prototype declarations 