### PR TITLE
i.eb.hsebal95: fix iteration loop

### DIFF
--- a/src/imagery/i.eb.hsebal95/sensi_h.c
+++ b/src/imagery/i.eb.hsebal95/sensi_h.c
@@ -17,7 +17,7 @@ double sensi_h(int iteration, double tempk_water, double tempk_desert,
     /* Arrays Declarations */
     double dtair[ITER_MAX + 1], roh_air[ITER_MAX + 1], rah[ITER_MAX + 1];
 
-    double h[ITER_MAX+1];
+    double h[ITER_MAX + 1];
 
     double ustar[ITER_MAX+1], zom[ITER_MAX+1];
 

--- a/src/imagery/i.eb.hsebal95/sensi_h.c
+++ b/src/imagery/i.eb.hsebal95/sensi_h.c
@@ -15,11 +15,11 @@ double sensi_h(int iteration, double tempk_water, double tempk_desert,
                double t0_dem_desert, double u2m, double dem_desert)
 {
     /* Arrays Declarations */
-    double dtair[ITER_MAX], roh_air[ITER_MAX], rah[ITER_MAX];
+    double dtair[ITER_MAX+1], roh_air[ITER_MAX+1], rah[ITER_MAX+1];
 
-    double h[ITER_MAX];
+    double h[ITER_MAX+1];
 
-    double ustar[ITER_MAX], zom[ITER_MAX];
+    double ustar[ITER_MAX+1], zom[ITER_MAX+1];
 
     /* Declarations */
     int i, j, ic, debug = 0;

--- a/src/imagery/i.eb.hsebal95/sensi_h.c
+++ b/src/imagery/i.eb.hsebal95/sensi_h.c
@@ -15,7 +15,7 @@ double sensi_h(int iteration, double tempk_water, double tempk_desert,
                double t0_dem_desert, double u2m, double dem_desert)
 {
     /* Arrays Declarations */
-    double dtair[ITER_MAX+1], roh_air[ITER_MAX+1], rah[ITER_MAX+1];
+    double dtair[ITER_MAX + 1], roh_air[ITER_MAX + 1], rah[ITER_MAX + 1];
 
     double h[ITER_MAX+1];
 

--- a/src/imagery/i.eb.hsebal95/sensi_h.c
+++ b/src/imagery/i.eb.hsebal95/sensi_h.c
@@ -19,7 +19,7 @@ double sensi_h(int iteration, double tempk_water, double tempk_desert,
 
     double h[ITER_MAX + 1];
 
-    double ustar[ITER_MAX+1], zom[ITER_MAX+1];
+    double ustar[ITER_MAX + 1], zom[ITER_MAX + 1];
 
     /* Declarations */
     int i, j, ic, debug = 0;


### PR DESCRIPTION
The iteration loop for (ic = 1; ic < iteration + 1; ic++) runs ic up to iteration inclusive, and iteration is capped at ITER_MAX (10, the default) just  above the loop — so with default settings every one of these stack arrays gets  written at index 10, one past its declared size of 10 (valid indices 0-9).  Classic off-by-one stack buffer overflow.