### PR TITLE
CI: disable PDAL in cronjob compilation

### DIFF
--- a/utils/cronjobs_osgeo_lxd/cron_grass_current_stable_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_current_stable_build_binaries.sh
@@ -104,7 +104,7 @@ CFLAGS=$CFLAGSSTRING LDFLAGS=$LDFLAGSSTRING ./configure \
   --with-postgres --with-postgres-includes=/usr/include/postgresql \
   --with-freetype --with-freetype-includes=/usr/include/freetype2 \
   --with-netcdf \
-  --with-pdal \
+  --without-pdal \
   --with-fftw \
   --with-nls \
   --with-libsvm \

--- a/utils/cronjobs_osgeo_lxd/cron_grass_legacy_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_legacy_build_binaries.sh
@@ -107,7 +107,7 @@ CFLAGS=$CFLAGSSTRING LDFLAGS=$LDFLAGSSTRING ./configure \
   --with-postgres --with-postgres-includes=/usr/include/postgresql \
   --with-freetype --with-freetype-includes=/usr/include/freetype2 \
   --with-netcdf \
-  --with-pdal \
+  --without-pdal \
   --with-fftw \
   --with-nls \
   --with-blas \

--- a/utils/cronjobs_osgeo_lxd/cron_grass_old_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_old_build_binaries.sh
@@ -107,7 +107,7 @@ CFLAGS=$CFLAGSSTRING LDFLAGS=$LDFLAGSSTRING ./configure \
   --with-postgres --with-postgres-includes=/usr/include/postgresql \
   --with-freetype --with-freetype-includes=/usr/include/freetype2 \
   --with-netcdf \
-  --with-pdal \
+  --without-pdal \
   --with-fftw \
   --with-nls \
   --with-blas \

--- a/utils/cronjobs_osgeo_lxd/cron_grass_preview_build_binaries.sh
+++ b/utils/cronjobs_osgeo_lxd/cron_grass_preview_build_binaries.sh
@@ -104,7 +104,7 @@ CFLAGS=$CFLAGSSTRING LDFLAGS=$LDFLAGSSTRING ./configure \
   --with-postgres --with-postgres-includes=/usr/include/postgresql \
   --with-freetype --with-freetype-includes=/usr/include/freetype2 \
   --with-netcdf \
-  --with-pdal \
+  --without-pdal \
   --with-fftw \
   --with-nls \
   --with-libsvm \


### PR DESCRIPTION
Since 2022, PDAL is no longer a Debian package (see [here](https://tracker.debian.org/pkg/pdal).

Subsequently, the cronjobs are adjusted in this PR to avoid `configure` failures (after today's Debian update on grass.osgeo.org).