### PR TITLE
cmake: add support for raster Addons

### DIFF
--- a/src/raster/r.agent/CMakeLists.txt
+++ b/src/raster/r.agent/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.agent LANGUAGES NONE)
+
+include(build_addon)
+
+add_subdirectory(libagent)
+
+build_addon(
+  ${PROJECT_NAME}
+  ADDONS
+    r.agent.aco
+    r.agent.rand
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.agent/libagent/CMakeLists.txt
+++ b/src/raster/r.agent/libagent/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_files_to_etc_dir(
+  "r.agent/libagent"
+  FILES
+    __init__.py
+    agent.py
+    ant.py
+    anthill.py
+    error.py
+    grassland.py
+    playground.py
+    world.py)

--- a/src/raster/r.agent/r.agent.aco/CMakeLists.txt
+++ b/src/raster/r.agent/r.agent.aco/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(r.agent.aco)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.agent/r.agent.rand/CMakeLists.txt
+++ b/src/raster/r.agent/r.agent.rand/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(r.agent.rand)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.area.createweight/CMakeLists.txt
+++ b/src/raster/r.area.createweight/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.area.createweight LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_area_createweight_census_final.png
+    r_area_createweight_census_initial.png
+    r_area_createweight_census_merge.png
+    r_area_createweight_distance_streets.png
+    r_area_createweight_gridded_spatial_units.png
+    r_area_createweight_importances_plot_names.png
+    r_area_createweight_importances_plot_nonames.png
+    r_area_createweight_input_spatial_units.png
+    r_area_createweight_overlap_admin.png
+    r_area_createweight_weights.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.area/CMakeLists.txt
+++ b/src/raster/r.area/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.area)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    main.c
+  GRASSLIBS
+    gis
+    raster
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.basin/CMakeLists.txt
+++ b/src/raster/r.basin/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.basin LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_basin_map.png
+    r_basin1.png
+    r_basin2.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.bearing.distance/CMakeLists.txt
+++ b/src/raster/r.bearing.distance/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.bearing.distance)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  azimuth.c
+  azimuth.h
+  file.c
+  file.h
+  global_vars.h
+  main.c
+  raster_file.c
+  raster_file.h)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS
+    LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.bioclim/CMakeLists.txt
+++ b/src/raster/r.bioclim/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.bioclim LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.bitpattern/CMakeLists.txt
+++ b/src/raster/r.bitpattern/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.bitpattern)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES main.c
+  GRASSLIBS
+    gis
+    raster
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.boxplot/CMakeLists.txt
+++ b/src/raster/r.boxplot/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.boxplot LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_boxplot_01.png
+    r_boxplot_02.png
+    r_boxplot_03.png
+    r_boxplot_04.png
+    r_boxplot_05.png
+    r_boxplot_06.png
+    r_boxplot_map_03.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.buildvrt.gdal/CMakeLists.txt
+++ b/src/raster/r.buildvrt.gdal/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.buildvrt.gdal LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.catchment/CMakeLists.txt
+++ b/src/raster/r.catchment/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.catchment LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.category.trim/CMakeLists.txt
+++ b/src/raster/r.category.trim/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.category.trim LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.cell.area/CMakeLists.txt
+++ b/src/raster/r.cell.area/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.cell.area LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.centroids/CMakeLists.txt
+++ b/src/raster/r.centroids/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.centroids LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_centroids_basin_50K.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.change.info/CMakeLists.txt
+++ b/src/raster/r.change.info/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.change.info)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  bufs.c
+  chisq.c
+  dist.c
+  gain.c
+  gather.c
+  gini.c
+  local_proto.h
+  main.c
+  ncb.h
+  null_cats.c
+  ratio.c
+  readcell.c
+  window.h)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS
+    LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.clip/CMakeLists.txt
+++ b/src/raster/r.clip/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.clip LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.colors.contrastbrightness/CMakeLists.txt
+++ b/src/raster/r.colors.contrastbrightness/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.colors.contrastbrightness)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES main.c
+  GRASSLIBS
+    gis
+    raster
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.colors.cubehelix/CMakeLists.txt
+++ b/src/raster/r.colors.cubehelix/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.colors.cubehelix LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_colors_cubehelix_two_colors.png
+    r_colors_cubehelix.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.colors.out_sld/CMakeLists.txt
+++ b/src/raster/r.colors.out_sld/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.colors.out_sld LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.confusionmatrix/CMakeLists.txt
+++ b/src/raster/r.confusionmatrix/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.confusionmatrix LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.connectivity/CMakeLists.txt
+++ b/src/raster/r.connectivity/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.connectivity LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  ADDONS
+    r.connectivity.corridors
+    r.connectivity.distance
+    r.connectivity.network
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.connectivity/r.connectivity.corridors/CMakeLists.txt
+++ b/src/raster/r.connectivity/r.connectivity.corridors/CMakeLists.txt
@@ -1,0 +1,12 @@
+project(r.connectivity.corridors)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_connectivity_corridors_cf_u_sum_all.png
+    r_connectivity_corridors_mst_eb.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.connectivity/r.connectivity.distance/CMakeLists.txt
+++ b/src/raster/r.connectivity/r.connectivity.distance/CMakeLists.txt
@@ -1,0 +1,14 @@
+project(r.connectivity.distance)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_connectivity_distance_costs.png
+    r_connectivity_distance_network.png
+    r_connectivity_distance_patches.png
+    r_connectivity_distance_shortest_paths.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.connectivity/r.connectivity.network/CMakeLists.txt
+++ b/src/raster/r.connectivity/r.connectivity.network/CMakeLists.txt
@@ -1,0 +1,15 @@
+project(r.connectivity.network)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+  overview.png
+    r_connectivity_network_deg_udc.png
+    r_connectivity_network_ebc_udc.png
+    r_connectivity_network_kernel.png
+    r_connectivity_network_overview.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.convergence/CMakeLists.txt
+++ b/src/raster/r.convergence/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.convergence)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  local_proto.h
+  main.c
+  memory.c
+  slope_aspect.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS
+    LIBM
+  DOCFILES
+    conv.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.cpt2grass/CMakeLists.txt
+++ b/src/raster/r.cpt2grass/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.cpt2grass LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_cpt2grass_color_table_DEM_screen.png
+    r_cpt2grass_color_table_YlOrBr_09.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.crater/CMakeLists.txt
+++ b/src/raster/r.crater/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.crater)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  crater.c
+  crater.h
+  main.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS
+    LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.damflood/CMakeLists.txt
+++ b/src/raster/r.damflood/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.damflood)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  main.c
+  SWE.c
+  SWE.h)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS
+    LIBM
+  DOCFILES
+    dam_failure.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.denoise/CMakeLists.txt
+++ b/src/raster/r.denoise/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.denoise LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.divergence/CMakeLists.txt
+++ b/src/raster/r.divergence/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.divergence LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.diversity/CMakeLists.txt
+++ b/src/raster/r.diversity/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.diversity LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.droka/CMakeLists.txt
+++ b/src/raster/r.droka/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.droka LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_droka_img.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.earthworks/CMakeLists.txt
+++ b/src/raster/r.earthworks/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.earthworks LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_earthworks_01.png
+    r_earthworks_02.png
+    r_earthworks_03.png
+    r_earthworks_04.png
+    r_earthworks_05.png
+    r_earthworks_06.png
+    r_earthworks_07.png
+    r_earthworks_08.png
+    r_earthworks_09.png
+    r_earthworks_10.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.edm.eval/CMakeLists.txt
+++ b/src/raster/r.edm.eval/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.edm.eval LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_edm_eval_01.png
+    r_edm_eval_02.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.euro.ecosystem/CMakeLists.txt
+++ b/src/raster/r.euro.ecosystem/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.euro.ecosystem LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.exdet/CMakeLists.txt
+++ b/src/raster/r.exdet/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.exdet LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.extract/CMakeLists.txt
+++ b/src/raster/r.extract/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.extract LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.fidimo/CMakeLists.txt
+++ b/src/raster/r.fidimo/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.fidimo LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.fill.category/CMakeLists.txt
+++ b/src/raster/r.fill.category/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.fill.category LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.findtheriver/CMakeLists.txt
+++ b/src/raster/r.findtheriver/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.findtheriver)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  find_stream.c
+  global.h
+  main.c
+  point_list.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS
+    LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.flexure/CMakeLists.txt
+++ b/src/raster/r.flexure/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.flexure LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.flip/CMakeLists.txt
+++ b/src/raster/r.flip/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.flip)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES main.c
+  GRASSLIBS
+    gis
+    raster
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.flowfill/CMakeLists.txt
+++ b/src/raster/r.flowfill/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.flowfill LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.forcircular/CMakeLists.txt
+++ b/src/raster/r.forcircular/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.forcircular LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    avoided_emission.png
+    dip.png
+    parcel.png
+    stumpage_function.png
+    stumpage.png
+    tech_function.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.forestfrag/CMakeLists.txt
+++ b/src/raster/r.forestfrag/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.forestfrag LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_forestfrag_window_11.png
+    r_forestfrag_window_7.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.fusion/CMakeLists.txt
+++ b/src/raster/r.fusion/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.fusion LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.futures/CMakeLists.txt
+++ b/src/raster/r.futures/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.futures LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  ADDONS
+    r.futures.calib
+    r.futures.demand
+    r.futures.devpressure
+    r.futures.gridvalidation
+    r.futures.parallelpga
+    r.futures.pga
+    r.futures.potential
+    r.futures.potsurface
+    r.futures.simulation
+    r.futures.validation
+  DOCFILES
+    FUTURES_inputs_diagram.png
+    r_futures_ncsmp.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.futures/r.futures.calib/CMakeLists.txt
+++ b/src/raster/r.futures/r.futures.calib/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(r.futures.calib LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.futures/r.futures.demand/CMakeLists.txt
+++ b/src/raster/r.futures/r.futures.demand/CMakeLists.txt
@@ -1,0 +1,15 @@
+project(r.futures.demand LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_futures_demand_plot_exp_approach.png
+    r_futures_demand_plot_exponential.png
+    r_futures_demand_plot_linear.png
+    r_futures_demand_plot_logarithmic.png
+    r_futures_demand_plot_logarithmic2.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.futures/r.futures.devpressure/CMakeLists.txt
+++ b/src/raster/r.futures/r.futures.devpressure/CMakeLists.txt
@@ -1,0 +1,11 @@
+project(r.futures.devpressure LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    devpressure_example.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.futures/r.futures.gridvalidation/CMakeLists.txt
+++ b/src/raster/r.futures/r.futures.gridvalidation/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(r.futures.gridvalidation LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.futures/r.futures.parallelpga/CMakeLists.txt
+++ b/src/raster/r.futures/r.futures.parallelpga/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(r.futures.parallelpga LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.futures/r.futures.pga/CMakeLists.txt
+++ b/src/raster/r.futures/r.futures.pga/CMakeLists.txt
@@ -1,0 +1,42 @@
+project(r.futures.pga)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  devpressure.c
+  devpressure.h
+  inputs.c
+  inputs.h
+  keyvalue.c
+  keyvalue.h
+  main.c
+  output.c
+  output.h
+  patch.c
+  patch.h
+  simulation.c
+  simulation.h
+  utils.c
+  utils.h)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    datetime
+    gis
+    raster
+    segment
+  DEPENDS
+    LIBM
+  DOCFILES
+    incentive.png
+    r_futures_detail.png
+    r_futures_scenario_infill.png
+    r_futures_scenario_sprawl.png
+    r_futures_scenario_status_quo.png
+    r_futures.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.futures/r.futures.potential/CMakeLists.txt
+++ b/src/raster/r.futures/r.futures.potential/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(r.futures.potential LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.futures/r.futures.potsurface/CMakeLists.txt
+++ b/src/raster/r.futures/r.futures.potsurface/CMakeLists.txt
@@ -1,0 +1,11 @@
+project(r.futures.potsurface LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_futures_potsurface.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.futures/r.futures.simulation/CMakeLists.txt
+++ b/src/raster/r.futures/r.futures.simulation/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(r.futures.simulation LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.futures/r.futures.validation/CMakeLists.txt
+++ b/src/raster/r.futures/r.futures.validation/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(r.futures.validation LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.fuzzy.logic/CMakeLists.txt
+++ b/src/raster/r.fuzzy.logic/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.fuzzy.logic)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  local_proto.h
+  logic.c
+  main.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS
+    LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.fuzzy.set/CMakeLists.txt
+++ b/src/raster/r.fuzzy.set/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.fuzzy.set)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  fuzzy.c
+  local_proto.h
+  main.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS
+    LIBM
+  DOCFILES
+    boundary.png
+    set.png
+    shape.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.fuzzy.system/CMakeLists.txt
+++ b/src/raster/r.fuzzy.system/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.fuzzy.system)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  fuzzylogic.c
+  helpers.c
+  io.c
+  local_proto.h
+  main.c
+  map_parser.c
+  rule_parser.c
+  system.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS
+    LIBM
+  DOCFILES
+    f_result.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.gradient/CMakeLists.txt
+++ b/src/raster/r.gradient/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.gradient LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.gravity.terrain/CMakeLists.txt
+++ b/src/raster/r.gravity.terrain/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.gravity.terrain LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_gravity_terrain.png
+    TC_compare.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.green/CMakeLists.txt
+++ b/src/raster/r.green/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.green LANGUAGES NONE)
+
+include(build_addon)
+
+add_subdirectory(libgreen)
+
+build_addon(
+  ${PROJECT_NAME}
+  ADDONS
+    r.green.biomassfor
+    r.green.gshp
+    r.green.hydro
+    r.green.install
+  DOCFILES
+    r_green.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.green/libgreen/CMakeLists.txt
+++ b/src/raster/r.green/libgreen/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_files_to_etc_dir(
+  r.green/libgreen
+  FILES
+    __init__.py
+    checkparameter.py
+    utils.py)

--- a/src/raster/r.green/r.green.biomassfor/CMakeLists.txt
+++ b/src/raster/r.green/r.green.biomassfor/CMakeLists.txt
@@ -1,0 +1,19 @@
+project(r.green.biomassfor)
+
+include(build_addon)
+
+add_subdirectory(libforest)
+
+build_addon(
+  ${PROJECT_NAME}
+  ADDONS
+    r.green.biomassfor.co2
+    r.green.biomassfor.financial
+    r.green.biomassfor.impact
+    r.green.biomassfor.legal
+    r.green.biomassfor.recommended
+    r.green.biomassfor.technical
+    r.green.biomassfor.theoretical
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.green/r.green.biomassfor/libforest/CMakeLists.txt
+++ b/src/raster/r.green/r.green.biomassfor/libforest/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_files_to_etc_dir(
+  "r.green/libforest"
+  FILES
+    __init__.py
+    financial.py
+    harvesting.py)

--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.co2/CMakeLists.txt
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.co2/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(r.green.biomassfor.co2)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.financial/CMakeLists.txt
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.financial/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(r.green.biomassfor.financial)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.impact/CMakeLists.txt
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.impact/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(r.green.biomassfor.impact)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.legal/CMakeLists.txt
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.legal/CMakeLists.txt
@@ -1,0 +1,12 @@
+project(r.green.biomassfor.legal)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    legal_input.png
+    legal_output.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.recommended/CMakeLists.txt
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.recommended/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(r.green.biomassfor.recommended)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.technical/CMakeLists.txt
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.technical/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(r.green.biomassfor.technical)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.theoretical/CMakeLists.txt
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.theoretical/CMakeLists.txt
@@ -1,0 +1,12 @@
+project(r.green.biomassfor.theoretical)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    theoretical_input.png
+    theoretical_output.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.green/r.green.gshp/CMakeLists.txt
+++ b/src/raster/r.green/r.green.gshp/CMakeLists.txt
@@ -1,0 +1,14 @@
+project(r.green.gshp)
+
+include(build_addon)
+
+add_subdirectory(libgshp)
+
+build_addon(
+  ${PROJECT_NAME}
+  ADDONS
+    r.green.gshp.technical
+    r.green.gshp.theoretical
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.green/r.green.gshp/libgshp/CMakeLists.txt
+++ b/src/raster/r.green/r.green.gshp/libgshp/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_files_to_etc_dir(
+  "r.green/libgshp"
+  FILES
+    __init__.py
+    ashrae.py
+    gpot.py)

--- a/src/raster/r.green/r.green.gshp/r.green.gshp.technical/CMakeLists.txt
+++ b/src/raster/r.green/r.green.gshp/r.green.gshp.technical/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(r.green.gshp.technical)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.green/r.green.gshp/r.green.gshp.theoretical/CMakeLists.txt
+++ b/src/raster/r.green/r.green.gshp/r.green.gshp.theoretical/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(r.green.gshp.theoretical)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.green/r.green.hydro/CMakeLists.txt
+++ b/src/raster/r.green/r.green.hydro/CMakeLists.txt
@@ -1,0 +1,22 @@
+project(r.green.hydro)
+
+include(build_addon)
+
+add_subdirectory(libhydro)
+
+build_addon(
+  ${PROJECT_NAME}
+  ADDONS
+    r.green.hydro.closest
+    r.green.hydro.delplants
+    r.green.hydro.discharge
+    r.green.hydro.financial
+    r.green.hydro.optimal
+    r.green.hydro.planning
+    r.green.hydro.recommended
+    r.green.hydro.structure
+    r.green.hydro.technical
+    r.green.hydro.theoretical
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.green/r.green.hydro/libhydro/CMakeLists.txt
+++ b/src/raster/r.green/r.green.hydro/libhydro/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_files_to_etc_dir(
+  r.green/libhydro
+  FILES
+    __init__.py
+    basin.py
+    optimal.py
+    plant.py)

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.closest/CMakeLists.txt
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.closest/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(r.green.hydro.closest)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.delplants/CMakeLists.txt
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.delplants/CMakeLists.txt
@@ -1,0 +1,12 @@
+project(r.green.hydro.delplants)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_green_hydro_delplants_input.png
+    r_green_hydro_delplants_output.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.discharge/CMakeLists.txt
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.discharge/CMakeLists.txt
@@ -1,0 +1,13 @@
+project(r.green.hydro.discharge)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r.green.hydro.discharge_input.png
+    r.green.hydro.discharge_output_table.png
+    r.green.hydro.discharge_output.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.financial/CMakeLists.txt
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.financial/CMakeLists.txt
@@ -1,0 +1,20 @@
+project(r.green.hydro.financial)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_green_hydro_financial_compmap.png
+    r_green_hydro_financial_excmap.png
+    r_green_hydro_financial_fcompensation.png
+    r_green_hydro_financial_fexcavation.png
+    r_green_hydro_financial_fgamma.png
+    r_green_hydro_financial_flinearcost.png
+    r_green_hydro_financial_fnpv.png
+    r_green_hydro_financial_fvu.png
+    r_green_hydro_financial_input.png
+    r_green_hydro_financial_tableeco.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.optimal/CMakeLists.txt
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.optimal/CMakeLists.txt
@@ -1,0 +1,12 @@
+project(r.green.hydro.optimal)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_green_hydro_optimal_input.png
+    r_green_hydro_optimal_output.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.planning/CMakeLists.txt
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.planning/CMakeLists.txt
@@ -1,0 +1,15 @@
+project(r.green.hydro.planning)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_green_hydro_planning_input_PNAM.png
+    r_green_hydro_planning_input.png
+    r_green_hydro_planning_output_park.png
+    r_green_hydro_planning_output_PNAM3.png
+    r_green_hydro_planning_output_points.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.recommended/CMakeLists.txt
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.recommended/CMakeLists.txt
@@ -1,0 +1,15 @@
+project(r.green.hydro.recommended)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_green_hydro_recommended_input_PNAM.png
+    r_green_hydro_recommended_input.png
+    r_green_hydro_recommended_output_park.png
+    r_green_hydro_recommended_output_PNAM3.png
+    r_green_hydro_recommended_output_points.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.structure/CMakeLists.txt
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.structure/CMakeLists.txt
@@ -1,0 +1,13 @@
+project(r.green.hydro.structure)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_green_hydro_structure_input.png
+    r_green_hydro_structure_output.png
+    r_green_hydro_structure_picstruct.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.technical/CMakeLists.txt
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.technical/CMakeLists.txt
@@ -1,0 +1,13 @@
+project(r.green.hydro.technical)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_green_hydro_technical_input.png
+    r_green_hydro_technical_output.png
+    r_green_hydro_technical_picstruct.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.theoretical/CMakeLists.txt
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.theoretical/CMakeLists.txt
@@ -1,0 +1,13 @@
+project(r.green.hydro.theoretical)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_green_hydro_theoretical_input.png
+    r_green_hydro_theoretical_output.png
+    r_green_hydro_theoretical_streams.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.green/r.green.install/CMakeLists.txt
+++ b/src/raster/r.green/r.green.install/CMakeLists.txt
@@ -1,0 +1,11 @@
+project(r.green.install)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_green_install_permissions.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.gsflow.hydrodem/CMakeLists.txt
+++ b/src/raster/r.gsflow.hydrodem/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.gsflow.hydrodem LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.gwr/CMakeLists.txt
+++ b/src/raster/r.gwr/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.gwr)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  bufs.c
+  bufs.h
+  estimate_bw.c
+  flag.c
+  flag.h
+  gwr.c
+  gwr.h
+  gwra.c
+  local_proto.h
+  main.c
+  pavl.c
+  pavl.h
+  rclist.c
+  rclist.h
+  weights.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    gmath
+    raster
+    segment
+  DEPENDS
+    LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.hants/CMakeLists.txt
+++ b/src/raster/r.hants/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.hants)
+
+include(build_addon)
+
+find_M()
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES main.c
+  GRASSLIBS
+    gis
+    gmath
+    raster
+  DEPENDS
+    LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.hazard.flood/CMakeLists.txt
+++ b/src/raster/r.hazard.flood/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.hazard.flood LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.houghtransform/CMakeLists.txt
+++ b/src/raster/r.houghtransform/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.houghtransform)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  hough.cpp
+  hough.h
+  houghparameters.h
+  houghtransform.cpp
+  houghtransform.h
+  linesegmentsextractor.cpp
+  linesegmentsextractor.h
+  main.cpp
+  matrix.h)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    gmath
+    raster
+    vector
+  DEPENDS
+    LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.hydro.flatten/CMakeLists.txt
+++ b/src/raster/r.hydro.flatten/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.hydro.flatten LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_hydro_flatten_input.png
+    r_hydro_flatten_output_elevation.png
+    r_hydro_flatten_output_stddev.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.hydrodem/CMakeLists.txt
+++ b/src/raster/r.hydrodem/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.hydrodem)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  bseg.c
+  close.c
+  cseg.c
+  do_astar.c
+  dseg.c
+  flag.h
+  hydro_con.c
+  init_search.c
+  load.c
+  local_proto.h
+  main.c
+  seg.c
+  seg.h)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    raster
+    segment
+    vector
+  DEPENDS
+    LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.in.ahn/CMakeLists.txt
+++ b/src/raster/r.in.ahn/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.in.ahn LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_in_ahn_01.png
+    r_in_ahn_02.png
+    r_in_ahn_03.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.in.nasadem/CMakeLists.txt
+++ b/src/raster/r.in.nasadem/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.in.nasadem LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_in_nasadem_etna.jpg
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.in.ogc/CMakeLists.txt
+++ b/src/raster/r.in.ogc/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.in.ogc LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  ADDONS
+    r.in.ogc.coverages
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.in.ogc/r.in.ogc.coverages/CMakeLists.txt
+++ b/src/raster/r.in.ogc/r.in.ogc.coverages/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(r.in.ogc.coverages)
+
+include(build_addon LANGUAGES NONE)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.in.srtm.region/CMakeLists.txt
+++ b/src/raster/r.in.srtm.region/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.in.srtm.region LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_in_srtm_region_etna.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.in.usgs/CMakeLists.txt
+++ b/src/raster/r.in.usgs/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.in.usgs LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_in_usgs.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.in.wcs/CMakeLists.txt
+++ b/src/raster/r.in.wcs/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.in.wcs LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.jpdf/CMakeLists.txt
+++ b/src/raster/r.jpdf/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.jpdf)
+
+include(build_addon)
+
+find_M()
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES main.c
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS
+    LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.lake.series/CMakeLists.txt
+++ b/src/raster/r.lake.series/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.lake.series LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r.lake.series.jpg
+    rural_flooding_105.jpg
+    rural_flooding_108.jpg
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.landscape.evol.old/CMakeLists.txt
+++ b/src/raster/r.landscape.evol.old/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.landscape.evol.old LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_landscape_evol_equation1.png
+    r_landscape_evol_equation2.png
+    r_landscape_evol_equation3.png
+    r_landscape_evol_equation4.png
+    r_landscape_evol_equation5.png
+    r_landscape_evol_equation6.png
+    r_landscape_evol_Flow_acc_vs_curvature.png
+    r_landscape_evol_Map1.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.landscape.evol/CMakeLists.txt
+++ b/src/raster/r.landscape.evol/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.landscape.evol LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.learn.ml/CMakeLists.txt
+++ b/src/raster/r.learn.ml/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.learn.ml LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    rfclassification.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.learn.ml2/CMakeLists.txt
+++ b/src/raster/r.learn.ml2/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.learn.ml2 LANGUAGES NONE)
+
+include(build_addon)
+
+add_subdirectory(rlearnlib)
+
+build_addon(
+  ${PROJECT_NAME}
+  ADDONS
+    r.learn.predict
+    r.learn.train
+  DOCFILES
+    lsat7_2000_b742.png
+    rfclassification.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.learn.ml2/r.learn.predict/CMakeLists.txt
+++ b/src/raster/r.learn.ml2/r.learn.predict/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(r.learn.predict LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.learn.ml2/r.learn.train/CMakeLists.txt
+++ b/src/raster/r.learn.ml2/r.learn.train/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(r.learn.train LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.learn.ml2/rlearnlib/CMakeLists.txt
+++ b/src/raster/r.learn.ml2/rlearnlib/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_files_to_etc_dir(
+  r.learn.ml2/rlearnlib
+  FILES
+    indexing.py
+    raster.py
+    stats.py
+    transformers.py
+    utils.py)

--- a/src/raster/r.lfp/CMakeLists.txt
+++ b/src/raster/r.lfp/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.lfp)
+
+include(build_addon)
+
+find_OpenMP()
+find_M()
+
+set(sources
+  direction.c
+  gettimeofday.c
+  global.h
+  lfp_funcs.h
+  main.c
+  outlet_list.c
+  outlets.c
+  point_list.c
+  timeval_diff.c
+  write.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    dbmibase
+    dbmiclient
+    gis
+    raster
+    vector
+  DEPENDS
+    LIBM
+  OPTIONAL_DEPENDS
+    OpenMP::OpenMP_C
+  DOCFILES
+    r_lfp_custom_formats.png
+    r_lfp_elev_state_500m_example.png
+    r_lfp_elevation_example.png
+    r_lfp_formats.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.local.relief/CMakeLists.txt
+++ b/src/raster/r.local.relief/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.local.relief LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r.local.relief_redblue.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.mapcalc.tiled/CMakeLists.txt
+++ b/src/raster/r.mapcalc.tiled/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.mapcalc.tiled LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.massmov/CMakeLists.txt
+++ b/src/raster/r.massmov/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.massmov)
+
+include(build_addon)
+
+find_OpenMP()
+find_M()
+
+set(sources
+  filters.c
+  filters.h
+  general_f.c
+  general_f.h
+  main.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS
+    LIBM
+  OPTIONAL_DEPENDS
+    OpenMP::OpenMP_C
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.maxent.lambdas/CMakeLists.txt
+++ b/src/raster/r.maxent.lambdas/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.maxent.lambdas LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.maxent.predict/CMakeLists.txt
+++ b/src/raster/r.maxent.predict/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.maxent.predict LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_maxent_predict_01.png
+    r_maxent_predict_02.png
+    r_maxent_predict_workflow.png
+    r_maxent_train.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.maxent.setup/CMakeLists.txt
+++ b/src/raster/r.maxent.setup/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.maxent.setup LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.maxent.train/CMakeLists.txt
+++ b/src/raster/r.maxent.train/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.maxent.train LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_maxent_train_01.png
+    r_maxent_train_02.png
+    r_maxent_train_workflow.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.mblend/CMakeLists.txt
+++ b/src/raster/r.mblend/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.mblend LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    blended.png
+    both_inputs.png
+    edges.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.mcda.ahp/CMakeLists.txt
+++ b/src/raster/r.mcda.ahp/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.mcda.ahp LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.mcda.electre/CMakeLists.txt
+++ b/src/raster/r.mcda.electre/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.mcda.electre)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  dominance.c
+  local_proto.h
+  main.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS
+    LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.mcda.input/CMakeLists.txt
+++ b/src/raster/r.mcda.input/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.mcda.input LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.mcda.output/CMakeLists.txt
+++ b/src/raster/r.mcda.output/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.mcda.output LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.mcda.promethee/CMakeLists.txt
+++ b/src/raster/r.mcda.promethee/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.mcda.promethee)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  local_proto.h
+  main.c
+  promethee.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS
+    LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.mcda.roughset/CMakeLists.txt
+++ b/src/raster/r.mcda.roughset/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.mcda.roughset LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.mcda.topsis/CMakeLists.txt
+++ b/src/raster/r.mcda.topsis/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.mcda.topsis LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.meb/CMakeLists.txt
+++ b/src/raster/r.meb/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.meb LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_meb_concept.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.mess/CMakeLists.txt
+++ b/src/raster/r.mess/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.mess LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_mess_Ex_01.png
+    r_mess_Ex_02.png
+    r_mess_Ex_03.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.mregression.series/CMakeLists.txt
+++ b/src/raster/r.mregression.series/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.mregression.series LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.mwprecip/CMakeLists.txt
+++ b/src/raster/r.mwprecip/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.mwprecip LANGUAGES NONE)
+
+include(build_addon)
+
+add_files_to_etc_dir(${PROJECT_NAME} FILES pgwrapper.py)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.neighborhoodmatrix/CMakeLists.txt
+++ b/src/raster/r.neighborhoodmatrix/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.neighborhoodmatrix)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  main.c
+  pavl.c
+  pavl.h)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS
+    LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.niche.similarity/CMakeLists.txt
+++ b/src/raster/r.niche.similarity/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.niche.similarity LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_niche_similarity.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.northerness.easterness/CMakeLists.txt
+++ b/src/raster/r.northerness.easterness/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.northerness.easterness LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.null.all/CMakeLists.txt
+++ b/src/raster/r.null.all/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.null.all LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.object.activelearning/CMakeLists.txt
+++ b/src/raster/r.object.activelearning/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.object.activelearning LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.object.spatialautocor/CMakeLists.txt
+++ b/src/raster/r.object.spatialautocor/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.object.spatialautocor LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.object.thickness/CMakeLists.txt
+++ b/src/raster/r.object.thickness/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.object.thickness LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.out.kde/CMakeLists.txt
+++ b/src/raster/r.out.kde/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.out.kde LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_out_kde.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.out.legend/CMakeLists.txt
+++ b/src/raster/r.out.legend/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.out.legend LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_out_legend_1.png
+    r_out_legend_2.png
+    r_out_legend_3.png
+    r_out_legend_4.png
+    r_out_legend_5.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.out.maxent_swd/CMakeLists.txt
+++ b/src/raster/r.out.maxent_swd/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.out.maxent_swd LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.out.ntv2/CMakeLists.txt
+++ b/src/raster/r.out.ntv2/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.out.ntv2 LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.patch.smooth/CMakeLists.txt
+++ b/src/raster/r.patch.smooth/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.patch.smooth LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_patch_smooth_overview.png
+    r_patch_smooth_parallel_smoothing.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.pi/CMakeLists.txt
+++ b/src/raster/r.pi/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.pi)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  ADDONS
+    r.pi.corearea
+    r.pi.corr.mw
+    r.pi.csr.mw
+    r.pi.energy
+    r.pi.energy.pr
+    r.pi.enn
+    r.pi.enn.pr
+    r.pi.export
+    r.pi.fnn
+    r.pi.graph
+    r.pi.graph.dec
+    r.pi.graph.pr
+    r.pi.graph.red
+    r.pi.grow
+    r.pi.import
+    r.pi.index
+    r.pi.library
+    r.pi.lm
+    r.pi.neigh
+    r.pi.nlm
+    r.pi.nlm.circ
+    r.pi.nlm.stats
+    r.pi.odc
+    r.pi.prob.mw
+    r.pi.prox
+    r.pi.rectangle
+    r.pi.searchtime
+    r.pi.searchtime.mw
+    r.pi.searchtime.pr
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.pi/r.pi.corearea/CMakeLists.txt
+++ b/src/raster/r.pi/r.pi.corearea/CMakeLists.txt
@@ -1,0 +1,23 @@
+project(r.pi.corearea)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  func.c
+  local_proto.h
+  main.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    raster
+    stats
+  DEPENDS
+    LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.popgrowth/CMakeLists.txt
+++ b/src/raster/r.popgrowth/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.popgrowth LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.pops.spread/CMakeLists.txt
+++ b/src/raster/r.pops.spread/CMakeLists.txt
@@ -1,0 +1,54 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.pops.spread)
+
+include(build_addon)
+
+find_M()
+find_OpenMP()
+
+set(sources
+  graster.hpp
+  main.cpp)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    datetime
+    gis
+    raster
+    vector
+  DEPENDS
+    LIBM
+  OPTIONAL_DEPENDS
+    OpenMP::OpenMP_CXX
+  DOCFILES
+    pops_logo.png
+    r_pops_spread.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)
+
+target_include_directories(${PROJECT_NAME} PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/pops-core/include>)
+
+target_sources(${PROJECT_NAME} PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/pops-core/include/pops/config.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/pops-core/include/pops/date.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/pops-core/include/pops/deterministic_kernel.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/pops-core/include/pops/kernel_types.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/pops-core/include/pops/kernel.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/pops-core/include/pops/model.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/pops-core/include/pops/natural_anthropogenic_kernel.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/pops-core/include/pops/neighbor_kernel.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/pops-core/include/pops/quarantine.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/pops-core/include/pops/radial_kernel.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/pops-core/include/pops/raster.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/pops-core/include/pops/scheduling.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/pops-core/include/pops/simulation.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/pops-core/include/pops/spread_rate.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/pops-core/include/pops/statistics.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/pops-core/include/pops/switch_kernel.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/pops-core/include/pops/treatments.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/pops-core/include/pops/uniform_kernel.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/pops-core/include/pops/utils.hpp)

--- a/src/raster/r.prominence/CMakeLists.txt
+++ b/src/raster/r.prominence/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.prominence)
+
+include(build_addon)
+
+find_M()
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES main.c
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS
+    LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.quantile.ref/CMakeLists.txt
+++ b/src/raster/r.quantile.ref/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.quantile.ref)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES main.c
+  GRASSLIBS
+    gis
+    raster
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.random.walk/CMakeLists.txt
+++ b/src/raster/r.random.walk/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.random.walk LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_random_walk_example_2.png
+    r_random_walk_example.png
+    random_walk_output.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.random.weight/CMakeLists.txt
+++ b/src/raster/r.random.weight/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.random.weight LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.recode.attr/CMakeLists.txt
+++ b/src/raster/r.recode.attr/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.recode.attr LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_recode_attr_01.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.regression.series/CMakeLists.txt
+++ b/src/raster/r.regression.series/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.regression.series)
+
+include(build_addon)
+
+find_M()
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES main.c
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS
+    LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.resamp.tps/CMakeLists.txt
+++ b/src/raster/r.resamp.tps/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.regression.series)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  cache.c
+  cache.h
+  flag.c
+  flag.h
+  main.c
+  pavlrc.c
+  pavlrc.h
+  rclist.c
+  rclist.h
+  tps.c
+  tps.h)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    raster
+    segment
+  DEPENDS
+    LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.richdem.breachdepressions/CMakeLists.txt
+++ b/src/raster/r.richdem.breachdepressions/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.richdem.breachdepressions LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.richdem.filldepressions/CMakeLists.txt
+++ b/src/raster/r.richdem.filldepressions/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.richdem.filldepressions LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.richdem.flowaccumulation/CMakeLists.txt
+++ b/src/raster/r.richdem.flowaccumulation/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.richdem.flowaccumulation LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.richdem.resolveflats/CMakeLists.txt
+++ b/src/raster/r.richdem.resolveflats/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.richdem.resolveflats LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.richdem.terrainattribute/CMakeLists.txt
+++ b/src/raster/r.richdem.terrainattribute/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.richdem.terrainattribute LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.rock.stability/CMakeLists.txt
+++ b/src/raster/r.rock.stability/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.rock.stability LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.sample.category/CMakeLists.txt
+++ b/src/raster/r.sample.category/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.sample.category LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r.sample.category.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.scatterplot/CMakeLists.txt
+++ b/src/raster/r.scatterplot/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.scatterplot)
+
+include(build_addon)
+
+set(sources
+  main.c
+  vector_mask.c
+  vector_mask.h)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    raster
+    vector
+  DOCFILES
+    r_scatterplot_2_variables_3rd_color.png
+    r_scatterplot_2_variables_3rd_z_4th_color.png
+    r_scatterplot_2_variables_3rd_z_4th_color2.png
+    r_scatterplot_2_variables_3rd_z.png
+    r_scatterplot_2_variables.png
+    r_scatterplot_3_variables_3_colors_overlap.png
+    r_scatterplot_3_variables_3_colors.png
+    r_scatterplot_3_variables.png
+    r_scatterplot_density_full.png
+    r_scatterplot_density_grid_hexagons.png
+    r_scatterplot_density_grid_rectangles_res_1.png
+    r_scatterplot_density_grid_rectangles.png
+    r_scatterplot_density_res_120.png
+    r_scatterplot_density_res_240.png
+    r_scatterplot.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.seasons/CMakeLists.txt
+++ b/src/raster/r.seasons/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.seasons)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES main.c
+  GRASSLIBS
+    gis
+    raster
+  DOCFILES
+    global_ndvi.png
+    ndvi_season2_end1.png
+    ndvi_season2_start1.png
+    number_seasons_ndvi.png
+    time_series_ndvi.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.series.boxplot/CMakeLists.txt
+++ b/src/raster/r.series.boxplot/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.series.boxplot LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_series_boxplot_1.png
+    r_series_boxplot_2.png
+    r_series_boxplot_3.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.series.decompose/CMakeLists.txt
+++ b/src/raster/r.series.decompose/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.series.decompose LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.series.diversity/CMakeLists.txt
+++ b/src/raster/r.series.diversity/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.series.diversity LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.series.filter/CMakeLists.txt
+++ b/src/raster/r.series.filter/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.series.filter LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    flt.png
+    signal.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.series.lwr/CMakeLists.txt
+++ b/src/raster/r.series.lwr/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.series.lwr)
+
+include(build_addon)
+
+find_M()
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES main.c
+  GRASSLIBS
+    gis
+    gmath
+    raster
+  DEPENDS
+    LIBM
+  DOCFILES
+    r_series_lwr_cla_201281.png
+    r_series_lwr_cla_lwr1_lwr2.png
+    r_series_lwr_cla_lwr3_lwr4.png
+    r_series_lwr_cla_lwr7_201281.png
+    r_series_lwr_cla_orig_lwr5.png
+    r_series_lwr_cla_orig.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.shaded.pca/CMakeLists.txt
+++ b/src/raster/r.shaded.pca/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.shaded.pca LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r.shaded.pca.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.shalstab/CMakeLists.txt
+++ b/src/raster/r.shalstab/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.shalstab LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.sim.terrain/CMakeLists.txt
+++ b/src/raster/r.sim.terrain/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.sim.terrain LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_sim_terrain_rusle.png
+    r_sim_terrain.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.sim.water.mp/CMakeLists.txt
+++ b/src/raster/r.sim.water.mp/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.sim.water.mp)
+
+include(build_addon)
+
+find_M()
+find_OpenMP()
+
+set(sources
+  erod.c
+  hydro.c
+  input.c
+  main.c
+  observation_points.c
+  output.c
+  random.c
+  simlib.h
+  utils.c
+  waterglobs.h)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    bitmap
+    gis
+    gmath
+    linkm
+    raster
+    vector
+  DEPENDS
+    LIBM
+    OpenMP::OpenMP_C
+  DOCFILES
+    r_sim_water.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.skyview/CMakeLists.txt
+++ b/src/raster/r.skyview/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.skyview LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    elevation.jpg
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.slope.direction/CMakeLists.txt
+++ b/src/raster/r.slope.direction/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.slope.direction LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_slope_direction_fdir_slope_1.png
+    r_slope_direction_fdir_slope_13.png
+    r_slope_direction_fdir_slope_5.png
+    r_slope_direction_streets_wake_slope_1.png
+    r_slope_direction_streets_wake_slope_13.png
+    r_slope_direction_streets_wake_slope_5.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.slopeunits/CMakeLists.txt
+++ b/src/raster/r.slopeunits/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.slopeunits LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  ADDONS
+    r.slopeunits.clean
+    r.slopeunits.create
+    r.slopeunits.metrics
+    r.slopeunits.optimize
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.slopeunits/r.slopeunits.clean/CMakeLists.txt
+++ b/src/raster/r.slopeunits/r.slopeunits.clean/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(r.slopeunits.clean LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.slopeunits/r.slopeunits.create/CMakeLists.txt
+++ b/src/raster/r.slopeunits/r.slopeunits.create/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(r.slopeunits.create LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.slopeunits/r.slopeunits.metrics/CMakeLists.txt
+++ b/src/raster/r.slopeunits/r.slopeunits.metrics/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(r.slopeunits.metrics LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.slopeunits/r.slopeunits.optimize/CMakeLists.txt
+++ b/src/raster/r.slopeunits/r.slopeunits.optimize/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(r.slopeunits.optimize LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.smooth.seg/CMakeLists.txt
+++ b/src/raster/r.smooth.seg/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.smooth.seg)
+
+include(build_addon)
+
+find_M()
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    main.c
+    varseg.c
+    varseg.h
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS
+    LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.soillossbare/CMakeLists.txt
+++ b/src/raster/r.soillossbare/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.soillossbare LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.soils.texture/CMakeLists.txt
+++ b/src/raster/r.soils.texture/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.soils.texture)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    local_include.h
+    main.c
+  GRASSLIBS
+    gis
+    raster
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.stone/CMakeLists.txt
+++ b/src/raster/r.stone/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.stone)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  fixed_parameters.c
+  fixed_parameters.h
+  future_parameters.c
+  future_parameters.h
+  main.c
+  mmath.c
+  mmath.h
+  points.c
+  random2.c
+  random2.h
+  stone.c
+  stone.h
+  utils.c
+  utils.h)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS
+    LIBM
+  DOCFILES
+    counters.png
+    dem_source.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.stream.channel/CMakeLists.txt
+++ b/src/raster/r.stream.channel/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.stream.channel)
+
+include(build_addon)
+
+find_M()
+
+set(sources
+  io.c
+  io.h
+  local_proto.h
+  local_vars.h
+  main.c
+  stream_topology.c
+  stream_write.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${sources}
+  GRASSLIBS
+    gis
+    raster
+    segment
+  DEPENDS
+    LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.subdayprecip.design/CMakeLists.txt
+++ b/src/raster/r.subdayprecip.design/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.subdayprecip.design LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_subdayprecip_design_basin.png
+    r_subdayprecip_design_h_rast.png
+    r_subdayprecip_design_result.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.suitability.regions/CMakeLists.txt
+++ b/src/raster/r.suitability.regions/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.suitability.regions LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_suitability_regions_01.png
+    r_suitability_regions_02.png
+    r_suitability_regions_03.png
+    r_suitability_regions_04.png
+    r_suitability_regions_05.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.sun.daily/CMakeLists.txt
+++ b/src/raster/r.sun.daily/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.sun.daily LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.sun.hourly/CMakeLists.txt
+++ b/src/raster/r.sun.hourly/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.sun.hourly LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_sun_hourly.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.surf.idw2/CMakeLists.txt
+++ b/src/raster/r.surf.idw2/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.surf.idw2)
+
+include(build_addon)
+
+set(sources
+  local_proto.h
+  main.c
+  read_cell.c)
+
+build_addon(
+  ${PROJECT_NAME}
+  GRASSLIBS
+    gis
+    raster
+  SOURCES ${sources}
+  DOCFILES
+  ${PROJECT_NAME}.html
+  ${PROJECT_NAME}.md)

--- a/src/raster/r.surf.nnbathy/CMakeLists.txt
+++ b/src/raster/r.surf.nnbathy/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.surf.nnbathy LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.survey/CMakeLists.txt
+++ b/src/raster/r.survey/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.survey LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_survey_fig_2.png
+    r_survey_view_angle.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.terrain.texture/CMakeLists.txt
+++ b/src/raster/r.terrain.texture/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.terrain.texture LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    classification_example.png
+    convexity_example.png
+    flowchart.png
+    texture_example.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.texture.tiled/CMakeLists.txt
+++ b/src/raster/r.texture.tiled/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.texture.tiled LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.threshold/CMakeLists.txt
+++ b/src/raster/r.threshold/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.threshold LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.to.vect.lines/CMakeLists.txt
+++ b/src/raster/r.to.vect.lines/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.to.vect.lines LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_to_vect_lines_example.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.to.vect.tiled/CMakeLists.txt
+++ b/src/raster/r.to.vect.tiled/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.to.vect.tiled LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.traveltime/CMakeLists.txt
+++ b/src/raster/r.traveltime/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.traveltime)
+
+include(build_addon)
+
+find_M()
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES main.c
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS
+    LIBM
+  DOCFILES
+    r_traveltime.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.tri/CMakeLists.txt
+++ b/src/raster/r.tri/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.tri LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_tri.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.univar2/CMakeLists.txt
+++ b/src/raster/r.univar2/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.univar2)
+
+include(build_addon)
+
+find_M()
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    globals.h
+    r.univar_main.c
+    sort.c
+    stats.c
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS
+    LIBM
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.valley.bottom/CMakeLists.txt
+++ b/src/raster/r.valley.bottom/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.valley.bottom LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_valley_bottom_mrvbf.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.vect.stats/CMakeLists.txt
+++ b/src/raster/r.vect.stats/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.vect.stats LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_to_vect_schools_count.png
+    r_to_vect_schools_sum.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.vector.ruggedness/CMakeLists.txt
+++ b/src/raster/r.vector.ruggedness/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.vector.ruggedness LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.viewshed.cva/CMakeLists.txt
+++ b/src/raster/r.viewshed.cva/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.viewshed.cva LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.viewshed.exposure/CMakeLists.txt
+++ b/src/raster/r.viewshed.exposure/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.viewshed.exposure LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_viewshed_exposure_example_binary.png
+    r_viewshed_exposure_example_solid_angle.png
+    r_viewshed_exposure_workflow.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.vif/CMakeLists.txt
+++ b/src/raster/r.vif/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.vif LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_vif_example1.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.vol.dem/CMakeLists.txt
+++ b/src/raster/r.vol.dem/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.vol.dem)
+
+include(build_addon)
+
+find_M()
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    chull.c
+    chull.h
+    globals.h
+    macros.h
+    main.c
+  GRASSLIBS
+    gis
+    raster
+  DEPENDS
+    LIBM
+  DOCFILES
+    r_vol_dem_layerdown.jpg
+    r_vol_dem_layerup.jpg
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.wateroutlet.lessmem/CMakeLists.txt
+++ b/src/raster/r.wateroutlet.lessmem/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.wateroutlet.lessmem)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES
+    global.h
+    main.c
+    over_cells.c
+  GRASSLIBS
+    gis
+    raster
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.width.funct/CMakeLists.txt
+++ b/src/raster/r.width.funct/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.width.funct LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.windfetch/CMakeLists.txt
+++ b/src/raster/r.windfetch/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.windfetch LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    r_windfetch.png
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)

--- a/src/raster/r.zonal.classes/CMakeLists.txt
+++ b/src/raster/r.zonal.classes/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(r.zonal.classes LANGUAGES NONE)
+
+include(build_addon)
+
+build_addon(
+  ${PROJECT_NAME}
+  SOURCES ${PROJECT_NAME}.py
+  DOCFILES
+    ${PROJECT_NAME}.html
+    ${PROJECT_NAME}.md)


### PR DESCRIPTION
Add CMake support for most of the raster Addons.

There are code changes, updates needed for some Addons, which I will address elsewhere.

Addons not included here are: `r.pi`, `r.stream.variables`, `r.stream.watersheds` and `r.sun.mp` (`r.sun.mp`, by the way, could be removed I guess as it is in core now).

I tested all C/C++ based Addons, and the less-than-trivial Python based. There was some problem with Python path in build directory for e.g. `r.green` that has to be addressed in code (core).
