### PR TITLE
manual: various minor fixes

### DIFF
--- a/src/imagery/i.histo.match/i.histo.match.py
+++ b/src/imagery/i.histo.match/i.histo.match.py
@@ -7,7 +7,7 @@ AUTHOR(S):  Stefan Blumentrath (Norway) parallel / Numpy re-implementation
             Luca Delucchi, Fondazione E. Mach (Italy)
             original PERL code was developed by:
             Laura Zampa (2004) student of Dipartimento di Informatica e
-            Telecomunicazioni, Facoltà di Ingegneria,
+            Telecomunicazioni, Facolta' di Ingegneria,
             University of Trento  and ITC-irst, Trento (Italy)
 
 PURPOSE:    Calculate histogram matching of several images

--- a/src/imagery/i.segment.gsoc/i.segment.gsoc.html
+++ b/src/imagery/i.segment.gsoc/i.segment.gsoc.html
@@ -214,7 +214,7 @@ GRASS GIS</a> is also available on the wiki.
 <a href="https://grass.osgeo.org/grass-stable/manuals/i.maxlik.html">i.maxlik</a>,
 <a href="r.fuzzy">r.fuzzy</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/i.smap.html">i.smap</a>,
-<a href="r.seg.html">r.seg</a> (Addon)
+<a href="r.smooth.seg.html">r.smooth.seg</a> (Addon)
 </em>
 
 <h2>AUTHORS</h2>

--- a/src/imagery/i.segment.gsoc/i.segment.gsoc.md
+++ b/src/imagery/i.segment.gsoc/i.segment.gsoc.md
@@ -223,10 +223,10 @@ available on the wiki.
 
 *[i.group](https://grass.osgeo.org/grass-stable/manuals/i.group.html),
 [i.maxlik](https://grass.osgeo.org/grass-stable/manuals/i.maxlik.html),
-[r.fuzzy](r.fuzzy),
+[r.fuzzy](r.fuzzy.md),
 [i.smap](https://grass.osgeo.org/grass-stable/manuals/i.smap.html),
 [i.segment](https://grass.osgeo.org/grass-stable/manuals/i.segment.html),
-r.seg (GRASS 6 addon)*
+[r.smooth.seg](r.smooth.seg.md)*
 
 ## AUTHORS
 

--- a/src/raster/r.smooth.seg/r.smooth.seg.html
+++ b/src/raster/r.smooth.seg/r.smooth.seg.html
@@ -142,9 +142,9 @@ ISPRS Journal of Photogrammetry and Remote Sensing, 69:50-64, 2012.<br>
 DOI: 10.1016/j.isprsjprs.2012.02.005
 
 <li> <b>[4]</b> A. Vitti. <em>Free discontinuity
-problems in image and signal segmentatiion</em>. <br>
+problems in image and signal segmentation</em>. <br>
 Ph.D. Thesis - University of Trento (Italy), 2008. <br> <a
-href="https://www.ing.unitn.it/~vittia/misc/vitti_phd.pdf">https://www.ing.unitn.it/~vittia/misc/vitti_phd.pdf</a>
+href="https://documentation.ensg.eu/index.php?lvl=author_see&id=24344">https://documentation.ensg.eu/index.php?lvl=author_see&id=24344</a>
 </ul>
 
 

--- a/src/raster/r.smooth.seg/r.smooth.seg.md
+++ b/src/raster/r.smooth.seg/r.smooth.seg.md
@@ -132,9 +132,9 @@ r.smooth.seg in_g=ortho_2001_t792_1m out_u=u4_OF out_z=z4_OF lambda=1 alpha=200 
     2012.  
     DOI: 10.1016/j.isprsjprs.2012.02.005
 - **\[4\]** A. Vitti. *Free discontinuity problems in image and signal
-    segmentatiion*.  
+    segmentation*.
     Ph.D. Thesis - University of Trento (Italy), 2008.  
-    <https://www.ing.unitn.it/~vittia/misc/vitti_phd.pdf>
+    <https://documentation.ensg.eu/index.php?lvl=author_see&id=24344>
 
 ## SEE ALSO
 


### PR DESCRIPTION
- `i.histo.match`: fix UTF-8 error (probably relevant during `g.parser generates --md-description` step), see addon compile logs
- `i.segment.gsoc`: fix `r.seg` -> `r.smooth.seg`
- `r.smooth.seg`: fix  Ph.D. Thesis URL and typo