### PR TITLE
Lazy loading to fix missing tools in documentation

### DIFF
--- a/src/imagery/i.hyper/i.hyper.preproc/i.hyper.preproc.py
+++ b/src/imagery/i.hyper/i.hyper.preproc/i.hyper.preproc.py
@@ -197,7 +197,7 @@
 
 import sys
 import numpy as np
-from scipy.interpolate import interp1d
+
 import grass.script as gs
 import grass.script.array as garray
 from grass.script.utils import get_lib_path
@@ -600,6 +600,10 @@ def preprocess_hyperspectral(
 
 def main():
     options, flags = gs.parser()
+    try:
+        from scipy.interpolate import interp1d  # noqa: E402
+    except ModuleNotFoundError:
+        gs.fatal(_("SciPy library not installed"))
 
     preprocess_hyperspectral(
         inp=options["input"],

--- a/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
+++ b/src/imagery/i.landsat/i.landsat.download/i.landsat.download.py
@@ -156,7 +156,6 @@
 import os
 import json
 import sys
-import yaml
 from datetime import datetime, timezone, timedelta, date
 import grass.script as gs
 from grass.exceptions import CalledModuleError
@@ -479,6 +478,7 @@ if __name__ == "__main__":
         import eodag
         from eodag import EODataAccessGateway
         from eodag.utils.exceptions import AuthenticationError
+        import yaml
 
         gs.find_program("i.eodag", "--help")
     except ImportError:

--- a/src/misc/m.cdo.download/m.cdo.download.py
+++ b/src/misc/m.cdo.download/m.cdo.download.py
@@ -150,7 +150,6 @@
 
 import sys
 import os
-import requests
 import json
 import grass.script as gs
 from grass.script.utils import separator
@@ -306,6 +305,11 @@ def print_table(outf, records, fields, fs, exclude_colnames):
 
 
 def main():
+    try:
+        import requests  # noqa: E402
+    except ModuleNotFoundError:
+        gs.fatal(_("requests library not installed."))
+
     global tokens
 
     if tokens_env_name not in os.environ or not os.environ[tokens_env_name]:

--- a/src/misc/m.tnm.download/m.tnm.download.py
+++ b/src/misc/m.tnm.download/m.tnm.download.py
@@ -85,7 +85,6 @@
 
 import sys
 import os
-import requests
 import grass.script as gs
 from grass.script.utils import separator
 
@@ -225,6 +224,11 @@ def download_file(item, code, compare_file_size):
 
 
 def main():
+    try:
+        import requests  # noqa: E402
+    except ModuleNotFoundError:
+        gs.fatal(_("requests library not installed."))
+
     dataset = options["dataset"].split(",")
     type_ = options["type"]
     code = options["code"].split(",")

--- a/src/raster/r.green/r.green.install/r.green.install.py
+++ b/src/raster/r.green/r.green.install/r.green.install.py
@@ -32,13 +32,13 @@
 # import system libraries
 from __future__ import print_function
 
-import imp
 import os
 import platform
 import shutil
 import subprocess
 import sys
 import time
+import importlib.util
 import xml.etree.ElementTree as ET
 from collections import namedtuple
 from os.path import join
@@ -460,13 +460,9 @@ def win_install(libs):
 def fix_missing_libraries(install=False):
     """Check if the external libraries used by r.green are
     available in the current path."""
-    to_be_installed = []
-    for lib in CHECK_LIBRARIES:
-        try:
-            imp.find_module(lib)
-            print(lib, "available in the sys path")
-        except ImportError:
-            to_be_installed.append(lib)
+    to_be_installed = [
+        lib for lib in CHECK_LIBRARIES if importlib.util.find_spec(lib) is None
+    ]
 
     if to_be_installed:
         print("the following libraries are missing:")

--- a/src/raster/r.in.vect/r.in.vect.py
+++ b/src/raster/r.in.vect/r.in.vect.py
@@ -144,7 +144,6 @@ import atexit
 import os
 import sys
 import numpy as np
-from osgeo import ogr, gdal, osr
 import grass.script as gs
 
 clean_maps = []
@@ -330,6 +329,10 @@ def raster_labels(vector_file, layer_name, raster, column_name, column_rat, wher
 
 def main(options, flags):
     global _temp_region_used
+    try:
+        from osgeo import ogr, gdal, osr  # noqa: E402
+    except ModuleNotFoundError:
+        gs.fatal(_("GDAL Python package is not installed."))
 
     ogr.UseExceptions()
 

--- a/src/raster/r.mregression.series/r.mregression.series.py
+++ b/src/raster/r.mregression.series/r.mregression.series.py
@@ -56,7 +56,7 @@ import sys
 
 import csv
 import numpy as np
-from numpy.linalg.linalg import LinAlgError
+from numpy.linalg import LinAlgError
 
 # statsmodels lazy imported at the end of the file
 


### PR DESCRIPTION
Some tools are missing in online documentation and the only thing that seems to be common for them is they have python packages that don't come with standard library or deprecated python imports. 
Lazy import should fix that:
https://github.com/OSGeo/grass/blob/main/doc/development/style_guide.md#lazy-import-of-optional-dependencies