### PR TITLE
Fix GeoTIFF Metadata Loss by Explicitly Closing GDAL Dataset Before r.in.gdal Import

### DIFF
--- a/src/imagery/i.ann.maskrcnn/i.ann.maskrcnn.detect/i.ann.maskrcnn.detect.py
+++ b/src/imagery/i.ann.maskrcnn/i.ann.maskrcnn.detect/i.ann.maskrcnn.detect.py
@@ -495,6 +495,7 @@ def parse_instances(
                 target.SetGeoTransform(trans)
                 target.SetProjection(proj)
                 target.FlushCache()
+                target = None  # close dataset so GeoTIFF IFD metadata is written to disk
                 mList.append(maskName)
                 if class_ids[index] not in cList:
                     cList.append(class_ids[index])
@@ -573,6 +574,7 @@ def parse_instances(
                 target.SetGeoTransform(trans)
                 target.SetProjection(proj)
                 target.FlushCache()
+                target = None  # close dataset so GeoTIFF IFD metadata is written to disk
                 mList.append(maskName)
                 if class_ids[index] not in cList:
                     cList.append(class_ids[index])


### PR DESCRIPTION
# Summary

This PR fixes a silent geospatial metadata corruption issue in
`src/imagery/i.ann.maskrcnn/i.ann.maskrcnn.detect/i.ann.maskrcnn.detect.py`,
specifically inside the `parse_instances()` function.

In both the **polygon** and **point** output branches, a GeoTIFF file is written using Matplotlib and then reopened with GDAL in `GA_Update` mode to assign georeferencing metadata (GeoTransform and Projection). However, the GDAL dataset handle was not explicitly closed before invoking `r.in.gdal`.

The relevant pattern was:

```python
target = gdal.Open(targetPath, gdal.GA_Update)
target.SetGeoTransform(trans)
target.SetProjection(proj)
target.FlushCache()

gs.run_command(
    "r.in.gdal",
    input=targetPath,
    output=maskName,
    ...
)
```

Although `FlushCache()` was called, the dataset remained open while the GRASS subprocess read the file. For GeoTIFF, spatial metadata (GeoTransform and projection tags) is committed only during `GDALClose()`, which is triggered in Python when the dataset object is destroyed.

As a result, `r.in.gdal` imported rasters without spatial metadata, causing silent mis-georeferencing of all generated masks.

---

# Fix

The fix explicitly closes the GDAL dataset before invoking `r.in.gdal` by dropping the reference:

```python
target = gdal.Open(targetPath, gdal.GA_Update)
target.SetGeoTransform(trans)
target.SetProjection(proj)
target.FlushCache()
target = None  # ensure GDALClose() is called before subprocess

gs.run_command(
    "r.in.gdal",
    input=targetPath,
    output=maskName,
    ...
)
```

This change was applied in both identical code paths:

* Polygon branch (lines ~491–509)
* Point branch (lines ~569–587)

Setting `target = None` ensures `GDALClose()` is executed immediately in CPython, committing GeoTIFF IFD metadata (GeoTIFF tags) to disk before the subprocess opens the file.

The change is minimal (one line per branch) and does not alter program logic or performance.

---

# Verification

The fix was verified using batch detection over a directory of georeferenced GeoTIFFs.

### Before Fix

* `r.info map=<mask>` showed projection as unknown / EPSG:0
* `g.region raster=<mask>` reported pixel-space coordinates
* Output rasters were spatially misaligned

### After Fix

* `r.info` reports the correct CRS
* `g.region` reflects projected geographic coordinates
* Vector outputs (`r.to.vect`, `v.patch`) align correctly with source imagery

Additionally, monitoring open file descriptors during execution confirms the dataset is closed before `r.in.gdal` accesses the file.



This PR resolves a deterministic data integrity issue affecting all batch runs using the external georeferencing path, ensuring masks are imported into GRASS GIS with correct spatial metadata.

