### PR TITLE
r.richdem: clarify resolveflats input; port dephier/fsm tests to step DEM

### DIFF
--- a/src/raster/r.richdem/r.richdem.dephier/testsuite/test_r_richdem_dephier.py
+++ b/src/raster/r.richdem/r.richdem.dephier/testsuite/test_r_richdem_dephier.py
@@ -3,18 +3,17 @@
 Synthetic DEM (5 x 5, 1 m resolution):
 
     5 5 5 5 5
-    5 3 3 3 5
-    5 3 1 3 3   <- centre pit (1); channel exits at right border (3)
-    5 3 3 3 5
+    5 9 9 9 5
+    5 9 1 4 5   <- pit=1, saddle=4 immediately left of right border
+    5 9 9 9 5
     5 5 5 5 5
 
-Pour-point elevation = 3 (the channel row connects the pit directly to
-the right border at elevation 3).
+Pour-point elevation = 5 (border cell adjacent to the saddle at elevation 4).
 
 Expected hierarchy properties:
-  - One leaf depression: the inner 3 x 3 basin draining to the centre pit.
-  - Pour-point elevation = 3 (channel border cell at row 3, col 5).
-  - Depression volume > 0 (centre cell is 2 m below the pour point).
+  - One leaf depression: the basin draining to the centre pit.
+  - Pour-point elevation = 5 (border cell at row 3, col 5).
+  - Depression volume > 0 (centre cell is below the pour point).
   - Border cells drain directly to the DEM boundary (label 0 / OCEAN).
   - Flow directions are in [0, 8] for all cells (8 marks the pit).
 """
@@ -37,11 +36,11 @@ _LABELS = "tmp_richdem_dephier_labels"
 _FLOWDIRS = "tmp_richdem_dephier_flowdirs"
 _HIERARCHY = "tmp_richdem_dephier_hierarchy"
 
-# 5x5: border=5, inner ring=3, centre=1; outlet at right border (row 3, col 5 = 3)
+# 5x5: border=5, ring=9, pit=1, saddle=4 at (row=3, col=4)
 _DEM_EXPR = (
     "if(row()==3 && col()==3, 1,"
-    " if(row()==3 && col()==5, 3,"
-    " if(row()==1 || row()==5 || col()==1 || col()==5, 5, 3)))"
+    " if(row()==3 && col()==4, 4,"
+    " if(row()==1 || row()==5 || col()==1 || col()==5, 5, 9)))"
 )
 
 

--- a/src/raster/r.richdem/r.richdem.dephier/testsuite/test_r_richdem_dephier.py
+++ b/src/raster/r.richdem/r.richdem.dephier/testsuite/test_r_richdem_dephier.py
@@ -4,11 +4,11 @@ Synthetic DEM (5 x 5, 1 m resolution):
 
     5 5 5 5 5
     5 9 9 9 5
-    5 9 1 4 5   <- pit=1, saddle=4 immediately left of right border
+    5 9 1 4 5   <- pit=1, step=4 immediately left of right border
     5 9 9 9 5
     5 5 5 5 5
 
-Pour-point elevation = 5 (border cell adjacent to the saddle at elevation 4).
+Pour-point elevation = 5 (border cell adjacent to the step at elevation 4).
 
 Expected hierarchy properties:
   - One leaf depression: the basin draining to the centre pit.
@@ -36,7 +36,7 @@ _LABELS = "tmp_richdem_dephier_labels"
 _FLOWDIRS = "tmp_richdem_dephier_flowdirs"
 _HIERARCHY = "tmp_richdem_dephier_hierarchy"
 
-# 5x5: border=5, ring=9, pit=1, saddle=4 at (row=3, col=4)
+# 5x5: border=5, ring=9, pit=1, step=4 at (row=3, col=4)
 _DEM_EXPR = (
     "if(row()==3 && col()==3, 1,"
     " if(row()==3 && col()==4, 4,"

--- a/src/raster/r.richdem/r.richdem.fsm/testsuite/test_r_richdem_fsm.py
+++ b/src/raster/r.richdem/r.richdem.fsm/testsuite/test_r_richdem_fsm.py
@@ -3,13 +3,12 @@
 Synthetic DEM (5 x 5, 1 m resolution):
 
     5 5 5 5 5
-    5 3 3 3 5
-    5 3 1 3 3   <- centre pit (1); channel exits at right border (3)
-    5 3 3 3 5
+    5 9 9 9 5
+    5 9 1 4 5   <- pit=1, saddle=4 immediately left of right border
+    5 9 9 9 5
     5 5 5 5 5
 
-Pour-point elevation = 3 (the channel row connects the pit directly to
-the right border at elevation 3).
+Pour-point elevation = 5 (border cell adjacent to the saddle at elevation 4).
 
 r.richdem.dephier is run once in setUpClass; its outputs feed FSM.
 Water-table depth (wtd) convention: negative = unsaturated (below
@@ -20,8 +19,8 @@ Two water scenarios are tested:
   Dry   wtd = −1 everywhere (no ponded water)
   Wet   wtd = +1.5 in depression cells, −1 elsewhere
 
-With the pour point at elevation 3 and 1.5 m of ponded water on inner
-ring cells (surface elevation 3 + 1.5 = 4.5 m > pour point), water
+With the pour point at elevation 5 and 1.5 m of ponded water on ring
+cells (surface elevation 9 + 1.5 = 10.5 m > pour point), water
 spills and FSM redistributes it, reducing the domain mean wtd.
 
 Note: when the maximum value in a DCELL raster is exactly 0.0, GRASS
@@ -52,11 +51,11 @@ _WTD_WET = "tmp_richdem_fsm_wtd_wet"
 _OUT_DRY = "tmp_richdem_fsm_out_dry"
 _OUT_WET = "tmp_richdem_fsm_out_wet"
 
-# 5x5: border=5, inner ring=3, centre=1; outlet at right border (row 3, col 5 = 3)
+# 5x5: border=5, ring=9, pit=1, saddle=4 at (row=3, col=4)
 _DEM_EXPR = (
     "if(row()==3 && col()==3, 1,"
-    " if(row()==3 && col()==5, 3,"
-    " if(row()==1 || row()==5 || col()==1 || col()==5, 5, 3)))"
+    " if(row()==3 && col()==4, 4,"
+    " if(row()==1 || row()==5 || col()==1 || col()==5, 5, 9)))"
 )
 
 

--- a/src/raster/r.richdem/r.richdem.fsm/testsuite/test_r_richdem_fsm.py
+++ b/src/raster/r.richdem/r.richdem.fsm/testsuite/test_r_richdem_fsm.py
@@ -4,11 +4,11 @@ Synthetic DEM (5 x 5, 1 m resolution):
 
     5 5 5 5 5
     5 9 9 9 5
-    5 9 1 4 5   <- pit=1, saddle=4 immediately left of right border
+    5 9 1 4 5   <- pit=1, step=4 immediately left of right border
     5 9 9 9 5
     5 5 5 5 5
 
-Pour-point elevation = 5 (border cell adjacent to the saddle at elevation 4).
+Pour-point elevation = 5 (border cell adjacent to the step at elevation 4).
 
 r.richdem.dephier is run once in setUpClass; its outputs feed FSM.
 Water-table depth (wtd) convention: negative = unsaturated (below
@@ -51,7 +51,7 @@ _WTD_WET = "tmp_richdem_fsm_wtd_wet"
 _OUT_DRY = "tmp_richdem_fsm_out_dry"
 _OUT_WET = "tmp_richdem_fsm_out_wet"
 
-# 5x5: border=5, ring=9, pit=1, saddle=4 at (row=3, col=4)
+# 5x5: border=5, ring=9, pit=1, step=4 at (row=3, col=4)
 _DEM_EXPR = (
     "if(row()==3 && col()==3, 1,"
     " if(row()==3 && col()==4, 4,"

--- a/src/raster/r.richdem/r.richdem.resolveflats/r.richdem.resolveflats.py
+++ b/src/raster/r.richdem/r.richdem.resolveflats/r.richdem.resolveflats.py
@@ -7,7 +7,7 @@
 # %end
 # %option G_OPT_R_INPUT
 # % key: input
-# % description: Input elevation raster
+# % description: Input (filled or breached) elevation raster
 # %end
 # %option G_OPT_R_OUTPUT
 # % key: output


### PR DESCRIPTION
## Summary

- `r.richdem.resolveflats`: clarify that the input must be a filled or breached DEM (closes awickert/r.richdem#2)
- `r.richdem.dephier` tests: replace channel DEM with the shared step DEM used by the fill/breach test suites (closes awickert/r.richdem#1)
- `r.richdem.fsm` tests: same step DEM port; wet-scenario assertion unchanged and verified

## Details

### `r.richdem.resolveflats` parameter description (1-line fix)

The input parameter was described as `"Input elevation raster"`. Updated to `"Input (filled or breached) elevation raster"` to match the prerequisite already documented in the NOTES section, so users who only glance at the parameter panel are not misled.

### Step DEM port (`r.richdem.dephier`, `r.richdem.fsm`)

The fill and breach test suites use a step DEM that produces three distinguishable outputs on the same input. The dephier and fsm suites previously used an older channel DEM. Both are now updated to the shared step DEM:

```
5 5 5 5 5
5 9 9 9 5
5 9 1 4 5   ← pit=1, step=4 immediately left of right border
5 9 9 9 5
5 5 5 5 5
```

The cell at elevation 4 is a step — an intermediate elevation in the exit path pit(1)→step(4)→border(5). Pour-point elevation = 5 (border cell adjacent to the step). All structural assertions (leaf depression exists, dep_vol > 0, schema columns, ocean_links layer, flow directions in [0,8]) remain valid with the new DEM.

The same DEM design was independently validated in the MNiMORPH/processing_richdem QGIS plugin test suite (42/42 tests pass).

## Test plan

- [x] `r.richdem.resolveflats` testsuite: 4/4 pass
- [x] `r.richdem.dephier` testsuite: 10/10 pass
- [x] `r.richdem.fsm` testsuite: 4/4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)