### PR TITLE
t.rast.line: bugfix handle with timestamps with fractional seconds

### DIFF
--- a/src/temporal/t.rast.line/t.rast.line.html
+++ b/src/temporal/t.rast.line/t.rast.line.html
@@ -242,6 +242,9 @@ University of Applied Sciences.
 
 <h2>AUTHOR</h2>
 
-Paulo van Breugel<br> Applied Geo-information Sciences<br> <a
-href="https://www.has.nl/">HAS green academy, University of Applied
-Sciences</a><br>
+<a href="https://ecodiv.earth">Paulo van Breugel</a>, <a
+href="https://has.nl">HAS green academy</a>, <a
+href="https://www.has.nl/en/research/professorships/innovative-bio-monitoring-professorship/">Innovative
+Biomonitoring research group</a>, <a
+href="https://www.has.nl/en/research/professorships/climate-robust-landscapes-professorship/">Climate-robust
+Landscapes research group</a>

--- a/src/temporal/t.rast.line/t.rast.line.md
+++ b/src/temporal/t.rast.line/t.rast.line.md
@@ -194,7 +194,8 @@ of the HAS University of Applied Sciences.
 
 ## AUTHOR
 
-Paulo van Breugel  
-Applied Geo-information Sciences  
-[HAS green academy, University of Applied
-Sciences](https://www.has.nl/)
+[Paulo van Breugel](https://ecodiv.earth), [HAS green
+academy](https://has.nl), [Innovative Biomonitoring research
+group](https://www.has.nl/en/research/professorships/innovative-bio-monitoring-professorship/),
+[Climate-robust Landscapes research
+group](https://www.has.nl/en/research/professorships/climate-robust-landscapes-professorship/)

--- a/src/temporal/t.rast.line/t.rast.line.py
+++ b/src/temporal/t.rast.line/t.rast.line.py
@@ -208,20 +208,9 @@ import atexit
 import os
 import sys
 from datetime import datetime
-
-
-def _parse_dt(value):
-    """Parse a datetime string, tolerating optional fractional seconds."""
-    for fmt in ("%Y-%m-%d %H:%M:%S.%f", "%Y-%m-%d %H:%M:%S"):
-        try:
-            return datetime.strptime(value, fmt)
-        except ValueError:
-            continue
-    raise ValueError("Unrecognized datetime format: %s" % value)
-
-
 import grass.script as gs
 from grass.exceptions import CalledModuleError
+from grass.temporal.datetime_math import string_to_datetime
 from math import sqrt
 import matplotlib.dates as mdates
 from random import random
@@ -411,13 +400,13 @@ def line_stats(strds, coverlayer, error, n, threads, temp_type, where, x_value):
         if temp_type == "absolute":
             if not bool(idx_end):
                 date_points = [
-                    _parse_dt(x[idx_start])
+                    string_to_datetime(x[idx_start])
                     for x in univar[1:]
                     if int(x[idx_zone]) == zone_ids[0]
                 ]
             else:
                 s_points = [
-                    _parse_dt(x[idx_start])
+                    string_to_datetime(x[idx_start])
                     for x in univar[1:]
                     if int(x[idx_zone]) == zone_ids[0]
                 ]
@@ -425,9 +414,9 @@ def line_stats(strds, coverlayer, error, n, threads, temp_type, where, x_value):
                 e_tmp = [x for x in univar[1:] if int(x[idx_zone]) == zone_ids[0]]
                 e_points = [
                     (
-                        _parse_dt(x[idx_end])
+                        string_to_datetime(x[idx_end])
                         if x[idx_end] != "None"
-                        else _parse_dt(x[idx_start])
+                        else string_to_datetime(x[idx_start])
                     )
                     for x in e_tmp
                 ]
@@ -444,7 +433,7 @@ def line_stats(strds, coverlayer, error, n, threads, temp_type, where, x_value):
                         )
                         for s, e in zip(date_start, date_end)
                     ]
-                    date_points = [_parse_dt(dp) for dp in date_points]
+                    date_points = [string_to_datetime(dp) for dp in date_points]
         else:
             if not bool(idx_end):
                 date_points = [
@@ -497,15 +486,15 @@ def line_stats(strds, coverlayer, error, n, threads, temp_type, where, x_value):
     else:
         if temp_type == "absolute":
             if not bool(idx_end):
-                date_points = [_parse_dt(x[idx_start]) for x in univar[1:]]
+                date_points = [string_to_datetime(x[idx_start]) for x in univar[1:]]
             else:
-                s_points = [_parse_dt(x[idx_start]) for x in univar[1:]]
+                s_points = [string_to_datetime(x[idx_start]) for x in univar[1:]]
                 # Check if end slots have date or None
                 e_points = [
                     (
-                        _parse_dt(x[idx_end])
+                        string_to_datetime(x[idx_end])
                         if x[idx_end] != "None"
-                        else _parse_dt(x[idx_start])
+                        else string_to_datetime(x[idx_start])
                     )
                     for x in univar[1:]
                 ]
@@ -522,7 +511,7 @@ def line_stats(strds, coverlayer, error, n, threads, temp_type, where, x_value):
                         )
                         for s, e in zip(date_start, date_end)
                     ]
-                    date_points = [_parse_dt(dp) for dp in date_points]
+                    date_points = [string_to_datetime(dp) for dp in date_points]
         else:
             if not bool(idx_end):
                 date_points = [int(x[idx_start]) for x in univar[1:]]

--- a/src/temporal/t.rast.line/t.rast.line.py
+++ b/src/temporal/t.rast.line/t.rast.line.py
@@ -9,7 +9,7 @@
 #               of the raster values. If a zonal map is set, trendlines are
 #               drawn for each of the zones of the zonal layer.
 #
-# COPYRIGHT:    (c) 2024 Paulo van Breugel, and the GRASS Development Team
+# COPYRIGHT:    (c) 2024-2026 Paulo van Breugel, and the GRASS Development Team
 #               This program is free software under the GNU General Public
 #               License (>=v2). Read the file COPYING that comes with GRASS
 #               for details.
@@ -208,6 +208,16 @@ import atexit
 import os
 import sys
 from datetime import datetime
+
+
+def _parse_dt(value):
+    """Parse a datetime string, tolerating optional fractional seconds."""
+    for fmt in ("%Y-%m-%d %H:%M:%S.%f", "%Y-%m-%d %H:%M:%S"):
+        try:
+            return datetime.strptime(value, fmt)
+        except ValueError:
+            continue
+    raise ValueError("Unrecognized datetime format: %s" % value)
 import grass.script as gs
 from grass.exceptions import CalledModuleError
 from math import sqrt
@@ -399,13 +409,13 @@ def line_stats(strds, coverlayer, error, n, threads, temp_type, where, x_value):
         if temp_type == "absolute":
             if not bool(idx_end):
                 date_points = [
-                    datetime.strptime(x[idx_start], "%Y-%m-%d %H:%M:%S")
+                    _parse_dt(x[idx_start])
                     for x in univar[1:]
                     if int(x[idx_zone]) == zone_ids[0]
                 ]
             else:
                 s_points = [
-                    datetime.strptime(x[idx_start], "%Y-%m-%d %H:%M:%S")
+                    _parse_dt(x[idx_start])
                     for x in univar[1:]
                     if int(x[idx_zone]) == zone_ids[0]
                 ]
@@ -413,9 +423,9 @@ def line_stats(strds, coverlayer, error, n, threads, temp_type, where, x_value):
                 e_tmp = [x for x in univar[1:] if int(x[idx_zone]) == zone_ids[0]]
                 e_points = [
                     (
-                        datetime.strptime(x[idx_end], "%Y-%m-%d %H:%M:%S")
+                        _parse_dt(x[idx_end])
                         if x[idx_end] != "None"
-                        else datetime.strptime(x[idx_start], "%Y-%m-%d %H:%M:%S")
+                        else _parse_dt(x[idx_start])
                     )
                     for x in e_tmp
                 ]
@@ -433,7 +443,7 @@ def line_stats(strds, coverlayer, error, n, threads, temp_type, where, x_value):
                         for s, e in zip(date_start, date_end)
                     ]
                     date_points = [
-                        datetime.strptime(dp, "%Y-%m-%d %H:%M:%S") for dp in date_points
+                        _parse_dt(dp) for dp in date_points
                     ]
         else:
             if not bool(idx_end):
@@ -488,20 +498,20 @@ def line_stats(strds, coverlayer, error, n, threads, temp_type, where, x_value):
         if temp_type == "absolute":
             if not bool(idx_end):
                 date_points = [
-                    datetime.strptime(x[idx_start], "%Y-%m-%d %H:%M:%S")
+                    _parse_dt(x[idx_start])
                     for x in univar[1:]
                 ]
             else:
                 s_points = [
-                    datetime.strptime(x[idx_start], "%Y-%m-%d %H:%M:%S")
+                    _parse_dt(x[idx_start])
                     for x in univar[1:]
                 ]
                 # Check if end slots have date or None
                 e_points = [
                     (
-                        datetime.strptime(x[idx_end], "%Y-%m-%d %H:%M:%S")
+                        _parse_dt(x[idx_end])
                         if x[idx_end] != "None"
-                        else datetime.strptime(x[idx_start], "%Y-%m-%d %H:%M:%S")
+                        else _parse_dt(x[idx_start])
                     )
                     for x in univar[1:]
                 ]
@@ -519,7 +529,7 @@ def line_stats(strds, coverlayer, error, n, threads, temp_type, where, x_value):
                         for s, e in zip(date_start, date_end)
                     ]
                     date_points = [
-                        datetime.strptime(dp, "%Y-%m-%d %H:%M:%S") for dp in date_points
+                        _parse_dt(dp) for dp in date_points
                     ]
         else:
             if not bool(idx_end):

--- a/src/temporal/t.rast.line/t.rast.line.py
+++ b/src/temporal/t.rast.line/t.rast.line.py
@@ -218,6 +218,8 @@ def _parse_dt(value):
         except ValueError:
             continue
     raise ValueError("Unrecognized datetime format: %s" % value)
+
+
 import grass.script as gs
 from grass.exceptions import CalledModuleError
 from math import sqrt
@@ -442,9 +444,7 @@ def line_stats(strds, coverlayer, error, n, threads, temp_type, where, x_value):
                         )
                         for s, e in zip(date_start, date_end)
                     ]
-                    date_points = [
-                        _parse_dt(dp) for dp in date_points
-                    ]
+                    date_points = [_parse_dt(dp) for dp in date_points]
         else:
             if not bool(idx_end):
                 date_points = [
@@ -497,15 +497,9 @@ def line_stats(strds, coverlayer, error, n, threads, temp_type, where, x_value):
     else:
         if temp_type == "absolute":
             if not bool(idx_end):
-                date_points = [
-                    _parse_dt(x[idx_start])
-                    for x in univar[1:]
-                ]
+                date_points = [_parse_dt(x[idx_start]) for x in univar[1:]]
             else:
-                s_points = [
-                    _parse_dt(x[idx_start])
-                    for x in univar[1:]
-                ]
+                s_points = [_parse_dt(x[idx_start]) for x in univar[1:]]
                 # Check if end slots have date or None
                 e_points = [
                     (
@@ -528,9 +522,7 @@ def line_stats(strds, coverlayer, error, n, threads, temp_type, where, x_value):
                         )
                         for s, e in zip(date_start, date_end)
                     ]
-                    date_points = [
-                        _parse_dt(dp) for dp in date_points
-                    ]
+                    date_points = [_parse_dt(dp) for dp in date_points]
         else:
             if not bool(idx_end):
                 date_points = [int(x[idx_start]) for x in univar[1:]]


### PR DESCRIPTION
The module failed when registered raster maps had timestamps that included fractional seconds. Fixed