### PR TITLE
r.futures: fix html doc

### DIFF
--- a/src/raster/r.futures/r.futures.gridvalidation/r.futures.gridvalidation.html
+++ b/src/raster/r.futures/r.futures.gridvalidation/r.futures.gridvalidation.html
@@ -81,7 +81,7 @@ r.futures.gridvalidation simulated=simulated_2016_reclass reference=reference_20
     Ecological Modelling, Volume 222, Issue 8.
 </li>
 </ul>
-</p>
+
 <p>FUTURES references:
 <ul>
 <li>
@@ -110,7 +110,6 @@ r.futures.gridvalidation simulated=simulated_2016_reclass reference=reference_20
     DOI: <a href="https://doi.org/10.1038/s41598-023-46195-9">10.1038/s41598-023-46195-9</a>
 </li>
 </ul>
-</p>
 
 
 <h2>SEE ALSO</h2>

--- a/src/raster/r.futures/r.futures.validation/r.futures.validation.html
+++ b/src/raster/r.futures/r.futures.validation/r.futures.validation.html
@@ -91,7 +91,6 @@ Example output:
     Ecological Modelling, Volume 222, Issue 8.
 </li>
 </ul>
-</p>
 
 <p>FUTURES references:
 <ul>
@@ -121,7 +120,6 @@ Example output:
     DOI: <a href="https://doi.org/10.1038/s41598-023-46195-9">10.1038/s41598-023-46195-9</a>
 </li>
 </ul>
-</p>
 
 <h2>SEE ALSO</h2>
 


### PR DESCRIPTION
This fixes:
```
Compiling...
/tmp/grass8-akratoc-2038748/tmpv6znl_pe/r.futures.gridvalidation/docs/html/r.futures.gridvalidation.html:192:0: Error (IndexError('pop from empty list')): </p>

make: *** [/home/akratoc/dev/grass/grass_main/dist.x86_64-pc-linux-gnu/include/Make/Html.make:15: /tmp/grass8-akratoc-2038748/tmpv6znl_pe/r.futures.gridvalidation/docs/man/man1/r.futures.gridvalidation.1] Error 1
ERROR: Compilation failed, sorry. Please check above error messages.
```