### PR TITLE
r.runoff: Fixed cmake compilation 

### DIFF
--- a/src/raster/r.runoff/CMakeLists.txt
+++ b/src/raster/r.runoff/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.22)
-project(r.runoff LANGUAGES NONE))
+project(r.runoff LANGUAGES NONE)
 
 include(build_addon)
 


### PR DESCRIPTION
Removed extra `)` preventing tool from compiling with CMake.