### PR TITLE
v.flexure: fix crash and add fatal for empty input vector map

### DIFF
--- a/src/vector/v.flexure/testsuite/test_v_flexure.py
+++ b/src/vector/v.flexure/testsuite/test_v_flexure.py
@@ -579,6 +579,7 @@ class TestVFlexureInputErrors(TestCase):
     """Input-validation errors raised inside main() — gFlex must be importable."""
 
     loads = "test_vflex_ierr_loads"
+    empty_loads = "test_vflex_ierr_empty"
 
     @classmethod
     def setUpClass(cls):
@@ -605,11 +606,15 @@ class TestVFlexureInputErrors(TestCase):
             value="1e15",
             where="cat=1",
         )
+        cls.runModule("v.edit", map=cls.empty_loads, tool="create")
 
     @classmethod
     def tearDownClass(cls):
         cls.del_temp_region()
         cls.runModule("g.remove", flags="f", type="vector", name=cls.loads, quiet=True)
+        cls.runModule(
+            "g.remove", flags="f", type="vector", name=cls.empty_loads, quiet=True
+        )
 
     def test_missing_column(self):
         """Module exits with error when the named column is absent from the input map."""
@@ -617,6 +622,17 @@ class TestVFlexureInputErrors(TestCase):
             "v.flexure",
             input=self.loads,
             column="nonexistent",
+            te="10000",
+            te_units="m",
+            output="dummy_out",
+        )
+
+    def test_empty_input(self):
+        """Module exits with error when the input vector map contains no points."""
+        self.assertModuleFail(
+            "v.flexure",
+            input=self.empty_loads,
+            column="q",
             te="10000",
             te_units="m",
             output="dummy_out",

--- a/src/vector/v.flexure/v.flexure.py
+++ b/src/vector/v.flexure/v.flexure.py
@@ -156,6 +156,8 @@ def get_points_xy(vect_name):
         "v.out.ascii", input=vect_name, format="point", separator="space", quiet=True
     )
     rows = [line.split() for line in out.strip().splitlines() if line.strip()]
+    if not rows:
+        return np.array([]), np.array([])
     coords = np.array([[float(r[0]), float(r[1])] for r in rows], dtype=float)
     return coords[:, 0], coords[:, 1]  # x, y
 

--- a/src/vector/v.flexure/v.flexure.py
+++ b/src/vector/v.flexure/v.flexure.py
@@ -221,6 +221,8 @@ def main():
 
     # x, y, q — load point coordinates and magnitudes
     flex.x, flex.y = get_points_xy(options["input"])
+    if len(flex.x) == 0:
+        gs.fatal(_("Input vector map <%s> contains no points.") % options["input"])
     vect_db = gs.vector_db_select(options["input"])
     col_names = np.array(vect_db["columns"])
     q_col = col_names == options["column"]


### PR DESCRIPTION
## Summary

Follow-up to #1745. Two bugs in the zero-load-point edge case:

- `get_points_xy` crashed with `IndexError` when passed a vector map containing no points: `np.array([], dtype=float)` has shape `(0,)`, so `coords[:, 0]` raises `IndexError: too many indices for array`. Fixed by returning empty 1-D arrays directly when there are no rows.
- A zero-point input would have silently produced all-zero deflection (gFlex treats it as no load, which is mathematically correct but almost certainly a user error). Added a `gs.fatal` immediately after coordinate loading so the user gets a clear message rather than a flat raster with no warning.

Note: the summary in #1745 incorrectly claimed "validates minimum of 2 load points" — that check was never implemented, and the claim was a hallucination in the AI-generated PR description. The minimum is 1 point (a single-point load works correctly and is the primary test fixture). This PR adds the zero-point guard only.

## Test plan

- [ ] `v.flexure` testsuite: 15/15 tests pass (14 from #1745 + `test_empty_input` added here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)