### PR TITLE
doc: fix several broken links to tools

### DIFF
--- a/src/imagery/i.gravity/i.gravity.md
+++ b/src/imagery/i.gravity/i.gravity.md
@@ -24,7 +24,7 @@ For more details on the algorithms see \[1\].
 
 ## SEE ALSO
 
-*[i.latlon](i.latlon.md)*
+*[r.latlong](https://grass.osgeo.org/grass-stable/manuals/r.latlong.html)*
 
 ## REFERENCES
 

--- a/src/imagery/i.segment.gsoc/i.segment.gsoc.md
+++ b/src/imagery/i.segment.gsoc/i.segment.gsoc.md
@@ -225,7 +225,8 @@ available on the wiki.
 [i.maxlik](https://grass.osgeo.org/grass-stable/manuals/i.maxlik.html),
 [r.fuzzy](r.fuzzy),
 [i.smap](https://grass.osgeo.org/grass-stable/manuals/i.smap.html),
-[r.seg](r.seg.md) (Addon)*
+[i.segment](https://grass.osgeo.org/grass-stable/manuals/i.segment.html),
+r.seg (GRASS 6 addon)*
 
 ## AUTHORS
 

--- a/src/raster/r.fill.category/r.fill.category.md
+++ b/src/raster/r.fill.category/r.fill.category.md
@@ -81,7 +81,7 @@ current directory.
 *[r.neighbors](https://grass.osgeo.org/grass-stable/manuals/r.neighbors.html),
 [r.reclass.area](https://grass.osgeo.org/grass-stable/manuals/r.reclass.area.html),
 [r.out.mpeg](https://grass.osgeo.org/grass-stable/manuals/r.out.mpeg.html),
-[r.fill.gaps](r.fill.gaps.md)*
+[r.fill.stats](https://grass.osgeo.org/grass-stable/manuals/r.fill.stats.html)*
 
 ## AUTHORS
 

--- a/src/raster/r.maxent.setup/r.maxent.setup.md
+++ b/src/raster/r.maxent.setup/r.maxent.setup.md
@@ -62,8 +62,8 @@ that you may need administrator rightrs to edit the osgeo4w.bat file.
 
 ## SEE ALSO
 
-- [v.maxent.train](v.maxent.train.md)
-- [v.maxent.predict](v.maxent.predict.md)
+- [r.maxent.train](r.maxent.train.md)
+- [r.maxent.predict](r.maxent.predict.md)
 
 ## AUTHOR
 

--- a/src/raster/r.mcda.promethee/r.mcda.promethee.md
+++ b/src/raster/r.mcda.promethee/r.mcda.promethee.md
@@ -39,7 +39,7 @@ GRASS Development Team (2015)
 
 [*r.mcda.ahp*](r.mcda.ahp.html),
 [*r.mcda.electre*](r.mcda.electre.html),
-[*r.mcda.roughet*](r.mcda.roughet.html),
+[*r.mcda.roughset*](r.mcda.roughset.md),
 [*r.mapcalc*](https://grass.osgeo.org/grass-stable/manuals/r.mapcalc.html)
 
 ## AUTHORS

--- a/src/raster/r.pi/r.pi.md
+++ b/src/raster/r.pi/r.pi.md
@@ -156,8 +156,7 @@ the module and might also be influenced by the resolution.
 [r.pi.searchtime.pr](r.pi.searchtime.pr.md),
 [r.pi.searchtime.mw](r.pi.searchtime.mw.md)*
 
-*[r.le](r.le.md),
-[r.li](https://grass.osgeo.org/grass-stable/manuals/r.li.html)*
+*[r.li](https://grass.osgeo.org/grass-stable/manuals/r.li.html)*
 
 ## REFERENCE
 


### PR DESCRIPTION
Fixes several links to non-existing/old tools in md documentation. These were mostly clear how to fix, there are more that need more investigation.