### PR TITLE
v.rast.move: Fix import of exception

### DIFF
--- a/src/vector/v.rast.move/tests/test_v_rast_move.py
+++ b/src/vector/v.rast.move/tests/test_v_rast_move.py
@@ -3,6 +3,7 @@
 import pytest
 
 import grass.script as gs
+from grass.exceptions import CalledModuleError
 
 
 def test_displacement_result(line_dataset):
@@ -61,7 +62,7 @@ def test_nulls_as_zeros(line_dataset):
 def test_nulls_fail(line_dataset):
     """Check that an error is generated for nulls"""
     result = "result_fails"
-    with pytest.raises(gs.CalledModuleError):
+    with pytest.raises(CalledModuleError):
         gs.run_command(
             "v.rast.move",
             input=line_dataset.name,


### PR DESCRIPTION
The import of CalledModuleError was wrong, this changes it to the standard import pattern (CalledModuleError is not part of grass.script, but of grass.exceptions).
