### PR TITLE
i.eodag: always lazy import eodag

### DIFF
--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -273,7 +273,6 @@ from pathlib import Path
 from subprocess import PIPE
 
 import grass.script as gs
-from eodag.utils.exceptions import AuthenticationError
 from grass.pygrass.modules import Module
 
 try:
@@ -284,6 +283,7 @@ except ImportError:
 try:
     import eodag
     import yaml
+    from eodag.utils.exceptions import AuthenticationError
 
     EODAG_VERSION = int(eodag.__version__.split(".")[0])
 except ImportError:


### PR DESCRIPTION
Currently, compilation of i.eodag fails if eodag library is not installed on the system. See:
https://grass.osgeo.org/grass-stable/manuals/addons/i.eodag.html

Culprit is the import of the AuthenticationError from eodag at toplevel:
https://github.com/OSGeo/grass-addons/blob/a9c6855720b3e00e5e2ca5e8c5c710eecf69752a/src/imagery/i.eodag/i.eodag.py#L276

This PR moves simply this to lazy import. That should be safe because existence of eodag is tested at runtime, so, the addon fails with a clear error message if eodag is not available anyway...