### PR TITLE
cmake: add support for vector Addons

### DIFF
--- a/src/vector/v.area.stats/CMakeLists.txt
+++ b/src/vector/v.area.stats/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.area.stats)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  areas.c
+  export.c
+  global.h
+  main.c
+  parse.c)
+
+set(doc_files
+  v.area.stats.html
+  v.area.stats.md)
+
+build_addon(
+  ${PROJECT_NAME}
+  GRASSLIBS gis raster vector
+  DEPENDS LIBM
+  SOURCES ${sources}
+  DOCFILES ${doc_files})

--- a/src/vector/v.area.weigh/CMakeLists.txt
+++ b/src/vector/v.area.weigh/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.area.weigh)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES v.area.weigh.py
+  DOCFILES
+    v.area.weigh.html
+    v.area.weigh.md)

--- a/src/vector/v.boxplot/CMakeLists.txt
+++ b/src/vector/v.boxplot/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.boxplot)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES v.boxplot.py
+  DOCFILES
+    v_boxplot_01.png
+    v_boxplot_02.png
+    v.boxplot.html
+    v.boxplot.md)

--- a/src/vector/v.build.pg/CMakeLists.txt
+++ b/src/vector/v.build.pg/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.build.pg)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES v.build.pg.py
+  DOCFILES
+    v.build.pg.html
+    v.build.pg.md)

--- a/src/vector/v.centerline/CMakeLists.txt
+++ b/src/vector/v.centerline/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.centerline)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES v.centerline.py
+  DOCFILES
+    v_centerline_flightpaths.png
+    v_centerline_river.png
+    v.centerline.html
+    v.centerline.md)

--- a/src/vector/v.centerpoint/CMakeLists.txt
+++ b/src/vector/v.centerpoint/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.centerpoint)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  areas.c
+  lines.c
+  local_proto.h
+  main.c
+  points.c)
+
+set(doc_files
+  v.centerpoint.html
+  v.centerpoint.md)
+
+build_addon(
+  ${PROJECT_NAME}
+  GRASSLIBS gis vector
+  DEPENDS LIBM
+  SOURCES ${sources}
+  DOCFILES ${doc_files})

--- a/src/vector/v.civil/CMakeLists.txt
+++ b/src/vector/v.civil/CMakeLists.txt
@@ -1,0 +1,62 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.civil)
+
+include(build_addon)
+
+add_files_to_etc_dir(
+  ${PROJECT_NAME}
+  FILES
+    road_base.py
+    road_crosstools.py
+    road_displ.py
+    road_marks.py
+    road_plant.py
+    road_profiles.py
+    road_road.py
+    road_tables.py
+    road_terr.py
+    road_topotools.py
+    road_trans.py
+    road_vertical.py)
+
+set(doc_files
+  img_a_plan.png
+  img_a_tooladdrow.png
+  img_a_topotools_1.png
+  img_a_vcivilroad_7.png
+  img_a_vert.png
+  img_tables1.png
+  img_tables2_2.png
+  img_tables2_3.png
+  img_tables2.png
+  img_tables3_1.png
+  img_tables3_2.png
+  img_tables3.png
+  img_tables4_1.png
+  img_tables4_2.png
+  img_tables5_1.png
+  img_tables6_1.png
+  img_tables7_1.png
+  img1.png
+  img2_1.png
+  img2.png
+  img3_2.png
+  img3.png
+  img4_1.png
+  img4_2.png
+  img4_3.png
+  img4.png
+  img5.png
+  img6_1.png
+  img6.png
+  img7.png
+  img8_1.png
+  img8_2.png
+  v.civil.html
+  v.civil.md)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES v.civil.py
+  DOCFILES ${doc_files})

--- a/src/vector/v.class.ml/CMakeLists.txt
+++ b/src/vector/v.class.ml/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.class.ml)
+
+include(build_addon)
+
+add_files_to_etc_dir(
+  ${PROJECT_NAME}
+  FILES
+    features.py
+    ml_classifiers.py
+    ml_functions.py
+    npy2table.py
+    sqlite2npy.py
+    training_extraction.py)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES v.class.ml.py
+  DOCFILES
+    v.class.ml.html
+    v.class.ml.md)

--- a/src/vector/v.class.mlR/CMakeLists.txt
+++ b/src/vector/v.class.mlR/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.class.mlR)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES v.class.mlR.py
+  DOCFILES
+    v.class.mlR.html
+    v.class.mlR.md)

--- a/src/vector/v.class.mlpy/CMakeLists.txt
+++ b/src/vector/v.class.mlpy/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.class.ml)
+
+include(build_addon)
+
+add_files_to_etc_dir(
+  ${PROJECT_NAME}
+  FILES
+    features.py
+    ml_classifiers.py
+    ml_functions.py
+    npy2table.py
+    sqlite2npy.py
+    training_extraction.py)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES v.class.ml.py
+  DOCFILES
+    v.class.ml.html
+    v.class.ml.md)

--- a/src/vector/v.clean.ogr/CMakeLists.txt
+++ b/src/vector/v.clean.ogr/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.clean.ogr)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES v.clean.ogr.py
+  DOCFILES
+    v.clean.ogr.html
+    v.clean.ogr.md)

--- a/src/vector/v.colors2/CMakeLists.txt
+++ b/src/vector/v.colors2/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.colors2)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES v.colors2.py
+  DOCFILES
+    v.colors2.html
+    v.colors2.md)

--- a/src/vector/v.concave.hull/CMakeLists.txt
+++ b/src/vector/v.concave.hull/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.concave.hull)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES v.concave.hull.py
+  DOCFILES
+    v_concave_alpha_0_5.png
+    v_concave_alpha_8.png
+    v_concave_concave.png
+    v_concave_convex.png
+    v.concave.hull.html
+    v.concave.hull.md)

--- a/src/vector/v.convert.all/CMakeLists.txt
+++ b/src/vector/v.convert.all/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.convert.all)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES v.convert.all.py
+  DOCFILES
+    v.convert.all.html
+    v.convert.all.md)

--- a/src/vector/v.convert/CMakeLists.txt
+++ b/src/vector/v.convert/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.convert)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  att.c
+  conv.h
+  dist.c
+  local_proto.h
+  main.c
+  old2new.c
+  read.c
+  type.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  GRASSLIBS
+    dbmibase
+    dbmiclient
+    dig2
+    gis
+    raster
+    vector
+  DEPENDS LIBM
+  SOURCES ${sources}
+  DOCFILES
+    v.convert.html
+    v.convert.md)

--- a/src/vector/v.db.pyupdate/CMakeLists.txt
+++ b/src/vector/v.db.pyupdate/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.db.pyupdate)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES v.db.pyupdate.py
+  DOCFILES
+    v.db.pyupdate.html
+    v.db.pyupdate.md)

--- a/src/vector/v.delaunay3d/CMakeLists.txt
+++ b/src/vector/v.delaunay3d/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.delaunay3d)
+
+include(build_addon)
+
+find_package(CGAL REQUIRED)
+
+set(sources
+  local_proto.h
+  main.cpp
+  read.cpp
+  write.cpp)
+
+build_addon(
+  ${PROJECT_NAME}
+  GRASSLIBS
+    gis
+    vector
+  DEPENDS
+    CGAL::CGAL
+  SOURCES ${sources}
+  DOCFILES
+    v.delaunay3d.html
+    v.delaunay3d.md)

--- a/src/vector/v.ellipse/CMakeLists.txt
+++ b/src/vector/v.ellipse/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.ellipse)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  ellipse.c
+  main.c
+  proto.h
+  read.c
+  write.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  GRASSLIBS
+    dbmibase
+    gis
+    gmath
+    vector
+  DEPENDS
+    LIBM
+  SOURCES ${sources}
+  DOCFILES
+    v_ellipse.png
+    v.ellipse.html
+    v.ellipse.md)

--- a/src/vector/v.explode/CMakeLists.txt
+++ b/src/vector/v.explode/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.explode)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES v.explode.py
+  DOCFILES
+    v.explode.html
+    v.explode.md)

--- a/src/vector/v.external.all/CMakeLists.txt
+++ b/src/vector/v.external.all/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.external.all)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES v.external.all.py
+  DOCFILES
+    v.external.all.html
+    v.external.all.md)

--- a/src/vector/v.faultdirections/CMakeLists.txt
+++ b/src/vector/v.faultdirections/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.faultdirections)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES v.faultdirections.py
+  DOCFILES
+    v.faultdirections.html
+    v.faultdirections.md)

--- a/src/vector/v.fixed.segmentpoints/CMakeLists.txt
+++ b/src/vector/v.fixed.segmentpoints/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.fixed.segmentpoints)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.flexure/CMakeLists.txt
+++ b/src/vector/v.flexure/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.flexure)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.greedycolors/CMakeLists.txt
+++ b/src/vector/v.greedycolors/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.greedycolors)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  main.c
+  prb.c
+  prb.h)
+
+build_addon(
+  ${PROJECT_NAME}
+  GRASSLIBS
+    dbmibase
+    dbmiclient
+    gis
+    vector
+  DEPENDS
+    LIBM
+  SOURCES ${sources}
+  DOCFILES
+    v.greedycolors.html
+    v.greedycolors.md)

--- a/src/vector/v.gsflow.export/CMakeLists.txt
+++ b/src/vector/v.gsflow.export/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.gsflow.export)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.gsflow.gravres/CMakeLists.txt
+++ b/src/vector/v.gsflow.gravres/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.gsflow.gravres)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.gsflow.grid/CMakeLists.txt
+++ b/src/vector/v.gsflow.grid/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.gsflow.grid)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.gsflow.hruparams/CMakeLists.txt
+++ b/src/vector/v.gsflow.hruparams/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.gsflow.hruparams)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.gsflow.mapdata/CMakeLists.txt
+++ b/src/vector/v.gsflow.mapdata/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.gsflow.mapdata)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.gsflow.reaches/CMakeLists.txt
+++ b/src/vector/v.gsflow.reaches/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.gsflow.reaches)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.gsflow.segments/CMakeLists.txt
+++ b/src/vector/v.gsflow.segments/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.gsflow.segments)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.habitat.dem/CMakeLists.txt
+++ b/src/vector/v.habitat.dem/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.habitat.dem)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.histogram/CMakeLists.txt
+++ b/src/vector/v.histogram/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.histogram)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES v.histogram.py
+  DOCFILES
+    v_histogram.png
+    v.histogram.html
+    v.histogram.md)

--- a/src/vector/v.in.csv/CMakeLists.txt
+++ b/src/vector/v.in.csv/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.in.csv)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.in.gbif/CMakeLists.txt
+++ b/src/vector/v.in.gbif/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.in.gbif)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.in.geopaparazzi/CMakeLists.txt
+++ b/src/vector/v.in.geopaparazzi/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.in.geopaparazzi)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.in.gns/CMakeLists.txt
+++ b/src/vector/v.in.gns/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.in.gns)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.in.gps/CMakeLists.txt
+++ b/src/vector/v.in.gps/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.in.gps)
+
+include(build_addon)
+
+add_files_to_etc_dir(${PROJECT_NAME} FILES grass_write_ascii.style)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.in.natura2000/CMakeLists.txt
+++ b/src/vector/v.in.natura2000/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.in.natura2000)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.in.ogc/CMakeLists.txt
+++ b/src/vector/v.in.ogc/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.in.ogc)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  ADDONS
+    v.in.ogc.features
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.in.ogc/v.in.ogc.features/CMakeLists.txt
+++ b/src/vector/v.in.ogc/v.in.ogc.features/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.in.ogc.features)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.in.osm/CMakeLists.txt
+++ b/src/vector/v.in.osm/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.in.osm)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.in.ply/CMakeLists.txt
+++ b/src/vector/v.in.ply/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.in.ply)
+
+include(build_addon)
+
+set(sources
+  body.c
+  globals.h
+  header.c
+  local_proto.h
+  main.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  GRASSLIBS
+    dbmibase
+    dbmiclient
+    gis
+    vector
+  SOURCES ${sources}
+  DOCFILES
+    v.in.ply.html
+    v.in.ply.md)

--- a/src/vector/v.in.pygbif/CMakeLists.txt
+++ b/src/vector/v.in.pygbif/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.in.pygbif)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.in.redlist/CMakeLists.txt
+++ b/src/vector/v.in.redlist/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.in.redlist)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.in.redwg/CMakeLists.txt
+++ b/src/vector/v.in.redwg/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.in.redwg)
+
+include(build_addon)
+
+find_M()
+
+find_package(PkgConfig QUIET)
+pkg_check_modules(LibreDWG libredwg REQUIRED)
+if(LibreDWG_FOUND)
+  set(_LibreDWG_link_dirs "${LibreDWG_LIBDIR}" "${LibreDWG_LIBRARY_DIRS}")
+  list(REMOVE_DUPLICATES _LibreDWG_link_dirs)
+  find_library(LibreDWG_Library NAMES redwg PATHS ${LibreDWG_LIBDIR})
+  add_library(LibreDWG::LibreDWG UNKNOWN IMPORTED)
+  set_target_properties(
+    LibreDWG::LibreDWG
+    PROPERTIES IMPORTED_LOCATION "${LibreDWG_Library}"
+               INTERFACE_INCLUDE_DIRECTORIES "${LibreDWG_INCLUDE_DIRS}"
+               INTERFACE_LINK_LIBRARIES "${LibreDWG_LINK_LIBRARIES}"
+               INTERFACE_LINK_DIRECTORIES "${_LibreDWG_link_dirs}")
+endif()
+
+set(sources
+  entity.c
+  global.h
+  main.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  GRASSLIBS
+    dbmibase
+    dbmiclient
+    gis
+    vector
+  SOURCES ${sources}
+  DEPENDS
+    LIBM
+    LibreDWG::LibreDWG
+  DOCFILES
+    v.in.redwg.html
+    v.in.redwg.md)

--- a/src/vector/v.in.survey/CMakeLists.txt
+++ b/src/vector/v.in.survey/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.in.survey)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    img_lyrs_broken.png
+    img_NC_dxf.png
+    img_soils_correct.png
+    img_sorted_boundaries.png
+    v.in.survey.html
+    v.in.survey.md)

--- a/src/vector/v.in.wfs2/CMakeLists.txt
+++ b/src/vector/v.in.wfs2/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.in.wfs2)
+
+include(build_addon)
+
+add_files_to_etc_dir(
+  ${PROJECT_NAME}
+  FILES
+    wfs_base.py
+    wfs_drv.py
+    wfs_owslib_drv.py)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.isochrones/CMakeLists.txt
+++ b/src/vector/v.isochrones/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.isochrones)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    v_isochrones_cost.png
+    v_isochrones_net.png
+    v.isochrones.html
+    v.isochrones.md)

--- a/src/vector/v.krige/CMakeLists.txt
+++ b/src/vector/v.krige/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.krige)
+
+include(build_addon)
+
+add_files_to_etc_dir(${PROJECT_NAME} FILES vkrige_wxgui.py)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.kriging/CMakeLists.txt
+++ b/src/vector/v.kriging/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.kriging)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  geostat.c
+  getval.c
+  local_proto.h
+  main.c
+  quantile.c
+  spatial_index.c
+  stat.c
+  utils_kriging.c
+  utils_raster.c
+  utils_write.c
+  utils.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  GRASSLIBS
+    dbmibase
+    dbmiclient
+    gis
+    gmath
+    raster
+    raster3d
+    rtree
+    vector
+  SOURCES ${sources}
+  DEPENDS
+    LIBM
+  DOCFILES
+    v.kriging.html
+    v.kriging.md)

--- a/src/vector/v.label.sa/CMakeLists.txt
+++ b/src/vector/v.label.sa/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.label.sa)
+
+include(build_addon)
+
+find_M()
+find_package(Freetype REQUIRED)
+
+set(sources
+  annealing.c
+  font.c
+  labels.c
+  labels.h
+  main.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  GRASSLIBS
+    dig2
+    display
+    dbmibase
+    dbmiclient
+    gis
+    raster
+    vector
+  SOURCES ${sources}
+  DEPENDS
+    Freetype::Freetype
+    LIBM
+  DOCFILES
+    v_label_sa.jpg
+    v.label.sa.html
+    v.label.sa.md)

--- a/src/vector/v.lidar.mcc/CMakeLists.txt
+++ b/src/vector/v.lidar.mcc/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.lidar.mcc)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    v_lidar_mcc.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.link.precip/CMakeLists.txt
+++ b/src/vector/v.link.precip/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.link.precip)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.mapcalc/CMakeLists.txt
+++ b/src/vector/v.mapcalc/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.mapcalc)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.maxent.swd/CMakeLists.txt
+++ b/src/vector/v.maxent.swd/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.maxent.swd)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.median/CMakeLists.txt
+++ b/src/vector/v.median/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.median)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.mrmr/CMakeLists.txt
+++ b/src/vector/v.mrmr/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.mrmr)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.multi2singlepart/CMakeLists.txt
+++ b/src/vector/v.multi2singlepart/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.multi2singlepart)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    example.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.neighborhoodmatrix/CMakeLists.txt
+++ b/src/vector/v.neighborhoodmatrix/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.neighborhoodmatrix)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.net.curvedarcs/CMakeLists.txt
+++ b/src/vector/v.net.curvedarcs/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.net.curvedarcs)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    v_net_curvedarcs.png
+    v_net_curvedarcs2.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.net.salesman.opt/CMakeLists.txt
+++ b/src/vector/v.net.salesman.opt/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.net.salesman.opt)
+
+include(build_addon)
+
+set(sources
+  evolution.c
+  local_proto.h
+  main.c
+  optimize.c
+  tour.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  GRASSLIBS
+    gis
+    vector
+  SOURCES ${sources}
+  DOCFILES
+    v.net.salesman.opt.html
+    v.net.salesman.opt.md
+    vnetsalesman.png
+    vnetsalesmantime.png)

--- a/src/vector/v.nnstat/CMakeLists.txt
+++ b/src/vector/v.nnstat/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.nnstat)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  getval.c
+  hull.h
+  local_proto.h
+  macros.h
+  main.c
+  mbb.c
+  mbb.h
+  mbr.c
+  nearest_neighbour.c
+  spatial_index.c
+  utils.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  GRASSLIBS
+    dbmibase
+    dbmiclient
+    gis
+    gmath
+    rtree
+    vector
+  SOURCES ${sources}
+  DEPENDS
+    LIBM
+  DOCFILES
+   v.nnstat.html
+   v.nnstat.md)

--- a/src/vector/v.out.gps/CMakeLists.txt
+++ b/src/vector/v.out.gps/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.out.gps)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.out.ply/CMakeLists.txt
+++ b/src/vector/v.out.ply/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.out.ply)
+
+include(build_addon)
+
+set(sources
+  args.c
+  body.c
+  header.c
+  local_proto.h
+  main.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  GRASSLIBS
+    dbmibase
+    dbmiclient
+    gis
+    gmath
+    vector
+  SOURCES ${sources}
+  DOCFILES
+    v.out.ply.html
+    v.out.ply.md)

--- a/src/vector/v.out.png/CMakeLists.txt
+++ b/src/vector/v.out.png/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.out.png)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.percolate/CMakeLists.txt
+++ b/src/vector/v.percolate/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.percolate)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  distance.c
+  distance.h
+  edge_array.c
+  edge_array.h
+  file.c
+  file.h
+  global_vars.h
+  groups.c
+  groups.h
+  main.c
+  node.c
+  node.h
+  percolate.c
+  percolate.h
+  vector.c
+  vector.h)
+
+build_addon(
+  ${PROJECT_NAME}
+  GRASSLIBS
+    dbmibase
+    dbmiclient
+    gis
+    vector
+  SOURCES ${sources}
+  DEPENDS
+    LIBM
+  DOCFILES
+    v.percolate.html
+    v.percolate.md)

--- a/src/vector/v.ply.rectify/CMakeLists.txt
+++ b/src/vector/v.ply.rectify/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.ply.rectify)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.profile.points/CMakeLists.txt
+++ b/src/vector/v.profile.points/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.profile.points)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    v_profile_points_workspace.png
+    v_profile_points.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.rast.bufferstats/CMakeLists.txt
+++ b/src/vector/v.rast.bufferstats/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.rast.bufferstats)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.rast.move/CMakeLists.txt
+++ b/src/vector/v.rast.move/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.rast.move)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    v_rast_move.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.scatterplot/CMakeLists.txt
+++ b/src/vector/v.scatterplot/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.scatterplot)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    v_scatterplot_01.png
+    v_scatterplot_02.png
+    v_scatterplot_03.png
+    v_scatterplot_04.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.sort.points/CMakeLists.txt
+++ b/src/vector/v.sort.points/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.sort.points)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.stats/CMakeLists.txt
+++ b/src/vector/v.stats/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.stats)
+
+include(build_addon)
+
+add_files_to_etc_dir(${PROJECT_NAME} FILES imp_csv.py vstats.py)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.strds.stats/CMakeLists.txt
+++ b/src/vector/v.strds.stats/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.strds.stats)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.stream.inbasin/CMakeLists.txt
+++ b/src/vector/v.stream.inbasin/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.stream.inbasin)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.stream.network/CMakeLists.txt
+++ b/src/vector/v.stream.network/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.stream.network)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.stream.order/CMakeLists.txt
+++ b/src/vector/v.stream.order/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.stream.order)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    stream_network_order_drwal.png
+    stream_network_order_scheidegger.png
+    stream_network_order_shreve.png
+    stream_network_order_strahler.png
+    stream_network.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.stream.profiler/CMakeLists.txt
+++ b/src/vector/v.stream.profiler/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.stream.profiler)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.surf.icw/CMakeLists.txt
+++ b/src/vector/v.surf.icw/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.surf.icw)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.surf.mass/CMakeLists.txt
+++ b/src/vector/v.surf.mass/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.surf.mass)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  globals.h
+  main.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  GRASSLIBS
+    dbmibase
+    dbmiclient
+    gis
+    vector
+    raster
+    segment
+  SOURCES ${sources}
+  DEPENDS
+    LIBM
+  DOCFILES
+    v_surf_mass_pycno.png
+    v_surf_mass_voronoi.png
+    v.surf.mass.html
+    v.surf.mass.md)

--- a/src/vector/v.surf.nnbathy/CMakeLists.txt
+++ b/src/vector/v.surf.nnbathy/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.surf.nnbathy)
+
+include(build_addon)
+
+add_files_to_etc_dir(${PROJECT_NAME} FILES nnbathy.py)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.surf.tps/CMakeLists.txt
+++ b/src/vector/v.surf.tps/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.surf.tps)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  flag.c
+  flag.h
+  main.c
+  rclist.c
+  rclist.h
+  tps.c
+  tps.h)
+
+build_addon(
+  ${PROJECT_NAME}
+  GRASSLIBS
+    btree2
+    dbmibase
+    dbmiclient
+    gis
+    vector
+    raster
+    segment
+  SOURCES ${sources}
+  DEPENDS
+    LIBM
+  DOCFILES
+    v_surf_tps.png
+    v.surf.tps.html
+    v.surf.tps.md)

--- a/src/vector/v.tin.to.rast/CMakeLists.txt
+++ b/src/vector/v.tin.to.rast/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.tin.to.rast)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.to.rast.multi/CMakeLists.txt
+++ b/src/vector/v.to.rast.multi/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.to.rast.multi)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.transects/CMakeLists.txt
+++ b/src/vector/v.transects/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.transects)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    vtransect_options1.jpg
+    vtransect_options2.jpg
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.vect.stats.multi/CMakeLists.txt
+++ b/src/vector/v.vect.stats.multi/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.vect.stats.multi)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.vol.idw/CMakeLists.txt
+++ b/src/vector/v.vol.idw/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.vol.idw)
+
+include(build_addon)
+
+find_M()
+
+build_addon(
+  ${PROJECT_NAME}
+  GRASSLIBS
+    dbmibase
+    dbmiclient
+    gis
+    vector
+    raster3d
+  SOURCES "main.c"
+  DEPENDS
+    LIBM
+  DOCFILES
+    v.vol.idw.html
+    v.vol.idw.md)

--- a/src/vector/v.what.rast.label/CMakeLists.txt
+++ b/src/vector/v.what.rast.label/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.what.rast.label)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.what.rast.multi/CMakeLists.txt
+++ b/src/vector/v.what.rast.multi/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.what.rast.multi)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.what.spoly/CMakeLists.txt
+++ b/src/vector/v.what.spoly/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.what.spoly)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/vector/v.what.strds.timestamp/CMakeLists.txt
+++ b/src/vector/v.what.strds.timestamp/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(v.what.strds.timestamp)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)


### PR DESCRIPTION
Add CMake support for vector Addons.

I tested installation for all C/C++ addons, and most of the Python based.

A few of them fail because of code issues, which I will address separately (an outstanding one is the`get_lib_path()` in GRASS `grass/script/utils` which needs an adaptation to CMake build https://github.com/OSGeo/grass/pull/7098).