### PR TITLE
v.median: Fix stdout output and add pytest suite

### DIFF
--- a/src/vector/v.median/tests/conftest.py
+++ b/src/vector/v.median/tests/conftest.py
@@ -1,0 +1,48 @@
+"""Fixtures for the v.median tests."""
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+import grass.script as gs
+from grass.experimental import TemporaryMapsetSession
+from grass.tools import Tools
+
+# Distinct x's and y's so the per-axis median lands on one input point (odd
+# count) or the average of the two middle points (even count).
+ODD_POINTS = [(1, 10), (2, 20), (3, 30), (4, 40), (5, 50)]
+EVEN_POINTS = [(1, 10), (2, 20), (3, 30), (4, 40)]
+
+
+def base_session(tmp_path_factory):
+    """Build a project with odd- and even-count point maps once per module."""
+    project = tmp_path_factory.mktemp("v_median") / "project"
+    gs.create_project(project, epsg="4326")
+    with gs.setup.init(project, env=os.environ.copy()) as session:
+        with Tools(session=session) as tools:
+            for name, points in (
+                ("odd_points", ODD_POINTS),
+                ("even_points", EVEN_POINTS),
+            ):
+                ascii_file = tmp_path_factory.mktemp(name) / "points.txt"
+                ascii_file.write_text("\n".join(f"{x}|{y}" for x, y in points))
+                tools.v_in_ascii(input=str(ascii_file), output=name, separator="pipe")
+        yield session
+
+
+@pytest.fixture(scope="module")
+def module_session(tmp_path_factory):
+    yield from base_session(tmp_path_factory)
+
+
+def median_fixture(module_session):
+    """Isolated per-test mapset + Tools handle over the module-scoped base session."""
+    with TemporaryMapsetSession(env=module_session.env) as session:
+        with Tools(session=session) as tools:
+            yield SimpleNamespace(tools=tools, env=session.env)
+
+
+@pytest.fixture
+def median(module_session):
+    yield from median_fixture(module_session)

--- a/src/vector/v.median/tests/conftest.py
+++ b/src/vector/v.median/tests/conftest.py
@@ -15,7 +15,8 @@ ODD_POINTS = [(1, 10), (2, 20), (3, 30), (4, 40), (5, 50)]
 EVEN_POINTS = [(1, 10), (2, 20), (3, 30), (4, 40)]
 
 
-def base_session(tmp_path_factory):
+@pytest.fixture(scope="module")
+def module_session(tmp_path_factory):
     """Build a project with odd- and even-count point maps once per module."""
     project = tmp_path_factory.mktemp("v_median") / "project"
     gs.create_project(project, epsg="4326")
@@ -31,18 +32,9 @@ def base_session(tmp_path_factory):
         yield session
 
 
-@pytest.fixture(scope="module")
-def module_session(tmp_path_factory):
-    yield from base_session(tmp_path_factory)
-
-
-def median_fixture(module_session):
+@pytest.fixture
+def median(module_session):
     """Isolated per-test mapset + Tools handle over the module-scoped base session."""
     with TemporaryMapsetSession(env=module_session.env) as session:
         with Tools(session=session) as tools:
             yield SimpleNamespace(tools=tools, env=session.env)
-
-
-@pytest.fixture
-def median(module_session):
-    yield from median_fixture(module_session)

--- a/src/vector/v.median/tests/test_v_median.py
+++ b/src/vector/v.median/tests/test_v_median.py
@@ -29,6 +29,11 @@ def test_stdout_output_prints_median(median):
     assert (x, y) == pytest.approx(ODD_EXPECTED, abs=1e-6)
 
 
+def test_stdout_output_creates_no_map(median):
+    median.tools.v_median(input="odd_points", output="-")
+    assert median.tools.g_list(type="vector", mapset=".", format="json").json == []
+
+
 def test_overwrite_protection(median):
     tools = median.tools
     tools.v_median(input="odd_points", output="median_overwrite")

--- a/src/vector/v.median/tests/v_median_test.py
+++ b/src/vector/v.median/tests/v_median_test.py
@@ -1,0 +1,46 @@
+"""Tests for the v.median addon."""
+
+import pytest
+from grass.exceptions import CalledModuleError
+
+# v.median computes the median of x's and y's independently, not a true
+# geometric median. For ODD_POINTS (x: 1..5, y: 10..50) that lands exactly on
+# the middle input point: x=3, y=30.
+ODD_EXPECTED = (3.0, 30.0)
+# For EVEN_POINTS (x: 1..4, y: 10..40) numpy averages the two middle values:
+# x=(2+3)/2=2.5, y=(20+30)/2=25.
+EVEN_EXPECTED = (2.5, 25.0)
+
+
+def test_output_to_vector_map_matches_expected_median(median):
+    tools = median.tools
+    tools.v_median(input="odd_points", output="median_out")
+
+    info = tools.v_info(map="median_out", format="json")
+    assert info["points"] == 1
+
+    x, y, _cat = tools.v_out_ascii(input="median_out", separator="pipe").text.split("|")
+    assert (float(x), float(y)) == pytest.approx(ODD_EXPECTED, abs=1e-6)
+
+
+def test_stdout_output_prints_median(median):
+    text = median.tools.v_median(input="odd_points", output="-").text
+    x, y = (float(v) for v in text.split("|"))
+    assert (x, y) == pytest.approx(ODD_EXPECTED, abs=1e-6)
+
+
+def test_overwrite_protection(median):
+    tools = median.tools
+    tools.v_median(input="odd_points", output="median_overwrite")
+    with pytest.raises(CalledModuleError):
+        tools.v_median(input="odd_points", output="median_overwrite")
+
+
+def test_even_point_count_averages_middle_values(median):
+    tools = median.tools
+    tools.v_median(input="even_points", output="median_even")
+
+    x, y, _cat = tools.v_out_ascii(input="median_even", separator="pipe").text.split(
+        "|"
+    )
+    assert (float(x), float(y)) == pytest.approx(EVEN_EXPECTED, abs=1e-6)

--- a/src/vector/v.median/v.median.py
+++ b/src/vector/v.median/v.median.py
@@ -71,7 +71,9 @@ def main():
     overwrite = os.getenv("GRASS_OVERWRITE")
     # if output is not set return to stdout
     if map_name == "-":
-        grass.message(output)
+        # Data output goes to stdout via print(); grass.message() is for
+        # informational messages, which are sent to stderr.
+        print(output)
     # else
     else:
         # output file

--- a/src/vector/v.median/v.median.py
+++ b/src/vector/v.median/v.median.py
@@ -71,8 +71,6 @@ def main():
     overwrite = os.getenv("GRASS_OVERWRITE")
     # if output is not set return to stdout
     if map_name == "-":
-        # Data output goes to stdout via print(); grass.message() is for
-        # informational messages, which are sent to stderr.
         print(output)
     # else
     else:


### PR DESCRIPTION
Fixes a bug in `v.median`'s stdout output and adds a pytest suite under `tests/`.

**Fix:** the `-` output mode wrote the result via `grass.message()`, which routes to stderr, not stdout. Switched to `print()` so the module's data output actually reaches stdout. `v.median out=-` previously produced no stdout at all.

**Tests:** cover the median written to a vector map, the median printed to stdout, that stdout mode creates no map, overwrite protection, and the even-count averaging case.