### PR TITLE
r.in.usgs: add current vs historical options for NED

### DIFF
--- a/src/raster/r.in.usgs/r.in.usgs.html
+++ b/src/raster/r.in.usgs/r.in.usgs.html
@@ -19,6 +19,13 @@ National Land Cover Dataset (NLCD) is no longer available through the API.
 <p>
 NED data are available at resolutions of 1 arc-second (about 30 meters),
 1/3 arc-second (about 10 meters), and in limited areas at 1/9 arc-second (about 3 meters).
+USGS periodically re-collects and re-publishes NED tiles.
+Use <b>ned_release</b> to choose between the <i>current</i> (most recent) tiles
+(default), the <i>historical</i> (superseded) tiles, or <i>all</i> of them.
+This applies only to the 1 arc-second and 1/3 arc-second datasets; the
+1/9 arc-second dataset is not split this way, so all of its tiles are always used.
+When multiple tiles overlap, use the <b>i</b> flag to list them first and
+<b>title_filter</b> to select a specific one.
 
 <p>
 NAIP is available at 1 m resolution.

--- a/src/raster/r.in.usgs/r.in.usgs.md
+++ b/src/raster/r.in.usgs/r.in.usgs.md
@@ -19,7 +19,13 @@ API.
 
 NED data are available at resolutions of 1 arc-second (about 30 meters),
 1/3 arc-second (about 10 meters), and in limited areas at 1/9 arc-second
-(about 3 meters).
+(about 3 meters). USGS periodically re-collects and re-publishes NED tiles.
+Use **ned\_release** to choose between the *current* (most recent) tiles
+(default), the *historical* (superseded) tiles, or *all* of them. This
+applies only to the 1 arc-second and 1/3 arc-second datasets; the
+1/9 arc-second dataset is not split this way, so all of its tiles are
+always used. When multiple tiles overlap, use the **i** flag to list them
+first and **title\_filter** to select a specific one.
 
 NAIP is available at 1 m resolution.
 

--- a/src/raster/r.in.usgs/r.in.usgs.py
+++ b/src/raster/r.in.usgs/r.in.usgs.py
@@ -59,6 +59,17 @@
 # %end
 
 # %option
+# % key: ned_release
+# % required: no
+# % options: current,historical,all
+# % answer: current
+# % label: NED data release
+# % description: Restrict the NED dataset to the current (most recent) tiles, superseded historical tiles, or all of them
+# % descriptions: current;Current (most recent) tiles only;historical;Historical (superseded) tiles only;all;Current and historical tiles
+# % guisection: NED
+# %end
+
+# %option
 # % key: input_srs
 # % type: string
 # % required: no
@@ -382,6 +393,24 @@ def main():
             ned_data_abbrv = "ned_19arc_"
             ned_api_name = "1/9 arc-second"
         product_tag = product + " " + ned_api_name
+        # The TNM API exposes the data release as a suffix on the dataset tag.
+        # "Current" returns the most recent tiles, "Historical" the superseded
+        # ones. The combined "Current and Historical" tag is not queryable in
+        # the products endpoint, so "all" uses the bare tag, which returns both.
+        # Only the 1 and 1/3 arc-second datasets are split this way; the
+        # 1/9 arc-second dataset is not, so its tag is always used as is.
+        if options["ned_dataset"] in ("ned1sec", "ned13sec"):
+            if options["ned_release"] == "current":
+                product_tag += " Current"
+            elif options["ned_release"] == "historical":
+                product_tag += " Historical"
+        elif options["ned_release"] != "all":
+            gs.verbose(
+                _(
+                    "The ned_release option is not applicable to the {dataset}"
+                    " dataset; all available tiles will be used."
+                ).format(dataset=ned_api_name)
+            )
 
     if gui_product == "nlcd":
         gui_dataset = options["nlcd_dataset"]


### PR DESCRIPTION
Allow to select to filter Current/Historical/all NED datasets.