### PR TITLE
Deploy website from the CI-built release artifact

### DIFF
--- a/utils/cronjobs_osgeo_lxd/README.md
+++ b/utils/cronjobs_osgeo_lxd/README.md
@@ -30,13 +30,17 @@ programmer's manual.
   - The website is built by GitHub Actions in the
     [grass-website](https://github.com/OSGeo/grass-website) repo
     (`.github/workflows/build-production-site.yml`) on every push to `master`
-    and published as a checksummed tarball on the rolling
-    [`production` release](https://github.com/OSGeo/grass-website/releases/tag/production).
-    This job downloads the tarball, verifies its SHA256 checksum, and rsyncs it
-    into `/var/www/html/`. It only needs `curl`, `tar`, `sha256sum`, and
-    `rsync`; no Hugo, Node.js, or Dart Sass on the server, and no GitHub token
-    (public release URL over HTTPS). The formerly used `~/grass-website`
-    checkout and the go-installed `hugo` binary are no longer needed.
+    and published as a checksummed tarball on a per-deploy GitHub release, the
+    newest of which is marked
+    [`latest`](https://github.com/OSGeo/grass-website/releases/latest).
+    This job downloads the tarball from the `latest` release, verifies its
+    SHA256 checksum, and rsyncs it into `/var/www/html/`. It only needs `curl`,
+    `tar`, `sha256sum`, and `rsync`; no Hugo, Node.js, or Dart Sass on the
+    server, and no GitHub token (public release URL over HTTPS). To roll back a
+    bad build, mark an older release as latest (`gh release edit <tag>
+    --latest`) and this job deploys it on its next run. The formerly used
+    `~/grass-website` checkout and the go-installed `hugo` binary are no longer
+    needed.
 - GRASS GIS source code weekly snapshots:
   - `cron_grass_legacy_src_snapshot.sh`
   - `cron_grass_old_src_snapshot.sh`

--- a/utils/cronjobs_osgeo_lxd/README.md
+++ b/utils/cronjobs_osgeo_lxd/README.md
@@ -25,8 +25,18 @@ programmer's manual.
   - IMPORTANT: to activate any cronjob change, run the following on `grasslxd`
     container (as user `neteler`):
     - `crontab $HOME/cronjobs/cron_job_list_grass && crontab -l`
-- generate and deploy the GRASS GIS Web pages at <https://grass.osgeo.org/>:
+- deploy the GRASS GIS Web pages at <https://grass.osgeo.org/>:
   - `hugo_clean_and_update_job.sh`
+  - The website is built by GitHub Actions in the
+    [grass-website](https://github.com/OSGeo/grass-website) repo
+    (`.github/workflows/build-production-site.yml`) on every push to `master`
+    and published as a checksummed tarball on the rolling
+    [`production` release](https://github.com/OSGeo/grass-website/releases/tag/production).
+    This job downloads the tarball, verifies its SHA256 checksum, and rsyncs it
+    into `/var/www/html/`. It only needs `curl`, `tar`, `sha256sum`, and
+    `rsync`; no Hugo, Node.js, or Dart Sass on the server, and no GitHub token
+    (public release URL over HTTPS). The formerly used `~/grass-website`
+    checkout and the go-installed `hugo` binary are no longer needed.
 - GRASS GIS source code weekly snapshots:
   - `cron_grass_legacy_src_snapshot.sh`
   - `cron_grass_old_src_snapshot.sh`

--- a/utils/cronjobs_osgeo_lxd/hugo_clean_and_update_job.sh
+++ b/utils/cronjobs_osgeo_lxd/hugo_clean_and_update_job.sh
@@ -14,13 +14,15 @@
 # The website is no longer built on this server. GitHub Actions
 # (grass-website: .github/workflows/build-production-site.yml) builds the
 # site with the pinned Hugo Extended + Dart Sass + Node toolchain on every
-# push to master and publishes it as a checksummed tarball on the rolling
-# "production" release:
-#   https://github.com/OSGeo/grass-website/releases/tag/production
+# push to master and publishes it as a checksummed tarball on a per-deploy
+# GitHub release, marking the newest one "latest":
+#   https://github.com/OSGeo/grass-website/releases/latest
 #
-# This job downloads that tarball, verifies its SHA256 checksum, and rsyncs
-# it into the web root. It requires only curl, tar, sha256sum, and rsync.
-# No GitHub token is needed (public release URL over HTTPS).
+# This job downloads that tarball from the "latest" release, verifies its
+# SHA256 checksum, and rsyncs it into the web root. It requires only curl,
+# tar, sha256sum, and rsync. No GitHub token is needed (public release URL
+# over HTTPS). To roll back a bad build, mark an older release as latest
+# (gh release edit <tag> --latest) and this job deploys it on the next run.
 ####
 # Procedure:
 #  1. fetch the published checksum; exit early if it matches the deployed one
@@ -32,7 +34,7 @@
 ####
 
 # Overridable for testing (e.g. RELEASE_URL="file:///tmp/fake" TARGET=/tmp/www ...)
-RELEASE_URL="${RELEASE_URL:-https://github.com/OSGeo/grass-website/releases/download/production}"
+RELEASE_URL="${RELEASE_URL:-https://github.com/OSGeo/grass-website/releases/latest/download}"
 WORK="${WORK:-${HOME}/grass-website-deploy}"
 TARGET="${TARGET:-/var/www/html}"
 CODE_AND_DATA="${CODE_AND_DATA:-/var/www/code_and_data}"

--- a/utils/cronjobs_osgeo_lxd/hugo_clean_and_update_job.sh
+++ b/utils/cronjobs_osgeo_lxd/hugo_clean_and_update_job.sh
@@ -3,28 +3,42 @@
 ############################################################################
 #
 # TOOL:         hugo_clean_and_update_job.sh
-# AUTHOR(s):    Markus Neteler
-# PURPOSE:      Deploy updated web site from github repo
-# COPYRIGHT:    (c) 2020-2025  Markus Netelerand the GRASS Development Team
+# AUTHOR(s):    Markus Neteler, Corey T. White
+# PURPOSE:      Deploy updated web site from the CI-built release artifact
+# COPYRIGHT:    (c) 2020-2026 Markus Neteler and the GRASS Development Team
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 
-# Preparations:
-#  sudo chown -R neteler.users /var/www
-# get grass-website repo
-#  cd ~/
-#  git clone https://github.com/OSGeo/grass-website.git
+# The website is no longer built on this server. GitHub Actions
+# (grass-website: .github/workflows/build-production-site.yml) builds the
+# site with the pinned Hugo Extended + Dart Sass + Node toolchain on every
+# push to master and publishes it as a checksummed tarball on the rolling
+# "production" release:
+#   https://github.com/OSGeo/grass-website/releases/tag/production
+#
+# This job downloads that tarball, verifies its SHA256 checksum, and rsyncs
+# it into the web root. It requires only curl, tar, sha256sum, and rsync.
+# No GitHub token is needed (public release URL over HTTPS).
 ####
 # Procedure:
-#  1. change into local git repo copy
-#  2. update local repo from github
-#  3. build updated pages with hugo into clean directory
+#  1. fetch the published checksum; exit early if it matches the deployed one
+#  2. download the tarball and verify the checksum (abort on mismatch)
+#  3. unpack into a clean staging directory
 #  4. rsync over updated pages to target web directory, deleting leftover files
 #  5. generate links from src code directory content into web directory
 #  6. restore timestamps of links from their original time stamps in src directory
 ####
+
+# Overridable for testing (e.g. RELEASE_URL="file:///tmp/fake" TARGET=/tmp/www ...)
+RELEASE_URL="${RELEASE_URL:-https://github.com/OSGeo/grass-website/releases/download/production}"
+WORK="${WORK:-${HOME}/grass-website-deploy}"
+TARGET="${TARGET:-/var/www/html}"
+CODE_AND_DATA="${CODE_AND_DATA:-/var/www/code_and_data}"
+
+TARBALL="grass-website.tar.gz"
+CHECKSUM="${TARBALL}.sha256"
 
 # function to update timestamp of link to the source timestamp
 fix_link_timestamp()
@@ -45,10 +59,22 @@ fix_link_timestamp()
  done
 }
 
-cd /home/neteler/grass-website/ && \
-   git pull origin master && \
-   rm -rf /home/neteler/grass-website/public/* && \
-   nice /home/neteler/go/bin/hugo && \
-   rsync -a --delete /home/neteler/grass-website/public/ /var/www/html/ && \
-   ln -s /var/www/code_and_data/* /var/www/html/ && \
-   (cd /var/www/html/ && fix_link_timestamp .)
+mkdir -p "$WORK" && cd "$WORK" || exit 1
+
+# fetch the published checksum first
+curl -fsSL -o "$CHECKSUM" "$RELEASE_URL/$CHECKSUM" || exit 1
+
+# nothing to do if the published build is already deployed
+if [ -f deployed.sha256 ] && cmp -s "$CHECKSUM" deployed.sha256 ; then
+   echo "Published build already deployed, nothing to do."
+   exit 0
+fi
+
+curl -fsSL -o "$TARBALL" "$RELEASE_URL/$TARBALL" && \
+   sha256sum -c "$CHECKSUM" && \
+   rm -rf public && mkdir public && \
+   tar -xzf "$TARBALL" -C public && \
+   rsync -a --delete "$WORK/public/" "$TARGET/" && \
+   ln -s "$CODE_AND_DATA"/* "$TARGET/" && \
+   (cd "$TARGET/" && fix_link_timestamp .) && \
+   cp "$CHECKSUM" deployed.sha256

--- a/utils/cronjobs_osgeo_lxd/hugo_clean_and_update_job.sh
+++ b/utils/cronjobs_osgeo_lxd/hugo_clean_and_update_job.sh
@@ -11,7 +11,7 @@
 #
 #############################################################################
 
-# The website is no longer built on this server. GitHub Actions
+# The website is no longer built on the grass.osgeo.org server. GitHub Actions
 # (grass-website: .github/workflows/build-production-site.yml) builds the
 # site with the pinned Hugo Extended + Dart Sass + Node toolchain on every
 # push to master and publishes it as a checksummed tarball on a per-deploy


### PR DESCRIPTION
> **Do not merge before OSGeo/grass-website#635.** The workflow that publishes the release must land first.

## What this does

Reworks `hugo_clean_and_update_job.sh` so grass.osgeo.org **deploys** the website instead of **building** it. GitHub Actions (OSGeo/grass-website#635) builds the site on every push to `master` and publishes it as a checksummed tarball on the rolling [`production` release](https://github.com/OSGeo/grass-website/releases/tag/production). This job downloads it, verifies the SHA256, and rsyncs it into `/var/www/html/`.

## Why

The Bootstrap 5 / Dart Sass migration (OSGeo/grass-website#600, starting with the approved OSGeo/grass-website#599) changes the build requirements to **Hugo Extended + npm + Dart Sass**. The current cronjob builds with a plain go-installed Hugo and would fail on every run after that merges. Moving the build to CI keeps the toolchain pinned in one place and means nothing has to be installed or upgraded on the grasslxd container — ever — for website toolchain changes.

## Operational notes (@neteler)

- **No crontab change**: same filename, same `30 */12` schedule.
- **No new toolchain**: needs only `curl`, `tar`, `sha256sum`, `rsync` (all present). No Hugo, Node, or Dart Sass on the server.
- **No token**: public release URL over HTTPS — avoids the expiring-PAT caveat of the `gh`-based manual-pages fetch.
- `code_and_data` symlink handling and `fix_link_timestamp` are retained verbatim.
- Unchanged builds are a cheap no-op (checksum marker in `~/grass-website-deploy/`); any failure aborts **before** rsync, so the live site is never left broken (same failure mode as today).
- One-time after the workflow lands: run the script manually once to switch over. The `~/grass-website` checkout and go-installed `hugo` binary can be retired afterwards.

## Tested

All variables are env-overridable, so the script was exercised locally against `file://` fixtures:
- fresh deploy: extracts, rsyncs, recreates `code_and_data` symlinks, fixes link timestamps, records marker
- unchanged release: early no-op exit
- corrupted checksum: aborts, web root untouched
- unreachable URL: fails cleanly

The upstream workflow was tested end-to-end on a fork: release + assets published, checksum verifies, tarball sitemap page count matches the live site exactly (228 == 228).
