### PR TITLE
r.sun.hourly: add option to provide horizon information map as input.

### DIFF
--- a/src/raster/r.sun.hourly/r.sun.hourly.py
+++ b/src/raster/r.sun.hourly/r.sun.hourly.py
@@ -103,9 +103,8 @@
 # % required: no
 # % description: Name of input raster map containing latitudes [decimal degrees]
 # %end
-# %option
+# %option G_OPT_R_BASENAME_INPUT
 # % key: horizon_basename
-# % type: string
 # % required: no
 # % description: The horizon information input map basename
 # %end

--- a/src/raster/r.sun.hourly/r.sun.hourly.py
+++ b/src/raster/r.sun.hourly/r.sun.hourly.py
@@ -103,21 +103,18 @@
 # % required: no
 # % description: Name of input raster map containing latitudes [decimal degrees]
 # %end
-
 # %option
 # % key: horizon_basename
 # % type: string
 # % required: no
 # % description: The horizon information input map basename
 # %end
-
 # %option
 # % key: horizon_step
 # % type: double
 # % required: no
 # % description: Angle step size for multidirectional horizon [degrees]
 # %end
-
 # %option G_OPT_R_INPUT
 # % key: long
 # % required: no
@@ -373,9 +370,9 @@ def run_r_sun(
     if solar_constant is not None:
         params.update({"solar_constant": solar_constant})
     if horizon_basename is not None:
-        params.update({"horizon_basename": horizon_basename})    
+        params.update({"horizon_basename": horizon_basename})
     if horizon_step is not None:
-        params.update({"horizon_step": horizon_step}) 
+        params.update({"horizon_step": horizon_step})
 
     gs.run_command(
         "r.sun",
@@ -564,9 +561,9 @@ def main():
     long_ = options["long"]
     horizon_basename = options["horizon_basename"]
     if options["horizon_step"]:
-            horizon_step = float(options["horizon_step"])
-            if horizon_step.is_integer():
-                horizon_step = int(horizon_step)
+        horizon_step = float(options["horizon_step"])
+        if horizon_step.is_integer():
+            horizon_step = int(horizon_step)
     else:
         horizon_step = None
 

--- a/src/raster/r.sun.hourly/r.sun.hourly.py
+++ b/src/raster/r.sun.hourly/r.sun.hourly.py
@@ -238,6 +238,12 @@
 # % description: If not specified, r.sun default will be used.
 # %end
 # %option
+# % key: npartitions
+# % type: integer
+# % description: Read the input files in this number of chunks
+# % answer: 1
+# %end
+# %option
 # % key: nprocs
 # % type: integer
 # % description: Number of r.sun processes to run in parallel
@@ -331,6 +337,7 @@ def run_r_sun(
     solar_constant,
     horizon_basename,
     horizon_step,
+    npartitions,
     flags,
 ):
     params = {}
@@ -372,6 +379,8 @@ def run_r_sun(
         params.update({"horizon_basename": horizon_basename})
     if horizon_step is not None:
         params.update({"horizon_step": horizon_step})
+    if npartitions is not None:
+        params.update({"npartitions": npartitions})
 
     gs.run_command(
         "r.sun",
@@ -617,6 +626,7 @@ def main():
         rsun_flags += "m"
     if flags["p"]:
         rsun_flags += "p"
+    partitions = int(options["npartitions"])
 
     # check: start < end
     if start_time > end_time:
@@ -766,6 +776,7 @@ def main():
                     solar_constant,
                     horizon_basename,
                     horizon_step,
+                    partitions,
                     rsun_flags,
                 ),
             )

--- a/src/raster/r.sun.hourly/r.sun.hourly.py
+++ b/src/raster/r.sun.hourly/r.sun.hourly.py
@@ -274,7 +274,9 @@
 # %rules
 # % requires_all: -m,horizon_basename,horizon_step
 # %end
-
+# %rules
+# % requires_all: npartitions,horizon_basename,horizon_step
+# %end
 
 import os
 import datetime

--- a/src/raster/r.sun.hourly/r.sun.hourly.py
+++ b/src/raster/r.sun.hourly/r.sun.hourly.py
@@ -103,6 +103,21 @@
 # % required: no
 # % description: Name of input raster map containing latitudes [decimal degrees]
 # %end
+
+# %option
+# % key: horizon_basename
+# % type: string
+# % required: no
+# % description: The horizon information input map basename
+# %end
+
+# %option
+# % key: horizon_step
+# % type: double
+# % required: no
+# % description: Angle step size for multidirectional horizon [degrees]
+# %end
+
 # %option G_OPT_R_INPUT
 # % key: long
 # % required: no
@@ -254,6 +269,10 @@
 # % key: m
 # % description: Use the low-memory version of the program
 # %end
+# %rules
+# % requires_all: -m,horizon_basename,horizon_step
+# %end
+
 
 import os
 import datetime
@@ -314,6 +333,8 @@ def run_r_sun(
     time_step,
     distance_step,
     solar_constant,
+    horizon_basename,
+    horizon_step,
     flags,
 ):
     params = {}
@@ -351,6 +372,10 @@ def run_r_sun(
         params.update({"distance_step": distance_step})
     if solar_constant is not None:
         params.update({"solar_constant": solar_constant})
+    if horizon_basename is not None:
+        params.update({"horizon_basename": horizon_basename})    
+    if horizon_step is not None:
+        params.update({"horizon_step": horizon_step}) 
 
     gs.run_command(
         "r.sun",
@@ -537,6 +562,13 @@ def main():
     coeff_dh_strds = options["coeff_dh_strds"]
     lat = options["lat"]
     long_ = options["long"]
+    horizon_basename = options["horizon_basename"]
+    if options["horizon_step"]:
+            horizon_step = float(options["horizon_step"])
+            if horizon_step.is_integer():
+                horizon_step = int(horizon_step)
+    else:
+        horizon_step = None
 
     beam_rad_basename = beam_rad_basename_user = options["beam_rad_basename"]
     diff_rad_basename = diff_rad_basename_user = options["diff_rad_basename"]
@@ -736,6 +768,8 @@ def main():
                     None if mode1 else time_step,
                     distance_step,
                     solar_constant,
+                    horizon_basename,
+                    horizon_step,
                     rsun_flags,
                 ),
             )

--- a/src/raster/r.sun.hourly/r.sun.hourly.py
+++ b/src/raster/r.sun.hourly/r.sun.hourly.py
@@ -242,6 +242,7 @@
 # % type: integer
 # % description: Read the input files in this number of chunks
 # % answer: 1
+# % required: no
 # %end
 # %option
 # % key: nprocs
@@ -628,8 +629,10 @@ def main():
         rsun_flags += "m"
     if flags["p"]:
         rsun_flags += "p"
-    partitions = int(options["npartitions"])
-
+    if options["npartitions"]:
+        partitions = int(options["npartitions"])
+    else:
+        partitions = 1
     # check: start < end
     if start_time > end_time:
         gs.fatal(_("Start time is after end time."))


### PR DESCRIPTION
The module has the `m` to enable the low-memory version of the program. However, using it fails with the message that using this flag requires the user to provide a *horizon information input map basename* and the *horizon_step*.

I did not find a clear description of this in the manual page of r.sun or r.sun.hourly, but adding the input options does solve the error message.

P.s., as the module takes a lot of memory and therefore easily runs out of memory, would it be an idea to expose the `npartitions` parameter from `r.sun` in the `r.sun.hourly` as well?
