### PR TITLE
cmake: add support for imagery Addons

### DIFF
--- a/src/imagery/i.ann.maskrcnn/CMakeLists.txt
+++ b/src/imagery/i.ann.maskrcnn/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.ann.maskrcnn LANGUAGES NONE)
+
+include(build_addon)
+
+add_subdirectory(maskrcnnlib)
+
+build_addon(
+  ${PROJECT_NAME}
+  ADDONS
+    i.ann.maskrcnn.detect
+    i.ann.maskrcnn.train
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.ann.maskrcnn/i.ann.maskrcnn.detect/CMakeLists.txt
+++ b/src/imagery/i.ann.maskrcnn/i.ann.maskrcnn.detect/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(i.ann.maskrcnn.detect)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.ann.maskrcnn/i.ann.maskrcnn.train/CMakeLists.txt
+++ b/src/imagery/i.ann.maskrcnn/i.ann.maskrcnn.train/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(i.ann.maskrcnn.train)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.ann.maskrcnn/maskrcnnlib/CMakeLists.txt
+++ b/src/imagery/i.ann.maskrcnn/maskrcnnlib/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_files_to_etc_dir(
+  maskrcnn
+  FILES
+    __init__.py
+    config.py
+    model.py
+    parallel_model.py
+    utils.py)

--- a/src/imagery/i.cutlines/CMakeLists.txt
+++ b/src/imagery/i.cutlines/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.cva LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    i.cva_1angle.png
+    i.cva_2angleclass.png
+    i.cva_3magnitude.png
+    i.cva_4change.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.cva/CMakeLists.txt
+++ b/src/imagery/i.cva/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.cutlines LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    i_cutlines_canny.png
+    i_cutlines_default.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.destripe/CMakeLists.txt
+++ b/src/imagery/i.destripe/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.destripe)
+
+include(build_addon)
+
+find_M()
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    fourier.c
+    main.c
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.eb.deltat/CMakeLists.txt
+++ b/src/imagery/i.eb.deltat/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.eb.deltat)
+
+include(build_addon)
+
+find_M()
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    delta_t.c
+    main.c
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.eb.hsebal95/CMakeLists.txt
+++ b/src/imagery/i.eb.hsebal95/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.eb.hsebal95)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  dtair_desert.c
+  dtair.c
+  functions.h
+  h_0.c
+  h1.c
+  main.c
+  psi_h.c
+  psi_m.c
+  rah_0.c
+  rah1.c
+  roh_air_0.c
+  roh_air.c
+  sensi_h.c
+  U_0.c
+  u_star.c
+  zom_0.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.eb.z0m/CMakeLists.txt
+++ b/src/imagery/i.eb.z0m/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.eb.z0m)
+
+include(build_addon)
+
+find_M()
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    main.c
+    z0m.c
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.eb.z0m0/CMakeLists.txt
+++ b/src/imagery/i.eb.z0m0/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.eb.z0m0)
+
+include(build_addon)
+
+find_M()
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    main.c
+    zom_0.c
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.edge/CMakeLists.txt
+++ b/src/imagery/i.edge/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.edge)
+
+include(build_addon)
+
+find_M()
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    canny.c
+    canny.h
+    gauss.c
+    gauss.h
+    main.c
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.eodag/CMakeLists.txt
+++ b/src/imagery/i.eodag/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.eodag LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.evapo.potrad/CMakeLists.txt
+++ b/src/imagery/i.evapo.potrad/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.evapo.potrad)
+
+include(build_addon)
+
+find_M()
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    et_pot_day.c
+    main.c
+    r_net_day_bandara98.c
+    r_net_day.c
+    solar_day_3d.c
+    solar_day.c
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.evapo.senay/CMakeLists.txt
+++ b/src/imagery/i.evapo.senay/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.evapo.senay)
+
+include(build_addon)
+
+find_M()
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    et_pot_day.c
+    evapfr_senay.c
+    main.c
+    r_net_day_bandara98.c
+    r_net_day.c
+    solar_day_3d.c
+    solar_day.c
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.evapo.zk/CMakeLists.txt
+++ b/src/imagery/i.evapo.zk/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.evapo.zk)
+
+include(build_addon)
+
+find_M()
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    main.c
+    zk_daily_et.c
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.feotio2/CMakeLists.txt
+++ b/src/imagery/i.feotio2/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.feotio2)
+
+include(build_addon)
+
+find_M()
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    clementine_mapplanet.c
+    feo.c
+    main.c
+    tio2.c
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.fusion.hpf/CMakeLists.txt
+++ b/src/imagery/i.fusion.hpf/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.fusion.hpf LANGUAGES NONE)
+
+include(build_addon)
+
+add_files_to_etc_dir(
+  ${PROJECT_NAME}
+  FILES
+    constants.py
+    high_pass_filter.py)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    i_fusion_hpf_lsat7_hpf_rgb.png
+    i_fusion_hpf_lsat7_orig_rgb.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.gabor/CMakeLists.txt
+++ b/src/imagery/i.gabor/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.gabor LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    i_gabor_imaginary.png
+    i_gabor_individual.png
+    i_gabor_ortho.png
+    i_gabor_quant.png
+    i_gabor_segment.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.gcp/CMakeLists.txt
+++ b/src/imagery/i.gcp/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.gcp)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    main.c
+    points.c
+  GRASSLIBS
+    gis
+    imagery
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.gravity/CMakeLists.txt
+++ b/src/imagery/i.gravity/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.gravity)
+
+include(build_addon)
+
+find_M()
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    gravity.c
+    main.c
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.histo.match/CMakeLists.txt
+++ b/src/imagery/i.histo.match/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.histo.match LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    i_histo_match_matched.png
+    i_histo_match_original.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.image.bathymetry/CMakeLists.txt
+++ b/src/imagery/i.image.bathymetry/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.image.bathymetry LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.in.probav/CMakeLists.txt
+++ b/src/imagery/i.in.probav/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.in.probav LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.lmf/CMakeLists.txt
+++ b/src/imagery/i.lmf/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.lmf)
+
+include(build_addon)
+
+find_M()
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    fitting.c
+    invert_matrix.c
+    lmf.c
+    main.c
+    make_matrix.c
+    maxmin.c
+    minmax.c
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.lswt/CMakeLists.txt
+++ b/src/imagery/i.lswt/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.lswt LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.modis/CMakeLists.txt
+++ b/src/imagery/i.modis/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.modis LANGUAGES NONE)
+
+include(build_addon)
+
+add_subdirectory(libmodis)
+
+build_addon(
+  ${PROJECT_NAME}
+  ADDONS
+    i.modis.download
+    i.modis.import
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.modis/i.modis.download/CMakeLists.txt
+++ b/src/imagery/i.modis/i.modis.download/CMakeLists.txt
@@ -1,0 +1,8 @@
+project(i.modis.download LANGUAGES NONE)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.modis/i.modis.import/CMakeLists.txt
+++ b/src/imagery/i.modis/i.modis.import/CMakeLists.txt
@@ -1,0 +1,8 @@
+project(i.modis.import LANGUAGES NONE)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.modis/libmodis/CMakeLists.txt
+++ b/src/imagery/i.modis/libmodis/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_files_to_etc_dir(
+  i.modis
+  FILES
+    __init__.py
+    rmodislib.py)

--- a/src/imagery/i.nightlights.intercalibration/CMakeLists.txt
+++ b/src/imagery/i.nightlights.intercalibration/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.nightlights.intercalibration LANGUAGES NONE)
+
+include(build_addon)
+
+add_files_to_etc_dir(
+  ${PROJECT_NAME}
+  FILES
+    intercalibration_coefficients.py
+    intercalibration_equations.py
+    intercalibration_models.py)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.ortho.corr/CMakeLists.txt
+++ b/src/imagery/i.ortho.corr/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.ortho.corr LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.pysptools.unmix/CMakeLists.txt
+++ b/src/imagery/i.pysptools.unmix/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.pysptools.unmix LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.rh/CMakeLists.txt
+++ b/src/imagery/i.rh/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.rh)
+
+include(build_addon)
+
+find_M()
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    main.c
+    rh.c
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.rotate/CMakeLists.txt
+++ b/src/imagery/i.rotate/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.rotate)
+
+include(build_addon)
+
+find_M()
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    main.c
+  GRASSLIBS
+    gis
+    gproj
+    raster
+  DEPENDS LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.sam2/CMakeLists.txt
+++ b/src/imagery/i.sam2/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.sam2 LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    i_sam2_trees.jpg
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.sar.speckle/CMakeLists.txt
+++ b/src/imagery/i.sar.speckle/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.sar.speckle LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.segment.gsoc/CMakeLists.txt
+++ b/src/imagery/i.segment.gsoc/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.segment.gsoc)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  create_isegs.c
+  estimate_threshold.c
+  flag.c
+  flag.h
+  iseg.h
+  main.c
+  open_files.c
+  parse_args.c
+  write_output.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    btree2
+    gis
+    imagery
+    linkm
+    raster
+    segment
+  DEPENDS LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.segment.hierarchical/CMakeLists.txt
+++ b/src/imagery/i.segment.hierarchical/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.segment.hierarchical LANGUAGES NONE)
+
+include(build_addon)
+
+add_files_to_etc_dir(
+  ${PROJECT_NAME}
+  FILES
+    isegpatch.py)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.segment.stats/CMakeLists.txt
+++ b/src/imagery/i.segment.stats/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.segment.stats LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.segment.uspo/CMakeLists.txt
+++ b/src/imagery/i.segment.uspo/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.segment.uspo LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.signature.copy/CMakeLists.txt
+++ b/src/imagery/i.signature.copy/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.signature.copy LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.signature.list/CMakeLists.txt
+++ b/src/imagery/i.signature.list/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.signature.list LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.spec.sam/CMakeLists.txt
+++ b/src/imagery/i.spec.sam/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.spec.sam)
+
+include(build_addon)
+
+find_M()
+find_OpenMP()
+
+set(sources
+  global.h
+  hist.c
+  local_proto.h
+  main.c
+  open.c
+  spec_angle.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    gmath
+    imagery
+    raster
+  DEPENDS LIBM
+  OPTIONAL_DEPENDS
+    OpenMP::OpenMP_C
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.spec.unmix/CMakeLists.txt
+++ b/src/imagery/i.spec.unmix/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.spec.unmix)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  global.h
+  hist.c
+  histogram.c
+  main.c
+  open.c
+  spec_angle.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    gmath
+    imagery
+    raster
+  DEPENDS LIBM
+  DOCFILES
+    mixed_pixels_spectrum.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.superpixels.slic/CMakeLists.txt
+++ b/src/imagery/i.superpixels.slic/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.superpixels.slic)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  cache.c
+  cache.h
+  main.c
+  minsize.c
+  pavl.c
+  pavl.h
+  rclist.c
+  rclist.h)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    imagery
+    segment
+    raster
+  DEPENDS LIBM
+  DOCFILES
+    i_superpixels_slic.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.theilsen/CMakeLists.txt
+++ b/src/imagery/i.theilsen/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.theilsen)
+
+include(build_addon)
+
+find_M()
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    main.c
+    mk.c
+  GRASSLIBS
+    gis
+    imagery
+    raster
+  DEPENDS LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.variance/CMakeLists.txt
+++ b/src/imagery/i.variance/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.variance LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    i_variance_region1.png
+    i_variance_region2.png
+    i_variance_region3.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.water/CMakeLists.txt
+++ b/src/imagery/i.water/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.water)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    main.c
+    water_modis.c
+    water.c
+  GRASSLIBS
+    gis
+    raster
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.wavelet/CMakeLists.txt
+++ b/src/imagery/i.wavelet/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.wavelet)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  arrays.c
+  arrays.h
+  main.c
+  w_daubechies.h
+  wt_haar.c
+  wt_haar.h
+  wt.c
+  wt.h)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    imagery
+    raster
+  DEPENDS LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.wi/CMakeLists.txt
+++ b/src/imagery/i.wi/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.wi)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  awei.c
+  lswi.c
+  main.c
+  ndwi.c
+  tcw.c
+  wi.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/imagery/i.zero2null/CMakeLists.txt
+++ b/src/imagery/i.zero2null/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(i.zero2null LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    i_zero2null_s2_corr.png
+    i_zero2null_s2_uncorr.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)


### PR DESCRIPTION
Add CMake support for (the rest of) imagery Addons.

Missing addons are `i.pr`, which is broken since GRASS 7 API (I believe), quite some work to make that work at all; and `i.vi.mpi`, which I have not been able to work yet.