### PR TITLE
i.eb.hsebal95: fix numerical limitation at near-calm wind

### DIFF
--- a/src/imagery/i.eb.hsebal95/sensi_h.c
+++ b/src/imagery/i.eb.hsebal95/sensi_h.c
@@ -43,7 +43,6 @@ double sensi_h(int iteration, double tempk_water, double tempk_desert,
     if (u2m < 1.0) {
         u2m = 1.0;
     }
-    
     if (debug == 1) {
         printf("*****************************\n");
         printf("t0_dem = %5.3f\n", t0_dem);

--- a/src/imagery/i.eb.hsebal95/sensi_h.c
+++ b/src/imagery/i.eb.hsebal95/sensi_h.c
@@ -40,7 +40,10 @@ double sensi_h(int iteration, double tempk_water, double tempk_desert,
     if (iteration > ITER_MAX) {
         iteration = ITER_MAX;
     }
-
+    if (u2m < 1.0) {
+        u2m = 1.0;
+    }
+    
     if (debug == 1) {
         printf("*****************************\n");
         printf("t0_dem = %5.3f\n", t0_dem);


### PR DESCRIPTION
Known numerical limitation of Monin-Obukhov similarity theory at near-calm wind: operational SEBAL/METRIC implementations universally floor 2m wind speed at some minimum (commonly ~1.0 m/s) specifically to avoid this singularity, since the log-wind-profile assumptions themselves break down physically at near-zero wind.