### PR TITLE
CI(Renovate): Override base branch and ignore pinning of grass action from main

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -7,6 +7,7 @@
         "github>OSGeo/grass:renovate.json5",
         "customManagers:biomeVersions",
     ],
+    "baseBranchPatterns": [ "$default" ],
 
     "packageRules": [
         {
@@ -15,6 +16,12 @@
                 "biomejs/pre-commit",
                 "@biomejs/biome",
             ],
+        },
+        {
+            "matchPackageNames": [ "OSGeo/grass" ],
+            "matchUpdateTypes": [ "pinDigest" ],
+            "matchDatasources": [ "github-digest" ],
+            "enabled": false,
         },
     ],
 }


### PR DESCRIPTION
Since using the config from the main repo, a warning that the base branches listed in the main repo doesn't exist here has appeared. This PR tries to fix this by setting the base branch patterns, hoping that it will override the config that was extended.


Second part of the PR tries to ignore the pinning of the github action that comes from the main branch of the grass repo. We control both of these, and the grass-addons renovate PR is updated for each commit of the main repo, since we are not merging it. See https://github.com/OSGeo/grass-addons/pull/1683