### PR TITLE
i.eb.hsebal95: fix numerical instability

### DIFF
--- a/src/imagery/i.eb.hsebal95/u_star.c
+++ b/src/imagery/i.eb.hsebal95/u_star.c
@@ -22,7 +22,6 @@ double u_star(double t0_dem, double h, double ustar, double roh_air, double zom,
     if (u2m < 1.0) {
       u2m = 1.0;
     }
-    
     if (h != 0.0) {
         n5_temp =
             (-1004 * roh_air * pow(ustar, 3) * t0_dem) / (0.41 * 9.81 * h);

--- a/src/imagery/i.eb.hsebal95/u_star.c
+++ b/src/imagery/i.eb.hsebal95/u_star.c
@@ -18,7 +18,11 @@ double u_star(double t0_dem, double h, double ustar, double roh_air, double zom,
     double hv = 0.15; /* crop height (m)              */
 
     double bh = 200; /* blending height (m)          */
-
+    
+    if (u2m < 1.0) {
+      u2m = 1.0;
+    }
+    
     if (h != 0.0) {
         n5_temp =
             (-1004 * roh_air * pow(ustar, 3) * t0_dem) / (0.41 * 9.81 * h);

--- a/src/imagery/i.eb.hsebal95/u_star.c
+++ b/src/imagery/i.eb.hsebal95/u_star.c
@@ -20,7 +20,7 @@ double u_star(double t0_dem, double h, double ustar, double roh_air, double zom,
     double bh = 200; /* blending height (m)          */
     
     if (u2m < 1.0) {
-      u2m = 1.0;
+        u2m = 1.0;
     }
     if (h != 0.0) {
         n5_temp =

--- a/src/imagery/i.eb.hsebal95/u_star.c
+++ b/src/imagery/i.eb.hsebal95/u_star.c
@@ -18,7 +18,6 @@ double u_star(double t0_dem, double h, double ustar, double roh_air, double zom,
     double hv = 0.15; /* crop height (m)              */
 
     double bh = 200; /* blending height (m)          */
-    
     if (u2m < 1.0) {
         u2m = 1.0;
     }


### PR DESCRIPTION
Known numerical limitation of Monin-Obukhov similarity theory at near-calm wind: operational SEBAL/METRIC implementations universally floor 2m wind speed at some minimum (commonly ~1.0 m/s) specifically to avoid this singularity, since the log-wind-profile assumptions themselves break down physically at near-zero wind.