### PR TITLE
cmake: add math lib to r.flowaccumulation and r.skyline

### DIFF
--- a/src/raster/r.flowaccumulation/CMakeLists.txt
+++ b/src/raster/r.flowaccumulation/CMakeLists.txt
@@ -4,6 +4,8 @@ project(r.flowaccumulation)
 
 include(build_addon)
 
+find_M()
+
 set(sources
     accumulate_c.c
     accumulate_cm.c
@@ -52,5 +54,6 @@ set(doc_files
 build_addon(
   ${PROJECT_NAME}
   GRASSLIBS gis raster
+  DEPENDS LIBM
   SOURCES ${sources}
   DOCFILES ${doc_files})

--- a/src/raster/r.skyline/CMakeLists.txt
+++ b/src/raster/r.skyline/CMakeLists.txt
@@ -4,6 +4,8 @@ project(r.skyline)
 
 include(build_addon)
 
+find_M()
+
 set(sources
     azimuth.c
     file.c
@@ -21,5 +23,6 @@ set(doc_files
 
 build_addon(${PROJECT_NAME}
   GRASSLIBS gis raster
+  DEPENDS LIBM
   SOURCES ${sources}
   DOCFILES ${doc_files})


### PR DESCRIPTION
Add math library as dependency to r.flowaccumulation and r.skyline.

Addresses issue raised in https://github.com/OSGeo/grass-addons/pull/1592#issuecomment-3898922641.