### PR TITLE
r.in.redwg: undefine UNUSED before including dwg.h

### DIFF
--- a/src/vector/v.in.redwg/entity.c
+++ b/src/vector/v.in.redwg/entity.c
@@ -33,10 +33,16 @@
 #include <math.h>
 #include <fcntl.h>
 #include <unistd.h>
+
 #include <grass/gis.h>
 #include <grass/dbmi.h>
 #include <grass/vector.h>
+
+#if defined UNUSED
+#undef UNUSED
+#endif
 #include <dwg.h>
+
 #include "global.h"
 
 #define exampleprintf printf

--- a/src/vector/v.in.redwg/main.c
+++ b/src/vector/v.in.redwg/main.c
@@ -22,11 +22,17 @@
 #include <math.h>
 #include <fcntl.h>
 #include <unistd.h>
+
 #include <grass/gis.h>
 #include <grass/dbmi.h>
 #include <grass/vector.h>
 #include <grass/glocale.h>
+
+#if defined UNUSED
+#undef UNUSED
+#endif
 #include <dwg.h>
+
 #include "global.h"
 
 int cat;


### PR DESCRIPTION
Conflicting with the GRASS macro with the same name