### PR TITLE
cmake: add support for db.join, i.sentinel and r.gdd

### DIFF
--- a/src/db/db.join/CMakeLists.txt
+++ b/src/db/db.join/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(db.join)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    db.join.py
+  DOCFILES
+    db.join.html
+    db.join.md)

--- a/src/imagery/i.sentinel/CMakeLists.txt
+++ b/src/imagery/i.sentinel/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.sentinel)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  ADDONS
+    i.sentinel.coverage
+    i.sentinel.download
+    i.sentinel.import
+    i.sentinel.mask
+    i.sentinel.parallel.download
+    i.sentinel.preproc
+  DOCFILES
+    i.sentinel.html
+    i.sentinel.md)

--- a/src/imagery/i.sentinel/i.sentinel.coverage/CMakeLists.txt
+++ b/src/imagery/i.sentinel/i.sentinel.coverage/CMakeLists.txt
@@ -1,0 +1,11 @@
+project(i.sentinel.coverage)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    i.sentinel.coverage.py
+  DOCFILES
+    i.sentinel.coverage.html
+    i.sentinel.coverage.md)

--- a/src/imagery/i.sentinel/i.sentinel.download/CMakeLists.txt
+++ b/src/imagery/i.sentinel/i.sentinel.download/CMakeLists.txt
@@ -1,0 +1,11 @@
+project(i.sentinel.download)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    i.sentinel.download.py
+  DOCFILES
+    i.sentinel.download.html
+    i.sentinel.download.md)

--- a/src/imagery/i.sentinel/i.sentinel.import/CMakeLists.txt
+++ b/src/imagery/i.sentinel/i.sentinel.import/CMakeLists.txt
@@ -1,0 +1,14 @@
+project(i.sentinel.import)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    i.sentinel.import.py
+  DOCFILES
+    i_sentinel_import_with_cloud_shadow_mask_v1.png
+    i_sentinel_import_with_cloud_shadow_mask_v2.png
+    i_sentinel_import_without_cloud_mask.png
+    i.sentinel.import.html
+    i.sentinel.import.md)

--- a/src/imagery/i.sentinel/i.sentinel.mask/CMakeLists.txt
+++ b/src/imagery/i.sentinel/i.sentinel.mask/CMakeLists.txt
@@ -1,0 +1,18 @@
+project(i.sentinel.mask)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    i.sentinel.mask.py
+  DOCFILES
+    i_sentinel_mask_CD.png
+    i_sentinel_mask_CS.png
+    i_sentinel_mask_ES.png
+    i_sentinel_mask_GWF.png
+    i_sentinel_mask_indonesia_esa_sen2cor.png
+    i_sentinel_mask_indonesia_grass_gis.png
+    i_sentinel_mask_SD.png
+    i.sentinel.mask.html
+    i.sentinel.mask.md)

--- a/src/imagery/i.sentinel/i.sentinel.parallel.download/CMakeLists.txt
+++ b/src/imagery/i.sentinel/i.sentinel.parallel.download/CMakeLists.txt
@@ -1,0 +1,11 @@
+project(i.sentinel.parallel.download)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    i.sentinel.parallel.download.py
+  DOCFILES
+    i.sentinel.parallel.download.html
+    i.sentinel.parallel.download.md)

--- a/src/imagery/i.sentinel/i.sentinel.preproc/CMakeLists.txt
+++ b/src/imagery/i.sentinel/i.sentinel.preproc/CMakeLists.txt
@@ -1,0 +1,13 @@
+project(i.sentinel.preproc)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    i.sentinel.preproc.py
+  DOCFILES
+    i_sentinel_preproc_ES.png
+    i_sentinel_preproc_GWF.png
+    i.sentinel.preproc.html
+    i.sentinel.preproc.md)

--- a/src/raster/r.gdd/CMakeLists.txt
+++ b/src/raster/r.gdd/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.gdd)
+
+include(build_addon)
+
+find_OpenMP()
+
+build_addon(
+  ${PROJECT_NAME}
+  GRASSLIBS
+    gis
+    raster
+  OPTIONAL_DEPENDS
+    OpenMP::OpenMP_C
+  SOURCES main.c
+  DOCFILES
+    r.gdd.html
+    r.gdd.md)


### PR DESCRIPTION
Adding CMake support for `db.join`, `i.sentinel` and `r.gdd`.

These are used in GRASS repo tests.

