### PR TITLE
cmake: add support for misc Addons

### DIFF
--- a/src/misc/m.cdo.download/CMakeLists.txt
+++ b/src/misc/m.cdo.download/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(m.cdo.download LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    m_cdo_download_cdo_stations.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/misc/m.crawl.thredds/CMakeLists.txt
+++ b/src/misc/m.crawl.thredds/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(m.crawl.thredds LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/misc/m.csv.clean/CMakeLists.txt
+++ b/src/misc/m.csv.clean/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(m.csv.clean LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/misc/m.gcp.filter/CMakeLists.txt
+++ b/src/misc/m.gcp.filter/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(m.gcp.filter)
+
+include(build_addon)
+
+find_M()
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES main.c
+  GRASSLIBS
+    gis
+    imagery
+  DEPENDS LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/misc/m.printws/CMakeLists.txt
+++ b/src/misc/m.printws/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(m.printws LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    m.printws_filledagainwindow.png
+    m.printws_fullwindow.png
+    m.printws_pan.png
+    m.printws_sample_print.png
+    m.printws_screen.png
+    m.printws_smallerwindow.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/misc/m.prism.download/CMakeLists.txt
+++ b/src/misc/m.prism.download/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(m.prism.download LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/misc/m.tnm.download/CMakeLists.txt
+++ b/src/misc/m.tnm.download/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(m.tnm.download LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)


### PR DESCRIPTION
Add CMake support for misc Addons.

(`m.eigensystem` being a Fortran based addon, is not included.)