### PR TITLE
Restore cwd reliably in build-xml module scanning

### DIFF
--- a/utils/cronjobs_osgeo_lxd/build-xml.py
+++ b/utils/cronjobs_osgeo_lxd/build-xml.py
@@ -80,10 +80,13 @@ class BuildXML:
 
     def _get_module_files(self, name):
         cur_dir = os.getcwd()
-        os.chdir(os.path.join(self.build_path, name))
-        files = self._scandirs("*")
-        os.chdir(cur_dir)  # prevent gtask.parse_interface() return None
-        return files
+        module_dir = os.path.join(self.build_path, name)
+        try:
+            os.chdir(module_dir)
+            return self._scandirs("*")
+        finally:
+            # prevent follow-up failures when cwd is left in a module dir
+            os.chdir(cur_dir)
 
     def _get_module_metadata(self, name):
         path = os.environ["PATH"]


### PR DESCRIPTION
I noticed a small failure mode in utils/cronjobs_osgeo_lxd/build-xml.py: _get_module_files() changes into a module directory and restores cwd only on the success path. If _scandirs() raises, the process cwd stays changed and later steps can fail in confusing ways.\n\nThis patch wraps the chdir block in try/finally so cwd is always restored, including on exceptions. Behavior is unchanged on success, but error handling is now safer and deterministic.