### PR TITLE
cmake: Added build support for r.stream toolbox and other hydrology tools

### DIFF
--- a/src/raster/r.accumulate/CMakeLists.txt
+++ b/src/raster/r.accumulate/CMakeLists.txt
@@ -14,6 +14,7 @@ set(sources
     delineate_streams.c
     delineate_subwatersheds_iterative.c
     delineate_subwatersheds_recursive.c
+    global.h
     line_list.c
     point_list.c
     main.c

--- a/src/raster/r.accumulate/CMakeLists.txt
+++ b/src/raster/r.accumulate/CMakeLists.txt
@@ -1,0 +1,53 @@
+cmake_minimum_required(VERSION 3.22)
+project(r.accumulate)
+
+include(build_addon)
+
+find_OpenMP()
+find_M()
+
+set(sources
+    accumulate_iterative.c
+    accumulate_recursive.c
+    calculate_lfp_iterative.c
+    calculate_lfp_recursive.c
+    delineate_streams.c
+    delineate_subwatersheds_iterative.c
+    delineate_subwatersheds_recursive.c
+    line_list.c
+    point_list.c
+    main.c
+    raster.c
+    subaccumulate.c)
+
+set(doc_files
+    r.accumulate.html
+    r.accumulate.md
+    r_accumulate_formats.png
+    r_accumulate_nc_comparison.png
+    r_accumulate_nc_example.png
+    r_accumulate_nc_lfp_example_multiple.png
+    r_accumulate_nc_lfp_example_single.png
+    r_accumulate_nc_lfp_example_subwatersheds.png
+    r_accumulate_nc_stream_comparison.png
+    r_accumulate_nc_stream_example.png
+    r_accumulate_nc_subwatersheds_example.png
+    r_accumulate_nc_watershed_example.png
+    r_accumulate_r_watershed_nc_example.png)
+
+build_addon(
+  ${PROJECT_NAME}
+  GRASSLIBS
+    dbmibase
+    dbmiclient
+    dbmidriver
+    gmath
+    gis
+    raster
+    vector
+  DEPENDS
+    LIBM
+  OPTIONAL_DEPENDS
+    OpenMP::OpenMP_C
+  SOURCES ${sources}
+  DOCFILES ${doc_files})

--- a/src/raster/r.accumulate/CMakeLists.txt
+++ b/src/raster/r.accumulate/CMakeLists.txt
@@ -41,8 +41,6 @@ build_addon(
   GRASSLIBS
     dbmibase
     dbmiclient
-    dbmidriver
-    gmath
     gis
     raster
     vector

--- a/src/raster/r.curvenumber/CMakeLists.txt
+++ b/src/raster/r.curvenumber/CMakeLists.txt
@@ -6,6 +6,7 @@ include(build_addon)
 find_M()
 
 set(sources
+    global.h
     lut.c
     main.c)
 

--- a/src/raster/r.curvenumber/CMakeLists.txt
+++ b/src/raster/r.curvenumber/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.22)
+project(r.curvenumber)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+    lut.c
+    main.c)
+
+set(doc_files
+    r.curvenumber.html
+    r.curvenumber.md
+    r_curvenumber_output.png)
+
+build_addon(
+  ${PROJECT_NAME}
+  GRASSLIBS
+    dbmibase
+    dbmiclient
+    dbmidriver
+    gmath
+    gis
+    raster
+    vector
+  DEPENDS
+    LIBM
+  SOURCES ${sources}
+  DOCFILES ${doc_files})

--- a/src/raster/r.curvenumber/CMakeLists.txt
+++ b/src/raster/r.curvenumber/CMakeLists.txt
@@ -17,13 +17,8 @@ set(doc_files
 build_addon(
   ${PROJECT_NAME}
   GRASSLIBS
-    dbmibase
-    dbmiclient
-    dbmidriver
-    gmath
     gis
     raster
-    vector
   DEPENDS
     LIBM
   SOURCES ${sources}

--- a/src/raster/r.hydrobasin/CMakeLists.txt
+++ b/src/raster/r.hydrobasin/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.22)
+project(r.hydrobasin)
+
+include(build_addon)
+
+find_OpenMP()
+find_M()
+
+set(sources
+    delineate.c
+    delineate_lessmem.c
+    delineate_moremem.c
+    gettimeofday.c
+    main.c
+    outlet_list.c
+    raster_map.c
+    timeval_diff.c)
+
+set(doc_files
+    r.hydrobasin.html
+    r.hydrobasin.md
+    r_hydrobasin_bridge_wsheds.png
+    r_hydrobasin_formats.png
+    r_hydrobasin_wsheds.png)
+
+build_addon(
+  ${PROJECT_NAME}
+  GRASSLIBS
+    dbmibase
+    dbmiclient
+    dbmidriver
+    gmath
+    gis
+    raster
+    vector
+  DEPENDS
+    LIBM
+  OPTIONAL_DEPENDS
+    OpenMP::OpenMP_C
+  SOURCES ${sources}
+  DOCFILES ${doc_files})

--- a/src/raster/r.hydrobasin/CMakeLists.txt
+++ b/src/raster/r.hydrobasin/CMakeLists.txt
@@ -7,10 +7,12 @@ find_OpenMP()
 find_M()
 
 set(sources
+    delineate_funcs.h
     delineate.c
     delineate_lessmem.c
     delineate_moremem.c
     gettimeofday.c
+    global.h
     main.c
     outlet_list.c
     raster_map.c

--- a/src/raster/r.hydrobasin/CMakeLists.txt
+++ b/src/raster/r.hydrobasin/CMakeLists.txt
@@ -28,8 +28,6 @@ build_addon(
   GRASSLIBS
     dbmibase
     dbmiclient
-    dbmidriver
-    gmath
     gis
     raster
     vector

--- a/src/raster/r.runoff/CMakeLists.txt
+++ b/src/raster/r.runoff/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.22)
+project(r.runoff)
+
+include(build_addon)
+
+set(doc_files
+    r.runoff.html
+    r.runoff.md
+    us_ro_vol.png)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    r.runoff.py
+  DOCFILES ${doc_files})

--- a/src/raster/r.runoff/CMakeLists.txt
+++ b/src/raster/r.runoff/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.22)
-project(r.runoff)
+project(r.runoff LANGUAGES NONE))
 
 include(build_addon)
 

--- a/src/raster/r.stream.basins/CMakeLists.txt
+++ b/src/raster/r.stream.basins/CMakeLists.txt
@@ -19,11 +19,10 @@ set(doc_files
 build_addon(
   ${PROJECT_NAME}
   GRASSLIBS
-    gis
-    raster
     dbmibase
     dbmiclient
-    dbmidriver
+    gis
+    raster
     segment
     vector
   DEPENDS

--- a/src/raster/r.stream.basins/CMakeLists.txt
+++ b/src/raster/r.stream.basins/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.stream.basins)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+    basins_fill.c
+    basins_inputs.c
+    io.c
+    main.c)
+
+set(doc_files
+    r.stream.basins.html
+    r.stream.basins.md)
+
+build_addon(
+  ${PROJECT_NAME}
+  GRASSLIBS
+    gis
+    raster
+    dbmibase
+    dbmiclient
+    dbmidriver
+    segment
+    vector
+  DEPENDS
+    LIBM
+  SOURCES ${sources}
+  DOCFILES ${doc_files})

--- a/src/raster/r.stream.basins/CMakeLists.txt
+++ b/src/raster/r.stream.basins/CMakeLists.txt
@@ -10,6 +10,9 @@ set(sources
     basins_fill.c
     basins_inputs.c
     io.c
+    local_proto.h
+    local_vars.h
+    main.c
     main.c)
 
 set(doc_files

--- a/src/raster/r.stream.order/CMakeLists.txt
+++ b/src/raster/r.stream.order/CMakeLists.txt
@@ -8,6 +8,9 @@ find_M()
 
 set(sources
     io.c
+    io.h
+    local_proto.h
+    local_vars.h
     main.c
     stream_init.c
     stream_order.c

--- a/src/raster/r.stream.order/CMakeLists.txt
+++ b/src/raster/r.stream.order/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.stream.order)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+    io.c
+    main.c
+    stream_init.c
+    stream_order.c
+    stream_raster_close.c
+    stream_topology.c
+    stream_vector.c)
+
+set(doc_files
+    r.stream.order.html
+    r.stream.order.md
+    orders.png)
+
+build_addon(
+  ${PROJECT_NAME}
+  GRASSLIBS
+    gis
+    raster
+    vector
+    segement
+    dbmibase
+    dbmiclient
+    dbmidriver
+  DEPENDS
+    LIBM
+  SOURCES ${sources}
+  DOCFILES ${doc_files})

--- a/src/raster/r.stream.order/CMakeLists.txt
+++ b/src/raster/r.stream.order/CMakeLists.txt
@@ -23,13 +23,12 @@ set(doc_files
 build_addon(
   ${PROJECT_NAME}
   GRASSLIBS
-    gis
-    raster
-    vector
-    segment
     dbmibase
     dbmiclient
-    dbmidriver
+    gis
+    raster
+    segment
+    vector
   DEPENDS
     LIBM
   SOURCES ${sources}

--- a/src/raster/r.stream.segment/CMakeLists.txt
+++ b/src/raster/r.stream.segment/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.22)
 
-project(r.stream.order)
+project(r.stream.segment)
 
 include(build_addon)
 
@@ -9,16 +9,16 @@ find_M()
 set(sources
     io.c
     main.c
-    stream_init.c
-    stream_order.c
-    stream_raster_close.c
+    stream_segment.c
     stream_topology.c
-    stream_vector.c)
+    stream_vector.c
+)
 
 set(doc_files
-    r.stream.order.html
-    r.stream.order.md
-    orders.png)
+    r.stream.segment.html
+    r.stream.segment.md
+    dirs.png
+    sectors.png)
 
 build_addon(
   ${PROJECT_NAME}

--- a/src/raster/r.stream.segment/CMakeLists.txt
+++ b/src/raster/r.stream.segment/CMakeLists.txt
@@ -8,6 +8,9 @@ find_M()
 
 set(sources
     io.c
+    io.h
+    local_proto.h
+    local_vars.h
     main.c
     stream_segment.c
     stream_topology.c

--- a/src/raster/r.stream.segment/CMakeLists.txt
+++ b/src/raster/r.stream.segment/CMakeLists.txt
@@ -23,13 +23,12 @@ set(doc_files
 build_addon(
   ${PROJECT_NAME}
   GRASSLIBS
-    gis
-    raster
-    vector
-    segment
     dbmibase
     dbmiclient
-    dbmidriver
+    gis
+    raster
+    segment
+    vector
   DEPENDS
     LIBM
   SOURCES ${sources}

--- a/src/raster/r.stream.slope/CMakeLists.txt
+++ b/src/raster/r.stream.slope/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.stream.slope)
+
+include(build_addon)
+
+find_M()
+
+set(doc_files
+    r.stream.slope.html
+    r.stream.slope.md)
+
+build_addon(
+  ${PROJECT_NAME}
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS
+    LIBM
+  SOURCES main.c
+  DOCFILES ${doc_files})

--- a/src/raster/r.stream.snap/CMakeLists.txt
+++ b/src/raster/r.stream.snap/CMakeLists.txt
@@ -8,6 +8,9 @@ find_M()
 
 set(sources
     io.c
+    io.h
+    local_proto.h
+    local_vars.h
     main.c
     points_io.c
     snap.c

--- a/src/raster/r.stream.snap/CMakeLists.txt
+++ b/src/raster/r.stream.snap/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.22)
 
-project(r.stream.order)
+project(r.stream.snap)
 
 include(build_addon)
 
@@ -9,16 +9,13 @@ find_M()
 set(sources
     io.c
     main.c
-    stream_init.c
-    stream_order.c
-    stream_raster_close.c
-    stream_topology.c
-    stream_vector.c)
+    points_io.c
+    snap.c
+)
 
 set(doc_files
-    r.stream.order.html
-    r.stream.order.md
-    orders.png)
+    r.stream.snap.html
+    r.stream.snap.md)
 
 build_addon(
   ${PROJECT_NAME}

--- a/src/raster/r.stream.snap/CMakeLists.txt
+++ b/src/raster/r.stream.snap/CMakeLists.txt
@@ -20,13 +20,12 @@ set(doc_files
 build_addon(
   ${PROJECT_NAME}
   GRASSLIBS
-    gis
-    raster
-    vector
-    segment
     dbmibase
     dbmiclient
-    dbmidriver
+    gis
+    raster
+    segment
+    vector
   DEPENDS
     LIBM
   SOURCES ${sources}

--- a/src/raster/r.stream.stats/CMakeLists.txt
+++ b/src/raster/r.stream.stats/CMakeLists.txt
@@ -8,6 +8,9 @@ find_M()
 
 set(sources
     io.c
+    io.h
+    local_proto.h
+    local_vars.h
     main.c
     stats_calculate.c
     stats_prepare.c

--- a/src/raster/r.stream.stats/CMakeLists.txt
+++ b/src/raster/r.stream.stats/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.stream.stats)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+    io.c
+    main.c
+    stats_calculate.c
+    stats_prepare.c
+    stats_print.c)
+
+set(doc_files
+    r.stream.stats.html
+    r.stream.stats.md)
+
+build_addon(
+  ${PROJECT_NAME}
+  GRASSLIBS
+    gis
+    raster
+    segment
+  DEPENDS
+    LIBM
+  SOURCES ${sources}
+  DOCFILES ${doc_files})

--- a/src/raster/r.timeofconcentration/CMakeLists.txt
+++ b/src/raster/r.timeofconcentration/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.22)
-project(r.timeofconcentration)
+project(r.timeofconcentration LANGUAGES NONE)
 
 include(build_addon)
 

--- a/src/raster/r.timeofconcentration/CMakeLists.txt
+++ b/src/raster/r.timeofconcentration/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.22)
+project(r.timeofconcentration)
+
+include(build_addon)
+
+set(doc_files
+    r.timeofconcentration.html
+    r.timeofconcentration.md
+    tc_nc.png)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    r.timeofconcentration.py
+  DOCFILES ${doc_files})


### PR DESCRIPTION
Supported tools

* r.stream.basins
* r.stream.channel
* r.stream.distance
* r.stream.order
* r.stream.segment
* r.stream.slope
* r.stream.snap
* r.stream.stats
* r.accumulate
* r.curvenumber
* r.hydrobasin
* r.runoff
* r.timeofconcentraion

I didn't added the following `r.stream` tools because the are shell scripts.

* r.stream.variables
* r.stream.watersheds