### PR TITLE
tests: Add pytest in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,8 @@ jobs:
           # Addons that bundle a Python package install it under etc/<tool>/;
           # add those dirs so their tests can import the package.
           etc_paths="$(find "$GISBASE/etc" -maxdepth 1 -type d -name '*.*' | paste -sd: -)"
-          export PYTHONPATH="$(grass --config python_path):${etc_paths}:${PYTHONPATH}"
+          PYTHONPATH="$(grass --config python_path):${etc_paths}:${PYTHONPATH}"
+          export PYTHONPATH
           export LD_LIBRARY_PATH="${GISBASE}/lib:${LD_LIBRARY_PATH}"
           status=0
           while IFS= read -r tests_dir; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,35 @@ jobs:
           cd grass-addons/src
           ../.github/workflows/test.sh --config ../.gunittest.cfg
 
+      - name: Run pytest tests
+        timeout-minutes: 20
+        run: |
+          cd grass-addons/src
+          GISBASE="$(grass --config path)"
+          # Addons that bundle a Python package install it under etc/<tool>/;
+          # add those dirs so their tests can import the package.
+          etc_paths="$(find "$GISBASE/etc" -maxdepth 1 -type d -name '*.*' | paste -sd: -)"
+          export PYTHONPATH="$(grass --config python_path):${etc_paths}:${PYTHONPATH}"
+          export LD_LIBRARY_PATH="${GISBASE}/lib:${LD_LIBRARY_PATH}"
+          status=0
+          while IFS= read -r tests_dir; do
+            addon="$(dirname "$tests_dir")"
+            # r.estimap.recreation uses downloads data
+            # over the network, so we skip it for CI.
+            if [ "$addon" = "./raster/r.estimap.recreation" ]; then continue; fi
+            if [ -f "$addon/requirements.txt" ]; then
+              pip install -r "$addon/requirements.txt"
+            fi
+            echo "::group::pytest $addon"
+            # For increased isolation, run each addon in its own process.
+            rc=0
+            pytest --verbose --color=yes -ra "$tests_dir" || rc=$?
+            echo "::endgroup::"
+            # rc 5 means no tests were collected; only other codes are failures.
+            if [ "$rc" -ne 0 ] && [ "$rc" -ne 5 ]; then status=1; fi
+          done < <(find . -type d -name tests | sort)
+          exit "$status"
+
       - name: Make HTML test report available
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,2 +1,4 @@
 matplotlib
 numpy
+pytest
+pytest-timeout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,24 @@
 name = "grass-addons"
 requires-python = ">=3.8"
 
+[tool.pytest.ini_options]
+addopts = """
+    --import-mode=importlib
+    --ignore-glob='bin.*'
+    --ignore-glob='dist.*'
+    --ignore-glob='*/tests/data/*'
+"""
+minversion = "8.2"
+python_files = """
+    */tests/*_test.py
+    */tests/test_*.py
+"""
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "needs_solo_run: marks tests that must be run without any other tests running in parallel",
+]
+timeout = 300
+
 [tool.black]
 extend-exclude = '''
 (


### PR DESCRIPTION
Run pytest-based addon tests in CI, in addition to the existing
gunittest runs. A new CI step discovers each addon's tests/ directory
and runs pytest per addon in a separate process for isolation. When an
addon ships a requirements.txt, it is installed first, and tools that
need network access (e.g. r.estimap.recreation) are skipped. A directory
with no collected tests is not treated as a failure.

Add the pytest configuration (import mode, test-file patterns, markers,
and a per-test timeout) to pyproject.toml, and add pytest and
pytest-timeout to the CI requirements.

This is one step toward running pytest for addons; fixes for individual
tools follow in separate pull requests.

The CI configuration was generated with the help of Claude and tested
locally.
