### PR TITLE
doc: fix html links in md

### DIFF
--- a/src/imagery/i.eb.hsebal95/i.eb.hsebal95.md
+++ b/src/imagery/i.eb.hsebal95/i.eb.hsebal95.md
@@ -65,7 +65,7 @@ r.mapcalc 'NSR=0.0036\*(beam+diffuse+reflected)';
 ## SEE ALSO
 
 *[i.eb.h\_iter](i.eb.h_iter.md), [i.eb.h0](i.eb.h0.md),
-[i.evapo.pm](i.evapo.pm.md)*
+[i.evapo.pm](https://grass.osgeo.org/grass-stable/manuals/i.evapo.pm.html)*
 
 ## REFERENCES
 

--- a/src/imagery/i.eb.z0m0/i.eb.z0m0.md
+++ b/src/imagery/i.eb.z0m0/i.eb.z0m0.md
@@ -18,7 +18,7 @@ related to z0m by a factor 7. If you happen to have a vegetation height
 
 ## SEE ALSO
 
-*[i.eb.h0](i.eb.h0.md), [i.eb.h\_SEBAL95](i.eb.h_SEBAL95.md),
+*[i.eb.h0](i.eb.h0.md), [i.eb.h\_SEBAL95](i.eb.hsebal95.md),
 [i.eb.h\_iter](i.eb.h_iter.md), [i.eb.z0m](i.eb.z0m.md)*
 
 ## AUTHOR

--- a/src/imagery/i.evapo.zk/i.evapo.zk.md
+++ b/src/imagery/i.evapo.zk/i.evapo.zk.md
@@ -85,7 +85,7 @@ internal parameters of the model*
 [i.evapo.mh](https://grass.osgeo.org/grass-stable/manuals/i.evapo.mh.html)  
 [i.evapo.senay](i.evapo.senay.md)  
 [i.eb.netrad](https://grass.osgeo.org/grass-stable/manuals/i.eb.netrad.html)  
-[i.eb.soilheatflux](i.eb.soilheatflux.md)  
+[i.eb.soilheatflux](https://grass.osgeo.org/grass-stable/manuals/i.eb.soilheatflux.html)  
 *
 
 ## REFERENCES

--- a/src/imagery/i.hyper/i.hyper.composite/i.hyper.composite.md
+++ b/src/imagery/i.hyper/i.hyper.composite/i.hyper.composite.md
@@ -3,8 +3,8 @@
 *i.hyper.composite* creates RGB, CIR, SWIR and custom false-color
 composites from a hyperspectral 3D raster map (`raster_3d`). The module
 reads per-band wavelength metadata from `hyper.json`
-(as written by [i.hyper.import](i.hyper.import.html) /
-[i.hyper.preproc](i.hyper.preproc.html)). It then selects the nearest
+(as written by [i.hyper.import](i.hyper.import.md) /
+[i.hyper.preproc](i.hyper.preproc.md)). It then selects the nearest
 available bands to requested wavelengths, enhances contrast, and composes
 a 2D color raster.
 
@@ -105,10 +105,10 @@ resample spectrally.
 
 ## SEE ALSO
 
-[i.hyper.import](i.hyper.import.html),
-[i.hyper.preproc](i.hyper.preproc.html),
-[i.hyper.explore](i.hyper.explore.html),
-[i.hyper.export](i.hyper.export.html),
+[i.hyper.import](i.hyper.import.md),
+[i.hyper.preproc](i.hyper.preproc.md),
+[i.hyper.explore](i.hyper.explore.md),
+[i.hyper.export](i.hyper.export.md),
 [r3.to.rast](https://grass.osgeo.org/grass-stable/manuals/r3.to.rast.html),
 [r.composite](https://grass.osgeo.org/grass-stable/manuals/r.composite.html),
 [i.colors.enhance](https://grass.osgeo.org/grass-stable/manuals/i.colors.enhance.html),

--- a/src/imagery/i.hyper/i.hyper.explore/i.hyper.explore.md
+++ b/src/imagery/i.hyper/i.hyper.explore/i.hyper.explore.md
@@ -15,8 +15,8 @@ interactively.
 
 *i.hyper.explore* automatically reads wavelength metadata, measurement
 type (e.g., *reflectance*, *radiance*), and units from `hyper.json`
-produced by [i.hyper.import](i.hyper.import.html) or
-[i.hyper.preproc](i.hyper.preproc.html). If the map contains principal
+produced by [i.hyper.import](i.hyper.import.md) or
+[i.hyper.preproc](i.hyper.preproc.md). If the map contains principal
 components or other dimensionally reduced features, the module detects
 this and adjusts the X-axis to component indices.
 

--- a/src/imagery/i.hyper/i.hyper.export/i.hyper.export.md
+++ b/src/imagery/i.hyper/i.hyper.export/i.hyper.export.md
@@ -101,10 +101,10 @@ cube in `(band,row,col)` order together with embedded metadata.
 
 ## SEE ALSO
 
-[i.hyper.import](i.hyper.import.html),
-[i.hyper.preproc](i.hyper.preproc.html),
-[i.hyper.metadata](i.hyper.metadata.html),
-[i.hyper.explore](i.hyper.explore.html),
+[i.hyper.import](i.hyper.import.md),
+[i.hyper.preproc](i.hyper.preproc.md),
+[i.hyper.metadata](i.hyper.metadata.md),
+[i.hyper.explore](i.hyper.explore.md),
 [r.pack](https://grass.osgeo.org/grass-stable/manuals/r.pack.html)
 
 ## AUTHORS

--- a/src/imagery/i.hyper/i.hyper.import/i.hyper.import.md
+++ b/src/imagery/i.hyper/i.hyper.import/i.hyper.import.md
@@ -12,10 +12,10 @@ of the 3D raster represents the spectral dimension, where each cell
 *i.hyper.import* is part of the **i.hyper** module family designed for
 hyperspectral data import, processing, and analysis in GRASS. It is
 typically used in combination with
-[i.hyper.preproc](i.hyper.preproc.html),
-[i.hyper.explore](i.hyper.explore.html),
-[i.hyper.composite](i.hyper.composite.html), and
-[i.hyper.export](i.hyper.export.html).
+[i.hyper.preproc](i.hyper.preproc.md),
+[i.hyper.explore](i.hyper.explore.md),
+[i.hyper.composite](i.hyper.composite.md), and
+[i.hyper.export](i.hyper.export.md).
 
 The module currently supports the following hyperspectral products:
 
@@ -188,11 +188,11 @@ the `output` option is ignored.
 [EnMAP Example Data
 Products](https://www.enmap.org/data_tools/exampledata/), Tanager Core
 Imagery,
-[i.hyper.preproc](i.hyper.preproc.html),
-[i.hyper.metadata](i.hyper.metadata.html),
-[i.hyper.explore](i.hyper.explore.html),
-[i.hyper.composite](i.hyper.composite.html),
-[i.hyper.export](i.hyper.export.html),
+[i.hyper.preproc](i.hyper.preproc.md),
+[i.hyper.metadata](i.hyper.metadata.md),
+[i.hyper.explore](i.hyper.explore.md),
+[i.hyper.composite](i.hyper.composite.md),
+[i.hyper.export](i.hyper.export.md),
 [r3.stats](https://grass.osgeo.org/grass-stable/manuals/r3.stats.html),
 [r3.univar](https://grass.osgeo.org/grass-stable/manuals/r3.univar.html)
 

--- a/src/imagery/i.hyper/i.hyper.md
+++ b/src/imagery/i.hyper/i.hyper.md
@@ -65,12 +65,12 @@ using:
 
 ## SEE ALSO
 
-*[i.hyper.import](i.hyper.import.html),
-[i.hyper.preproc](i.hyper.preproc.html),
-[i.hyper.metadata](i.hyper.metadata.html),
-[i.hyper.explore](i.hyper.explore.html),
-[i.hyper.composite](i.hyper.composite.html),
-[i.hyper.export](i.hyper.export.html)
+*[i.hyper.import](i.hyper.import.md),
+[i.hyper.preproc](i.hyper.preproc.md),
+[i.hyper.metadata](i.hyper.metadata.md),
+[i.hyper.explore](i.hyper.explore.md),
+[i.hyper.composite](i.hyper.composite.md),
+[i.hyper.export](i.hyper.export.md)
 [r3.what](https://grass.osgeo.org/grass-stable/manuals/addons/r3.what.html)*
 
 ## AUTHORS

--- a/src/imagery/i.hyper/i.hyper.metadata/i.hyper.metadata.md
+++ b/src/imagery/i.hyper/i.hyper.metadata/i.hyper.metadata.md
@@ -232,10 +232,10 @@ Show ATCORR-ready metadata subset (geometry + atmosphere + timing):
 
 ## SEE ALSO
 
-*[i.hyper](i.hyper.html),
-[i.hyper.import](i.hyper.import.html),
-[i.hyper.preproc](i.hyper.preproc.html),
-[i.hyper.explore](i.hyper.explore.html)*
+*[i.hyper](i.hyper.md),
+[i.hyper.import](i.hyper.import.md),
+[i.hyper.preproc](i.hyper.preproc.md),
+[i.hyper.explore](i.hyper.explore.md)*
 
 ## AUTHORS
 

--- a/src/imagery/i.hyper/i.hyper.preproc/i.hyper.preproc.md
+++ b/src/imagery/i.hyper/i.hyper.preproc/i.hyper.preproc.md
@@ -7,7 +7,7 @@ representations better suited for scientific analysis and machine
 learning workflows.
 
 The module operates directly on hyperspectral cubes imported with
-[i.hyper.import](i.hyper.import.html) or other compatible 3D raster
+[i.hyper.import](i.hyper.import.md) or other compatible 3D raster
 datasets. All transformations are performed along the spectral (*z*)
 dimension for each spatial position (*x, y*).
 
@@ -173,11 +173,11 @@ or exported with *i.hyper.export* for further analysis.
 
 ## SEE ALSO
 
-[i.hyper.metadata](i.hyper.metadata.html),
-[i.hyper.explore](i.hyper.explore.html),
-[i.hyper.composite](i.hyper.composite.html),
-[i.hyper.export](i.hyper.export.html),
-[i.hyper.import](i.hyper.import.html),
+[i.hyper.metadata](i.hyper.metadata.md),
+[i.hyper.explore](i.hyper.explore.md),
+[i.hyper.composite](i.hyper.composite.md),
+[i.hyper.export](i.hyper.export.md),
+[i.hyper.import](i.hyper.import.md),
 [r3.stats](https://grass.osgeo.org/grass-stable/manuals/r3.stats.html)
 [r3.stats](https://grass.osgeo.org/grass-stable/manuals/r3.univar.html)
 

--- a/src/imagery/i.landsat/i.landsat.qa/i.landsat.qa.md
+++ b/src/imagery/i.landsat/i.landsat.qa/i.landsat.qa.md
@@ -103,7 +103,7 @@ r.reclass input=LC81980182015183LGN00_BQA \
 ## SEE ALSO
 
 *[r.reclass](https://grass.osgeo.org/grass-stable/manuals/r.reclass.html),
-[i.modis.qc](i.modis.qc.md), [r.bitpattern](r.bitpattern.md),
+[i.modis.qc](https://grass.osgeo.org/grass-stable/manuals/i.modis.qc.html), [r.bitpattern](r.bitpattern.md),
 [i.landsat](i.landsat.md) [i.landsat8.swlst](i.landsat8.swlst.md)*
 
 ## REFERENCES

--- a/src/imagery/i.ortho.corr/i.ortho.corr.md
+++ b/src/imagery/i.ortho.corr/i.ortho.corr.md
@@ -53,7 +53,7 @@ i.ortho.corr input=image.photo tiles=tile_images osuffix=.photo csuffix=.camera
 ## SEE ALSO
 
 *[i.ortho.photo](https://grass.osgeo.org/grass-stable/manuals/i.ortho.photo.html),
-[i.ortho.rectify](i.ortho.rectify.md)*
+[i.ortho.rectify](https://grass.osgeo.org/grass-stable/manuals/i.ortho.rectify.html)*
 
 ## AUTHOR
 

--- a/src/imagery/i.pr/i.pr.training/description.md
+++ b/src/imagery/i.pr/i.pr.training/description.md
@@ -128,7 +128,7 @@ only required when the interactive mode of i.pr.training is used.
 
 ## SEE ALSO
 
-*[i.pr\_features](i.pr_features.md)*  
+*[i.pr\_features](i.pr.features.md)*
 
 ## AUTHORS
 

--- a/src/imagery/i.sentinel/i.sentinel.coverage/i.sentinel.coverage.md
+++ b/src/imagery/i.sentinel/i.sentinel.coverage/i.sentinel.coverage.md
@@ -72,8 +72,8 @@ t.sentinel.import settings=credentials.txt s2names=s2names.txt nprocs=4 \
 ## SEE ALSO
 
 *[i.sentinel.download](i.sentinel.download.md),
-[v.dissolve](v.dissolve.md), [v.overlay](v.overlay.md),
-[v.to.db](v.to.db.md)*
+[v.dissolve](https://grass.osgeo.org/grass-stable/manuals/v.dissolve.html), [v.overlay](https://grass.osgeo.org/grass-stable/manuals/v.overlay.html),
+[v.to.db](https://grass.osgeo.org/grass-stable/manuals/v.to.db.html)*
 
 ## AUTHOR
 

--- a/src/imagery/i.sentinel/i.sentinel.mask/i.sentinel.mask.md
+++ b/src/imagery/i.sentinel/i.sentinel.mask/i.sentinel.mask.md
@@ -5,7 +5,8 @@ shadows in Sentinel-2 images. The algorithm works on reflectance values
 (Bottom of Atmosphere Reflectance - BOA). Therefore, the atmospheric
 correction has to be applied to all input bands (see
 [i.sentinel.preproc](i.sentinel.preproc.md) or
-[i.atcorr](i.atcorr.html)) (level 1C and 2A).
+[i.atcorr](https://grass.osgeo.org/grass-stable/manuals/i.atcorr.html))
+(level 1C and 2A).
 
 The following figures show the difference between the standard cloud
 mask as provided in Sentinel-2 SAFE products and the cloud detection

--- a/src/raster/r.flexure/r.flexure.md
+++ b/src/raster/r.flexure/r.flexure.md
@@ -6,9 +6,9 @@ for plate bending. This phenomenon is known as "flexural isostasy"
 and is relevant to glacier/ice-cap/ice-sheet loading, sedimentary
 basin filling, mountain belt growth, volcano emplacement, sea-level
 change, and other geologic processes. *r.flexure* and
-*[v.flexure](v.flexure.html)* are the GRASS GIS interfaces to the
+*[v.flexure](v.flexure.md)* are the GRASS GIS interfaces to the
 model [**gFlex**](https://gflex.readthedocs.io/). As both *r.flexure*
-and *[v.flexure](v.flexure.html)* are interfaces to gFlex, it must be
+and *[v.flexure](v.flexure.md)* are interfaces to gFlex, it must be
 downloaded and installed. *r.flexure* requires **gFlex ≥ 2.0.0**:
 
     pip install "gflex>=2.0.0"
@@ -188,7 +188,7 @@ set the relevant edge to **free**:
 
 ## SEE ALSO
 
-*[v.flexure](v.flexure.html)*
+*[v.flexure](v.flexure.md)*
 
 ## REFERENCES
 

--- a/src/raster/r.forcircular/r.forcircular.md
+++ b/src/raster/r.forcircular/r.forcircular.md
@@ -100,7 +100,7 @@ the indicators and results of SMCA process are computed on forest
 surface with financial efficiency of production process or, in other
 terms, the area where a positive stumpage value can be reached. The
 calculation of stumpage value is carried out following the approach of
-another GRASS GIS add-on: [r.green.biomassfor](r.green.biomassfor.html).
+another GRASS GIS add-on: [r.green.biomassfor](r.green.biomassfor.md).
 
 The model in *r.forcircular* starts with importation of geodata and
 conversion of vector into raster. Then, through a multistep approach,

--- a/src/raster/r.futures/r.futures.calib/r.futures.calib.md
+++ b/src/raster/r.futures/r.futures.calib/r.futures.calib.md
@@ -126,7 +126,7 @@ For all other parameters not mentioned above, please refer to
 [r.futures.gridvalidation](r.futures.gridvalidation.md),
 [r.futures.validation](r.futures.validation.md),
 [r.sample.category](r.sample.category.md),
-[r.object.geometry](r.object.geometry.md)
+[r.object.geometry](https://grass.osgeo.org/grass-stable/manuals/r.object.geometry.html)
 
 ## AUTHORS
 

--- a/src/raster/r.futures/r.futures.gridvalidation/r.futures.gridvalidation.md
+++ b/src/raster/r.futures/r.futures.gridvalidation/r.futures.gridvalidation.md
@@ -3,7 +3,7 @@
 Tool *r.futures.gridvalidation* allows to
 validate land change simulation results spatially.
 It is a wrapper around
-[r.futures.validation](r.futures.validation.html)
+[r.futures.validation](r.futures.validation.md)
 that computes validation metrics for each cell of a grid
 or for each polygon of a vector layer.
 It computes:
@@ -18,7 +18,7 @@ It computes:
 When **original** is provided and the input rasters contain
 only binary categories (0 for undeveloped and 1 for developed),
 the tool additionally computes change detection metrics
-(see [r.futures.validation](r.futures.validation.html)
+(see [r.futures.validation](r.futures.validation.md)
 for details).
 When more than two categories are present,
 these metrics are skipped.

--- a/src/raster/r.futures/r.futures.md
+++ b/src/raster/r.futures/r.futures.md
@@ -62,7 +62,8 @@ influencing site suitability for the next step. PGA is implemented in
 We need to collect the following data:
 
 *Study extent and resolution*  
-Specified with *[g.region](g.region.md)* command.
+Specified with *[g.region](https://grass.osgeo.org/grass-stable/manuals/g.region.html)*
+command.
 
 *Subregions*  
 FUTURES is designed to capture variation across specified subregions

--- a/src/raster/r.futures/r.futures.validation/r.futures.validation.md
+++ b/src/raster/r.futures/r.futures.validation/r.futures.validation.md
@@ -129,7 +129,7 @@ FUTURES references:
 
 For alternative validation metrics see
 [r.confusionmatrix](r.confusionmatrix.md),
-[r.kappa](r.kappa.md)
+[r.kappa](https://grass.osgeo.org/grass-stable/manuals/r.kappa.html)
 
 ## AUTHORS
 

--- a/src/raster/r.hand/r.hand.md
+++ b/src/raster/r.hand/r.hand.md
@@ -86,7 +86,9 @@ hydrologically relevant new terrain model. Journal of Hydrology 404, 13–29. <h
 
 ## SEE ALSO
 
-*[r.watershed](r.watershed.md), [r.lake](r.lake.md), [r.lake.series](addons/r.lake.series.md)*
+*[r.watershed](https://grass.osgeo.org/grass-stable/manuals/r.watershed.html),
+[r.lake](https://grass.osgeo.org/grass-stable/manuals/r.lake.html),
+[r.lake.series](r.lake.series.md)*
 
 ## AUTHORS
 

--- a/src/raster/r.hydro.flatten/r.hydro.flatten.md
+++ b/src/raster/r.hydro.flatten/r.hydro.flatten.md
@@ -3,7 +3,7 @@
 The tool derives single elevation value for water bodies based on lidar
 data. These values are used for hydro-flattening a digital elevation
 model. The **input** raster is expected to represent ground surface
-created by binning lidar data (e.g., using *[r.in.pdal](r.in.pdal.md)*)
+created by binning lidar data (e.g., using *[r.in.pdal](https://grass.osgeo.org/grass-stable/manuals/r.in.pdal.html)*)
 with averaged ground elevation. Small gaps in the input are expected.
 Large gaps are interpreted as water bodies. The minimum size of a water
 body can be set with **min\_size** option in map units.

--- a/src/raster/r.maxent.predict/r.maxent.predict.md
+++ b/src/raster/r.maxent.predict/r.maxent.predict.md
@@ -191,12 +191,12 @@ BCC-CSM2-MR and SSP 585.*
     files and prediction rasters that can be used directly by the
     *r.maxent.train* addon (or the Maxent software itself) to create
     species distribution models.
-- [r.out.maxent\_swd](r.out.maxent_swd.html), creating species and
+- [r.out.maxent\_swd](r.out.maxent_swd.md), creating species and
     background swd files based on species distribution data in raster
     format.
 - [r.maxent.train](r.maxent.train.md), creates a maxent model based on
     presence point data a set of environmental predictor layers.
-- [r.maxent.setup](r.maxent.setup.html), helper function to allow
+- [r.maxent.setup](r.maxent.setup.md), helper function to allow
     GRASS to use Maxent.
 
 ## AUTHOR

--- a/src/raster/r.maxent.train/r.maxent.train.md
+++ b/src/raster/r.maxent.train/r.maxent.train.md
@@ -17,8 +17,8 @@ input, the addon requires two comma-separated files, one with the
 species locations and another of background points locations. Both need
 to include columns with the X, Y and sample values of the environmental
 variables that you want to use as predictor variables. You can use the
-[r.out.maxent\_swd](r.out.maxent_swd.html) or
-[v.maxent.swd](v.maxent.swd.html) addons to create these files. For more
+[r.out.maxent\_swd](r.out.maxent_swd.md) or
+[v.maxent.swd](v.maxent.swd.md) addons to create these files. For more
 details about the structure of these files, see the [Maxent
 website](https://biodiversityinformatics.amnh.org/open_source/maxent/).
 
@@ -209,13 +209,13 @@ BCC-CSM2-MR and SSP 585.*
     files and prediction rasters that can be used directly by the
     *r.maxent.train* addon (or the Maxent software itself) to create
     species distribution models.
-- [r.out.maxent\_swd](r.out.maxent_swd.html), creating species and
+- [r.out.maxent\_swd](r.out.maxent_swd.md), creating species and
     background swd files based on species distribution data in raster
     format.
 - [r.maxent.predict](r.maxent.predict.md), creating a suitability
     layer based on a set of environmental layers and a Maxent model,
     e.g., created using the r.maxent.train addon.
-- [r.maxent.setup](r.maxent.setup.html), helper function to allow
+- [r.maxent.setup](r.maxent.setup.md), helper function to allow
     GRASS to use Maxent.
 
 ## AUTHOR

--- a/src/raster/r.mcda.promethee/r.mcda.promethee.md
+++ b/src/raster/r.mcda.promethee/r.mcda.promethee.md
@@ -37,8 +37,8 @@ GRASS Development Team (2015)
 
 ## SEE ALSO
 
-[*r.mcda.ahp*](r.mcda.ahp.html),
-[*r.mcda.electre*](r.mcda.electre.html),
+[*r.mcda.ahp*](r.mcda.ahp.md),
+[*r.mcda.electre*](r.mcda.electre.md),
 [*r.mcda.roughet*](r.mcda.roughet.html),
 [*r.mapcalc*](https://grass.osgeo.org/grass-stable/manuals/r.mapcalc.html)
 

--- a/src/raster/r.object.activelearning/r.object.activelearning.md
+++ b/src/raster/r.object.activelearning/r.object.activelearning.md
@@ -150,7 +150,7 @@ added to the update file.
 
 This module requires the *scikit-learn* python package. This module
 needs to be installed in your GRASS GIS Python environment. Please refer
-to [*r.learn.ml*](r.learn.ml.html)'s notes on how to install this
+to [*r.learn.ml*](r.learn.ml.md)'s notes on how to install this
 package.
 
 The memory usage for \~1450 samples of 52 features each is around \~650

--- a/src/raster/r.skyline/r.skyline.md
+++ b/src/raster/r.skyline/r.skyline.md
@@ -49,7 +49,7 @@ then the **hoz\_inclination** map will record either the inclination
 (*r.viewshed* default), simply '1' meaning that the cell was visible
 (*r.viewshed* **-b** flag), or the elevation difference between the
 viewpoint and horizon cell (*r.viewshed* **-e** flag). If the input
-viewshed map was computed with the older*[r.los](r.los.md)* then the
+viewshed map was computed with the older *r.los* then the
 **hoz\_inclination** map will record the inclination at which the
 horizon cells appear from the viewpoint. Note that in all cases the
 horizon depicted on this map may include cells that occur at the maximum
@@ -141,7 +141,8 @@ non-integer).
 
 ## SEE ALSO
 
-*[r.bearing.distance](r.bearing.distance.md)*, *[r.los](r.los.md)*,
+*[r.bearing.distance](r.bearing.distance.md)*,
+*r.los*,
 *[r.viewshed](https://grass.osgeo.org/grass-stable/manuals/r.viewshed.html)*.
 
 ## AUTHOR

--- a/src/raster/r.stream.segment/r.stream.segment.md
+++ b/src/raster/r.stream.segment/r.stream.segment.md
@@ -23,7 +23,8 @@ partitioning of streams into near-straight-line segments is required.
     produced by the same module. Stream background shall have NULL value
     or zero value. Background values of NULL are by default produced by
     *r.watershed* and *r.stream.extract*. If not 0 or NULL use
-    *[r.mapcalc](r.mapcalc.html)* to set background values to null.
+    *[r.mapcalc](https://grass.osgeo.org/grass-stable/manuals/r.mapcalc.html)*
+    to set background values to null.
 - **direction**  
     Flow direction: name of input direction map produced by
     *r.watershed* or *r.stream.extract*. If r.stream.extract output map

--- a/src/raster/r.upflowlength/r.upflowlength.md
+++ b/src/raster/r.upflowlength/r.upflowlength.md
@@ -72,10 +72,10 @@ r.upflowlength input=nc_drain format=custom encoding=8,7,6,5,4,3,2,1 output=nc_u
 
 ## SEE ALSO
 
-*[r.hydrobasin](r.hydrobasin.html),
-[r.lfp](r.lfp.html),
-[r.flowaccumulation](r.flowaccumulation.html),
-[r.accumulate](r.accumulate.html),
+*[r.hydrobasin](r.hydrobasin.md),
+[r.lfp](r.lfp.md),
+[r.flowaccumulation](r.flowaccumulation.md),
+[r.accumulate](r.accumulate.md),
 [r.watershed](https://grass.osgeo.org/grass-stable/manuals/r.watershed.html)*
 
 ## REFERENCES

--- a/src/temporal/t.rast.out.xyz/t.rast.out.xyz.md
+++ b/src/temporal/t.rast.out.xyz/t.rast.out.xyz.md
@@ -25,7 +25,7 @@ t.rast.out.xyz -i strds=mystrds output=/tmp/mystrds.csv \
 ## SEE ALSO
 
 [r.out.xyz](https://grass.osgeo.org/grass-stable/manuals/r.out.xyz.html),
-[t.rast.out.vtk](t.rast.out.vtk.md)
+[t.rast.out.vtk](https://grass.osgeo.org/grass-stable/manuals/t.rast.out.vtk.html)
 
 ## AUTHOR
 

--- a/src/vector/v.class.mlR/v.class.mlR.md
+++ b/src/vector/v.class.mlR/v.class.mlR.md
@@ -15,7 +15,8 @@ classified.
 The user can provide input either as vector maps (*segments\_map* and
 *training\_map*, or as csv files (*segments\_file* and *training file*,
 or a combination of both. Csv files have to be formatted in line with
-the default output of [v.db.select](v.db.select.md), i.e. with a header.
+the default output of [v.db.select](https://grass.osgeo.org/grass-stable/manuals/v.db.select.html),
+i.e. with a header.
 The field separator can be set with the *separator* parameter. Output
 can consist of either additional columns in the vector input map of
 features, a text file (*classification\_results*) or reclassed raster

--- a/src/vector/v.flexure/v.flexure.md
+++ b/src/vector/v.flexure/v.flexure.md
@@ -6,7 +6,7 @@ equations for plate bending. This phenomenon is known as "flexural
 isostasy" and is relevant to glacier/ice-cap/ice-sheet loading,
 sedimentary basin filling, mountain belt growth, volcano emplacement,
 sea-level change, and other geologic processes. *v.flexure* and
-*[r.flexure](r.flexure.html)* are the GRASS GIS interfaces to the
+*[r.flexure](r.flexure.md)* are the GRASS GIS interfaces to the
 model [**gFlex**](https://gflex.readthedocs.io/). *v.flexure* requires
 **gFlex ≥ 2.0.0**:
 
@@ -29,7 +29,7 @@ stress into the values stored in the attribute column specified by
 
 **te**, written in standard notation as T<sub>e</sub>, is the
 lithospheric elastic thickness (scalar only for *v.flexure*; use
-*[r.flexure](r.flexure.html)* for spatially variable T<sub>e</sub>).
+*[r.flexure](r.flexure.md)* for spatially variable T<sub>e</sub>).
 
 **output** is a raster map of deflections at the spacing and extent of
 the current GRASS computational region. Be sure to use
@@ -89,7 +89,7 @@ independent; their deflections add linearly everywhere.
 
 ## SEE ALSO
 
-*[r.flexure](r.flexure.html)*,
+*[r.flexure](r.flexure.md)*,
 *[v.surf.bspline](https://grass.osgeo.org/grass-stable/manuals/v.surf.bspline.html)*
 
 ## REFERENCES

--- a/src/vector/v.greedycolors/v.greedycolors.md
+++ b/src/vector/v.greedycolors/v.greedycolors.md
@@ -71,7 +71,7 @@ v.db.update map=my_boundary_county column=GRASSRGB value="255:255:153" where="gr
 
 ## SEE ALSO
 
-*[v.colors](v.colors.md), [v.category](v.category.md)*
+*[v.colors](https://grass.osgeo.org/grass-stable/manuals/v.colors.html), [v.category](https://grass.osgeo.org/grass-stable/manuals/v.category.html)*
 
 ## AUTHOR
 

--- a/src/vector/v.percolate/v.percolate.md
+++ b/src/vector/v.percolate/v.percolate.md
@@ -139,7 +139,7 @@ threshold difference, a situation which DBSCAN avoids.
 
 ## SEE ALSO
 
-*[v.cluster](v.cluster.md)*.
+*[v.cluster](https://grass.osgeo.org/grass-stable/manuals/v.cluster.html)*.
 
 ## AUTHORS
 

--- a/src/vector/v.rast.move/v.rast.move.md
+++ b/src/vector/v.rast.move/v.rast.move.md
@@ -59,13 +59,17 @@ left, white no shift)*
 
 ## SEE ALSO
 
-- *[v.transform](v.transform.md)* for changing coordinates for the
+- *[v.transform](https://grass.osgeo.org/grass-stable/manuals/v.transform.html)*
+    for changing coordinates for the
     whole vector map or feature by feature based on the attributes,
-- *[v.perturb](v.perturb.md)* for randomly changing point positions by
+- *[v.perturb](https://grass.osgeo.org/grass-stable/manuals/v.perturb.html)*
+    for randomly changing point positions by
     small amounts,
-- *[r.mapcalc](r.mapcalc.md)* for generating or adjusting the raster
+- *[r.mapcalc](https://grass.osgeo.org/grass-stable/manuals/r.mapcalc.html)*
+    for generating or adjusting the raster
     maps,
-- *[g.region](g.region.md)* to set the computational region before the
+- *[g.region](https://grass.osgeo.org/grass-stable/manuals/g.region.html)*
+    to set the computational region before the
     computation.
 
 ## AUTHOR

--- a/src/vector/v.surf.rst.cv/v.surf.rst.cv.md
+++ b/src/vector/v.surf.rst.cv/v.surf.rst.cv.md
@@ -147,7 +147,7 @@ Philadelphia, Pennsylvania.
 
 ## SEE ALSO
 
-*[v.surf.rst](v.surf.rst.md)*
+*[v.surf.rst](https://grass.osgeo.org/grass-stable/manuals/v.surf.rst.html)*
 
 ## AUTHORS
 

--- a/src/vector/v.vect.stats.multi/v.vect.stats.multi.md
+++ b/src/vector/v.vect.stats.multi/v.vect.stats.multi.md
@@ -126,7 +126,8 @@ v.vect.stats.multi points=firestations areas=zipcodes method=sum \
     table,
 - *[v.what.rast.multi](v.what.rast.multi.md)* for querying multiple
     raster maps by one vector points map,
-- *[g.copy](g.copy.md)* for creating a copy of vector map to update
+- *[g.copy](https://grass.osgeo.org/grass-stable/manuals/g.copy.html)*
+    for creating a copy of vector map to update
     (to preserve the original data given that this module performs a
     large automated operation).
 


### PR DESCRIPTION
This fixes cases in markdown files:
* linking html instead of md for addons
* links to core tools now have the complete url
* miscellaneous not working links (not comprehensive)

