### PR TITLE
v.class.ml: replace removed `lgettext` with Python 3.11

### DIFF
--- a/src/vector/v.class.ml/training_extraction.py
+++ b/src/vector/v.class.ml/training_extraction.py
@@ -7,7 +7,7 @@ Created on Sat Nov  2 13:30:33 2013
 """
 
 from __future__ import absolute_import, division, print_function, unicode_literals
-from gettext import lgettext as _
+import gettext
 import numpy as np
 
 from grass.script.core import overwrite
@@ -17,6 +17,7 @@ from grass.pygrass.vector.geometry import Line, Area, intersects
 from grass.pygrass.vector.basic import Bbox, BoxList
 from grass.pygrass.messages import get_msgr
 
+_ = gettext.gettext
 
 COLS = [
     ("cat", "INTEGER PRIMARY KEY"),


### PR DESCRIPTION
Replace removed `lgettext` with [Python 3.11](https://docs.python.org/3/whatsnew/3.11.html#removed)