### PR TITLE
packaging: Explain the minimal Python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [project]
 name = "grass-addons"
+# Addons need to work at least with the latest release and the development
+# version, so the minimum follows the latest release, not GRASS main (see
+# RFC 8). Ruff has no target version configured and derives it from this value.
 requires-python = ">=3.8"
 
 [tool.black]


### PR DESCRIPTION
Nothing recorded why the minimum Python version here does not follow the minimum in GRASS main, which makes it look out of date.

Addons need to work at least with the latest release and the development version, so the minimum follows the latest release. The comment also notes that Ruff has no target version configured and derives it from this value, which is easy to miss when changing it.

The current situation is that we want the addon Python code to work with 8.4 which supports Python all the way back to 3.8.

The companion change in GRASS updates RFC 8 to match, since the RFC currently says the minimum is raised for GRASS and grass-addons at the same time. https://github.com/OSGeo/grass/pull/7691

## Commit message

Addon tools need to work at least with the latest release and the development
version, so the minimal Python version follows the latest release, not
GRASS main. Note that Ruff derives its target version from this value.
While this was already present, it was not clear from the immediate context
what is the rule here.