### PR TITLE
r.cell.area: deprecate in favour of r.mapcalc area()

### DIFF
--- a/src/raster/r.cell.area/r.cell.area.html
+++ b/src/raster/r.cell.area/r.cell.area.html
@@ -1,12 +1,47 @@
 <h2>DESCRIPTION</h2>
 
-<em>r.cell.area</em> uses the current computational region to compute the area of each raster cell. It can do so on a projected coordinate system or on a geographic coordinate system; the latter is accomplished via the latitude of the cell's midpoint. This approximation can generate ~1% error with coarse lat/lon cells near the poles.
+<p><b>r.cell.area is deprecated.</b> Use the built-in <tt>area()</tt>
+function in
+<em><a href="https://grass.osgeo.org/grass-stable/manuals/r.mapcalc.html">r.mapcalc</a></em>
+instead (available since GRASS 7.4). It provides an ellipsoidal
+cell-area calculation and requires no extra module.</p>
+
+<p><em>r.cell.area</em> computes the area of each raster cell in the
+current computational region and writes the result to a new raster map.
+It is now a thin wrapper around the <tt>area()</tt> function in
+<em>r.mapcalc</em> and emits a deprecation warning on every run.</p>
 
 <h2>NOTES</h2>
 
-Output units can be either square meters or square kilometers.
+<p>The <tt>area()</tt> function in <em>r.mapcalc</em> returns cell area
+in square metres using an ellipsoidal model. Multiply by a constant to
+obtain other units:</p>
 
-This module is useful for determining the flow accumulation area to weight flow accumulation algorithms by rainfall and/or on lat/lon grids.
+<table>
+  <tr><th>r.cell.area units</th><th>Equivalent r.mapcalc expression</th></tr>
+  <tr><td>m2</td>    <td><tt>r.mapcalc "output = area()"</tt></td></tr>
+  <tr><td>km2</td>   <td><tt>r.mapcalc "output = area() * 1e-6"</tt></td></tr>
+  <tr><td>ha</td>    <td><tt>r.mapcalc "output = area() * 1e-4"</tt></td></tr>
+  <tr><td>acres</td> <td><tt>r.mapcalc "output = area() / 4046.8564224"</tt></td></tr>
+  <tr><td>mi2</td>   <td><tt>r.mapcalc "output = area() / 2589988.110336"</tt></td></tr>
+</table>
+
+<h2>EXAMPLES</h2>
+
+<p>Compute cell area in square metres (recommended, no module needed):</p>
+<div class="code"><pre>
+r.mapcalc "cell_area_m2 = area()"
+</pre></div>
+
+<p>Compute cell area in hectares:</p>
+<div class="code"><pre>
+r.mapcalc "cell_area_ha = area() * 1e-4"
+</pre></div>
+
+<p>Using r.cell.area (deprecated, emits a warning):</p>
+<div class="code"><pre>
+r.cell.area output=cell_area units=ha
+</pre></div>
 
 <h2>SEE ALSO</h2>
 

--- a/src/raster/r.cell.area/r.cell.area.md
+++ b/src/raster/r.cell.area/r.cell.area.md
@@ -1,16 +1,47 @@
 ## DESCRIPTION
 
-*r.cell.area* uses the current computational region to compute the area
-of each raster cell. It can do so on a projected coordinate system or on
-a geographic coordinate system; the latter is accomplished via the
-latitude of the cell's midpoint. This approximation can generate \~1%
-error with coarse lat/lon cells near the poles.
+**r.cell.area is deprecated.** Use the built-in `area()` function in
+[r.mapcalc](https://grass.osgeo.org/grass-stable/manuals/r.mapcalc.html)
+instead (available since GRASS 7.4). It provides an ellipsoidal
+cell-area calculation and requires no extra module.
+
+*r.cell.area* computes the area of each raster cell in the current
+computational region and writes the result to a new raster map. It is
+now a thin wrapper around the `area()` function in *r.mapcalc* and emits
+a deprecation warning on every run.
 
 ## NOTES
 
-Output units can be either square meters or square kilometers. This
-module is useful for determining the flow accumulation area to weight
-flow accumulation algorithms by rainfall and/or on lat/lon grids.
+The `area()` function in *r.mapcalc* returns cell area in square metres
+using an ellipsoidal model. Multiply by a constant to obtain other units:
+
+| r.cell.area units | Equivalent r.mapcalc expression                |
+|-------------------|------------------------------------------------|
+| `m2`              | `r.mapcalc "output = area()"`                  |
+| `km2`             | `r.mapcalc "output = area() * 1e-6"`           |
+| `ha`              | `r.mapcalc "output = area() * 1e-4"`           |
+| `acres`           | `r.mapcalc "output = area() / 4046.8564224"`   |
+| `mi2`             | `r.mapcalc "output = area() / 2589988.110336"` |
+
+## EXAMPLES
+
+Compute cell area in square metres (recommended, no module needed):
+
+```bash
+r.mapcalc "cell_area_m2 = area()"
+```
+
+Compute cell area in hectares:
+
+```bash
+r.mapcalc "cell_area_ha = area() * 1e-4"
+```
+
+Using r.cell.area (deprecated, emits a warning):
+
+```bash
+r.cell.area output=cell_area units=ha
+```
 
 ## SEE ALSO
 

--- a/src/raster/r.cell.area/r.cell.area.py
+++ b/src/raster/r.cell.area/r.cell.area.py
@@ -42,14 +42,6 @@
 # %  required: yes
 # %end
 
-##################
-# IMPORT MODULES #
-##################
-
-# PYTHON
-import math
-
-# GRASS
 import grass.script as gs
 
 
@@ -70,24 +62,12 @@ def main():
 
     projinfo = gs.parse_command("g.proj", flags="g")
 
-    projunits = str(projinfo.get("units", ""))
-    factor = _M2_TO_UNIT[units]
-
-    if projunits.lower() in ("degrees", "degree"):
-        rad = math.pi / 180.0
-        gs.mapcalc(
-            f"{output} = ( 111195. * nsres() )"
-            f" * ( ewres() * {rad} * 6371000. * cos(y()) ) * {factor}"
-        )
-    elif not projunits:
+    if not str(projinfo.get("units", "")):
         gs.fatal(_("Projection units are unknown; XY locations are not supported"))
-    else:
-        # Any projected CRS: use the meters-per-map-unit conversion factor so
-        # that feet, US survey feet, and all other linear units work correctly.
-        m = float(projinfo.get("meters", 0))
-        if m <= 0:
-            gs.fatal(_("Projection units '%s' are not supported") % projunits)
-        gs.mapcalc(f"{output} = nsres() * ewres() * {m**2 * factor}")
+
+    factor = _M2_TO_UNIT[units]
+    gs.warning(_("r.cell.area is deprecated; use r.mapcalc area() instead"))
+    gs.mapcalc(f"{output} = area() * {factor}")
 
 
 if __name__ == "__main__":

--- a/src/raster/r.cell.area/r.cell.area.py
+++ b/src/raster/r.cell.area/r.cell.area.py
@@ -34,7 +34,8 @@
 # %  key: units
 # %  type: string
 # %  description: Units for output areas
-# %  options: m2, km2
+# %  options: m2, km2, ha, acres, mi2
+# %  descriptions: m2;Square meters;km2;Square kilometers;ha;Hectares;acres;Acres;mi2;Square miles
 # %  required: yes
 # %end
 
@@ -49,6 +50,16 @@ import math
 import grass.script as gs
 
 
+# Conversion factors from m² — values match GRASS G_meters_to_units_factor_sq()
+_M2_TO_UNIT = {
+    "m2": 1.0,
+    "km2": 1.0e-6,
+    "ha": 1.0e-4,
+    "acres": 1.0 / 4046.8564224,
+    "mi2": 1.0 / 2589988.110336,
+}
+
+
 def main():
     """
     Compute cell areas
@@ -61,22 +72,16 @@ def main():
     projinfo = gs.parse_command("g.proj", flags="g")
 
     projunits = str(projinfo.get("units", ""))
+    factor = _M2_TO_UNIT[units]
 
     if projunits.lower() in ("degrees", "degree"):
-        if units == "m2":
-            gs.mapcalc(
-                "{out} = ( 111195. * nsres() )"
-                " * ( ewres() * {rad} * 6371000. * cos(y()) )".format(
-                    out=output, rad=math.pi / 180.0
-                )
+        rad = math.pi / 180.0
+        gs.mapcalc(
+            "{out} = ( 111195. * nsres() )"
+            " * ( ewres() * {rad} * 6371000. * cos(y()) ) * {f}".format(
+                out=output, rad=rad, f=factor
             )
-        elif units == "km2":
-            gs.mapcalc(
-                "{out} = ( 111.195 * nsres() )"
-                " * ( ewres() * {rad} * 6371. * cos(y()) )".format(
-                    out=output, rad=math.pi / 180.0
-                )
-            )
+        )
     elif not projunits:
         gs.fatal(_("Projection units are unknown; XY locations are not supported"))
     else:
@@ -85,12 +90,11 @@ def main():
         m = float(projinfo.get("meters", 0))
         if m <= 0:
             gs.fatal(_("Projection units '%s' are not supported") % projunits)
-        if units == "m2":
-            gs.mapcalc("{out} = nsres() * ewres() * {m2}".format(out=output, m2=m**2))
-        elif units == "km2":
-            gs.mapcalc(
-                "{out} = nsres() * ewres() * {m2} / 1.e6".format(out=output, m2=m**2)
+        gs.mapcalc(
+            "{out} = nsres() * ewres() * {coeff}".format(
+                out=output, coeff=m**2 * factor
             )
+        )
 
 
 if __name__ == "__main__":

--- a/src/raster/r.cell.area/r.cell.area.py
+++ b/src/raster/r.cell.area/r.cell.area.py
@@ -54,11 +54,11 @@ def main():
     Compute cell areas
     """
 
-    projinfo = gs.parse_command("g.proj", flags="g")
-
     options, flags = gs.parser()
     output = options["output"]
     units = options["units"]
+
+    projinfo = gs.parse_command("g.proj", flags="g")
 
     # First check if output exists
     if len(gs.parse_command("g.list", type="rast", pattern=options["output"])):

--- a/src/raster/r.cell.area/r.cell.area.py
+++ b/src/raster/r.cell.area/r.cell.area.py
@@ -16,6 +16,8 @@
 #
 #############################################################################
 #
+# SPDX-FileCopyrightText: 2017 Andrew Wickert
+# SPDX-License-Identifier: GPL-2.0-or-later
 
 # %module
 # % description: Calculate cell sizes within the computational region

--- a/src/raster/r.cell.area/r.cell.area.py
+++ b/src/raster/r.cell.area/r.cell.area.py
@@ -79,10 +79,8 @@ def main():
     if projunits.lower() in ("degrees", "degree"):
         rad = math.pi / 180.0
         gs.mapcalc(
-            "{out} = ( 111195. * nsres() )"
-            " * ( ewres() * {rad} * 6371000. * cos(y()) ) * {f}".format(
-                out=output, rad=rad, f=factor
-            )
+            f"{output} = ( 111195. * nsres() )"
+            f" * ( ewres() * {rad} * 6371000. * cos(y()) ) * {factor}"
         )
     elif not projunits:
         gs.fatal(_("Projection units are unknown; XY locations are not supported"))
@@ -92,11 +90,7 @@ def main():
         m = float(projinfo.get("meters", 0))
         if m <= 0:
             gs.fatal(_("Projection units '%s' are not supported") % projunits)
-        gs.mapcalc(
-            "{out} = nsres() * ewres() * {coeff}".format(
-                out=output, coeff=m**2 * factor
-            )
-        )
+        gs.mapcalc(f"{output} = nsres() * ewres() * {m**2 * factor}")
 
 
 if __name__ == "__main__":

--- a/src/raster/r.cell.area/r.cell.area.py
+++ b/src/raster/r.cell.area/r.cell.area.py
@@ -60,15 +60,6 @@ def main():
 
     projinfo = gs.parse_command("g.proj", flags="g")
 
-    # First check if output exists
-    if len(gs.parse_command("g.list", type="rast", pattern=options["output"])):
-        if not gs.overwrite():
-            gs.fatal(
-                "Raster map '"
-                + options["output"]
-                + "' already exists. Use '--o' to overwrite."
-            )
-
     projunits = str(projinfo.get("units", ""))
 
     if projunits.lower() in ("degrees", "degree"):

--- a/src/raster/r.cell.area/r.cell.area.py
+++ b/src/raster/r.cell.area/r.cell.area.py
@@ -43,7 +43,7 @@
 ##################
 
 # PYTHON
-import numpy as np
+import math
 
 # GRASS
 import grass.script as gs
@@ -67,14 +67,14 @@ def main():
             gs.mapcalc(
                 "{out} = ( 111195. * nsres() )"
                 " * ( ewres() * {rad} * 6371000. * cos(y()) )".format(
-                    out=output, rad=np.pi / 180.0
+                    out=output, rad=math.pi / 180.0
                 )
             )
         elif units == "km2":
             gs.mapcalc(
                 "{out} = ( 111.195 * nsres() )"
                 " * ( ewres() * {rad} * 6371. * cos(y()) )".format(
-                    out=output, rad=np.pi / 180.0
+                    out=output, rad=math.pi / 180.0
                 )
             )
     elif not projunits:

--- a/src/raster/r.cell.area/r.cell.area.py
+++ b/src/raster/r.cell.area/r.cell.area.py
@@ -64,10 +64,6 @@ _M2_TO_UNIT = {
 
 
 def main():
-    """
-    Compute cell areas
-    """
-
     options, flags = gs.parser()
     output = options["output"]
     units = options["units"]

--- a/src/raster/r.cell.area/r.cell.area.py
+++ b/src/raster/r.cell.area/r.cell.area.py
@@ -20,22 +20,23 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # %module
-# % description: Calculate cell sizes within the computational region
+# % description: Calculates the area of each raster cell for the computational region
 # % keyword: raster
-# % keyword: statistics
+# % keyword: geometry
 # %end
 
 # %option G_OPT_R_OUTPUT
 # %  key: output
-# %  type: string
-# %  description: Output grid of cell sizes
+# %  label: Output raster of cell areas
+# %  description: Name of output raster map containing cell areas
 # %  required: yes
 # %end
 
 # %option
 # %  key: units
 # %  type: string
-# %  description: Units for output areas
+# %  label: Output units
+# %  description: Units for output cell areas
 # %  options: m2, km2, ha, acres, mi2
 # %  descriptions: m2;Square meters;km2;Square kilometers;ha;Hectares;acres;Acres;mi2;Square miles
 # %  required: yes

--- a/src/raster/r.cell.area/testsuite/test_r_cell_area.py
+++ b/src/raster/r.cell.area/testsuite/test_r_cell_area.py
@@ -6,12 +6,12 @@ Tests for r.cell.area
 Coverage
 --------
 - Projected CRS (UTM, metres): m² and km² values, overwrite protection
-- Geographic CRS (degrees): m² and km² via spherical formula
+- Geographic CRS (degrees): output matches r.mapcalc area() directly
 - Projected CRS (US survey feet): m² and km² via meters conversion factor
 - XY (unprojected) location: module must exit non-zero
+- Deprecation warning: emitted on every successful run
 """
 
-import math
 import subprocess
 
 import grass.script as gs
@@ -120,18 +120,6 @@ class TestRCellAreaMeters(TestCase):
 class TestRCellAreaDegrees(TestCase):
     """Geographic CRS (EPSG:4326) — spawns a temporary GRASS project."""
 
-    # 1°×1° cell centred at lat=0.5° (equator region)
-    # Expected values computed from the spherical formula in r.cell.area:
-    #   m2  = (111195 * nsres) * (ewres * pi/180 * 6371000 * cos(lat_centre))
-    #   km2 = (111.195 * nsres) * (ewres * pi/180 * 6371    * cos(lat_centre))
-    _lat_centre = 0.5  # degrees
-    _expected_m2 = (111195.0 * 1.0) * (
-        1.0 * (math.pi / 180.0) * 6371000.0 * math.cos(_lat_centre * math.pi / 180.0)
-    )
-    _expected_km2 = _expected_m2 / 1.0e6
-    # Allow 0.01 % relative tolerance (rounding in mapcalc float arithmetic)
-    _rel_tol = 1e-4
-
     def _run_and_parse(self, units):
         """Run r.cell.area in EPSG:4326 at res=1 and return univar stats."""
         rc, stdout, stderr = _run_in_tmp_project(
@@ -149,26 +137,28 @@ class TestRCellAreaDegrees(TestCase):
         )
         return _parse_univar(stdout)
 
-    def test_m2_spherical_formula(self):
-        """Geographic CRS m² matches the spherical approximation."""
-        stats = self._run_and_parse("m2")
-        self.assertIn("min", stats)
-        self.assertIn("max", stats)
-        # Single cell → min == max
-        self.assertAlmostEqual(
-            stats["min"],
-            stats["max"],
-            delta=1.0,
-            msg="min and max should be equal for a single-cell region",
-        )
-        self.assertAlmostEqual(
-            stats["min"],
-            self._expected_m2,
-            delta=self._expected_m2 * self._rel_tol,
-            msg=(
-                f"m² value {stats['min']:.0f} differs from expected "
-                f"{self._expected_m2:.0f} by more than {self._rel_tol * 100}%"
+    def test_m2_matches_area_function(self):
+        """Geographic CRS m² output matches r.mapcalc area() directly."""
+        rc, stdout, stderr = _run_in_tmp_project(
+            "EPSG:4326",
+            (
+                "g.region n=1 s=0 e=1 w=0 res=1 && "
+                "r.cell.area output=area units=m2 && "
+                "r.mapcalc 'ref = area()' && "
+                "r.univar map=area flags=g separator='=' && "
+                "echo '---' && "
+                "r.univar map=ref flags=g separator='='"
             ),
+        )
+        self.assertEqual(rc, 0, msg=f"test failed:\n{stderr}")
+        parts = stdout.split("---")
+        stats_area = _parse_univar(parts[0])
+        stats_ref = _parse_univar(parts[1])
+        self.assertAlmostEqual(
+            stats_area["min"],
+            stats_ref["min"],
+            delta=stats_ref["min"] * 1e-9,
+            msg="r.cell.area m² does not match r.mapcalc area()",
         )
 
     def test_km2_consistent_with_m2(self):
@@ -179,7 +169,7 @@ class TestRCellAreaDegrees(TestCase):
         self.assertAlmostEqual(
             ratio,
             1.0e6,
-            delta=1.0e6 * self._rel_tol,
+            delta=1.0e6 * 1e-9,
             msg=f"km² / m² ratio {ratio:.2f} differs from 1 000 000",
         )
 
@@ -258,6 +248,23 @@ class TestRCellAreaXY(TestCase):
             rc,
             0,
             msg="r.cell.area should exit non-zero in an XY (unprojected) location",
+        )
+
+
+class TestRCellAreaDeprecationWarning(TestCase):
+    """Deprecation warning is emitted on every successful run."""
+
+    def test_warning_emitted(self):
+        """r.cell.area emits a deprecation warning on every successful run."""
+        rc, _stdout, stderr = _run_in_tmp_project(
+            "EPSG:4326",
+            "g.region n=1 s=0 e=1 w=0 res=1 && r.cell.area output=area units=m2",
+        )
+        self.assertEqual(rc, 0, msg=f"r.cell.area failed:\n{stderr}")
+        self.assertIn(
+            "deprecated",
+            stderr.lower(),
+            msg="No deprecation warning found in stderr",
         )
 
 


### PR DESCRIPTION
## Summary

Follows up on #1727. **Softly deprecates \`r.cell.area\`** in favour of the
built-in \`area()\` function in \`r.mapcalc\`. The module remains fully
functional and existing scripts are unaffected, but every run now emits a
\`gs.warning()\` directing users to \`r.mapcalc area()\` directly.

### Why deprecate?

\`r.cell.area\` was written in 2017. The \`area()\` function was committed to
GRASS trunk in December 2016 and first released in **GRASS 7.4 (January 2018)**.
It provides the same per-cell area using an ellipsoidal model
(\`G_area_of_cell_at_row()\`), which is more accurate than the spherical
approximation \`r.cell.area\` had been using for geographic CRS (~0.45% error
near the equator). \`r.cell.area\` has been a duplicate of built-in
functionality — and a less accurate one — since 2018.

### What to use instead

```bash
# square metres — no module needed
r.mapcalc "cell_area = area()"

# other units: multiply by the appropriate factor
r.mapcalc "cell_area_km2   = area() * 1e-6"
r.mapcalc "cell_area_ha    = area() * 1e-4"
r.mapcalc "cell_area_acres = area() / 4046.8564224"
r.mapcalc "cell_area_mi2   = area() / 2589988.110336"
```

### Other changes in this PR

The need for this deprecation was discovered en route to an update of this addon. Most of the update is complete, and is included here for continuity.

Minor code-quality cleanup (parser order, overwrite check, numpy→math, SPDX
tags, f-strings, keywords) and three new output units (\`ha\`, \`acres\`,
\`mi2\`) added on the way to the deprecation. Docs and testsuite updated to
match.

## Test plan

- [ ] \`TestRCellAreaMeters\` — 10 m × 10 m UTM cells = 100 m²; 1000 m cells = 1 km²; overwrite protection and flag
- [ ] \`TestRCellAreaDegrees\` — geographic CRS: \`r.cell.area\` m² matches \`r.mapcalc area()\` to 1 ppb; km²/m² ratio = 1 000 000
- [ ] \`TestRCellAreaFeet\` — US survey feet CRS (EPSG:2249): 100 ft × 100 ft ≈ 929.034 m²
- [ ] \`TestRCellAreaXY\` — XY location exits non-zero
- [ ] \`TestRCellAreaDeprecationWarning\` — "deprecated" in stderr on every successful run

🤖 Generated with [Claude Code](https://claude.com/claude-code)