### PR TITLE
CI: cronjobs preview version update to GRASS 8.6

### DIFF
--- a/utils/cronjobs_osgeo_lxd/cron_grass_preview_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_preview_build_binaries.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # script to build GRASS GIS preview binaries + addons from the `main` branch
-# (c) 2002-2025, GPL 2+ Markus Neteler <neteler@osgeo.org>
+# (c) 2002-2026, GPL 2+ Markus Neteler <neteler@osgeo.org>
 #
 # GRASS GIS github, https://github.com/OSGeo/grass
 #
@@ -23,7 +23,7 @@
 # - run this script
 # - one time only: cross-link code into web space on grasslxd server:
 #     cd /var/www/html/
-#     ln -s /var/www/code_and_data/grass85 .
+#     ln -s /var/www/code_and_data/grass86 .
 #     ln -s /var/www/code_and_data/grass-devel .
 #
 #################################
@@ -34,7 +34,7 @@ PATH=$MAINDIR/bin:/bin:/usr/bin:/usr/local/bin
 
 # https://github.com/OSGeo/grass/tags
 GMAJOR=8
-GMINOR=5
+GMINOR=6
 GPATCH="0dev"  # required by grass-addons-index.sh
 BRANCH=main
 DOTVERSION=$GMAJOR.$GMINOR

--- a/utils/cronjobs_osgeo_lxd/cron_grass_preview_src_snapshot.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_preview_src_snapshot.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # script to build GRASS GIS preview source package from the `main` branch
-# (c) 2002-2024, GPL 2+ Markus Neteler <neteler@osgeo.org>
+# (c) 2002-2026, GPL 2+ Markus Neteler <neteler@osgeo.org>
 #
 # GRASS GIS github, https://github.com/OSGeo/grass
 #
@@ -23,7 +23,7 @@ PATH=$MAINDIR/bin:/bin:/usr/bin:/usr/local/bin
 
 # https://github.com/OSGeo/grass/tags
 GMAJOR=8
-GMINOR=5
+GMINOR=6
 BRANCH=main
 GVERSION=$GMAJOR.$GMINOR.git
 DOTVERSION=$GMAJOR.$GMINOR


### PR DESCRIPTION
Here the overdue update to increment the preview version cronjobs for source tarball and Linux binaries (needed for manual pages and programmer's manual) from GRASS 8.5 to GRASS 8.6.

:mega: Note: must not be merged until

- Update of grass.osgeo.org to Debian 12 (https://trac.osgeo.org/osgeo/ticket/3548)

has been completed (due to the need of PROJ 9.x).