### PR TITLE
r.centroids: Add pytest suite

### DIFF
--- a/src/raster/r.centroids/tests/conftest.py
+++ b/src/raster/r.centroids/tests/conftest.py
@@ -34,7 +34,7 @@ def clumps_session(tmp_path_factory):
 
 
 @pytest.fixture
-def centroids(clumps_session):
+def clump_setup(clumps_session):
     """Isolated per-test mapset + Tools handle over the module-scoped clumps raster."""
     with TemporaryMapsetSession(env=clumps_session.env) as session:
         with Tools(session=session) as tools:

--- a/src/raster/r.centroids/tests/conftest.py
+++ b/src/raster/r.centroids/tests/conftest.py
@@ -1,0 +1,44 @@
+"""Fixtures for the r.centroids tests."""
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+import grass.script as gs
+from grass.experimental import TemporaryMapsetSession
+from grass.tools import Tools
+
+
+@pytest.fixture(scope="module")
+def clumps_session(tmp_path_factory):
+    """Project with a raster of 4 separated same-valued blocks in PERMANENT.
+
+    Region is 10x10 at resolution 1; the blocks sit in the four corners
+    with background 0 between them, so each stays a single clump.
+    """
+    project = tmp_path_factory.mktemp("r_centroids") / "project"
+    gs.create_project(project, epsg="4326")
+    with gs.setup.init(project, env=os.environ.copy()) as session:
+        with Tools(session=session) as tools:
+            tools.g_region(n=10, s=0, e=10, w=0, res=1)
+            tools.r_mapcalc(
+                expression=(
+                    "clumps = if(row() <= 3 && col() <= 3, 1,"
+                    " if(row() <= 3 && col() >= 8, 2,"
+                    " if(row() >= 8 && col() <= 3, 3,"
+                    " if(row() >= 8 && col() >= 8, 4, 0))))"
+                )
+            )
+        yield session
+
+
+@pytest.fixture
+def centroids(clumps_session):
+    """Isolated per-test mapset + Tools handle over the module-scoped clumps raster."""
+    with TemporaryMapsetSession(env=clumps_session.env) as session:
+        with Tools(session=session) as tools:
+            # A new mapset starts with its own default region, so align it
+            # with the raster built in PERMANENT.
+            tools.g_region(raster="clumps")
+            yield SimpleNamespace(tools=tools, input="clumps")

--- a/src/raster/r.centroids/tests/r_centroids_test.py
+++ b/src/raster/r.centroids/tests/r_centroids_test.py
@@ -1,0 +1,57 @@
+"""Tests for the r.centroids addon."""
+
+import pytest
+
+from grass.exceptions import CalledModuleError
+
+# cat -> (x range, y range) of the source quadrant, for the loose
+# extent-containment check below.
+QUADRANTS = {
+    1: ((0, 3), (7, 10)),
+    2: ((7, 10), (7, 10)),
+    3: ((0, 3), (0, 3)),
+    4: ((7, 10), (0, 3)),
+}
+
+
+def test_output_has_one_point_per_clump_excluding_background(centroids):
+    """One centroid is produced per non-zero clump value; 0 is background."""
+    tools = centroids.tools
+    tools.r_centroids(input=centroids.input, output="out_centroids")
+
+    info = tools.v_info(map="out_centroids", flags="t", format="json")
+    assert info["points"] == 4
+
+    records = tools.v_db_select(map="out_centroids", format="json")["records"]
+    assert {row["cat"] for row in records} == {1, 2, 3, 4}
+
+
+def test_volume_columns_are_dropped(centroids):
+    """r.volume's volume/sum/count/average columns are removed."""
+    tools = centroids.tools
+    tools.r_centroids(input=centroids.input, output="out_columns")
+
+    columns = tools.v_info(map="out_columns", flags="c", format="json")
+    assert {col["name"] for col in columns} == {"cat"}
+
+
+def test_overwrite_protection(centroids):
+    """Reusing an output name without --overwrite fails."""
+    tools = centroids.tools
+    tools.r_centroids(input=centroids.input, output="out_overwrite")
+    with pytest.raises(CalledModuleError):
+        tools.r_centroids(input=centroids.input, output="out_overwrite")
+
+
+def test_centroid_lies_within_source_clump_extent(centroids):
+    """Each centroid falls inside the bounding box of the quadrant it came from."""
+    tools = centroids.tools
+    tools.r_centroids(input=centroids.input, output="out_extent")
+
+    lines = tools.v_out_ascii(input="out_extent", format="point").stdout.splitlines()
+    assert len(lines) == 4
+    for line in lines:
+        x, y, cat = line.split("|")
+        x_range, y_range = QUADRANTS[int(cat)]
+        assert x_range[0] <= float(x) <= x_range[1]
+        assert y_range[0] <= float(y) <= y_range[1]

--- a/src/raster/r.centroids/tests/r_centroids_test.py
+++ b/src/raster/r.centroids/tests/r_centroids_test.py
@@ -50,4 +50,8 @@ def test_centroid_matches_expected_coordinates(clump_setup):
         int(cat): (float(x), float(y))
         for x, y, cat in (line.split("|") for line in lines)
     }
-    assert points == pytest.approx(EXPECTED)
+    # pytest.approx doesn't recurse into dict values, so compare per key to
+    # keep the tolerance on each (x, y) tuple instead of an exact dict match.
+    assert points.keys() == EXPECTED.keys()
+    for cat, expected_point in EXPECTED.items():
+        assert points[cat] == pytest.approx(expected_point)

--- a/src/raster/r.centroids/tests/r_centroids_test.py
+++ b/src/raster/r.centroids/tests/r_centroids_test.py
@@ -2,22 +2,19 @@
 
 import pytest
 
-from grass.exceptions import CalledModuleError
+from grass.tools import ToolError
 
-# cat -> (x range, y range) of the source quadrant, for the loose
-# extent-containment check below.
-QUADRANTS = {
-    1: ((0, 3), (7, 10)),
-    2: ((7, 10), (7, 10)),
-    3: ((0, 3), (0, 3)),
-    4: ((7, 10), (0, 3)),
-}
+# Exact centroid per clump (region 10x10, res 1). These symmetric 3x3 blocks
+# make r.volume's distance-weighted centroid land on the clump's middle cell,
+# so exact coordinates are stable here; irregular or even-sized clumps can
+# hit r.volume's counting/adjusted fallback and shift the point.
+EXPECTED = {1: (1.5, 8.5), 2: (8.5, 8.5), 3: (1.5, 1.5), 4: (8.5, 1.5)}
 
 
-def test_output_has_one_point_per_clump_excluding_background(centroids):
+def test_output_has_one_point_per_clump_excluding_background(clump_setup):
     """One centroid is produced per non-zero clump value; 0 is background."""
-    tools = centroids.tools
-    tools.r_centroids(input=centroids.input, output="out_centroids")
+    tools = clump_setup.tools
+    tools.r_centroids(input=clump_setup.input, output="out_centroids")
 
     info = tools.v_info(map="out_centroids", flags="t", format="json")
     assert info["points"] == 4
@@ -26,32 +23,31 @@ def test_output_has_one_point_per_clump_excluding_background(centroids):
     assert {row["cat"] for row in records} == {1, 2, 3, 4}
 
 
-def test_volume_columns_are_dropped(centroids):
+def test_volume_columns_are_dropped(clump_setup):
     """r.volume's volume/sum/count/average columns are removed."""
-    tools = centroids.tools
-    tools.r_centroids(input=centroids.input, output="out_columns")
+    tools = clump_setup.tools
+    tools.r_centroids(input=clump_setup.input, output="out_columns")
 
     columns = tools.v_info(map="out_columns", flags="c", format="json")
     assert {col["name"] for col in columns} == {"cat"}
 
 
-def test_overwrite_protection(centroids):
+def test_overwrite_protection(clump_setup):
     """Reusing an output name without --overwrite fails."""
-    tools = centroids.tools
-    tools.r_centroids(input=centroids.input, output="out_overwrite")
-    with pytest.raises(CalledModuleError):
-        tools.r_centroids(input=centroids.input, output="out_overwrite")
+    tools = clump_setup.tools
+    tools.r_centroids(input=clump_setup.input, output="out_overwrite")
+    with pytest.raises(ToolError):
+        tools.r_centroids(input=clump_setup.input, output="out_overwrite")
 
 
-def test_centroid_lies_within_source_clump_extent(centroids):
-    """Each centroid falls inside the bounding box of the quadrant it came from."""
-    tools = centroids.tools
-    tools.r_centroids(input=centroids.input, output="out_extent")
+def test_centroid_matches_expected_coordinates(clump_setup):
+    """Each centroid lands on its source clump's exact expected point."""
+    tools = clump_setup.tools
+    tools.r_centroids(input=clump_setup.input, output="out_extent")
 
     lines = tools.v_out_ascii(input="out_extent", format="point").stdout.splitlines()
-    assert len(lines) == 4
-    for line in lines:
-        x, y, cat = line.split("|")
-        x_range, y_range = QUADRANTS[int(cat)]
-        assert x_range[0] <= float(x) <= x_range[1]
-        assert y_range[0] <= float(y) <= y_range[1]
+    points = {
+        int(cat): (float(x), float(y))
+        for x, y, cat in (line.split("|") for line in lines)
+    }
+    assert points == pytest.approx(EXPECTED)


### PR DESCRIPTION
Adds a pytest suite under `tests/` for r.centroids.

Covers: centroid count per clump (background excluded), removal of r.volume's extra columns, overwrite protection, and centroid location within its source clump extent.