### PR TITLE
Fix CI to fail on test failures, closes #946

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
         timeout-minutes: 45
         run: |
           cd grass-addons/src
-          ../.github/workflows/test.sh --config ../.gunittest.cfg
+            ../.github/workflows/test.sh --config ../.gunittest.cfg || exit 1
 
       - name: Make HTML test report available
         if: ${{ always() }}


### PR DESCRIPTION
Fix CI to fail on test failures #946

Add || exit 1 to test.sh command in ci.yml so GitHub Actions fails when tests fail.

Fixes https://github.com/OSGeo/grass-addons/issues/946