### PR TITLE
r.neighborhoodmatrix: Fix incorrect parameter

### DIFF
--- a/src/raster/r.neighborhoodmatrix/r.neighborhoodmatrix.html
+++ b/src/raster/r.neighborhoodmatrix/r.neighborhoodmatrix.html
@@ -61,14 +61,14 @@ Send the neighborhood matrix of the counties in the boundary_county map of the
 North Carolina dataset to standard output:
 
 <div class="code"><pre>
-r.neighborhoodmatrix in=bc_int sep=comma
+r.neighborhoodmatrix input=bc_int sep=comma
 </pre></div>
 
 <p>
 Idem, but also calculating neighborhood length, sending the output to a file:
 
 <div class="code"><pre>
-r.neighborhoodmatrix -l in=bc_int sep=comma output=county_neighbors.csv
+r.neighborhoodmatrix -l input=bc_int sep=comma output=county_neighbors.csv
 </pre></div>
 
 <h2>SEE ALSO</h2>

--- a/src/raster/r.neighborhoodmatrix/r.neighborhoodmatrix.html
+++ b/src/raster/r.neighborhoodmatrix/r.neighborhoodmatrix.html
@@ -68,7 +68,7 @@ r.neighborhoodmatrix in=bc_int sep=comma
 Idem, but also calculating neighborhood length, sending the output to a file:
 
 <div class="code"><pre>
-r.neighborhoodmatrix -l n=bc_int sep=comma output=county_neighbors.csv
+r.neighborhoodmatrix -l in=bc_int sep=comma output=county_neighbors.csv
 </pre></div>
 
 <h2>SEE ALSO</h2>

--- a/src/raster/r.neighborhoodmatrix/r.neighborhoodmatrix.md
+++ b/src/raster/r.neighborhoodmatrix/r.neighborhoodmatrix.md
@@ -52,14 +52,14 @@ Send the neighborhood matrix of the counties in the boundary\_county map
 of the North Carolina dataset to standard output:
 
 ```sh
-r.neighborhoodmatrix in=bc_int sep=comma
+r.neighborhoodmatrix input=bc_int sep=comma
 ```
 
 Idem, but also calculating neighborhood length, sending the output to a
 file:
 
 ```sh
-r.neighborhoodmatrix -l in=bc_int sep=comma output=county_neighbors.csv
+r.neighborhoodmatrix -l input=bc_int sep=comma output=county_neighbors.csv
 ```
 
 ## SEE ALSO

--- a/src/raster/r.neighborhoodmatrix/r.neighborhoodmatrix.md
+++ b/src/raster/r.neighborhoodmatrix/r.neighborhoodmatrix.md
@@ -59,7 +59,7 @@ Idem, but also calculating neighborhood length, sending the output to a
 file:
 
 ```sh
-r.neighborhoodmatrix -l n=bc_int sep=comma output=county_neighbors.csv
+r.neighborhoodmatrix -l in=bc_int sep=comma output=county_neighbors.csv
 ```
 
 ## SEE ALSO


### PR DESCRIPTION
Describe the bug

The documentation (manual page) of the r.neighborhoodmatrix addon contains an incorrect example. The example uses the parameter n= which is not recognized by the module. It should be input= (or in=).

#1637 This pull request open for this Issue