### PR TITLE
v.flexure: update for gFlex v2.0.0; redesign interface; add testsuite

### DIFF
--- a/src/vector/v.flexure/testsuite/test_v_flexure.py
+++ b/src/vector/v.flexure/testsuite/test_v_flexure.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python
+
+############################################################################
+#
+# MODULE:       test_v_flexure
+# AUTHOR:       Andrew Wickert
+# PURPOSE:      Tests for v.flexure (point-load flexural isostasy)
+# COPYRIGHT:    (C) 2026 by Andrew Wickert and the GRASS Development Team
+#
+#               This program is free software under the GNU General Public
+#               License (>=v2). Read the file COPYING that comes with GRASS
+#               for details.
+#
+############################################################################
+
+"""
+Tests for v.flexure.
+
+Creates a synthetic single-point load vector (no NC dataset required) and
+exercises the SAS_NG solver with scalar Te values. Skips automatically when
+gFlex >= 2.0.0 is not installed.
+
+Run inside a GRASS session (e.g., with --tmp-location XY):
+    python -m grass.gunittest.main
+"""
+
+import unittest
+
+import grass.script as grass
+from grass.gunittest.case import TestCase
+from grass.gunittest.main import test
+
+
+def _gflex_ok():
+    """Return True if gFlex is importable."""
+    try:
+        import gflex  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+@unittest.skipUnless(_gflex_ok(), "gFlex not available")
+class TestVFlexure(TestCase):
+    """Test v.flexure with a synthetic single-point load (no NC dataset required)."""
+
+    loads = "test_vflex_loads"
+    output = "test_vflex_rout"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.use_temp_region()
+        # 10×10 grid at 100 m resolution (1 km × 1 km)
+        cls.runModule("g.region", n=1000, s=0, e=1000, w=0, res=100)
+        # Single point at domain center (500, 500), loaded as a point force [N]
+        cls.runModule(
+            "v.in.ascii",
+            format="point",
+            input="-",
+            stdin_="500 500",
+            separator="space",
+            output=cls.loads,
+        )
+        cls.runModule("v.db.addtable", map=cls.loads)
+        cls.runModule(
+            "v.db.addcolumn",
+            map=cls.loads,
+            columns="q double precision",
+        )
+        cls.runModule(
+            "v.db.update",
+            map=cls.loads,
+            column="q",
+            value="1e15",
+            where="cat=1",
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.del_temp_region()
+        cls.runModule(
+            "g.remove", flags="f", type="vector", name=cls.loads, quiet=True
+        )
+
+    def tearDown(self):
+        self.runModule(
+            "g.remove", flags="f", type="raster", name=self.output, quiet=True
+        )
+
+    def test_basic_deflection(self):
+        """SAS_NG solver produces a valid raster output."""
+        self.assertModule(
+            "v.flexure",
+            input=self.loads,
+            column="q",
+            te="10000",
+            te_units="m",
+            output=self.output,
+        )
+        self.assertRasterExists(self.output)
+        self.assertRasterFitsUnivar(
+            raster=self.output, reference={"n": 100}, precision=0
+        )
+        stats = grass.parse_command("r.univar", map=self.output, flags="g")
+        min_w = float(stats["min"])
+        self.assertLess(min_w, 0,
+                        "Deflection under a downward load must be negative")
+        self.assertGreater(min_w, -1000,
+                           "Deflection magnitude must be physically plausible (< 1 km)")
+
+    def test_w_points_output(self):
+        """w_points writes deflection values into an existing vector map."""
+        w_pts = "test_vflex_wpts"
+        try:
+            # Create a small set of arbitrary evaluation points
+            self.runModule(
+                "v.in.ascii",
+                format="point",
+                input="-",
+                stdin_="200 200\n500 500\n800 800",
+                separator="space",
+                output=w_pts,
+            )
+            self.runModule("v.db.addtable", map=w_pts)
+            self.assertModule(
+                "v.flexure",
+                input=self.loads,
+                column="q",
+                te="10000",
+                te_units="m",
+                output=self.output,
+                w_points=w_pts,
+            )
+            self.assertRasterExists(self.output)
+            # The w column should now exist and be populated
+            db = grass.vector_db_select(w_pts)
+            col_lower = [c.lower() for c in db["columns"]]
+            self.assertIn("w", col_lower,
+                          "w column should be present in w_points map")
+            w_idx = col_lower.index("w")
+            w_vals = [float(row[w_idx]) for row in db["values"].values()]
+            self.assertTrue(any(v < 0 for v in w_vals),
+                            "At least one deflection value should be negative")
+        finally:
+            self.runModule(
+                "g.remove", flags="f", type="vector", name=w_pts, quiet=True
+            )
+
+    def test_w_points_custom_column(self):
+        """w_column parameter controls the name of the written column."""
+        w_pts = "test_vflex_wpts_col"
+        try:
+            self.runModule(
+                "v.in.ascii",
+                format="point",
+                input="-",
+                stdin_="500 500",
+                separator="space",
+                output=w_pts,
+            )
+            self.runModule("v.db.addtable", map=w_pts)
+            self.assertModule(
+                "v.flexure",
+                input=self.loads,
+                column="q",
+                te="10000",
+                te_units="m",
+                output=self.output,
+                w_points=w_pts,
+                w_column="deflection",
+            )
+            db = grass.vector_db_select(w_pts)
+            self.assertIn("deflection", [c.lower() for c in db["columns"]],
+                          "deflection column should be present in w_points map")
+        finally:
+            self.runModule(
+                "g.remove", flags="f", type="vector", name=w_pts, quiet=True
+            )
+
+    def test_te_km_units(self):
+        """Te in km produces output without error."""
+        self.assertModule(
+            "v.flexure",
+            input=self.loads,
+            column="q",
+            te="10",
+            te_units="km",
+            output=self.output,
+        )
+        self.assertRasterExists(self.output)
+
+    def test_custom_material_params(self):
+        """Non-default Young's modulus and mantle density are accepted."""
+        self.assertModule(
+            "v.flexure",
+            input=self.loads,
+            column="q",
+            te="10000",
+            te_units="m",
+            output=self.output,
+            ym="70E9",
+            rho_m="3200",
+        )
+        self.assertRasterExists(self.output)
+
+    def test_te_km_m_equivalence(self):
+        """Te=10 km and Te=10000 m must produce identical deflections.
+
+        Interface-layer test: verifies that the km→m conversion (Te *= 1000)
+        is applied correctly.
+        """
+        out_km = "test_vflex_te_km"
+        out_m = "test_vflex_te_m"
+        try:
+            self.assertModule(
+                "v.flexure", input=self.loads, column="q",
+                te="10", te_units="km", output=out_km,
+            )
+            self.assertModule(
+                "v.flexure", input=self.loads, column="q",
+                te="10000", te_units="m", output=out_m,
+            )
+            stats_km = grass.parse_command("r.univar", map=out_km, flags="g")
+            stats_m = grass.parse_command("r.univar", map=out_m, flags="g")
+            self.assertAlmostEqual(
+                float(stats_km["min"]), float(stats_m["min"]), places=10,
+                msg="Te in km and m must give identical min deflection",
+            )
+        finally:
+            self.runModule(
+                "g.remove", flags="f", type="raster",
+                name=",".join([out_km, out_m]), quiet=True,
+            )
+
+    def test_deflection_decays_with_distance(self):
+        """Deflection magnitude decreases with distance from the load point.
+
+        The load is at the domain centre (500, 500).  The minimum deflection
+        (peak subsidence, most negative) must be more negative than the mean,
+        which is pulled toward zero by cells far from the load.
+        """
+        self.assertModule(
+            "v.flexure",
+            input=self.loads,
+            column="q",
+            te="10000",
+            te_units="m",
+            output=self.output,
+        )
+        stats = grass.parse_command("r.univar", map=self.output, flags="g")
+        min_w = float(stats["min"])
+        mean_w = float(stats["mean"])
+        self.assertLess(
+            min_w, mean_w,
+            "Peak subsidence at load centre must exceed mean deflection",
+        )
+        self.assertLess(mean_w, 0, "Mean deflection must be negative")
+
+    def test_multi_point_loads(self):
+        """Two load points are processed correctly; exercises the SQL attribute loop."""
+        loads2 = "test_vflex_loads2"
+        output2 = "test_vflex_rout2"
+        try:
+            self.runModule(
+                "v.in.ascii",
+                format="point",
+                input="-",
+                stdin_="400 400\n600 600",
+                separator="space",
+                output=loads2,
+            )
+            self.runModule("v.db.addtable", map=loads2)
+            self.runModule(
+                "v.db.addcolumn", map=loads2, columns="q double precision"
+            )
+            self.runModule(
+                "v.db.update", map=loads2, column="q", value="1e15", where="cat=1"
+            )
+            self.runModule(
+                "v.db.update", map=loads2, column="q", value="8e14", where="cat=2"
+            )
+            self.assertModule(
+                "v.flexure",
+                input=loads2,
+                column="q",
+                te="10000",
+                te_units="m",
+                output=output2,
+            )
+            self.assertRasterExists(output2)
+        finally:
+            self.runModule(
+                "g.remove", flags="f", type="vector", name=loads2, quiet=True
+            )
+            self.runModule(
+                "g.remove", flags="f", type="raster", name=output2, quiet=True
+            )
+
+
+if __name__ == "__main__":
+    test()

--- a/src/vector/v.flexure/testsuite/test_v_flexure.py
+++ b/src/vector/v.flexure/testsuite/test_v_flexure.py
@@ -142,6 +142,12 @@ class TestVFlexure(TestCase):
             w_vals = [float(row[w_idx]) for row in db["values"].values()]
             self.assertTrue(any(v < 0 for v in w_vals),
                             "At least one deflection value should be negative")
+            # cat=2 is (500, 500) — the load location; must be the most negative
+            w_at_load = float(db["values"][2][w_idx])
+            self.assertEqual(
+                w_at_load, min(w_vals),
+                "Deflection at load point (500, 500) must be the most negative",
+            )
         finally:
             self.runModule(
                 "g.remove", flags="f", type="vector", name=w_pts, quiet=True
@@ -191,7 +197,7 @@ class TestVFlexure(TestCase):
         self.assertRasterExists(self.output)
 
     def test_custom_material_params(self):
-        """Non-default Young's modulus and mantle density are accepted."""
+        """Non-default Young's modulus, mantle density, and fill density are accepted."""
         self.assertModule(
             "v.flexure",
             input=self.loads,
@@ -201,6 +207,7 @@ class TestVFlexure(TestCase):
             output=self.output,
             ym="70E9",
             rho_m="3200",
+            rho_fill="500",
         )
         self.assertRasterExists(self.output)
 

--- a/src/vector/v.flexure/testsuite/test_v_flexure.py
+++ b/src/vector/v.flexure/testsuite/test_v_flexure.py
@@ -26,7 +26,7 @@ Run inside a GRASS session (e.g., with --tmp-location XY):
 
 import unittest
 
-import grass.script as grass
+import grass.script as gs
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 
@@ -102,7 +102,7 @@ class TestVFlexure(TestCase):
         self.assertRasterFitsUnivar(
             raster=self.output, reference={"n": 100}, precision=0
         )
-        stats = grass.parse_command("r.univar", map=self.output, flags="g")
+        stats = gs.parse_command("r.univar", map=self.output, flags="g")
         min_w = float(stats["min"])
         self.assertLess(min_w, 0,
                         "Deflection under a downward load must be negative")
@@ -134,7 +134,7 @@ class TestVFlexure(TestCase):
             )
             self.assertRasterExists(self.output)
             # The w column should now exist and be populated
-            db = grass.vector_db_select(w_pts)
+            db = gs.vector_db_select(w_pts)
             col_lower = [c.lower() for c in db["columns"]]
             self.assertIn("w", col_lower,
                           "w column should be present in w_points map")
@@ -176,7 +176,7 @@ class TestVFlexure(TestCase):
                 w_points=w_pts,
                 w_column="deflection",
             )
-            db = grass.vector_db_select(w_pts)
+            db = gs.vector_db_select(w_pts)
             self.assertIn("deflection", [c.lower() for c in db["columns"]],
                           "deflection column should be present in w_points map")
         finally:
@@ -228,8 +228,8 @@ class TestVFlexure(TestCase):
                 "v.flexure", input=self.loads, column="q",
                 te="10000", te_units="m", output=out_m,
             )
-            stats_km = grass.parse_command("r.univar", map=out_km, flags="g")
-            stats_m = grass.parse_command("r.univar", map=out_m, flags="g")
+            stats_km = gs.parse_command("r.univar", map=out_km, flags="g")
+            stats_m = gs.parse_command("r.univar", map=out_m, flags="g")
             self.assertAlmostEqual(
                 float(stats_km["min"]), float(stats_m["min"]), places=10,
                 msg="Te in km and m must give identical min deflection",
@@ -255,7 +255,7 @@ class TestVFlexure(TestCase):
             te_units="m",
             output=self.output,
         )
-        stats = grass.parse_command("r.univar", map=self.output, flags="g")
+        stats = gs.parse_command("r.univar", map=self.output, flags="g")
         min_w = float(stats["min"])
         mean_w = float(stats["mean"])
         self.assertLess(
@@ -317,8 +317,8 @@ class TestVFlexure(TestCase):
                 "v.flexure", input=self.loads, column="q",
                 te="10", te_units="km", output=out_km,
             )
-            stats_d = grass.parse_command("r.univar", map=out_default, flags="g")
-            stats_k = grass.parse_command("r.univar", map=out_km, flags="g")
+            stats_d = gs.parse_command("r.univar", map=out_default, flags="g")
+            stats_k = gs.parse_command("r.univar", map=out_km, flags="g")
             self.assertAlmostEqual(
                 float(stats_d["min"]), float(stats_k["min"]), places=10,
                 msg="Default te_units=km must match explicit te_units=km",
@@ -362,8 +362,8 @@ class TestVFlexure(TestCase):
                 "v.flexure", input=loads_2x, column="q",
                 te="10000", te_units="m", output=out_2x,
             )
-            stats_1x = grass.parse_command("r.univar", map=out_1x, flags="g")
-            stats_2x = grass.parse_command("r.univar", map=out_2x, flags="g")
+            stats_1x = gs.parse_command("r.univar", map=out_1x, flags="g")
+            stats_2x = gs.parse_command("r.univar", map=out_2x, flags="g")
             self.assertAlmostEqual(
                 float(stats_2x["min"]), 2.0 * float(stats_1x["min"]), places=6,
                 msg="Peak deflection must scale linearly with load force",
@@ -390,8 +390,8 @@ class TestVFlexure(TestCase):
                 "v.flexure", input=self.loads, column="q",
                 te="20000", te_units="m", output=out_stiff,
             )
-            stats_soft = grass.parse_command("r.univar", map=out_soft, flags="g")
-            stats_stiff = grass.parse_command("r.univar", map=out_stiff, flags="g")
+            stats_soft = gs.parse_command("r.univar", map=out_soft, flags="g")
+            stats_stiff = gs.parse_command("r.univar", map=out_stiff, flags="g")
             self.assertLess(
                 float(stats_soft["min"]), float(stats_stiff["min"]),
                 msg="Softer plate (Te=5 km) must deflect more than stiffer (Te=20 km)",
@@ -465,7 +465,7 @@ class TestVFlexureForebulge(TestCase):
             te_units="km",
             output=self.output,
         )
-        stats = grass.parse_command("r.univar", map=self.output, flags="g")
+        stats = gs.parse_command("r.univar", map=self.output, flags="g")
         self.assertLess(float(stats["min"]), 0,
                         "Central subsidence must be negative")
         self.assertGreater(float(stats["max"]), 0,

--- a/src/vector/v.flexure/testsuite/test_v_flexure.py
+++ b/src/vector/v.flexure/testsuite/test_v_flexure.py
@@ -526,5 +526,102 @@ class TestVFlexureForebulge(TestCase):
         )
 
 
+class TestVFlexureParserErrors(TestCase):
+    """Parser-level rejection — fires before main() and requires no gFlex."""
+
+    loads = "test_vflex_perr_loads"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.use_temp_region()
+        cls.runModule("g.region", n=1000, s=0, e=1000, w=0, res=100)
+        cls.runModule(
+            "v.in.ascii",
+            format="point",
+            input="-",
+            stdin_="500 500",
+            separator="space",
+            output=cls.loads,
+        )
+        cls.runModule("v.db.addtable", map=cls.loads)
+        cls.runModule(
+            "v.db.addcolumn",
+            map=cls.loads,
+            columns="q double precision",
+        )
+        cls.runModule(
+            "v.db.update",
+            map=cls.loads,
+            column="q",
+            value="1e15",
+            where="cat=1",
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.del_temp_region()
+        cls.runModule("g.remove", flags="f", type="vector", name=cls.loads, quiet=True)
+
+    def test_bad_te_units(self):
+        """Parser rejects te_units values outside the allowed set {m, km}."""
+        self.assertModuleFail(
+            "v.flexure",
+            input=self.loads,
+            column="q",
+            te="10",
+            te_units="feet",
+            output="dummy_out",
+        )
+
+
+@unittest.skipUnless(_gflex_ok(), "gFlex not available")
+class TestVFlexureInputErrors(TestCase):
+    """Input-validation errors raised inside main() — gFlex must be importable."""
+
+    loads = "test_vflex_ierr_loads"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.use_temp_region()
+        cls.runModule("g.region", n=1000, s=0, e=1000, w=0, res=100)
+        cls.runModule(
+            "v.in.ascii",
+            format="point",
+            input="-",
+            stdin_="500 500",
+            separator="space",
+            output=cls.loads,
+        )
+        cls.runModule("v.db.addtable", map=cls.loads)
+        cls.runModule(
+            "v.db.addcolumn",
+            map=cls.loads,
+            columns="q double precision",
+        )
+        cls.runModule(
+            "v.db.update",
+            map=cls.loads,
+            column="q",
+            value="1e15",
+            where="cat=1",
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.del_temp_region()
+        cls.runModule("g.remove", flags="f", type="vector", name=cls.loads, quiet=True)
+
+    def test_missing_column(self):
+        """Module exits with error when the named column is absent from the input map."""
+        self.assertModuleFail(
+            "v.flexure",
+            input=self.loads,
+            column="nonexistent",
+            te="10000",
+            te_units="m",
+            output="dummy_out",
+        )
+
+
 if __name__ == "__main__":
     test()

--- a/src/vector/v.flexure/testsuite/test_v_flexure.py
+++ b/src/vector/v.flexure/testsuite/test_v_flexure.py
@@ -297,6 +297,173 @@ class TestVFlexure(TestCase):
                 "g.remove", flags="f", type="raster", name=output2, quiet=True
             )
 
+    def test_te_units_default_km(self):
+        """Omitting te_units uses the km default; result must match explicit te_units=km."""
+        out_default = "test_vflex_te_default"
+        out_km = "test_vflex_te_km_explicit"
+        try:
+            self.assertModule(
+                "v.flexure", input=self.loads, column="q",
+                te="10", output=out_default,
+            )
+            self.assertModule(
+                "v.flexure", input=self.loads, column="q",
+                te="10", te_units="km", output=out_km,
+            )
+            stats_d = grass.parse_command("r.univar", map=out_default, flags="g")
+            stats_k = grass.parse_command("r.univar", map=out_km, flags="g")
+            self.assertAlmostEqual(
+                float(stats_d["min"]), float(stats_k["min"]), places=10,
+                msg="Default te_units=km must match explicit te_units=km",
+            )
+        finally:
+            self.runModule(
+                "g.remove", flags="f", type="raster",
+                name=",".join([out_default, out_km]), quiet=True,
+            )
+
+    def test_linearity(self):
+        """Doubling the load force doubles the peak deflection.
+
+        The elastic plate equation is linear in the load, so deflection scales
+        exactly with load magnitude.
+        """
+        loads_2x = "test_vflex_loads_2x"
+        out_1x = "test_vflex_linear_1x"
+        out_2x = "test_vflex_linear_2x"
+        try:
+            self.runModule(
+                "v.in.ascii",
+                format="point",
+                input="-",
+                stdin_="500 500",
+                separator="space",
+                output=loads_2x,
+            )
+            self.runModule("v.db.addtable", map=loads_2x)
+            self.runModule(
+                "v.db.addcolumn", map=loads_2x, columns="q double precision"
+            )
+            self.runModule(
+                "v.db.update", map=loads_2x, column="q", value="2e15", where="cat=1"
+            )
+            self.assertModule(
+                "v.flexure", input=self.loads, column="q",
+                te="10000", te_units="m", output=out_1x,
+            )
+            self.assertModule(
+                "v.flexure", input=loads_2x, column="q",
+                te="10000", te_units="m", output=out_2x,
+            )
+            stats_1x = grass.parse_command("r.univar", map=out_1x, flags="g")
+            stats_2x = grass.parse_command("r.univar", map=out_2x, flags="g")
+            self.assertAlmostEqual(
+                float(stats_2x["min"]), 2.0 * float(stats_1x["min"]), places=6,
+                msg="Peak deflection must scale linearly with load force",
+            )
+        finally:
+            self.runModule(
+                "g.remove", flags="f", type="vector", name=loads_2x, quiet=True
+            )
+            self.runModule(
+                "g.remove", flags="f", type="raster",
+                name=",".join([out_1x, out_2x]), quiet=True,
+            )
+
+    def test_stiffer_te_less_deflection(self):
+        """A stiffer plate (larger Te) deflects less under the same load."""
+        out_soft = "test_vflex_soft_te"
+        out_stiff = "test_vflex_stiff_te"
+        try:
+            self.assertModule(
+                "v.flexure", input=self.loads, column="q",
+                te="5000", te_units="m", output=out_soft,
+            )
+            self.assertModule(
+                "v.flexure", input=self.loads, column="q",
+                te="20000", te_units="m", output=out_stiff,
+            )
+            stats_soft = grass.parse_command("r.univar", map=out_soft, flags="g")
+            stats_stiff = grass.parse_command("r.univar", map=out_stiff, flags="g")
+            self.assertLess(
+                float(stats_soft["min"]), float(stats_stiff["min"]),
+                msg="Softer plate (Te=5 km) must deflect more than stiffer (Te=20 km)",
+            )
+        finally:
+            self.runModule(
+                "g.remove", flags="f", type="raster",
+                name=",".join([out_soft, out_stiff]), quiet=True,
+            )
+
+
+@unittest.skipUnless(_gflex_ok(), "gFlex not available")
+class TestVFlexureForebulge(TestCase):
+    """Test forebulge on a domain large enough to resolve it.
+
+    For Te=10 km, the flexural parameter α≈52 km and the forebulge peaks at
+    ~4.87α≈253 km from the load.  A 600×600 km domain (300 km half-width)
+    at 10 km resolution captures the forebulge ring.
+    """
+
+    loads = "test_vflex_fb_loads"
+    output = "test_vflex_fb_rout"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.use_temp_region()
+        cls.runModule(
+            "g.region", n=600000, s=0, e=600000, w=0, res=10000
+        )
+        cls.runModule(
+            "v.in.ascii",
+            format="point",
+            input="-",
+            stdin_="300000 300000",
+            separator="space",
+            output=cls.loads,
+        )
+        cls.runModule("v.db.addtable", map=cls.loads)
+        cls.runModule(
+            "v.db.addcolumn", map=cls.loads, columns="q double precision"
+        )
+        cls.runModule(
+            "v.db.update", map=cls.loads, column="q", value="1e18", where="cat=1"
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.del_temp_region()
+        cls.runModule(
+            "g.remove", flags="f", type="vector", name=cls.loads, quiet=True
+        )
+
+    def tearDown(self):
+        self.runModule(
+            "g.remove", flags="f", type="raster", name=self.output, quiet=True
+        )
+
+    def test_forebulge_present(self):
+        """SAS_NG produces a forebulge: some cells have positive (upward) deflection.
+
+        The analytical solution for a point load on an infinite elastic plate
+        predicts a ring of positive uplift (forebulge) at radius ~4.87α from
+        the load.  On a 600×600 km domain with Te=10 km this ring falls well
+        within the domain.
+        """
+        self.assertModule(
+            "v.flexure",
+            input=self.loads,
+            column="q",
+            te="10",
+            te_units="km",
+            output=self.output,
+        )
+        stats = grass.parse_command("r.univar", map=self.output, flags="g")
+        self.assertLess(float(stats["min"]), 0,
+                        "Central subsidence must be negative")
+        self.assertGreater(float(stats["max"]), 0,
+                           "Forebulge uplift must be positive on a 600 km domain")
+
 
 if __name__ == "__main__":
     test()

--- a/src/vector/v.flexure/testsuite/test_v_flexure.py
+++ b/src/vector/v.flexure/testsuite/test_v_flexure.py
@@ -112,46 +112,44 @@ class TestVFlexure(TestCase):
     def test_w_points_output(self):
         """w_points writes deflection values into an existing vector map."""
         w_pts = "test_vflex_wpts"
-        try:
-            # Create a small set of arbitrary evaluation points
-            self.runModule(
-                "v.in.ascii",
-                format="point",
-                input="-",
-                stdin_="200 200\n500 500\n800 800",
-                separator="space",
-                output=w_pts,
-            )
-            self.runModule("v.db.addtable", map=w_pts)
-            self.assertModule(
-                "v.flexure",
-                input=self.loads,
-                column="q",
-                te="10000",
-                te_units="m",
-                output=self.output,
-                w_points=w_pts,
-            )
-            self.assertRasterExists(self.output)
-            # The w column should now exist and be populated
-            db = gs.vector_db_select(w_pts)
-            col_lower = [c.lower() for c in db["columns"]]
-            self.assertIn("w", col_lower,
-                          "w column should be present in w_points map")
-            w_idx = col_lower.index("w")
-            w_vals = [float(row[w_idx]) for row in db["values"].values()]
-            self.assertTrue(any(v < 0 for v in w_vals),
-                            "At least one deflection value should be negative")
-            # cat=2 is (500, 500) — the load location; must be the most negative
-            w_at_load = float(db["values"][2][w_idx])
-            self.assertEqual(
-                w_at_load, min(w_vals),
-                "Deflection at load point (500, 500) must be the most negative",
-            )
-        finally:
-            self.runModule(
-                "g.remove", flags="f", type="vector", name=w_pts, quiet=True
-            )
+        self.addCleanup(
+            self.runModule, "g.remove", flags="f", type="vector", name=w_pts, quiet=True
+        )
+        # Create a small set of arbitrary evaluation points
+        self.runModule(
+            "v.in.ascii",
+            format="point",
+            input="-",
+            stdin_="200 200\n500 500\n800 800",
+            separator="space",
+            output=w_pts,
+        )
+        self.runModule("v.db.addtable", map=w_pts)
+        self.assertModule(
+            "v.flexure",
+            input=self.loads,
+            column="q",
+            te="10000",
+            te_units="m",
+            output=self.output,
+            w_points=w_pts,
+        )
+        self.assertRasterExists(self.output)
+        # The w column should now exist and be populated
+        db = gs.vector_db_select(w_pts)
+        col_lower = [c.lower() for c in db["columns"]]
+        self.assertIn("w", col_lower,
+                      "w column should be present in w_points map")
+        w_idx = col_lower.index("w")
+        w_vals = [float(row[w_idx]) for row in db["values"].values()]
+        self.assertTrue(any(v < 0 for v in w_vals),
+                        "At least one deflection value should be negative")
+        # cat=2 is (500, 500) — the load location; must be the most negative
+        w_at_load = float(db["values"][2][w_idx])
+        self.assertEqual(
+            w_at_load, min(w_vals),
+            "Deflection at load point (500, 500) must be the most negative",
+        )
 
     def test_w_points_custom_column(self):
         """w_column parameter controls the name of the written column."""
@@ -268,41 +266,39 @@ class TestVFlexure(TestCase):
         """Two load points are processed correctly; exercises the SQL attribute loop."""
         loads2 = "test_vflex_loads2"
         output2 = "test_vflex_rout2"
-        try:
-            self.runModule(
-                "v.in.ascii",
-                format="point",
-                input="-",
-                stdin_="400 400\n600 600",
-                separator="space",
-                output=loads2,
-            )
-            self.runModule("v.db.addtable", map=loads2)
-            self.runModule(
-                "v.db.addcolumn", map=loads2, columns="q double precision"
-            )
-            self.runModule(
-                "v.db.update", map=loads2, column="q", value="1e15", where="cat=1"
-            )
-            self.runModule(
-                "v.db.update", map=loads2, column="q", value="8e14", where="cat=2"
-            )
-            self.assertModule(
-                "v.flexure",
-                input=loads2,
-                column="q",
-                te="10000",
-                te_units="m",
-                output=output2,
-            )
-            self.assertRasterExists(output2)
-        finally:
-            self.runModule(
-                "g.remove", flags="f", type="vector", name=loads2, quiet=True
-            )
-            self.runModule(
-                "g.remove", flags="f", type="raster", name=output2, quiet=True
-            )
+        self.addCleanup(
+            self.runModule, "g.remove", flags="f", type="vector", name=loads2, quiet=True
+        )
+        self.addCleanup(
+            self.runModule, "g.remove", flags="f", type="raster", name=output2, quiet=True
+        )
+        self.runModule(
+            "v.in.ascii",
+            format="point",
+            input="-",
+            stdin_="400 400\n600 600",
+            separator="space",
+            output=loads2,
+        )
+        self.runModule("v.db.addtable", map=loads2)
+        self.runModule(
+            "v.db.addcolumn", map=loads2, columns="q double precision"
+        )
+        self.runModule(
+            "v.db.update", map=loads2, column="q", value="1e15", where="cat=1"
+        )
+        self.runModule(
+            "v.db.update", map=loads2, column="q", value="8e14", where="cat=2"
+        )
+        self.assertModule(
+            "v.flexure",
+            input=loads2,
+            column="q",
+            te="10000",
+            te_units="m",
+            output=output2,
+        )
+        self.assertRasterExists(output2)
 
     def test_te_units_default_km(self):
         """Omitting te_units uses the km default; result must match explicit te_units=km."""
@@ -338,44 +334,42 @@ class TestVFlexure(TestCase):
         loads_2x = "test_vflex_loads_2x"
         out_1x = "test_vflex_linear_1x"
         out_2x = "test_vflex_linear_2x"
-        try:
-            self.runModule(
-                "v.in.ascii",
-                format="point",
-                input="-",
-                stdin_="500 500",
-                separator="space",
-                output=loads_2x,
-            )
-            self.runModule("v.db.addtable", map=loads_2x)
-            self.runModule(
-                "v.db.addcolumn", map=loads_2x, columns="q double precision"
-            )
-            self.runModule(
-                "v.db.update", map=loads_2x, column="q", value="2e15", where="cat=1"
-            )
-            self.assertModule(
-                "v.flexure", input=self.loads, column="q",
-                te="10000", te_units="m", output=out_1x,
-            )
-            self.assertModule(
-                "v.flexure", input=loads_2x, column="q",
-                te="10000", te_units="m", output=out_2x,
-            )
-            stats_1x = gs.parse_command("r.univar", map=out_1x, flags="g")
-            stats_2x = gs.parse_command("r.univar", map=out_2x, flags="g")
-            self.assertAlmostEqual(
-                float(stats_2x["min"]), 2.0 * float(stats_1x["min"]), places=6,
-                msg="Peak deflection must scale linearly with load force",
-            )
-        finally:
-            self.runModule(
-                "g.remove", flags="f", type="vector", name=loads_2x, quiet=True
-            )
-            self.runModule(
-                "g.remove", flags="f", type="raster",
-                name=",".join([out_1x, out_2x]), quiet=True,
-            )
+        self.addCleanup(
+            self.runModule, "g.remove", flags="f", type="vector", name=loads_2x, quiet=True
+        )
+        self.addCleanup(
+            self.runModule, "g.remove", flags="f", type="raster",
+            name=",".join([out_1x, out_2x]), quiet=True,
+        )
+        self.runModule(
+            "v.in.ascii",
+            format="point",
+            input="-",
+            stdin_="500 500",
+            separator="space",
+            output=loads_2x,
+        )
+        self.runModule("v.db.addtable", map=loads_2x)
+        self.runModule(
+            "v.db.addcolumn", map=loads_2x, columns="q double precision"
+        )
+        self.runModule(
+            "v.db.update", map=loads_2x, column="q", value="2e15", where="cat=1"
+        )
+        self.assertModule(
+            "v.flexure", input=self.loads, column="q",
+            te="10000", te_units="m", output=out_1x,
+        )
+        self.assertModule(
+            "v.flexure", input=loads_2x, column="q",
+            te="10000", te_units="m", output=out_2x,
+        )
+        stats_1x = gs.parse_command("r.univar", map=out_1x, flags="g")
+        stats_2x = gs.parse_command("r.univar", map=out_2x, flags="g")
+        self.assertAlmostEqual(
+            float(stats_2x["min"]), 2.0 * float(stats_1x["min"]), places=6,
+            msg="Peak deflection must scale linearly with load force",
+        )
 
     def test_stiffer_te_less_deflection(self):
         """A stiffer plate (larger Te) deflects less under the same load."""

--- a/src/vector/v.flexure/testsuite/test_v_flexure.py
+++ b/src/vector/v.flexure/testsuite/test_v_flexure.py
@@ -79,9 +79,7 @@ class TestVFlexure(TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.del_temp_region()
-        cls.runModule(
-            "g.remove", flags="f", type="vector", name=cls.loads, quiet=True
-        )
+        cls.runModule("g.remove", flags="f", type="vector", name=cls.loads, quiet=True)
 
     def tearDown(self):
         self.runModule(
@@ -104,10 +102,10 @@ class TestVFlexure(TestCase):
         )
         stats = gs.parse_command("r.univar", map=self.output, flags="g")
         min_w = float(stats["min"])
-        self.assertLess(min_w, 0,
-                        "Deflection under a downward load must be negative")
-        self.assertGreater(min_w, -1000,
-                           "Deflection magnitude must be physically plausible (< 1 km)")
+        self.assertLess(min_w, 0, "Deflection under a downward load must be negative")
+        self.assertGreater(
+            min_w, -1000, "Deflection magnitude must be physically plausible (< 1 km)"
+        )
 
     def test_w_points_output(self):
         """w_points writes deflection values into an existing vector map."""
@@ -138,16 +136,18 @@ class TestVFlexure(TestCase):
         # The w column should now exist and be populated
         db = gs.vector_db_select(w_pts)
         col_lower = [c.lower() for c in db["columns"]]
-        self.assertIn("w", col_lower,
-                      "w column should be present in w_points map")
+        self.assertIn("w", col_lower, "w column should be present in w_points map")
         w_idx = col_lower.index("w")
         w_vals = [float(row[w_idx]) for row in db["values"].values()]
-        self.assertTrue(any(v < 0 for v in w_vals),
-                        "At least one deflection value should be negative")
+        self.assertTrue(
+            any(v < 0 for v in w_vals),
+            "At least one deflection value should be negative",
+        )
         # cat=2 is (500, 500) — the load location; must be the most negative
         w_at_load = float(db["values"][2][w_idx])
         self.assertEqual(
-            w_at_load, min(w_vals),
+            w_at_load,
+            min(w_vals),
             "Deflection at load point (500, 500) must be the most negative",
         )
 
@@ -175,12 +175,13 @@ class TestVFlexure(TestCase):
                 w_column="deflection",
             )
             db = gs.vector_db_select(w_pts)
-            self.assertIn("deflection", [c.lower() for c in db["columns"]],
-                          "deflection column should be present in w_points map")
-        finally:
-            self.runModule(
-                "g.remove", flags="f", type="vector", name=w_pts, quiet=True
+            self.assertIn(
+                "deflection",
+                [c.lower() for c in db["columns"]],
+                "deflection column should be present in w_points map",
             )
+        finally:
+            self.runModule("g.remove", flags="f", type="vector", name=w_pts, quiet=True)
 
     def test_te_km_units(self):
         """Te in km produces output without error."""
@@ -219,23 +220,36 @@ class TestVFlexure(TestCase):
         out_m = "test_vflex_te_m"
         try:
             self.assertModule(
-                "v.flexure", input=self.loads, column="q",
-                te="10", te_units="km", output=out_km,
+                "v.flexure",
+                input=self.loads,
+                column="q",
+                te="10",
+                te_units="km",
+                output=out_km,
             )
             self.assertModule(
-                "v.flexure", input=self.loads, column="q",
-                te="10000", te_units="m", output=out_m,
+                "v.flexure",
+                input=self.loads,
+                column="q",
+                te="10000",
+                te_units="m",
+                output=out_m,
             )
             stats_km = gs.parse_command("r.univar", map=out_km, flags="g")
             stats_m = gs.parse_command("r.univar", map=out_m, flags="g")
             self.assertAlmostEqual(
-                float(stats_km["min"]), float(stats_m["min"]), places=10,
+                float(stats_km["min"]),
+                float(stats_m["min"]),
+                places=10,
                 msg="Te in km and m must give identical min deflection",
             )
         finally:
             self.runModule(
-                "g.remove", flags="f", type="raster",
-                name=",".join([out_km, out_m]), quiet=True,
+                "g.remove",
+                flags="f",
+                type="raster",
+                name=",".join([out_km, out_m]),
+                quiet=True,
             )
 
     def test_deflection_decays_with_distance(self):
@@ -257,7 +271,8 @@ class TestVFlexure(TestCase):
         min_w = float(stats["min"])
         mean_w = float(stats["mean"])
         self.assertLess(
-            min_w, mean_w,
+            min_w,
+            mean_w,
             "Peak subsidence at load centre must exceed mean deflection",
         )
         self.assertLess(mean_w, 0, "Mean deflection must be negative")
@@ -267,10 +282,20 @@ class TestVFlexure(TestCase):
         loads2 = "test_vflex_loads2"
         output2 = "test_vflex_rout2"
         self.addCleanup(
-            self.runModule, "g.remove", flags="f", type="vector", name=loads2, quiet=True
+            self.runModule,
+            "g.remove",
+            flags="f",
+            type="vector",
+            name=loads2,
+            quiet=True,
         )
         self.addCleanup(
-            self.runModule, "g.remove", flags="f", type="raster", name=output2, quiet=True
+            self.runModule,
+            "g.remove",
+            flags="f",
+            type="raster",
+            name=output2,
+            quiet=True,
         )
         self.runModule(
             "v.in.ascii",
@@ -281,9 +306,7 @@ class TestVFlexure(TestCase):
             output=loads2,
         )
         self.runModule("v.db.addtable", map=loads2)
-        self.runModule(
-            "v.db.addcolumn", map=loads2, columns="q double precision"
-        )
+        self.runModule("v.db.addcolumn", map=loads2, columns="q double precision")
         self.runModule(
             "v.db.update", map=loads2, column="q", value="1e15", where="cat=1"
         )
@@ -306,23 +329,35 @@ class TestVFlexure(TestCase):
         out_km = "test_vflex_te_km_explicit"
         try:
             self.assertModule(
-                "v.flexure", input=self.loads, column="q",
-                te="10", output=out_default,
+                "v.flexure",
+                input=self.loads,
+                column="q",
+                te="10",
+                output=out_default,
             )
             self.assertModule(
-                "v.flexure", input=self.loads, column="q",
-                te="10", te_units="km", output=out_km,
+                "v.flexure",
+                input=self.loads,
+                column="q",
+                te="10",
+                te_units="km",
+                output=out_km,
             )
             stats_d = gs.parse_command("r.univar", map=out_default, flags="g")
             stats_k = gs.parse_command("r.univar", map=out_km, flags="g")
             self.assertAlmostEqual(
-                float(stats_d["min"]), float(stats_k["min"]), places=10,
+                float(stats_d["min"]),
+                float(stats_k["min"]),
+                places=10,
                 msg="Default te_units=km must match explicit te_units=km",
             )
         finally:
             self.runModule(
-                "g.remove", flags="f", type="raster",
-                name=",".join([out_default, out_km]), quiet=True,
+                "g.remove",
+                flags="f",
+                type="raster",
+                name=",".join([out_default, out_km]),
+                quiet=True,
             )
 
     def test_linearity(self):
@@ -335,11 +370,20 @@ class TestVFlexure(TestCase):
         out_1x = "test_vflex_linear_1x"
         out_2x = "test_vflex_linear_2x"
         self.addCleanup(
-            self.runModule, "g.remove", flags="f", type="vector", name=loads_2x, quiet=True
+            self.runModule,
+            "g.remove",
+            flags="f",
+            type="vector",
+            name=loads_2x,
+            quiet=True,
         )
         self.addCleanup(
-            self.runModule, "g.remove", flags="f", type="raster",
-            name=",".join([out_1x, out_2x]), quiet=True,
+            self.runModule,
+            "g.remove",
+            flags="f",
+            type="raster",
+            name=",".join([out_1x, out_2x]),
+            quiet=True,
         )
         self.runModule(
             "v.in.ascii",
@@ -350,24 +394,32 @@ class TestVFlexure(TestCase):
             output=loads_2x,
         )
         self.runModule("v.db.addtable", map=loads_2x)
-        self.runModule(
-            "v.db.addcolumn", map=loads_2x, columns="q double precision"
-        )
+        self.runModule("v.db.addcolumn", map=loads_2x, columns="q double precision")
         self.runModule(
             "v.db.update", map=loads_2x, column="q", value="2e15", where="cat=1"
         )
         self.assertModule(
-            "v.flexure", input=self.loads, column="q",
-            te="10000", te_units="m", output=out_1x,
+            "v.flexure",
+            input=self.loads,
+            column="q",
+            te="10000",
+            te_units="m",
+            output=out_1x,
         )
         self.assertModule(
-            "v.flexure", input=loads_2x, column="q",
-            te="10000", te_units="m", output=out_2x,
+            "v.flexure",
+            input=loads_2x,
+            column="q",
+            te="10000",
+            te_units="m",
+            output=out_2x,
         )
         stats_1x = gs.parse_command("r.univar", map=out_1x, flags="g")
         stats_2x = gs.parse_command("r.univar", map=out_2x, flags="g")
         self.assertAlmostEqual(
-            float(stats_2x["min"]), 2.0 * float(stats_1x["min"]), places=6,
+            float(stats_2x["min"]),
+            2.0 * float(stats_1x["min"]),
+            places=6,
             msg="Peak deflection must scale linearly with load force",
         )
 
@@ -377,23 +429,35 @@ class TestVFlexure(TestCase):
         out_stiff = "test_vflex_stiff_te"
         try:
             self.assertModule(
-                "v.flexure", input=self.loads, column="q",
-                te="5000", te_units="m", output=out_soft,
+                "v.flexure",
+                input=self.loads,
+                column="q",
+                te="5000",
+                te_units="m",
+                output=out_soft,
             )
             self.assertModule(
-                "v.flexure", input=self.loads, column="q",
-                te="20000", te_units="m", output=out_stiff,
+                "v.flexure",
+                input=self.loads,
+                column="q",
+                te="20000",
+                te_units="m",
+                output=out_stiff,
             )
             stats_soft = gs.parse_command("r.univar", map=out_soft, flags="g")
             stats_stiff = gs.parse_command("r.univar", map=out_stiff, flags="g")
             self.assertLess(
-                float(stats_soft["min"]), float(stats_stiff["min"]),
+                float(stats_soft["min"]),
+                float(stats_stiff["min"]),
                 msg="Softer plate (Te=5 km) must deflect more than stiffer (Te=20 km)",
             )
         finally:
             self.runModule(
-                "g.remove", flags="f", type="raster",
-                name=",".join([out_soft, out_stiff]), quiet=True,
+                "g.remove",
+                flags="f",
+                type="raster",
+                name=",".join([out_soft, out_stiff]),
+                quiet=True,
             )
 
 
@@ -412,9 +476,7 @@ class TestVFlexureForebulge(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.use_temp_region()
-        cls.runModule(
-            "g.region", n=600000, s=0, e=600000, w=0, res=10000
-        )
+        cls.runModule("g.region", n=600000, s=0, e=600000, w=0, res=10000)
         cls.runModule(
             "v.in.ascii",
             format="point",
@@ -424,9 +486,7 @@ class TestVFlexureForebulge(TestCase):
             output=cls.loads,
         )
         cls.runModule("v.db.addtable", map=cls.loads)
-        cls.runModule(
-            "v.db.addcolumn", map=cls.loads, columns="q double precision"
-        )
+        cls.runModule("v.db.addcolumn", map=cls.loads, columns="q double precision")
         cls.runModule(
             "v.db.update", map=cls.loads, column="q", value="1e18", where="cat=1"
         )
@@ -434,9 +494,7 @@ class TestVFlexureForebulge(TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.del_temp_region()
-        cls.runModule(
-            "g.remove", flags="f", type="vector", name=cls.loads, quiet=True
-        )
+        cls.runModule("g.remove", flags="f", type="vector", name=cls.loads, quiet=True)
 
     def tearDown(self):
         self.runModule(
@@ -460,10 +518,12 @@ class TestVFlexureForebulge(TestCase):
             output=self.output,
         )
         stats = gs.parse_command("r.univar", map=self.output, flags="g")
-        self.assertLess(float(stats["min"]), 0,
-                        "Central subsidence must be negative")
-        self.assertGreater(float(stats["max"]), 0,
-                           "Forebulge uplift must be positive on a 600 km domain")
+        self.assertLess(float(stats["min"]), 0, "Central subsidence must be negative")
+        self.assertGreater(
+            float(stats["max"]),
+            0,
+            "Forebulge uplift must be positive on a 600 km domain",
+        )
 
 
 if __name__ == "__main__":

--- a/src/vector/v.flexure/v.flexure.html
+++ b/src/vector/v.flexure/v.flexure.html
@@ -1,22 +1,22 @@
 <h2>DESCRIPTION</h2>
 
-<em>v.flexure</em> computes how the rigid outer shell of a planet deforms elastically in response to surface-normal point loads by solving equations for plate bending. This phenomenon is known as "flexural isostasy" and is relevant to glacier/ice-cap/ice-sheet loading, sedimentary basin filling, mountain belt growth, volcano emplacement, sea-level change, and other geologic processes. <em>v.flexure</em> and <em><a href="r.flexure.html">r.flexure</a></em> are the GRASS GIS interfaces to the model <a href="https://github.com/awickert/gFlex"><b>gFlex</b></a>.
+<em>v.flexure</em> computes how the rigid outer shell of a planet deforms elastically in response to surface-normal point loads by solving equations for plate bending. This phenomenon is known as "flexural isostasy" and is relevant to glacier/ice-cap/ice-sheet loading, sedimentary basin filling, mountain belt growth, volcano emplacement, sea-level change, and other geologic processes. <em>v.flexure</em> and <em><a href="r.flexure.html">r.flexure</a></em> are the GRASS GIS interfaces to the model <a href="https://gflex.readthedocs.io/"><b>gFlex</b></a>.
 
-As both <em>v.flexure</em> and <em><a href="r.flexure.html">r.flexure</a></em> are interfaces to gFlex, it must be downloaded and installed. <em>v.flexure</em> requires <b>gFlex &ge; 2.0.0</b>:
+<em>v.flexure</em> requires <b>gFlex &ge; 2.0.0</b>:
 
 <div class="code"><pre>
 pip install "gflex>=2.0.0"
 </pre></div>
 
-Source and further installation instructions are available at <a href="https://github.com/awickert/gFlex">https://github.com/awickert/gFlex</a>.
+Full documentation and installation instructions are at <a href="https://gflex.readthedocs.io/">https://gflex.readthedocs.io/</a>.
 
 <h2>NOTES</h2>
 
-<em>v.flexure</em> uses the Superposition of Analytical Solutions for Non-Gridded points (SAS_NG) method in gFlex. Each input point load is treated as a concentrated force, and the far-field deflection is computed analytically as the superposition of Kelvin-Bessel (kei) functions.
+<em>v.flexure</em> uses the Superposition of Analytical Solutions for Non-Gridded points (SAS_NG) method in gFlex. Each input point load is treated as a concentrated force, and the far-field deflection is computed analytically as the superposition of Kelvin&ndash;Bessel (kei) functions.
 
-<b>input</b> is a vector points file. Each point represents a load in units of force [N]. For a distributed load field discretized as points, the user should incorporate the tributary area and load stress into the values stored in the attribute table column specified by <b>column</b>.
+<b>input</b> is a vector points map. Each point represents a load in units of force [N]. For a distributed load field discretized as points, the user should incorporate the tributary area and load stress into the values stored in the attribute column specified by <b>column</b>.
 <p>
-<b>te</b>, written in standard notation as T<sub>e</sub>, is the lithospheric elastic thickness (scalar only for v.flexure).
+<b>te</b>, written in standard notation as T<sub>e</sub>, is the lithospheric elastic thickness (scalar only for <em>v.flexure</em>; use <em><a href="r.flexure.html">r.flexure</a></em> for spatially variable T<sub>e</sub>).
 <p>
 <b>output</b> is a raster map of deflections at the spacing and extent of the current GRASS computational region. Be sure to use <em><a href="https://grass.osgeo.org/grass-stable/manuals/g.region.html">g.region</a></em> to set the region before running the module.
 <p>
@@ -77,8 +77,6 @@ d.legend w_chain_rast
 <h2>REFERENCES</h2>
 
 Wickert, A. D. (2016), Open-source modular solutions for flexural isostasy: gFlex v1.0, <i>Geoscientific Model Development</i>, <i>9</i>(3), 997&ndash;1017, doi:<a href="https://doi.org/10.5194/gmd-9-997-2016">10.5194/gmd-9-997-2016</a>.
-<p>
-van Wees, J. D., and S. Cloetingh (1994), A Finite-Difference Technique to Incorporate Spatial Variations In Rigidity and Planar Faults Into 3-D Models For Lithospheric Flexure, <i>Geophysical Journal International</i>, <i>117</i>(1), 179&ndash;195, doi:<a href="https://doi.org/10.1111/j.1365-246X.1994.tb03311.x">10.1111/j.1365-246X.1994.tb03311.x</a>.
 
 <h2>AUTHOR</h2>
 

--- a/src/vector/v.flexure/v.flexure.html
+++ b/src/vector/v.flexure/v.flexure.html
@@ -1,35 +1,90 @@
 <h2>DESCRIPTION</h2>
 
-<em>v.flexure</em> computes how the rigid outer shell of a planet deforms elastically in response to surface-normal loads by solving equations for plate bending. This phenomenon is known as "flexural isostasy" and can be useful in cases of glacier/ice-cap/ice-sheet loading, sedimentary basin filling, mountain belt growth, volcano emplacement, sea-level change, and other geologic processes. <em>v.flexure</em> and <a href="r.flexure.html">r.flexure</a> are the GRASS GIS interfaces to the the model <a href="https://csdms.colorado.edu/wiki/Model:GFlex"><b>gFlex</b></a>.
+<em>v.flexure</em> computes how the rigid outer shell of a planet deforms elastically in response to surface-normal point loads by solving equations for plate bending. This phenomenon is known as "flexural isostasy" and is relevant to glacier/ice-cap/ice-sheet loading, sedimentary basin filling, mountain belt growth, volcano emplacement, sea-level change, and other geologic processes. <em>v.flexure</em> and <em><a href="r.flexure.html">r.flexure</a></em> are the GRASS GIS interfaces to the model <a href="https://github.com/awickert/gFlex"><b>gFlex</b></a>.
 
-As both <em>v.flexure</em> and <a href="r.flexure.html">r.flexure</a> are interfaces to gFlex, this must be downloaded and installed. The most recent versions of <b>gFlex</b> are available from <a href="https://github.com/awickert/gFlex">https://github.com/awickert/gFlex</a>, and installation instructions are avaliable on that page via the <em>README.md</em> file.
+As both <em>v.flexure</em> and <em><a href="r.flexure.html">r.flexure</a></em> are interfaces to gFlex, it must be downloaded and installed. <em>v.flexure</em> requires <b>gFlex &ge; 2.0.0</b>:
+
+<div class="code"><pre>
+pip install "gflex>=2.0.0"
+</pre></div>
+
+Source and further installation instructions are available at <a href="https://github.com/awickert/gFlex">https://github.com/awickert/gFlex</a>.
 
 <h2>NOTES</h2>
 
-<b>input</b> is a vector points file containing the loads in units of force. Typically, this will be a representation of a distributed field of loads as a set of points, so the user will implicitly include the area over which a stress (vertical load) acts into the quantities in the database table of <b>input</b>.
+<em>v.flexure</em> uses the Superposition of Analytical Solutions for Non-Gridded points (SAS_NG) method in gFlex. Each input point load is treated as a concentrated force, and the far-field deflection is computed analytically as the superposition of Kelvin-Bessel (kei) functions.
+
+<b>input</b> is a vector points file. Each point represents a load in units of force [N]. For a distributed load field discretized as points, the user should incorporate the tributary area and load stress into the values stored in the attribute table column specified by <b>column</b>.
 <p>
-<b>te</b>, written in standard text as T<sub>e</sub>, is the lithospheric elastic thickness.
+<b>te</b>, written in standard notation as T<sub>e</sub>, is the lithospheric elastic thickness (scalar only for v.flexure).
 <p>
-<b>output</b> is provided as a grid of vector points corresponding to the GRASS region when this command is invoked. Be sure to use <em>g.region</em> to properly set the input region! <b>raster_output</b> is the same output, except converted to a raster grid at the same resolution as the current computational region. If you have a grid spacing that is much smaller than a flexural wavelength, it is possible to interpolate the vector output to a much finer resolution than this raster output provides.
+<b>output</b> is a raster map of deflections at the spacing and extent of the current GRASS computational region. Be sure to use <em><a href="https://grass.osgeo.org/grass-stable/manuals/g.region.html">g.region</a></em> to set the region before running the module.
 <p>
-The <a href="https://csdms.colorado.edu">Community Surface Dynamics Modeling System</a>, into which <b>gFlex</b> is integrated, is a community-driven effort to build an open-source modeling infrastructure for Earth-surface processes.
+<b>w_points</b> is an optional existing vector points map at which deflection will also be evaluated. This allows deflection to be computed at arbitrary locations such as GPS stations, boreholes, or tide gauges that do not align with the raster grid. The deflection value at each point is written into the column specified by <b>w_column</b> (default: <tt>w</tt>), which is added to the map's attribute table if it does not already exist. The raster grid and the w_points locations are evaluated in a single gFlex solve, so there is no additional computational cost.
+<p>
+In latitude/longitude coordinates, <em>v.flexure</em> automatically computes great-circle distances between load and output points.
+
+<h2>EXAMPLES</h2>
+
+<h3>Three seamounts along a volcanic chain</h3>
+
+<p>
+Three point loads represent seamounts spaced 500&nbsp;km apart. Each
+force (~5&nbsp;&times;&nbsp;10<sup>16</sup>&nbsp;N) corresponds roughly to
+a seamount with a 25&nbsp;km base radius, 3&nbsp;km height, and basalt
+density. Because the flexural parameter
+&alpha;&nbsp;&asymp;&nbsp;41&nbsp;km for T<sub>e</sub>&nbsp;=&nbsp;25&nbsp;km
+is much smaller than the 500&nbsp;km spacing, the three depressions are
+essentially independent; their deflections add linearly everywhere.
+</p>
+
+<div class="code"><pre>
+# Domain: 2000 × 1000 km at 20 km resolution (projected CRS required)
+g.region n=1000000 s=0 e=2000000 w=0 res=20000
+
+# Three seamounts along the chain (x y, one per line)
+echo "500000 500000
+1000000 500000
+1500000 500000" | v.in.ascii format=point input=- output=seamount_chain
+
+# Add load column and set the same force [N] for all three points
+v.db.addtable map=seamount_chain
+v.db.addcolumn map=seamount_chain columns="force double precision"
+v.db.update map=seamount_chain column=force value=5e16
+
+# SAS_NG deflection; raster output required
+v.flexure input=seamount_chain column=force \
+    te=25 te_units=km \
+    output=w_chain_rast
+
+# Optionally also evaluate at a set of tide-gauge or GPS stations
+v.flexure input=seamount_chain column=force \
+    te=25 te_units=km \
+    output=w_chain_rast \
+    w_points=tide_gauges w_column=w_flexure
+
+d.rast w_chain_rast
+d.legend w_chain_rast
+</pre></div>
 
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="v.flexure.html">v.flexure</a>,
+<a href="r.flexure.html">r.flexure</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/v.surf.bspline.html">v.surf.bspline</a>
 </em>
 
-
 <h2>REFERENCES</h2>
 
-Wickert, A. D. (2015), Open-source modular solutions for flexural isostasy: gFlex v1.0, <i>Geoscientific Model Development Discussions</i>, <i>8</i>(6), 4245&ndash;4292, doi:10.5194/gmdd-8-4245-2015.
+Wickert, A. D. (2016), Open-source modular solutions for flexural isostasy: gFlex v1.0, <i>Geoscientific Model Development</i>, <i>9</i>(3), 997&ndash;1017, doi:<a href="https://doi.org/10.5194/gmd-9-997-2016">10.5194/gmd-9-997-2016</a>.
 <p>
-Wickert, A. D., G. E. Tucker, E. W. H. Hutton, B. Yan, and S. D. Peckham (2011), <a href="https://csdms.colorado.edu/csdms_wiki/images/Andrew_Wickert_CSDMS_2011_annual_meeting.pdf">Feedbacks between surface processes and flexural isostasy: a motivation for coupling models</a>, in <i>CSDMS 2011 Meeting: Impact of time and process scales</i>, Student Keynote, Boulder, CO.
-<p>
-van Wees, J. D., and S. Cloetingh (1994), A Finite-Difference Technique to Incorporate Spatial Variations In Rigidity and Planar Faults Into 3-D Models For Lithospheric Flexure, <i>Geophysical Journal International</i>, <i>117</i>(1), 179&ndash;195, <a href="https://doi.org/10.1111/j.1365-246X.1994.tb03311.x">doi:10.1111/j.1365-246X.1994.tb03311.x</a>.
+van Wees, J. D., and S. Cloetingh (1994), A Finite-Difference Technique to Incorporate Spatial Variations In Rigidity and Planar Faults Into 3-D Models For Lithospheric Flexure, <i>Geophysical Journal International</i>, <i>117</i>(1), 179&ndash;195, doi:<a href="https://doi.org/10.1111/j.1365-246X.1994.tb03311.x">10.1111/j.1365-246X.1994.tb03311.x</a>.
 
 <h2>AUTHOR</h2>
 
 Andrew D. Wickert
+
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->

--- a/src/vector/v.flexure/v.flexure.md
+++ b/src/vector/v.flexure/v.flexure.md
@@ -1,65 +1,71 @@
 ## DESCRIPTION
 
-*v.flexure* computes how the rigid outer shell of a planet deforms
-elastically in response to surface-normal loads by solving equations for
-plate bending. This phenomenon is known as "flexural isostasy" and can
-be useful in cases of glacier/ice-cap/ice-sheet loading, sedimentary
-basin filling, mountain belt growth, volcano emplacement, sea-level
-change, and other geologic processes. *v.flexure* and
-[r.flexure](r.flexure.md) are the GRASS GIS interfaces to the the model
-[**gFlex**](https://csdms.colorado.edu/wiki/Model:GFlex). As both
-*v.flexure* and [r.flexure](r.flexure.md) are interfaces to gFlex, this
-must be downloaded and installed. The most recent versions of **gFlex**
-are available from <https://github.com/awickert/gFlex>, and installation
-instructions are avaliable on that page via the *README.md* file.
+*v.flexure* computes how the rigid outer shell of a planet deforms elastically in response to surface-normal point loads by solving equations for plate bending. This phenomenon is known as "flexural isostasy" and is relevant to glacier/ice-cap/ice-sheet loading, sedimentary basin filling, mountain belt growth, volcano emplacement, sea-level change, and other geologic processes. *v.flexure* and *[r.flexure](r.flexure.html)* are the GRASS GIS interfaces to the model [**gFlex**](https://gflex.readthedocs.io/). *v.flexure* requires **gFlex ≥ 2.0.0**:
+
+<div class="code">
+
+    pip install "gflex>=2.0.0"
+
+</div>
+
+Full documentation and installation instructions are at <https://gflex.readthedocs.io/>.
 
 ## NOTES
 
-**input** is a vector points file containing the loads in units of
-force. Typically, this will be a representation of a distributed field
-of loads as a set of points, so the user will implicitly include the
-area over which a stress (vertical load) acts into the quantities in the
-database table of **input**.
+*v.flexure* uses the Superposition of Analytical Solutions for Non-Gridded points (SAS_NG) method in gFlex. Each input point load is treated as a concentrated force, and the far-field deflection is computed analytically as the superposition of Kelvin–Bessel (kei) functions. **input** is a vector points map. Each point represents a load in units of force \[N\]. For a distributed load field discretized as points, the user should incorporate the tributary area and load stress into the values stored in the attribute column specified by **column**.
 
-**te**, written in standard text as T<sub>e</sub>, is the lithospheric
-elastic thickness.
+**te**, written in standard notation as T<sub>e</sub>, is the lithospheric elastic thickness (scalar only for *v.flexure*; use *[r.flexure](r.flexure.html)* for spatially variable T<sub>e</sub>).
 
-**output** is provided as a grid of vector points corresponding to the
-GRASS region when this command is invoked. Be sure to use *g.region* to
-properly set the input region\! **raster\_output** is the same output,
-except converted to a raster grid at the same resolution as the current
-computational region. If you have a grid spacing that is much smaller
-than a flexural wavelength, it is possible to interpolate the vector
-output to a much finer resolution than this raster output provides.
+**output** is a raster map of deflections at the spacing and extent of the current GRASS computational region. Be sure to use *[g.region](https://grass.osgeo.org/grass-stable/manuals/g.region.html)* to set the region before running the module.
 
-The [Community Surface Dynamics Modeling
-System](https://csdms.colorado.edu), into which **gFlex** is integrated,
-is a community-driven effort to build an open-source modeling
-infrastructure for Earth-surface processes.
+**w_points** is an optional existing vector points map at which deflection will also be evaluated. This allows deflection to be computed at arbitrary locations such as GPS stations, boreholes, or tide gauges that do not align with the raster grid. The deflection value at each point is written into the column specified by **w_column** (default: `w`), which is added to the map's attribute table if it does not already exist. The raster grid and the w_points locations are evaluated in a single gFlex solve, so there is no additional computational cost.
+
+In latitude/longitude coordinates, *v.flexure* automatically computes great-circle distances between load and output points.
+
+## EXAMPLES
+
+### Three seamounts along a volcanic chain
+
+Three point loads represent seamounts spaced 500 km apart. Each force (~5 × 10<sup>16</sup> N) corresponds roughly to a seamount with a 25 km base radius, 3 km height, and basalt density. Because the flexural parameter α ≈ 41 km for T<sub>e</sub> = 25 km is much smaller than the 500 km spacing, the three depressions are essentially independent; their deflections add linearly everywhere.
+
+<div class="code">
+
+    # Domain: 2000 × 1000 km at 20 km resolution (projected CRS required)
+    g.region n=1000000 s=0 e=2000000 w=0 res=20000
+
+    # Three seamounts along the chain (x y, one per line)
+    echo "500000 500000
+    1000000 500000
+    1500000 500000" | v.in.ascii format=point input=- output=seamount_chain
+
+    # Add load column and set the same force [N] for all three points
+    v.db.addtable map=seamount_chain
+    v.db.addcolumn map=seamount_chain columns="force double precision"
+    v.db.update map=seamount_chain column=force value=5e16
+
+    # SAS_NG deflection; raster output required
+    v.flexure input=seamount_chain column=force \
+        te=25 te_units=km \
+        output=w_chain_rast
+
+    # Optionally also evaluate at a set of tide-gauge or GPS stations
+    v.flexure input=seamount_chain column=force \
+        te=25 te_units=km \
+        output=w_chain_rast \
+        w_points=tide_gauges w_column=w_flexure
+
+    d.rast w_chain_rast
+    d.legend w_chain_rast
+
+</div>
 
 ## SEE ALSO
 
-*[v.flexure](v.flexure.md),
-[v.surf.bspline](https://grass.osgeo.org/grass-stable/manuals/v.surf.bspline.html)*
+*[r.flexure](r.flexure.html), [v.surf.bspline](https://grass.osgeo.org/grass-stable/manuals/v.surf.bspline.html)*
 
 ## REFERENCES
 
-Wickert, A. D. (2015), Open-source modular solutions for flexural
-isostasy: gFlex v1.0, *Geoscientific Model Development Discussions*,
-*8*(6), 4245–4292, doi:10.5194/gmdd-8-4245-2015.
-
-Wickert, A. D., G. E. Tucker, E. W. H. Hutton, B. Yan, and S. D. Peckham
-(2011), [Feedbacks between surface processes and flexural isostasy: a
-motivation for coupling
-models](https://csdms.colorado.edu/csdms_wiki/images/Andrew_Wickert_CSDMS_2011_annual_meeting.pdf),
-in *CSDMS 2011 Meeting: Impact of time and process scales*, Student
-Keynote, Boulder, CO.
-
-van Wees, J. D., and S. Cloetingh (1994), A Finite-Difference Technique
-to Incorporate Spatial Variations In Rigidity and Planar Faults Into 3-D
-Models For Lithospheric Flexure, *Geophysical Journal International*,
-*117*(1), 179–195,
-[doi:10.1111/j.1365-246X.1994.tb03311.x](https://doi.org/10.1111/j.1365-246X.1994.tb03311.x).
+Wickert, A. D. (2016), Open-source modular solutions for flexural isostasy: gFlex v1.0, *Geoscientific Model Development*, *9*(3), 997–1017, doi:[10.5194/gmd-9-997-2016](https://doi.org/10.5194/gmd-9-997-2016).
 
 ## AUTHOR
 

--- a/src/vector/v.flexure/v.flexure.md
+++ b/src/vector/v.flexure/v.flexure.md
@@ -1,34 +1,64 @@
 ## DESCRIPTION
 
-*v.flexure* computes how the rigid outer shell of a planet deforms elastically in response to surface-normal point loads by solving equations for plate bending. This phenomenon is known as "flexural isostasy" and is relevant to glacier/ice-cap/ice-sheet loading, sedimentary basin filling, mountain belt growth, volcano emplacement, sea-level change, and other geologic processes. *v.flexure* and *[r.flexure](r.flexure.html)* are the GRASS GIS interfaces to the model [**gFlex**](https://gflex.readthedocs.io/). *v.flexure* requires **gFlex ≥ 2.0.0**:
-
-<div class="code">
+*v.flexure* computes how the rigid outer shell of a planet deforms
+elastically in response to surface-normal point loads by solving
+equations for plate bending. This phenomenon is known as "flexural
+isostasy" and is relevant to glacier/ice-cap/ice-sheet loading,
+sedimentary basin filling, mountain belt growth, volcano emplacement,
+sea-level change, and other geologic processes. *v.flexure* and
+*[r.flexure](r.flexure.html)* are the GRASS GIS interfaces to the
+model [**gFlex**](https://gflex.readthedocs.io/). *v.flexure* requires
+**gFlex ≥ 2.0.0**:
 
     pip install "gflex>=2.0.0"
 
-</div>
-
-Full documentation and installation instructions are at <https://gflex.readthedocs.io/>.
+Full documentation and installation instructions are at
+<https://gflex.readthedocs.io/>.
 
 ## NOTES
 
-*v.flexure* uses the Superposition of Analytical Solutions for Non-Gridded points (SAS_NG) method in gFlex. Each input point load is treated as a concentrated force, and the far-field deflection is computed analytically as the superposition of Kelvin–Bessel (kei) functions. **input** is a vector points map. Each point represents a load in units of force \[N\]. For a distributed load field discretized as points, the user should incorporate the tributary area and load stress into the values stored in the attribute column specified by **column**.
+*v.flexure* uses the Superposition of Analytical Solutions for
+Non-Gridded points (SAS_NG) method in gFlex. Each input point load is
+treated as a concentrated force, and the far-field deflection is
+computed analytically as the superposition of Kelvin–Bessel (kei)
+functions. **input** is a vector points map. Each point represents a
+load in units of force \[N\]. For a distributed load field discretized
+as points, the user should incorporate the tributary area and load
+stress into the values stored in the attribute column specified by
+**column**.
 
-**te**, written in standard notation as T<sub>e</sub>, is the lithospheric elastic thickness (scalar only for *v.flexure*; use *[r.flexure](r.flexure.html)* for spatially variable T<sub>e</sub>).
+**te**, written in standard notation as T<sub>e</sub>, is the
+lithospheric elastic thickness (scalar only for *v.flexure*; use
+*[r.flexure](r.flexure.html)* for spatially variable T<sub>e</sub>).
 
-**output** is a raster map of deflections at the spacing and extent of the current GRASS computational region. Be sure to use *[g.region](https://grass.osgeo.org/grass-stable/manuals/g.region.html)* to set the region before running the module.
+**output** is a raster map of deflections at the spacing and extent of
+the current GRASS computational region. Be sure to use
+*[g.region](https://grass.osgeo.org/grass-stable/manuals/g.region.html)*
+to set the region before running the module.
 
-**w_points** is an optional existing vector points map at which deflection will also be evaluated. This allows deflection to be computed at arbitrary locations such as GPS stations, boreholes, or tide gauges that do not align with the raster grid. The deflection value at each point is written into the column specified by **w_column** (default: `w`), which is added to the map's attribute table if it does not already exist. The raster grid and the w_points locations are evaluated in a single gFlex solve, so there is no additional computational cost.
+**w_points** is an optional existing vector points map at which
+deflection will also be evaluated. This allows deflection to be
+computed at arbitrary locations such as GPS stations, boreholes, or
+tide gauges that do not align with the raster grid. The deflection
+value at each point is written into the column specified by
+**w_column** (default: `w`), which is added to the map's attribute
+table if it does not already exist. The raster grid and the w_points
+locations are evaluated in a single gFlex solve, so there is no
+additional computational cost.
 
-In latitude/longitude coordinates, *v.flexure* automatically computes great-circle distances between load and output points.
+In latitude/longitude coordinates, *v.flexure* automatically computes
+great-circle distances between load and output points.
 
 ## EXAMPLES
 
 ### Three seamounts along a volcanic chain
 
-Three point loads represent seamounts spaced 500 km apart. Each force (~5 × 10<sup>16</sup> N) corresponds roughly to a seamount with a 25 km base radius, 3 km height, and basalt density. Because the flexural parameter α ≈ 41 km for T<sub>e</sub> = 25 km is much smaller than the 500 km spacing, the three depressions are essentially independent; their deflections add linearly everywhere.
-
-<div class="code">
+Three point loads represent seamounts spaced 500 km apart. Each force
+(~5 × 10<sup>16</sup> N) corresponds roughly to a seamount with a
+25 km base radius, 3 km height, and basalt density. Because the
+flexural parameter α ≈ 41 km for T<sub>e</sub> = 25 km is much
+smaller than the 500 km spacing, the three depressions are essentially
+independent; their deflections add linearly everywhere.
 
     # Domain: 2000 × 1000 km at 20 km resolution (projected CRS required)
     g.region n=1000000 s=0 e=2000000 w=0 res=20000
@@ -57,15 +87,17 @@ Three point loads represent seamounts spaced 500 km apart. Each force (~5 × 
     d.rast w_chain_rast
     d.legend w_chain_rast
 
-</div>
-
 ## SEE ALSO
 
-*[r.flexure](r.flexure.html), [v.surf.bspline](https://grass.osgeo.org/grass-stable/manuals/v.surf.bspline.html)*
+*[r.flexure](r.flexure.html)*,
+*[v.surf.bspline](https://grass.osgeo.org/grass-stable/manuals/v.surf.bspline.html)*
 
 ## REFERENCES
 
-Wickert, A. D. (2016), Open-source modular solutions for flexural isostasy: gFlex v1.0, *Geoscientific Model Development*, *9*(3), 997–1017, doi:[10.5194/gmd-9-997-2016](https://doi.org/10.5194/gmd-9-997-2016).
+Wickert, A. D. (2016), Open-source modular solutions for flexural
+isostasy: gFlex v1.0, *Geoscientific Model Development*, *9*(3),
+997–1017,
+doi:[10.5194/gmd-9-997-2016](https://doi.org/10.5194/gmd-9-997-2016).
 
 ## AUTHOR
 

--- a/src/vector/v.flexure/v.flexure.py
+++ b/src/vector/v.flexure/v.flexure.py
@@ -153,8 +153,7 @@ import grass.script as gs
 def get_points_xy(vect_name):
     """Return (x, y) coordinate arrays for all points in a vector map."""
     out = gs.read_command(
-        "v.out.ascii", input=vect_name, format="point",
-        separator="space", quiet=True
+        "v.out.ascii", input=vect_name, format="point", separator="space", quiet=True
     )
     rows = [line.split() for line in out.strip().splitlines() if line.strip()]
     coords = np.array([[float(r[0]), float(r[1])] for r in rows], dtype=float)
@@ -200,8 +199,7 @@ def main():
     )
     if _gver < (2, 0, 0):
         gs.fatal(
-            _("v.flexure requires gFlex >= 2.0.0; installed: ")
-            + gflex.__version__
+            _("v.flexure requires gFlex >= 2.0.0; installed: ") + gflex.__version__
         )
 
     ##########
@@ -246,7 +244,9 @@ def main():
     # appended so both are evaluated in a single gFlex solve.
     _tmp_vect = "tmp_vflex_{}".format(os.getpid())
     gs.run_command("v.mkgrid", map=_tmp_vect, type="point", overwrite=True, quiet=True)
-    gs.run_command("v.db.addcolumn", map=_tmp_vect, columns="w double precision", quiet=True)
+    gs.run_command(
+        "v.db.addcolumn", map=_tmp_vect, columns="w double precision", quiet=True
+    )
     grid_x, grid_y = get_points_xy(_tmp_vect)
     n_grid = len(grid_x)
 
@@ -338,9 +338,7 @@ def main():
         overwrite=gs.overwrite(),
         quiet=True,
     )
-    gs.run_command(
-        "r.colors", map=options["output"], color="differences", quiet=True
-    )
+    gs.run_command("r.colors", map=options["output"], color="differences", quiet=True)
     gs.run_command("g.remove", flags="f", type="vector", name=_tmp_vect, quiet=True)
 
     # Write deflection values to the user-supplied w_points map
@@ -349,8 +347,7 @@ def main():
         col = options["w_column"]
         # Add column if it does not already exist
         existing_cols = [
-            c.lower()
-            for c in gs.vector_db_select(options["w_points"])["columns"]
+            c.lower() for c in gs.vector_db_select(options["w_points"])["columns"]
         ]
         if col.lower() not in existing_cols:
             gs.run_command(

--- a/src/vector/v.flexure/v.flexure.py
+++ b/src/vector/v.flexure/v.flexure.py
@@ -8,7 +8,7 @@
 # PURPOSE:      Calculate flexure of the lithosphere under a specified
 #               set of loads and with a given elastic thickness (scalar)
 #
-# COPYRIGHT:    (c) 2014, 2015 Andrew Wickert
+# COPYRIGHT:    (c) 2014, 2015, 2026 Andrew Wickert
 #
 #               This program is free software under the GNU General Public
 #               License (>=v2). Read the file COPYING that comes with GRASS
@@ -17,9 +17,7 @@
 #############################################################################
 #
 # REQUIREMENTS:
-#      -  gFlex: https://csdms.colorado.edu/wiki/Model:GFlex
-#         (should be downloaded automatically along with the module)
-#         github repository: https://github.com/awickert/gFlex
+#      -  gFlex: https://github.com/awickert/gFlex
 
 # More information
 # Started 20 Jan 2015 to add GRASS GIS support for distributed point loads
@@ -43,7 +41,7 @@
 # %  guidependency: column
 # %end
 
-# %option G_OPT_DB_COLUMNS
+# %option G_OPT_DB_COLUMN
 # %  key: column
 # %  description: Column containing load values [N]
 # %  required : yes
@@ -52,7 +50,7 @@
 # %option
 # %  key: te
 # %  type: double
-# %  description: Elastic thicnkess: scalar; unis chosen in "te_units"
+# %  description: Elastic thickness: scalar; units chosen in "te_units"
 # %  required : yes
 # %end
 
@@ -61,19 +59,29 @@
 # %  type: string
 # %  description: Units for elastic thickness
 # %  options: m, km
-# %  required : yes
-# %end
-
-# %option G_OPT_V_OUTPUT
-# %  key: output
-# %  description: Output vector points map of vertical deflections [m]
-# %  required : yes
+# %  answer: km
+# %  required : no
 # %end
 
 # %option G_OPT_R_OUTPUT
-# %  key: raster_output
+# %  key: output
 # %  description: Output raster map of vertical deflections [m]
+# %  required : yes
+# %end
+
+# %option G_OPT_V_MAP
+# %  key: w_points
+# %  description: Existing vector points map to receive deflection values
 # %  required : no
+# %  guisection: Output
+# %end
+
+# %option G_OPT_DB_COLUMN
+# %  key: w_column
+# %  description: Column in w_points map to write deflection values [m]
+# %  answer: w
+# %  required : no
+# %  guisection: Output
 # %end
 
 # %option
@@ -82,6 +90,7 @@
 # %  description: gravitational acceleration at surface [m/s^2]
 # %  answer: 9.8
 # %  required : no
+# %  guisection: Material properties
 # %end
 
 # %option
@@ -90,6 +99,7 @@
 # %  description: Young's Modulus [Pa]
 # %  answer: 65E9
 # %  required : no
+# %  guisection: Material properties
 # %end
 
 # %option
@@ -98,6 +108,7 @@
 # %  description: Poisson's ratio
 # %  answer: 0.25
 # %  required : no
+# %  guisection: Material properties
 # %end
 
 # %option
@@ -106,6 +117,7 @@
 # %  description: Density of material that fills flexural depressions [kg/m^3]
 # %  answer: 0
 # %  required : no
+# %  guisection: Material properties
 # %end
 
 # %option
@@ -114,6 +126,7 @@
 # %  description: Mantle density [kg/m^3]
 # %  answer: 3300
 # %  required : no
+# %  guisection: Material properties
 # %end
 
 
@@ -122,11 +135,14 @@
 ##################
 
 # PYTHON
+import os
+import tempfile
+import warnings
+
 import numpy as np
 
 # GRASS
-import grass.script as gs
-from grass.pygrass import vector
+import grass.script as grass
 
 
 ####################
@@ -135,16 +151,13 @@ from grass.pygrass import vector
 
 
 def get_points_xy(vect_name):
-    """
-    to find x and y using pygrass, see my (A. Wickert's) StackOverflow answer:
-    https://gis.stackexchange.com/a/132786
-    """
-    points = vector.VectorTopo(vect_name)
-    points.open("r")
-    coords = []
-    for i in range(len(points)):
-        coords.append(points.read(i + 1).coords())
-    coords = np.array(coords)
+    """Return (x, y) coordinate arrays for all points in a vector map."""
+    out = grass.read_command(
+        "v.out.ascii", input=vect_name, format="point",
+        separator="space", quiet=True
+    )
+    rows = [line.split() for line in out.strip().splitlines() if line.strip()]
+    coords = np.array([[float(r[0]), float(r[1])] for r in rows], dtype=float)
     return coords[:, 0], coords[:, 1]  # x, y
 
 
@@ -159,23 +172,37 @@ def main():
     GRASS GIS
     """
 
-    options, flags = gs.parser()
+    options, flags = grass.parser()
     # if just interface description is requested, it will not get to this point
     # so gflex will not be needed
 
-    # GFLEX
-    # try to import gflex only after we know that
-    # we will actually do the computation
+    # Import gFlex only after we know we will actually do the computation
     try:
-        import gflex
-    except:
-        print("")
-        print("MODULE IMPORT ERROR.")
-        print("In order to run r.flexure or g.flexure, you must download and install")
-        print("gFlex. The most recent development version is available from")
-        print("https://github.com/awickert/gFlex")
-        print("Installation instructions are available on the page.")
-        gs.fatal("Software dependency must be installed.")
+        # cmcrameri is an optional plotting dependency; GRASS never uses
+        # gFlex's plots, so suppress the missing-package warning at import.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message="cmcrameri is not installed", category=UserWarning
+            )
+            import gflex
+    except ImportError:
+        grass.fatal(
+            _(
+                "Cannot import gFlex. Install it from source with:\n"
+                "  pip install -e /path/to/gFlex\n"
+                "or see https://github.com/awickert/gFlex for details."
+            )
+        )
+
+    _gver = tuple(
+        int(x.split("a")[0].split("b")[0].split("rc")[0])
+        for x in gflex.__version__.split(".")[:3]
+    )
+    if _gver < (2, 0, 0):
+        grass.fatal(
+            _("v.flexure requires gFlex >= 2.0.0; installed: ")
+            + gflex.__version__
+        )
 
     ##########
     # SET-UP #
@@ -187,65 +214,57 @@ def main():
     flex.grass = True
 
     # Method
-    flex.Method = "SAS_NG"
+    flex.method = "sas_ng"
 
     # Parameters that are often changed for the solution
     ######################################################
 
-    # x, y, q
+    # x, y, q — load point coordinates and magnitudes
     flex.x, flex.y = get_points_xy(options["input"])
-    # xw, yw: gridded output
-    if len(gs.parse_command("g.list", type="vect", pattern=options["output"])):
-        if not gs.overwrite():
-            gs.fatal(
-                "Vector map '"
-                + options["output"]
-                + "' already exists. Use '--o' to overwrite."
-            )
-    # Just check raster at the same time if it exists
-    if len(gs.parse_command("g.list", type="rast", pattern=options["raster_output"])):
-        if not gs.overwrite():
-            gs.fatal(
-                "Raster map '"
-                + options["raster_output"]
-                + "' already exists. Use '--o' to overwrite."
-            )
-    gs.run_command(
-        "v.mkgrid",
-        map=options["output"],
-        type="point",
-        overwrite=gs.overwrite(),
-        quiet=True,
-    )
-    gs.run_command(
-        "v.db.addcolumn",
-        map=options["output"],
-        columns="w double precision",
-        quiet=True,
-    )
-    flex.xw, flex.yw = get_points_xy(options["output"])  # gridded output coordinates
-    vect_db = gs.vector_db_select(options["input"])
+    vect_db = grass.vector_db_select(options["input"])
     col_names = np.array(vect_db["columns"])
     q_col = col_names == options["column"]
     if np.sum(q_col):
         col_values = np.array(list(vect_db["values"].values())).astype(float)
-        flex.q = col_values[:, q_col].squeeze()  # Make it 1D for consistency w/ x, y
+        flex.q = col_values[:, q_col].reshape(-1)  # always 1-D, even for a single point
     else:
-        gs.fatal(
-            "provided column name, "
-            + options["column"]
-            + " does not match\nany column in "
-            + options["q0"]
-            + "."
+        grass.fatal(
+            _("Column <%s> not found in vector map <%s>.")
+            % (options["column"], options["input"])
         )
+
+    # Overwrite check for raster output
+    if len(grass.parse_command("g.list", type="rast", pattern=options["output"])):
+        if not grass.overwrite():
+            grass.fatal(
+                _("Raster map <%s> already exists. Use '--o' to overwrite.")
+                % options["output"]
+            )
+
+    # Build the output coordinate arrays.
+    # The raster grid is always needed; w_points coordinates (if provided) are
+    # appended so both are evaluated in a single gFlex solve.
+    _tmp_vect = "tmp_vflex_{}".format(os.getpid())
+    grass.run_command("v.mkgrid", map=_tmp_vect, type="point", overwrite=True, quiet=True)
+    grass.run_command("v.db.addcolumn", map=_tmp_vect, columns="w double precision", quiet=True)
+    grid_x, grid_y = get_points_xy(_tmp_vect)
+    n_grid = len(grid_x)
+
+    if options["w_points"]:
+        pts_x, pts_y = get_points_xy(options["w_points"])
+        flex.xw = np.concatenate([grid_x, pts_x])
+        flex.yw = np.concatenate([grid_y, pts_y])
+    else:
+        flex.xw = grid_x
+        flex.yw = grid_y
     # Elastic thickness
-    flex.Te = float(options["te"])
+    flex.T_e = float(options["te"])
     if options["te_units"] == "km":
-        flex.Te *= 1000
+        flex.T_e *= 1000
     elif options["te_units"] == "m":
         pass
     else:
-        gs.fatal("Inappropriate te_units. How? Options should be limited by GRASS.")
+        grass.fatal(_("Inappropriate te_units; this should not be reachable."))
     flex.rho_fill = float(options["rho_fill"])
 
     # Parameters that often stay at their default values
@@ -257,84 +276,108 @@ def main():
     flex.nu = float(options["nu"])
     flex.rho_m = float(options["rho_m"])
 
-    # Set verbosity
-    if gs.verbosity() >= 2:
-        flex.Verbose = True
-    if gs.verbosity() >= 3:
-        flex.Debug = True
-    elif gs.verbosity() == 0:
-        flex.Quiet = True
+    # gFlex defaults to quiet (WARNING log level); opt in at --verbose (level 3).
+    if grass.verbosity() >= 3:
+        flex.verbose = True
+        flex.quiet = False
 
     # Check if lat/lon and let user know if verbosity is True
-    if gs.region_env()[6] == "3":
+    if grass.region_env()[6] == "3":
         flex.latlon = True
-        flex.PlanetaryRadius = float(gs.parse_command("g.proj", flags="j")["+a"])
-        if flex.Verbose:
-            print("Latitude/longitude grid.")
-            print("Based on r_Earth = 6371 km")
-            print("Computing distances between load points using great circle paths")
+        flex.planetary_radius = float(grass.parse_command("g.proj", flags="j")["+a"])
+        if flex.verbose:
+            grass.message(_("Latitude/longitude grid."))
+            grass.message(_("Based on r_Earth = 6371 km"))
+            grass.message(
+                _("Computing distances between load points using great circle paths")
+            )
 
     ##########
     # SOLVE! #
     ##########
 
-    flex.initialize()
-    flex.run()
-    flex.finalize()
+    grass.message(_("Computing deflections..."))
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        flex.initialize()
+        flex.run()
+        # finalize() deletes flex.w in gFlex v2, so capture it first
+        w_out = np.array(flex.w)
+        flex.finalize()
+    for warninfo in caught:
+        grass.warning(str(warninfo.message))
 
-    # Now to use lower-level GRASS vector commands to work with the database
-    # table and update its entries
-    # See for help:
-    # https://nbviewer.org/github/zarch/workshop-pygrass/blob/d183b7fb593623f23678bb597547a7b4378e2be5/02_Modules_pygrass.ipynb
-    w = vector.VectorTopo(options["output"])
-    w.open("rw")  # Get ready to read and write
-    wdb = w.dblinks[0]
-    wtable = wdb.table()
-    col = int(
-        (np.array(wtable.columns.names()) == "w").nonzero()[0]
-    )  # update this column
-    for i in range(1, len(w) + 1):
-        # ignoring 1st column: assuming it will be category (always true here)
-        wnewvalues = (
-            list(w[i].attrs.values())[1:col]
-            + tuple([flex.w[i - 1]])
-            + list(w[i].attrs.values())[col + 1 :]
+    # Split results: first n_grid values go to the raster grid
+    w_grid = w_out[:n_grid]
+
+    # Write grid deflections to the temporary vector, then rasterise
+    # v.mkgrid assigns sequential cats (1, 2, ...) in row-major order
+    sql_lines = [
+        "UPDATE {t} SET w = {val} WHERE cat = {cat};".format(
+            t=_tmp_vect, val=float(w_grid[i]), cat=i + 1
         )
-        wtable.update(key=i, values=wnewvalues)
-    wtable.conn.commit()  # Save this
-    w.close(build=False)  # don't build here b/c it is always verbose
-    gs.run_command("v.build", map=options["output"], quiet=True)
+        for i in range(n_grid)
+    ]
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".sql", delete=False) as f:
+        f.write("\n".join(sql_lines))
+        sql_file = f.name
+    try:
+        grass.run_command("db.execute", input=sql_file, quiet=True)
+    finally:
+        os.unlink(sql_file)
+    grass.run_command("v.build", map=_tmp_vect, quiet=True)
 
-    # And raster export
-    # "w" vector defined by raster resolution, so can do direct v.to.rast
-    # though if this option isn't selected, the user can do a finer-grained
-    # interpolation, which shouldn't introduce much error so long as these
-    # outputs are spaced at << 1 flexural wavelength.
-    if options["raster_output"]:
-        gs.run_command(
-            "v.to.rast",
-            input=options["output"],
-            output=options["raster_output"],
-            use="attr",
-            attribute_column="w",
-            type="point",
-            overwrite=gs.overwrite(),
-            quiet=True,
-        )
-        # And create a nice colormap!
-        gs.run_command(
-            "r.colors", map=options["raster_output"], color="differences", quiet=True
-        )
+    # Raster output (primary, required)
+    grass.run_command(
+        "v.to.rast",
+        input=_tmp_vect,
+        output=options["output"],
+        use="attr",
+        attribute_column="w",
+        type="point",
+        overwrite=grass.overwrite(),
+        quiet=True,
+    )
+    grass.run_command(
+        "r.colors", map=options["output"], color="differences", quiet=True
+    )
+    grass.run_command("g.remove", flags="f", type="vector", name=_tmp_vect, quiet=True)
 
-
-def install_dependencies():
-    print("PLACEHOLDER")
+    # Write deflection values to the user-supplied w_points map
+    if options["w_points"]:
+        w_pts = w_out[n_grid:]
+        col = options["w_column"]
+        # Add column if it does not already exist
+        existing_cols = [
+            c.lower()
+            for c in grass.vector_db_select(options["w_points"])["columns"]
+        ]
+        if col.lower() not in existing_cols:
+            grass.run_command(
+                "v.db.addcolumn",
+                map=options["w_points"],
+                columns="{} double precision".format(col),
+                quiet=True,
+            )
+        pts_cats = list(grass.vector_db_select(options["w_points"])["values"].keys())
+        sql_lines = [
+            "UPDATE {t} SET {col} = {val} WHERE cat = {cat};".format(
+                t=options["w_points"].split("@")[0],
+                col=col,
+                val=float(w_pts[i]),
+                cat=pts_cats[i],
+            )
+            for i in range(len(w_pts))
+        ]
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".sql", delete=False) as f:
+            f.write("\n".join(sql_lines))
+            sql_file = f.name
+        try:
+            grass.run_command("db.execute", input=sql_file, quiet=True)
+        finally:
+            os.unlink(sql_file)
+        grass.run_command("v.build", map=options["w_points"], quiet=True)
 
 
 if __name__ == "__main__":
-    import sys
-
-    if len(sys.argv) > 1 and sys.argv[1] == "--install-dependencies":
-        install_dependencies()
-    else:
-        main()
+    main()

--- a/src/vector/v.flexure/v.flexure.py
+++ b/src/vector/v.flexure/v.flexure.py
@@ -142,7 +142,7 @@ import warnings
 import numpy as np
 
 # GRASS
-import grass.script as grass
+import grass.script as gs
 
 
 ####################
@@ -152,7 +152,7 @@ import grass.script as grass
 
 def get_points_xy(vect_name):
     """Return (x, y) coordinate arrays for all points in a vector map."""
-    out = grass.read_command(
+    out = gs.read_command(
         "v.out.ascii", input=vect_name, format="point",
         separator="space", quiet=True
     )
@@ -172,7 +172,7 @@ def main():
     GRASS GIS
     """
 
-    options, flags = grass.parser()
+    options, flags = gs.parser()
     # if just interface description is requested, it will not get to this point
     # so gflex will not be needed
 
@@ -186,7 +186,7 @@ def main():
             )
             import gflex
     except ImportError:
-        grass.fatal(
+        gs.fatal(
             _(
                 "Cannot import gFlex. Install it from source with:\n"
                 "  pip install -e /path/to/gFlex\n"
@@ -199,7 +199,7 @@ def main():
         for x in gflex.__version__.split(".")[:3]
     )
     if _gver < (2, 0, 0):
-        grass.fatal(
+        gs.fatal(
             _("v.flexure requires gFlex >= 2.0.0; installed: ")
             + gflex.__version__
         )
@@ -221,22 +221,22 @@ def main():
 
     # x, y, q — load point coordinates and magnitudes
     flex.x, flex.y = get_points_xy(options["input"])
-    vect_db = grass.vector_db_select(options["input"])
+    vect_db = gs.vector_db_select(options["input"])
     col_names = np.array(vect_db["columns"])
     q_col = col_names == options["column"]
     if np.sum(q_col):
         col_values = np.array(list(vect_db["values"].values())).astype(float)
         flex.q = col_values[:, q_col].reshape(-1)  # always 1-D, even for a single point
     else:
-        grass.fatal(
+        gs.fatal(
             _("Column <%s> not found in vector map <%s>.")
             % (options["column"], options["input"])
         )
 
     # Overwrite check for raster output
-    if len(grass.parse_command("g.list", type="rast", pattern=options["output"])):
-        if not grass.overwrite():
-            grass.fatal(
+    if len(gs.parse_command("g.list", type="rast", pattern=options["output"])):
+        if not gs.overwrite():
+            gs.fatal(
                 _("Raster map <%s> already exists. Use '--o' to overwrite.")
                 % options["output"]
             )
@@ -245,8 +245,8 @@ def main():
     # The raster grid is always needed; w_points coordinates (if provided) are
     # appended so both are evaluated in a single gFlex solve.
     _tmp_vect = "tmp_vflex_{}".format(os.getpid())
-    grass.run_command("v.mkgrid", map=_tmp_vect, type="point", overwrite=True, quiet=True)
-    grass.run_command("v.db.addcolumn", map=_tmp_vect, columns="w double precision", quiet=True)
+    gs.run_command("v.mkgrid", map=_tmp_vect, type="point", overwrite=True, quiet=True)
+    gs.run_command("v.db.addcolumn", map=_tmp_vect, columns="w double precision", quiet=True)
     grid_x, grid_y = get_points_xy(_tmp_vect)
     n_grid = len(grid_x)
 
@@ -264,7 +264,7 @@ def main():
     elif options["te_units"] == "m":
         pass
     else:
-        grass.fatal(_("Inappropriate te_units; this should not be reachable."))
+        gs.fatal(_("Inappropriate te_units; this should not be reachable."))
     flex.rho_fill = float(options["rho_fill"])
 
     # Parameters that often stay at their default values
@@ -277,18 +277,18 @@ def main():
     flex.rho_m = float(options["rho_m"])
 
     # gFlex defaults to quiet (WARNING log level); opt in at --verbose (level 3).
-    if grass.verbosity() >= 3:
+    if gs.verbosity() >= 3:
         flex.verbose = True
         flex.quiet = False
 
     # Check if lat/lon and let user know if verbosity is True
-    if grass.region_env()[6] == "3":
+    if gs.region_env()[6] == "3":
         flex.latlon = True
-        flex.planetary_radius = float(grass.parse_command("g.proj", flags="j")["+a"])
+        flex.planetary_radius = float(gs.parse_command("g.proj", flags="j")["+a"])
         if flex.verbose:
-            grass.message(_("Latitude/longitude grid."))
-            grass.message(_("Based on r_Earth = 6371 km"))
-            grass.message(
+            gs.message(_("Latitude/longitude grid."))
+            gs.message(_("Based on r_Earth = 6371 km"))
+            gs.message(
                 _("Computing distances between load points using great circle paths")
             )
 
@@ -296,7 +296,7 @@ def main():
     # SOLVE! #
     ##########
 
-    grass.message(_("Computing deflections..."))
+    gs.message(_("Computing deflections..."))
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         flex.initialize()
@@ -305,7 +305,7 @@ def main():
         w_out = np.array(flex.w)
         flex.finalize()
     for warninfo in caught:
-        grass.warning(str(warninfo.message))
+        gs.warning(str(warninfo.message))
 
     # Split results: first n_grid values go to the raster grid
     w_grid = w_out[:n_grid]
@@ -322,26 +322,26 @@ def main():
         f.write("\n".join(sql_lines))
         sql_file = f.name
     try:
-        grass.run_command("db.execute", input=sql_file, quiet=True)
+        gs.run_command("db.execute", input=sql_file, quiet=True)
     finally:
         os.unlink(sql_file)
-    grass.run_command("v.build", map=_tmp_vect, quiet=True)
+    gs.run_command("v.build", map=_tmp_vect, quiet=True)
 
     # Raster output (primary, required)
-    grass.run_command(
+    gs.run_command(
         "v.to.rast",
         input=_tmp_vect,
         output=options["output"],
         use="attr",
         attribute_column="w",
         type="point",
-        overwrite=grass.overwrite(),
+        overwrite=gs.overwrite(),
         quiet=True,
     )
-    grass.run_command(
+    gs.run_command(
         "r.colors", map=options["output"], color="differences", quiet=True
     )
-    grass.run_command("g.remove", flags="f", type="vector", name=_tmp_vect, quiet=True)
+    gs.run_command("g.remove", flags="f", type="vector", name=_tmp_vect, quiet=True)
 
     # Write deflection values to the user-supplied w_points map
     if options["w_points"]:
@@ -350,16 +350,16 @@ def main():
         # Add column if it does not already exist
         existing_cols = [
             c.lower()
-            for c in grass.vector_db_select(options["w_points"])["columns"]
+            for c in gs.vector_db_select(options["w_points"])["columns"]
         ]
         if col.lower() not in existing_cols:
-            grass.run_command(
+            gs.run_command(
                 "v.db.addcolumn",
                 map=options["w_points"],
                 columns="{} double precision".format(col),
                 quiet=True,
             )
-        pts_cats = list(grass.vector_db_select(options["w_points"])["values"].keys())
+        pts_cats = list(gs.vector_db_select(options["w_points"])["values"].keys())
         sql_lines = [
             "UPDATE {t} SET {col} = {val} WHERE cat = {cat};".format(
                 t=options["w_points"].split("@")[0],
@@ -373,10 +373,10 @@ def main():
             f.write("\n".join(sql_lines))
             sql_file = f.name
         try:
-            grass.run_command("db.execute", input=sql_file, quiet=True)
+            gs.run_command("db.execute", input=sql_file, quiet=True)
         finally:
             os.unlink(sql_file)
-        grass.run_command("v.build", map=options["w_points"], quiet=True)
+        gs.run_command("v.build", map=options["w_points"], quiet=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Updates `v.flexure` for compatibility with [gFlex](https://gflex.readthedocs.io/) v2.0.0 (new API, `quiet`/`verbose` defaults, Python logging, `finalize()` method)
- Redesigns the interface: `te_units` parameter (default `km`) with `m`/`km` options; `rho_fill` density parameter; `w_column` for output deflection column name; ~~validates minimum of 2 load points~~
- Adds a full testsuite (12 tests) covering unit equivalence, linearity, multi-point loads, stiffer-Te behavior, forebulge detection, and material parameter handling
- Rewrites HTML documentation: links to gFlex ReadTheDocs, version requirement, rewritten NOTES describing the SAS_NG method and output columns
- Renames `grass.script` alias `grass` → `gs` throughout (ICN001)
- Regenerates `v.flexure.md` from updated HTML via pandoc

## Test plan

- [ ] `v.flexure` testsuite: 12/12 tests pass
- [ ] `ruff check` and `flake8` pass with no errors

## Notes

Requires `pip install "gflex>=2.0.0"` (currently available as 2.0.0b1). A version guard in the module enforces this at runtime and correctly handles pre-release suffixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)