### PR TITLE
i.eodag currently supports only EODAG v3

### DIFF
--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -999,6 +999,7 @@ def print_eodag_products(eodag_api, **kwargs) -> None:
         gs.message(_("Recognized product types offered by {}").format(provider))
     else:
         gs.message(_("Recognized product types"))
+
     products = eodag_api.list_product_types(provider)
     if product_type:
         # Check for parial matches
@@ -1339,6 +1340,8 @@ if __name__ == "__main__":
 
     try:
         import eodag
+        if int(eodag.__version__.split(".")[0]) != 3:
+            gs.fatal(_("Only EODAG version 3.x is currently supported"))
         from eodag import EODataAccessGateway, setup_logging
         from eodag.api.search_result import SearchResult
         from eodag.utils.exceptions import MisconfiguredError

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -1340,6 +1340,7 @@ if __name__ == "__main__":
 
     try:
         import eodag
+
         if int(eodag.__version__.split(".")[0]) != 3:
             gs.fatal(_("Only EODAG version 3.x is currently supported"))
         from eodag import EODataAccessGateway, setup_logging


### PR DESCRIPTION
`i.eodag` fails on EODAG v4 with:

```py
Traceback (most recent call last):
  File "/home/landamar/.grass8/addons/scripts/i.eodag", line 1358, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/landamar/.grass8/addons/scripts/i.eodag", line 1158, in main
    p["ID"] for p in dag.list_product_types(provider)
                     ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'EODataAccessGateway' object has no attribute 'list_product_types'
```

This PR changes the tool to fail gracefully with

```
ERROR: Only EODAG version 3.x is currently supported
```