### PR TITLE
tool: fix format definition in v.surf.rst.cv

### DIFF
--- a/src/vector/v.surf.rst.cv/v.surf.rst.cv.py
+++ b/src/vector/v.surf.rst.cv/v.surf.rst.cv.py
@@ -149,11 +149,9 @@
 # %end
 
 # %option G_OPT_F_FORMAT
-# % key: format
-# % label: Output format
-# % options: json,text
+# % options: plain,json
+# % descriptions: plain;Plain text output;json;JSON (JavaScript Object Notation);
 # % required: no
-# % description: Output format for the results
 # % guisection: Output
 # %end
 


### PR DESCRIPTION
Fix the use of G_OPT_F_FORMAT to avoid:

```sh
ERROR: Value <plain> out of range for parameter <format>
	Legal range: json,text
```
