### PR TITLE
docs: add SPDX License IDs to source code #DeepSeek4_v2

### DIFF
--- a/src/display/d.explanation.plot/d.explanation.plot.py
+++ b/src/display/d.explanation.plot/d.explanation.plot.py
@@ -6,12 +6,9 @@
 # AUTHOR(S):    Vaclav Petras <wenzeslaus gmail com>
 #
 # PURPOSE:      Draw plot for manual explaining a raster operation
-# COPYRIGHT:    (C) 2017-2022 by Vaclav Petras the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2017-2022 Vaclav Petras
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/display/d.frame/d.frame.py
+++ b/src/display/d.frame/d.frame.py
@@ -6,18 +6,9 @@
 # AUTHOR(S):    Martin Landa <landa.martin gmail.com>
 #               Based on d.frame from GRASS 6
 # PURPOSE:      Manages display frames on the user's graphics monitor
-# COPYRIGHT:    (C) 2014 by Martin Landa, and the GRASS Development Team
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
+# SPDX-FileCopyrightText: 2014 Martin Landa
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ############################################################################
 # %module
 # % description: Manages display frames on the user's graphics monitor.

--- a/src/display/d.region.grid/d.region.grid.py
+++ b/src/display/d.region.grid/d.region.grid.py
@@ -5,12 +5,9 @@
 # MODULE:        d.region.grid
 # AUTHOR(S):     Vaclav Petras <wenzeslaus gmail com>
 # PURPOSE:       Plot a grid defined by the computational region
-# COPYRIGHT:     (C) 2021 by Vaclav Petras and the GRASS Development Team
-#
-#                This program is free software under the GNU General Public
-#                License (>=v2). Read the file COPYING that comes with GRASS
-#                for details.
-#
+# SPDX-FileCopyrightText: 2021 Vaclav Petras
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/display/d.vect.thematic2/d.vect.thematic2.py
+++ b/src/display/d.vect.thematic2/d.vect.thematic2.py
@@ -7,12 +7,8 @@
 #               by Martin Landa, Jachym Cepicky, Daniel Calvelo Aros and Moritz Lennert
 # PURPOSE:	    Displays thematic vector map with graduated colors
 #               or graduated points and line thickneses
-# COPYRIGHT:	(C) 2006-2014 by the GRASS Development Team
-#
-# 		This program is free software under the GNU General Public
-# 		License (>=v2). Read the file COPYING that comes with GRASS
-# 		for details.
-#
+# SPDX-FileCopyrightText: 2006-2014 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 

--- a/src/general/g.citation/g.citation.py
+++ b/src/general/g.citation/g.citation.py
@@ -10,12 +10,9 @@
 #
 # PURPOSE:      Provide scientific citation for GRASS modules and add-ons.
 #
-# COPYRIGHT:    (C) 2018 by Vaclav Petras and the GRASS Development team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2018 Vaclav Petras
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/general/g.copyall/g.copyall.py
+++ b/src/general/g.copyall/g.copyall.py
@@ -9,13 +9,8 @@
 # PURPOSE:	Copies all or a filtered subset of GRASS files of a selected type
 #           from another mapset to the current working mapset
 #
-# COPYRIGHT:	(C) 2002-2012 by the GRASS Development Team
-#
-# 		This program is free software under the GNU General Public
-# 		License (>=v2). Read the file COPYING that comes with GRASS
-# 		for details.
-#
-#
+# SPDX-FileCopyrightText: 2002-2012 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %Module

--- a/src/general/g.download.location/g.download.location.py
+++ b/src/general/g.download.location/g.download.location.py
@@ -4,12 +4,8 @@
 # MODULE:    g.download.location
 # AUTHOR(S): Vaclav Petras <wenzeslaus gmail com>
 # PURPOSE:   Download and extract location from web
-# COPYRIGHT: (C) 2017 by the GRASS Development Team
-#
-#    This program is free software under the GNU General
-#    Public License (>=v2). Read the file COPYING that
-#    comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2017 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/general/g.proj.all/g.proj.all.py
+++ b/src/general/g.proj.all/g.proj.all.py
@@ -7,12 +7,8 @@
 #               Vaclav Petras (wenzeslaus gmail.com)
 #
 # PURPOSE:      Reproject the entire mapset
-# COPYRIGHT:    (C) 2013 by the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2013 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/general/g.projpicker/g.projpicker.py
+++ b/src/general/g.projpicker/g.projpicker.py
@@ -10,12 +10,9 @@
 #               wrapper around ProjPicker
 #               <https://pypi.org/project/projpicker/>.
 #
-# COPYRIGHT:    (C) 2021 by Huidae Cho and the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2021 Huidae Cho
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/general/g.rename.many/g.rename.many.py
+++ b/src/general/g.rename.many/g.rename.many.py
@@ -5,18 +5,9 @@
 # MODULE:       g.rename.many
 # AUTHOR(S):    Vaclav Petras <wenzeslaus gmail com>
 # PURPOSE:      Rename multiple maps using g.rename
-# COPYRIGHT:    (C) 2014-2015 by the authors above, and the GRASS Development Team
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
+# SPDX-FileCopyrightText: 2014-2015 the authors above
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ############################################################################
 
 # %module

--- a/src/gui/wxpython/wx.metadata/m.csw.update/m.csw.update.py
+++ b/src/gui/wxpython/wx.metadata/m.csw.update/m.csw.update.py
@@ -8,12 +8,9 @@
 #
 # PURPOSE:      Update csw connections resources candidates
 #
-# COPYRIGHT:    (C) 2020 by Tomas Zigo, and the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2020 Tomas Zigo
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/hadoop/hd/hd.db.connect/hd.db.connect.py
+++ b/src/hadoop/hd/hd.db.connect/hd.db.connect.py
@@ -5,12 +5,8 @@
 # MODULE:       hd.db.connect
 # AUTHOR(S):    Matej Krejci (matejkrejci@gmail.com
 #
-# COPYRIGHT:    (C) 2016 by the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2016 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/hadoop/hd/hd.esri2vector/hd.esri2vector.py
+++ b/src/hadoop/hd/hd.esri2vector/hd.esri2vector.py
@@ -5,12 +5,8 @@
 # MODULE:       hd.esri2vector
 # AUTHOR(S):    Matej Krejci (matejkrejci@gmail.com
 #
-# COPYRIGHT:    (C) 2016 by the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2016 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/hadoop/hd/hd.hdfs.in.fs/hd.hdfs.in.fs.py
+++ b/src/hadoop/hd/hd.hdfs.in.fs/hd.hdfs.in.fs.py
@@ -5,12 +5,8 @@
 # MODULE:       hd.hdfs.in.fs
 # AUTHOR(S):    Matej Krejci (matejkrejci@gmail.com
 #
-# COPYRIGHT:    (C) 2016 by the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2016 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/hadoop/hd/hd.hdfs.in.vector/hd.hdfs.in.vector.py
+++ b/src/hadoop/hd/hd.hdfs.in.vector/hd.hdfs.in.vector.py
@@ -5,12 +5,8 @@
 # MODULE:       hd.hdfs.in.vector
 # AUTHOR(S):    Matej Krejci (matejkrejci@gmail.com
 #
-# COPYRIGHT:    (C) 2016 by the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2016 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/hadoop/hd/hd.hdfs.info/hd.hdfs.info.py
+++ b/src/hadoop/hd/hd.hdfs.info/hd.hdfs.info.py
@@ -5,12 +5,8 @@
 # MODULE:       hd.hdfs.info
 # AUTHOR(S):    Matej Krejci (matejkrejci@gmail.com
 #
-# COPYRIGHT:    (C) 2016 by the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2016 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/hadoop/hd/hd.hdfs.out.vector/hd.hdfs.out.vector.py
+++ b/src/hadoop/hd/hd.hdfs.out.vector/hd.hdfs.out.vector.py
@@ -5,12 +5,8 @@
 # MODULE:       hd.hdfs.out.vector
 # AUTHOR(S):    Matej Krejci (matejkrejci@gmail.com
 #
-# COPYRIGHT:    (C) 2016 by the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2016 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/hadoop/hd/hd.hive.csv.table/hd.hive.csv.table.py
+++ b/src/hadoop/hd/hd.hive.csv.table/hd.hive.csv.table.py
@@ -5,12 +5,8 @@
 # MODULE:       hd.hive.csv.table
 # AUTHOR(S):    Matej Krejci (matejkrejci@gmail.com
 #
-# COPYRIGHT:    (C) 2016 by the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2016 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/hadoop/hd/hd.hive.execute/hd.hive.execute.py
+++ b/src/hadoop/hd/hd.hive.execute/hd.hive.execute.py
@@ -5,12 +5,8 @@
 # MODULE:       db.hive.execute
 # AUTHOR(S):    Matej Krejci (matejkrejci@gmail.com
 #
-# COPYRIGHT:    (C) 2016 by the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2016 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/hadoop/hd/hd.hive.info/hd.hive.info.py
+++ b/src/hadoop/hd/hd.hive.info/hd.hive.info.py
@@ -5,12 +5,8 @@
 # MODULE:       hd.hive.info
 # AUTHOR(S):    Matej Krejci (matejkrejci@gmail.com
 #
-# COPYRIGHT:    (C) 2016 by the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2016 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/hadoop/hd/hd.hive.json.table/hd.hive.json.table.py
+++ b/src/hadoop/hd/hd.hive.json.table/hd.hive.json.table.py
@@ -5,12 +5,8 @@
 # MODULE:       hd.hive.json.table
 # AUTHOR(S):    Matej Krejci (matejkrejci@gmail.com
 #
-# COPYRIGHT:    (C) 2016 by the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2016 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/hadoop/hd/hd.hive.load/hd.hive.load.py
+++ b/src/hadoop/hd/hd.hive.load/hd.hive.load.py
@@ -5,12 +5,8 @@
 # MODULE:       db.hive.load
 # AUTHOR(S):    Matej Krejci (matejkrejci@gmail.com
 #
-# COPYRIGHT:    (C) 2016 by the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2016 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/hadoop/hd/hd.hive.select/hd.hive.select.py
+++ b/src/hadoop/hd/hd.hive.select/hd.hive.select.py
@@ -5,12 +5,8 @@
 # MODULE:       hd.hive.execute
 # AUTHOR(S):    Matej Krejci (matejkrejci@gmail.com)
 #
-# COPYRIGHT:    (C) 2016 by the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2016 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/imagery/i.ann.maskrcnn/i.ann.maskrcnn.detect/i.ann.maskrcnn.detect.py
+++ b/src/imagery/i.ann.maskrcnn/i.ann.maskrcnn.detect/i.ann.maskrcnn.detect.py
@@ -5,12 +5,9 @@
 # MODULE:	    i.ann.maskrcnn.detect
 # AUTHOR(S):	Ondrej Pesek <pesej.ondrek@gmail.com>
 # PURPOSE:	    Train your Mask R-CNN network
-# COPYRIGHT:	(C) 2017 Ondrej Pesek and the GRASS Development Team
-#
-# 		This program is free software under the GNU General
-# 		Public License (>=v2). Read the file COPYING that
-# 		comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2017 Ondrej Pesek
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/imagery/i.ann.maskrcnn/i.ann.maskrcnn.train/i.ann.maskrcnn.train.py
+++ b/src/imagery/i.ann.maskrcnn/i.ann.maskrcnn.train/i.ann.maskrcnn.train.py
@@ -5,12 +5,9 @@
 # MODULE:	    i.ann.maskrcnn.train
 # AUTHOR(S):	Ondrej Pesek <pesej.ondrek@gmail.com>
 # PURPOSE:	    Train your Mask R-CNN network
-# COPYRIGHT:	(C) 2017 Ondrej Pesek and the GRASS Development Team
-#
-# 		This program is free software under the GNU General
-# 		Public License (>=v2). Read the file COPYING that
-# 		comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2017 Ondrej Pesek
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/imagery/i.cutlines/i.cutlines.py
+++ b/src/imagery/i.cutlines/i.cutlines.py
@@ -7,11 +7,8 @@
 #
 # PURPOSE:	Create tiles the borders of which do not cut across semantically
 #               meaningful objects
-# COPYRIGHT:	(C) 1997-2018 by the GRASS Development Team
-#
-# 		This program is free software under the GNU General Public
-# 		License (>=v2). Read the file COPYING that comes with GRASS
-# 		for details.
+# SPDX-FileCopyrightText: 1997-2018 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %Module

--- a/src/imagery/i.cva/i.cva.py
+++ b/src/imagery/i.cva/i.cva.py
@@ -7,12 +7,9 @@
 #
 # PURPOSE:	    Performs Change Vector Analysis (CVA) in two dimensions
 #
-# COPYRIGHT:	(C) 2016 by Anna Zanchetta and the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2016 Anna Zanchetta
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 # References:
 # Malila W A, Lafayette W. Change Vector Analysis: An Approach for Detecting

--- a/src/imagery/i.destripe/main.c
+++ b/src/imagery/i.destripe/main.c
@@ -5,12 +5,8 @@
  * PURPOSE:      Destripe a regularly striped image using Fourier
  *               Row based, works with stripes about up-down direction
  *
- * COPYRIGHT:    (C) 2014 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with
- *               GRASS for details.
- *
+ * SPDX-FileCopyrightText: 2014 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdio.h>

--- a/src/imagery/i.eb.deltat/main.c
+++ b/src/imagery/i.eb.deltat/main.c
@@ -6,12 +6,8 @@
  *                as seen in Pawan (2004)
  *                This is a SEBAL initialization parameter for sensible heat.
  *
- * COPYRIGHT:    (C) 2006-2016 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with
- *               GRASS for details.
- *
+ * SPDX-FileCopyrightText: 2006-2016 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdio.h>

--- a/src/imagery/i.eb.z0m/main.c
+++ b/src/imagery/i.eb.z0m/main.c
@@ -5,12 +5,8 @@
  * PURPOSE:      Calculates the momentum roughness length
  *               as seen in Bastiaanssen (1995), Pawan (2004)
  *
- * COPYRIGHT:    (C) 2002-2013 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with
- *               GRASS for details.
- *
+ * SPDX-FileCopyrightText: 2002-2013 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdio.h>

--- a/src/imagery/i.eb.z0m0/main.c
+++ b/src/imagery/i.eb.z0m0/main.c
@@ -5,12 +5,8 @@
  * PURPOSE:      Calculates the momentum roughness length
  *               as seen in Bastiaanssen (1995)
  *
- * COPYRIGHT:    (C) 2002-2016 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with
- *               GRASS for details.
- *
+ * SPDX-FileCopyrightText: 2002-2016 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdio.h>

--- a/src/imagery/i.edge/main.c
+++ b/src/imagery/i.edge/main.c
@@ -6,12 +6,8 @@
  *
  * PURPOSE:      Edge detection in raster images.
  *
- * COPYRIGHT:    (C) 2012-2021 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *                        License (>=v2). Read the file COPYING that comes with
- *GRASS for details.
- *
+ * SPDX-FileCopyrightText: 2012-2021 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdio.h>

--- a/src/imagery/i.eodag/i.eodag.py
+++ b/src/imagery/i.eodag/i.eodag.py
@@ -9,12 +9,9 @@
 #
 # PURPOSE:     Downloads imagery scenes e.g. Landsat, Sentinel, and MODIS
 #              using EODAG API.
-# COPYRIGHT:   (C) 2024-2025 by Hamed Elgizery, and the GRASS development team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2024-2025 Hamed Elgizery
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %Module

--- a/src/imagery/i.eodag/testsuite/test_eodag.py
+++ b/src/imagery/i.eodag/testsuite/test_eodag.py
@@ -8,12 +8,9 @@
 # PURPOSE:     Tests i.eodag input parsing / searching results.
 #              Uses NC Full data set.
 #
-# COPYRIGHT:   (C) 2024-2025 by Hamed Elgizery, and the GRASS development team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2024-2025 Hamed Elgizery
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 import json

--- a/src/imagery/i.evapo.potrad/main.c
+++ b/src/imagery/i.evapo.potrad/main.c
@@ -6,12 +6,8 @@
  *               the condition that all net radiation becomes ET
  *               (thus it can be called a "radiative ET pot")
  *
- * COPYRIGHT:    (C) 2002-2010 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with
- *               GRASS for details.
- *
+ * SPDX-FileCopyrightText: 2002-2010 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdio.h>

--- a/src/imagery/i.evapo.senay/main.c
+++ b/src/imagery/i.evapo.senay/main.c
@@ -5,12 +5,8 @@
  * PURPOSE:      Creates a map of actual evapotranspiration following
  *               the method of Senay (2007).
  *
- * COPYRIGHT:    (C) 2008-2011 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with
- *               GRASS for details.
- *
+ * SPDX-FileCopyrightText: 2008-2011 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdio.h>

--- a/src/imagery/i.gabor/i.gabor.py
+++ b/src/imagery/i.gabor/i.gabor.py
@@ -9,12 +9,9 @@
 # PURPOSE:      Compute and convolve Gabor filter banks and for spatial
 #               imagery.
 #
-# COPYRIGHT:    (C) 2021 by Owen Smith and the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2021 Owen Smith
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ############################################################################
 
 # %module

--- a/src/imagery/i.gcp/main.c
+++ b/src/imagery/i.gcp/main.c
@@ -6,12 +6,8 @@
  *
  * PURPOSE:      Manages ground control points non-interactively.
  *
- * COPYRIGHT:    (C) 2016 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2016 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdlib.h>

--- a/src/imagery/i.gravity/main.c
+++ b/src/imagery/i.gravity/main.c
@@ -4,12 +4,8 @@
  * AUTHOR(S):    Yann Chemin - yann.chemin@gmail.com
  * PURPOSE:      Calculates the Bouguer anomaly of a gravity dataset
  *
- * COPYRIGHT:    (C) 2002-2013 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with
- *               GRASS for details.
- *
+ * SPDX-FileCopyrightText: 2002-2013 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdio.h>

--- a/src/imagery/i.hyper/i.hyper.composite/i.hyper.composite.py
+++ b/src/imagery/i.hyper/i.hyper.composite/i.hyper.composite.py
@@ -4,7 +4,8 @@
 # AUTHOR(S): Alen Mangafic and Tomaž Žagar, Geodetic Institute of Slovenia
 # PURPOSE:   Create RGB/CIR/SWIR and custom false color composites
 #            from a hyperspectral 3D raster.
-# COPYRIGHT: (C) 2025 by Alen Mangafic and the GRASS Development Team
+# SPDX-FileCopyrightText: 2025 Alen Mangafic
+# SPDX-FileCopyrightText: Other GRASS authors
 # SPDX-License-Identifier: GPL-2.0-or-later
 ##############################################################################
 

--- a/src/imagery/i.hyper/i.hyper.explore/i.hyper.explore.py
+++ b/src/imagery/i.hyper/i.hyper.explore/i.hyper.explore.py
@@ -4,7 +4,8 @@
 # MODULE:    i.hyper.explore
 # AUTHOR(S): Tomaz Zagar <tomaz.zagar@gis.si>
 # PURPOSE:   Visualize spectra from hyperspectral 3D raster maps.
-# COPYRIGHT: (C) 2025 by Tomaz Zagar and the GRASS Development Team
+# SPDX-FileCopyrightText: 2025 Tomaz Zagar
+# SPDX-FileCopyrightText: Other GRASS authors
 # SPDX-License-Identifier: GPL-2.0-or-later
 ##############################################################################
 

--- a/src/imagery/i.hyper/i.hyper.export/i.hyper.export.py
+++ b/src/imagery/i.hyper/i.hyper.export/i.hyper.export.py
@@ -4,7 +4,8 @@
 # MODULE:    i.hyper.export
 # AUTHOR(S): Alen Mangafic and Tomaž Žagar, Geodetic Institute of Slovenia
 # PURPOSE:   Export 3D hyperspectral raster map.
-# COPYRIGHT: (C) 2025 by Alen Mangafic and the GRASS Development Team
+# SPDX-FileCopyrightText: 2025 Alen Mangafic
+# SPDX-FileCopyrightText: Other GRASS authors
 # SPDX-License-Identifier: GPL-2.0-or-later
 ##############################################################################
 

--- a/src/imagery/i.hyper/i.hyper.import/i.hyper.import.py
+++ b/src/imagery/i.hyper/i.hyper.import/i.hyper.import.py
@@ -3,7 +3,8 @@
 # MODULE:    i.hyper.import
 # AUTHOR(S): Alen Mangafic and Tomaž Žagar, Geodetic Institute of Slovenia
 # PURPOSE:   Hyperspectral imagery import.
-# COPYRIGHT: (C) 2025 by Alen Mangafic and the GRASS Development Team
+# SPDX-FileCopyrightText: 2025 Alen Mangafic
+# SPDX-FileCopyrightText: Other GRASS authors
 # SPDX-License-Identifier: GPL-2.0-or-later
 ##############################################################################
 

--- a/src/imagery/i.hyper/i.hyper.metadata/i.hyper.metadata.py
+++ b/src/imagery/i.hyper/i.hyper.metadata/i.hyper.metadata.py
@@ -6,7 +6,7 @@
 #            Alen Mangafić and Tomaž Žagar, Geodetic Institute of Slovenia
 #            Anna Petrasova, NCSU GeoForAll Lab
 # PURPOSE:   View and manage hyperspectral metadata for 3D raster maps.
-# COPYRIGHT: (C) 2025 by the authors
+# SPDX-FileCopyrightText: 2025 Other GRASS authors
 # SPDX-License-Identifier: GPL-2.0-or-later
 ##############################################################################
 

--- a/src/imagery/i.hyper/i.hyper.preproc/i.hyper.preproc.py
+++ b/src/imagery/i.hyper/i.hyper.preproc/i.hyper.preproc.py
@@ -4,7 +4,8 @@
 # MODULE:    i.hyper.preproc
 # AUTHOR(S): Alen Mangafic and Tomaž Žagar, Geodetic Institute of Slovenia
 # PURPOSE:   Hyperspectral imagery preprocessing.
-# COPYRIGHT: (C) 2025 by Alen Mangafic and the GRASS Development Team
+# SPDX-FileCopyrightText: 2025 Alen Mangafic
+# SPDX-FileCopyrightText: Other GRASS authors
 # SPDX-License-Identifier: GPL-2.0-or-later
 ##############################################################################
 

--- a/src/imagery/i.image.bathymetry/i.image.bathymetry.py
+++ b/src/imagery/i.image.bathymetry/i.image.bathymetry.py
@@ -6,12 +6,9 @@
 # AUTHOR(S): Vinayaraj Poliyapram <vinay223333@gmail.com> and Luca Delulucchi
 #
 # PURPOSE:   Script for estimating bathymetry from optical satellite images
-# COPYRIGHT: (C) Vinayaraj Poliyapram and by the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: Vinayaraj Poliyapram
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/imagery/i.in.probav/i.in.probav.py
+++ b/src/imagery/i.in.probav/i.in.probav.py
@@ -4,18 +4,9 @@
 # MODULE:       i.in.probav
 # AUTHOR(S):    Jonas Strobel, intern at mundialis and terrestris, Bonn
 # PURPOSE:      i.in.probav
-# COPYRIGHT:    (C) 2017 by stjo, and the GRASS Development Team
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
+# SPDX-FileCopyrightText: 2017 stjo
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ############################################################################
 
 # %module

--- a/src/imagery/i.landsat/i.landsat.import/i.landsat.import.py
+++ b/src/imagery/i.landsat/i.landsat.import/i.landsat.import.py
@@ -6,12 +6,9 @@
 # AUTHOR(S):   Veronica Andreo
 # PURPOSE:     Imports Landsat data downloaded from EarthExplorer using
 #              i.landsat.download.
-# COPYRIGHT:   (C) 2020-2021 by Veronica Andreo, and the GRASS development team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2020-2021 Veronica Andreo
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/imagery/i.lswt/i.lswt.py
+++ b/src/imagery/i.lswt/i.lswt.py
@@ -6,12 +6,8 @@
 # AUTHOR(S):	Sajid Pareeth
 #
 # PURPOSE:	Compute Lake Surface Water Temperature (inland waters) from TOA Brightness Temperatures(BT)
-# COPYRIGHT:	(C) 1997-2014 by the GRASS Development Team
-#
-# 		This program is free software under the GNU General Public
-# 		License (>=v2). Read the file COPYING that comes with GRASS
-# 		for details.
-#
+# SPDX-FileCopyrightText: 1997-2014 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 # References:
 # The satellite specific split-window coefficients are taken from:

--- a/src/imagery/i.modis/i.modis.import/i.modis.import.py
+++ b/src/imagery/i.modis/i.modis.import/i.modis.import.py
@@ -8,12 +8,9 @@
 # PURPOSE:       i.modis.import is an interface to pyModis for import into
 #                GRASS GIS level 3 MODIS produts
 #
-# COPYRIGHT:     (C) 2011-2020 by Luca Delucchi
-#
-#                This program is free software under the GNU General Public
-#                License (>=v2). Read the file COPYING that comes with GRASS
-#                for details.
-#
+# SPDX-FileCopyrightText: 2011-2020 Luca Delucchi
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 # REQUIREMENTS:

--- a/src/imagery/i.modis/libmodis/rmodislib.py
+++ b/src/imagery/i.modis/libmodis/rmodislib.py
@@ -8,12 +8,9 @@
 # PURPOSE:	Here there are some important class to run i.modis modules
 #
 #
-# COPYRIGHT:	(C) 2011-2017 by Luca Delucchi
-#
-# 		This program is free software under the GNU General Public
-# 		License (>=v2). Read the file COPYING that comes with GRASS
-# 		for details.
-#
+# SPDX-FileCopyrightText: 2011-2017 Luca Delucchi
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 import grass.script as gs
 

--- a/src/imagery/i.ortho.corr/i.ortho.corr.py
+++ b/src/imagery/i.ortho.corr/i.ortho.corr.py
@@ -8,12 +8,9 @@
 # PURPOSE:    Useful to correct orthophoto using the camera angle map
 #             create by i.ortho.photo
 #
-# COPYRIGHT:    (C) 2011 by Luca Delucchi
-#
-#        This program is free software under the GNU General Public
-#        License (>=v2). Read the file COPYING that comes with GRASS
-#        for details.
-#
+# SPDX-FileCopyrightText: 2011 Luca Delucchi
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 # %module
 # % description: Corrects orthophoto taking part of the adjacent orthophotos using a camera angle map.

--- a/src/imagery/i.pr/i.pr.blob/main.c
+++ b/src/imagery/i.pr/i.pr.blob/main.c
@@ -7,13 +7,8 @@
  *
  * PURPOSE:    i.pr - Pattern Recognition
  *
- * COPYRIGHT:  (C) 2007 by the GRASS Development Team
- *
- *             This program is free software under the
- *             GNU General Public License (>=v2).
- *             Read the file COPYING that comes with GRASS
- *             for details.
- *
+ * SPDX-FileCopyrightText: 2007 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  ****************************************************************/
 
 #include <stdlib.h>

--- a/src/imagery/i.pr/i.pr.classify/main.c
+++ b/src/imagery/i.pr/i.pr.classify/main.c
@@ -7,13 +7,8 @@
  *
  * PURPOSE:    i.pr - Pattern Recognition
  *
- * COPYRIGHT:  (C) 2007 by the GRASS Development Team
- *
- *             This program is free software under the
- *             GNU General Public License (>=v2).
- *             Read the file COPYING that comes with GRASS
- *             for details.
- *
+ * SPDX-FileCopyrightText: 2007 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  ****************************************************************/
 
 #include <stdlib.h>

--- a/src/imagery/i.pr/i.pr.features/main.c
+++ b/src/imagery/i.pr/i.pr.features/main.c
@@ -7,13 +7,8 @@
  *
  * PURPOSE:    i.pr - Pattern Recognition
  *
- * COPYRIGHT:  (C) 2007 by the GRASS Development Team
- *
- *             This program is free software under the
- *             GNU General Public License (>=v2).
- *             Read the file COPYING that comes with GRASS
- *             for details.
- *
+ * SPDX-FileCopyrightText: 2007 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  ****************************************************************/
 
 #include <stdlib.h>

--- a/src/imagery/i.pr/i.pr.features_additional/main.c
+++ b/src/imagery/i.pr/i.pr.features_additional/main.c
@@ -7,13 +7,8 @@
  *
  * PURPOSE:    i.pr - Pattern Recognition
  *
- * COPYRIGHT:  (C) 2007 by the GRASS Development Team
- *
- *             This program is free software under the
- *             GNU General Public License (>=v2).
- *             Read the file COPYING that comes with GRASS
- *             for details.
- *
+ * SPDX-FileCopyrightText: 2007 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  ****************************************************************/
 
 #include <stdlib.h>

--- a/src/imagery/i.pr/i.pr.features_extract/main.c
+++ b/src/imagery/i.pr/i.pr.features_extract/main.c
@@ -7,13 +7,8 @@
  *
  * PURPOSE:    i.pr - Pattern Recognition
  *
- * COPYRIGHT:  (C) 2007 by the GRASS Development Team
- *
- *             This program is free software under the
- *             GNU General Public License (>=v2).
- *             Read the file COPYING that comes with GRASS
- *             for details.
- *
+ * SPDX-FileCopyrightText: 2007 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  ****************************************************************/
 
 #include <stdlib.h>

--- a/src/imagery/i.pr/i.pr.features_selection/main.c
+++ b/src/imagery/i.pr/i.pr.features_selection/main.c
@@ -7,13 +7,8 @@
  *
  * PURPOSE:    i.pr - Pattern Recognition
  *
- * COPYRIGHT:  (C) 2007 by the GRASS Development Team
- *
- *             This program is free software under the
- *             GNU General Public License (>=v2).
- *             Read the file COPYING that comes with GRASS
- *             for details.
- *
+ * SPDX-FileCopyrightText: 2007 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  ****************************************************************/
 
 #include <stdlib.h>

--- a/src/imagery/i.pr/i.pr.model/main.c
+++ b/src/imagery/i.pr/i.pr.model/main.c
@@ -7,13 +7,8 @@
  *
  * PURPOSE:    i.pr - Pattern Recognition
  *
- * COPYRIGHT:  (C) 2007 by the GRASS Development Team
- *
- *             This program is free software under the
- *             GNU General Public License (>=v2).
- *             Read the file COPYING that comes with GRASS
- *             for details.
- *
+ * SPDX-FileCopyrightText: 2007 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  ****************************************************************/
 
 #include <stdlib.h>

--- a/src/imagery/i.pr/i.pr.sites_aggregate/main.c
+++ b/src/imagery/i.pr/i.pr.sites_aggregate/main.c
@@ -7,13 +7,8 @@
  *
  * PURPOSE:    i.pr - Pattern Recognition
  *
- * COPYRIGHT:  (C) 2007 by the GRASS Development Team
- *
- *             This program is free software under the
- *             GNU General Public License (>=v2).
- *             Read the file COPYING that comes with GRASS
- *             for details.
- *
+ * SPDX-FileCopyrightText: 2007 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  ****************************************************************/
 
 #include <stdlib.h>

--- a/src/imagery/i.pr/i.pr.statistics/main.c
+++ b/src/imagery/i.pr/i.pr.statistics/main.c
@@ -7,13 +7,8 @@
  *
  * PURPOSE:    i.pr - Pattern Recognition
  *
- * COPYRIGHT:  (C) 2007 by the GRASS Development Team
- *
- *             This program is free software under the
- *             GNU General Public License (>=v2).
- *             Read the file COPYING that comes with GRASS
- *             for details.
- *
+ * SPDX-FileCopyrightText: 2007 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  ****************************************************************/
 
 #include <stdlib.h>

--- a/src/imagery/i.pr/i.pr.subsets/main.c
+++ b/src/imagery/i.pr/i.pr.subsets/main.c
@@ -7,13 +7,8 @@
  *
  * PURPOSE:    i.pr - Pattern Recognition
  *
- * COPYRIGHT:  (C) 2007 by the GRASS Development Team
- *
- *             This program is free software under the
- *             GNU General Public License (>=v2).
- *             Read the file COPYING that comes with GRASS
- *             for details.
- *
+ * SPDX-FileCopyrightText: 2007 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  ****************************************************************/
 
 #include <stdlib.h>

--- a/src/imagery/i.pr/i.pr.uxb/main.c
+++ b/src/imagery/i.pr/i.pr.uxb/main.c
@@ -7,13 +7,8 @@
  *
  * PURPOSE:    i.pr - Pattern Recognition
  *
- * COPYRIGHT:  (C) 2007 by the GRASS Development Team
- *
- *             This program is free software under the
- *             GNU General Public License (>=v2).
- *             Read the file COPYING that comes with GRASS
- *             for details.
- *
+ * SPDX-FileCopyrightText: 2007 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  ****************************************************************/
 
 #include <stdlib.h>

--- a/src/imagery/i.rh/main.c
+++ b/src/imagery/i.rh/main.c
@@ -4,12 +4,8 @@
  * AUTHOR(S):    Yann Chemin - yann.chemin@gmail.com
  * PURPOSE:      Calculates relative humidity
  *
- * COPYRIGHT:    (C) 2017-2019 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *                        License (>=v2). Read the file COPYING that comes with
- *GRASS for details.
- *
+ * SPDX-FileCopyrightText: 2017-2019 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdio.h>

--- a/src/imagery/i.rotate/main.c
+++ b/src/imagery/i.rotate/main.c
@@ -5,12 +5,8 @@
  * PURPOSE:      Calculates an arbitrary rotation of the image from the
  *                  center of the computing window
  *
- * COPYRIGHT:    (C) 2012 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with
- *               GRASS for details.
- *
+ * SPDX-FileCopyrightText: 2012 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <grass/config.h>

--- a/src/imagery/i.sam2/i.sam2.py
+++ b/src/imagery/i.sam2/i.sam2.py
@@ -5,11 +5,9 @@
 # MODULE:       i.sam2
 # AUTHOR:       Corey T. White, OpenPlains Inc.
 # PURPOSE:      Uses the SAMGeo model for segmentation in GRASS GIS.
-# COPYRIGHT:    (C) 2023-2025 Corey White
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2023-2025 Corey White
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/imagery/i.segment.hierarchical/i.segment.hierarchical.py
+++ b/src/imagery/i.segment.hierarchical/i.segment.hierarchical.py
@@ -7,12 +7,8 @@
 #
 # AUTHOR(S):   Pietro Zambelli (University of Trento)
 #
-# COPYRIGHT:	(C) 2013 by the GRASS Development Team
-#
-# 		This program is free software under the GNU General Public
-# 		License (>=v2). Read the file COPYING that comes with GRASS
-# 		for details.
-#
+# SPDX-FileCopyrightText: 2013 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %Module

--- a/src/imagery/i.segment.uspo/i.segment.uspo.py
+++ b/src/imagery/i.segment.uspo/i.segment.uspo.py
@@ -7,12 +7,8 @@
 #
 # PURPOSE:	Finds optimimal segmentation parameters in an unsupervised
 #               process
-# COPYRIGHT:	(C) 1997-2016 by the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 1997-2016 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 # References:
 # G. M. Espindola , G. Camara , I. A. Reis , L. S. Bins , A. M. Monteiroi

--- a/src/imagery/i.sentinel/i.sentinel.coverage/i.sentinel.coverage.py
+++ b/src/imagery/i.sentinel/i.sentinel.coverage/i.sentinel.coverage.py
@@ -9,12 +9,9 @@
 # PURPOSE:      Checks the area coverage of the by filters selected
 #               Sentinel-1 or Sentinel-2 scenes
 #
-# COPYRIGHT:	(C) 2020 by mundialis and the GRASS Development Team
-#
-# 		This program is free software under the GNU General Public
-# 		License (>=v2). Read the file COPYING that comes with GRASS
-# 		for details.
-#
+# SPDX-FileCopyrightText: 2020 mundialis
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %Module

--- a/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
+++ b/src/imagery/i.sentinel/i.sentinel.import/i.sentinel.import.py
@@ -6,12 +6,9 @@
 # AUTHOR(S):   Martin Landa, Felix Kröber
 # PURPOSE:     Imports Sentinel data downloaded from Copernicus Open Access Hub
 #              using i.sentinel.download.
-# COPYRIGHT:   (C) 2018-2021 by Martin Landa, and the GRASS development team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2018-2021 Martin Landa
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %Module

--- a/src/imagery/i.sentinel/i.sentinel.parallel.download/i.sentinel.parallel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.parallel.download/i.sentinel.parallel.download.py
@@ -6,12 +6,9 @@
 # AUTHOR(S):    Guido Riembauer
 #
 # PURPOSE:      Downloads Sentinel-2 images in parallel using i.sentinel.download.
-# COPYRIGHT:    (C) 2020 by mundialis and the GRASS Development Team
-#
-# 		This program is free software under the GNU General Public
-# 		License (>=v2). Read the file COPYING that comes with GRASS
-# 		for details.
-#
+# SPDX-FileCopyrightText: 2020 mundialis
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ############################################################################
 
 # %module

--- a/src/imagery/i.sentinel/i.sentinel.preproc/i.sentinel.preproc.py
+++ b/src/imagery/i.sentinel/i.sentinel.preproc/i.sentinel.preproc.py
@@ -7,12 +7,9 @@
 # AUTHOR(S):    Roberta Fagandini, Moritz Lennert, Roberto Marzocchi
 # PURPOSE:  Import and perform atmospheric correction for Sentinel-2 images
 #
-# COPYRIGHT:    (C) 2018 by Roberta Fagandini, and the GRASS Development Team
-#
-#        This program is free software under the GNU General Public
-#        License (>=v2). Read the file COPYING that comes with GRASS
-#        for details.
-#
+# SPDX-FileCopyrightText: 2018 Roberta Fagandini
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ############################################################################
 
 # %Module

--- a/src/imagery/i.signature.copy/i.signature.copy.py
+++ b/src/imagery/i.signature.copy/i.signature.copy.py
@@ -6,12 +6,8 @@
 # AUTHOR(S):	Luca Delucchi
 #
 # PURPOSE:	Copies signature file from a group/subgroup
-# COPYRIGHT:	(C) 2018 by the GRASS Development Team
-#
-# 		This program is free software under the GNU General Public
-# 		License (>=v2). Read the file COPYING that comes with GRASS
-# 		for details.
-#
+# SPDX-FileCopyrightText: 2018 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/imagery/i.signature.list/i.signature.list.py
+++ b/src/imagery/i.signature.list/i.signature.list.py
@@ -6,12 +6,8 @@
 # AUTHOR(S):	Luca Delucchi
 #
 # PURPOSE:	Lists signature file for a group/subgroup
-# COPYRIGHT:	(C) 2018 by the GRASS Development Team
-#
-# 		This program is free software under the GNU General Public
-# 		License (>=v2). Read the file COPYING that comes with GRASS
-# 		for details.
-#
+# SPDX-FileCopyrightText: 2018 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/imagery/i.variance/i.variance.py
+++ b/src/imagery/i.variance/i.variance.py
@@ -6,12 +6,8 @@
 # AUTHOR(S):        Moritz Lennert
 #
 # PURPOSE:        Calculate variation of variance by variation of resolution
-# COPYRIGHT:        (C) 1997-2016 by the GRASS Development Team
-#
-#                This program is free software under the GNU General Public
-#                License (>=v2). Read the file COPYING that comes with GRASS
-#                for details.
-#
+# SPDX-FileCopyrightText: 1997-2016 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 # Curtis E. Woodcock, Alan H. Strahler, The factor of scale in remote sensing,
 # Remote Sensing of Environment, Volume 21, Issue 3, April 1987, Pages 311-332,

--- a/src/imagery/i.water/main.c
+++ b/src/imagery/i.water/main.c
@@ -6,12 +6,8 @@
  *                  two versions, 1) generic (albedo,ndvi)
  *                  2) Modis (surf_refl_7,ndvi)
  *
- * COPYRIGHT:    (C) 2008-2016 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with
- *               GRASS for details.
- *
+ * SPDX-FileCopyrightText: 2008-2016 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdio.h>

--- a/src/imagery/i.wi/main.c
+++ b/src/imagery/i.wi/main.c
@@ -4,12 +4,8 @@
  * AUTHOR(S):    Yann Chemin - yann.chemin@gmail.com
  * PURPOSE:      Calculates water indices
  *
- * COPYRIGHT:    (C) 2016 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with
- *               GRASS for details.
- *
+ * SPDX-FileCopyrightText: 2016 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdio.h>

--- a/src/imagery/i.zero2null/i.zero2null.py
+++ b/src/imagery/i.zero2null/i.zero2null.py
@@ -4,18 +4,9 @@
 # MODULE:       i.zero2null
 # AUTHOR(S):    Markus Metz
 # PURPOSE:      Replaces zero values with either NULL or appropriate neighboring values.
-# COPYRIGHT: (C) 2020 by mundialis and the GRASS Development Team
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
+# SPDX-FileCopyrightText: 2020 mundialis
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ############################################################################
 
 # %module

--- a/src/misc/m.cdo.download/m.cdo.download.py
+++ b/src/misc/m.cdo.download/m.cdo.download.py
@@ -6,12 +6,9 @@
 # PURPOSE:      Downloads data from NCEI's Climate Data Online (CDO) using
 #               their v2 API.
 #
-# COPYRIGHT:    (C) 2023 by Huidae Cho and the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2023 Huidae Cho
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 # %module
 # % description: Downloads data from NCEI's Climate Data Online (CDO) using their v2 API.

--- a/src/misc/m.gcp.filter/main.c
+++ b/src/misc/m.gcp.filter/main.c
@@ -4,12 +4,8 @@
  * AUTHOR(S):    Markus Metz
  *                  based on m.transform
  * PURPOSE:      Utility to filter GCPs with RMS threshold
- * COPYRIGHT:    (C) 2006-2014 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2006-2014 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdio.h>

--- a/src/misc/m.printws/m.printws.py
+++ b/src/misc/m.printws/m.printws.py
@@ -9,12 +9,8 @@
 # PURPOSE:      Creates carographic-like map sheet page from
 #               a workspace composition
 #
-# COPYRIGHT:    (C) 2016 by GRASS development team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2016 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/misc/m.prism.download/m.prism.download.py
+++ b/src/misc/m.prism.download/m.prism.download.py
@@ -5,12 +5,9 @@
 # AUTHOR(S):    Huidae Cho <grass4u gmail.com>
 # PURPOSE:      Downloads data from the PRISM Climate Group.
 #
-# COPYRIGHT:    (C) 2023 by Huidae Cho and the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2023 Huidae Cho
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 # %module
 # % description: Downloads data from the PRISM Climate Group.

--- a/src/misc/m.tnm.download/m.tnm.download.py
+++ b/src/misc/m.tnm.download/m.tnm.download.py
@@ -6,12 +6,9 @@
 # PURPOSE:      Downloads data for specified polygon codes from The National
 #               Map (TNM).
 #
-# COPYRIGHT:    (C) 2023 by Huidae Cho and the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2023 Huidae Cho
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 # %module
 # % description: Downloads data for specified polygon codes from The National Map (TNM).

--- a/src/raster/r.accumulate/main.c
+++ b/src/raster/r.accumulate/main.c
@@ -7,12 +7,9 @@
  * PURPOSE:      Calculates weighted flow accumulation, subwatersheds, stream
  *               networks, and longest flow paths using a flow direction map.
  *
- * COPYRIGHT:    (C) 2018, 2020 by Huidae Cho and the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2018, 2020 Huidae Cho
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define _MAIN_C_

--- a/src/raster/r.area/main.c
+++ b/src/raster/r.area/main.c
@@ -5,12 +5,8 @@
  * PURPOSE:      Calculate area of clumped areas. Remove areas smaller than
  *               given threshold.
  *
- * COPYRIGHT:    (C) 1999-2010 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 1999-2010 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  ****************************************************************************
  */
 

--- a/src/raster/r.bioclim/r.bioclim.py
+++ b/src/raster/r.bioclim/r.bioclim.py
@@ -5,12 +5,8 @@
 # MODULE:       r.bioclim
 # AUTHOR(S):    Markus Metz
 # PURPOSE:      Calculates bioclimatic indices from time series
-# COPYRIGHT:    (C) 2014 by the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2014 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/raster/r.bitpattern/main.c
+++ b/src/raster/r.bitpattern/main.c
@@ -22,12 +22,8 @@
  *                      binary: 0000 -> integer: 0 -> patval=0
  *                 If value can be arbitrary (0/1), then assume 0 value
  *
- * COPYRIGHT:    (C) 2002-2014 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2002-2014 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdio.h>

--- a/src/raster/r.boxplot/testsuite/test_r_boxplot.py
+++ b/src/raster/r.boxplot/testsuite/test_r_boxplot.py
@@ -8,12 +8,9 @@
 #
 # PURPOSE:   Tests for r.boxplot
 #
-# COPYRIGHT: (C) 2025 by Rajveer Bishnoi and the GRASS Development Team
-#
-#            This program is free software under the GNU General Public
-#            License (>=v2). Read the file COPYING that comes with GRASS
-#            for details.
-#
+# SPDX-FileCopyrightText: 2025 Rajveer Bishnoi
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 import os

--- a/src/raster/r.catchment/r.catchment.py
+++ b/src/raster/r.catchment/r.catchment.py
@@ -7,11 +7,9 @@
 # PURPOSE:              Creates a raster buffer of specified area around vector
 #                       points using cost distances. Module requires r.walk.
 # ACKNOWLEDGEMENTS:     National Science Foundation Grant #BCS0410269
-# COPYRIGHT:            (C) 2015 by Isaac Ullah, Arizona State University
-#                       This program is free software under the GNU General
-#                       Public License (>=v2). Read the file COPYING that comes
-#                       with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2015 Isaac Ullah, Arizona State University
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 

--- a/src/raster/r.category.trim/r.category.trim.py
+++ b/src/raster/r.category.trim/r.category.trim.py
@@ -11,12 +11,9 @@
 #               categories values, whereby the category labels and colors are
 #               retained.
 #
-# COPYRIGHT: (C) 2015-2026 Paulo van Breugel and the GRASS Development Team
-#
-#            This program is free software under the GNU General Public
-#            License (>=v2). Read the file COPYING that comes with GRASS
-#            for details.
-#
+# SPDX-FileCopyrightText: 2015-2026 Paulo van Breugel
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ########################################################################
 #
 # %Module

--- a/src/raster/r.centroids/r.centroids.py
+++ b/src/raster/r.centroids/r.centroids.py
@@ -10,12 +10,9 @@
 # PURPOSE:   Wrapper for r.volume. Creates vector map of centroids from a
 #            raster of "clumps"; r.clumps creates "clumps" of data.
 #
-# COPYRIGHT: (C) 2021 by Caitlin Haedrich and the GRASS Development Team
-#
-#            This program is free software under the GNU General Public
-#            License (>=v2). Read the file COPYING that comes with GRASS
-#            for details.
-#
+# SPDX-FileCopyrightText: 2021 Caitlin Haedrich
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/raster/r.centroids/testsuite/test_r_centroids.py
+++ b/src/raster/r.centroids/testsuite/test_r_centroids.py
@@ -8,12 +8,9 @@
 #
 # PURPOSE:   This is a test file for r.centroids
 #
-# COPYRIGHT: (C) 2021 by Caitlin Haedrich and the GRASS Development Team
-#
-#            This program is free software under the GNU General Public
-#            License (>=v2). Read the file COPYING that comes with GRASS
-#            for details.
-#
+# SPDX-FileCopyrightText: 2021 Caitlin Haedrich
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # Dependencies

--- a/src/raster/r.change.info/main.c
+++ b/src/raster/r.change.info/main.c
@@ -6,12 +6,8 @@
  *
  * PURPOSE:      Change assessment for categorical raster series
  *
- * COPYRIGHT:    (C) 2014 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2014 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <string.h>

--- a/src/raster/r.colors.cubehelix/r.colors.cubehelix.py
+++ b/src/raster/r.colors.cubehelix/r.colors.cubehelix.py
@@ -6,12 +6,9 @@
 # MODULE:       r.colors.cubehelix
 # AUTHOR:       Vaclav Petras <wenzeslaus gmail com>
 # PURPOSE:      Convert a GMT color table into a GRASS color rules file
-# COPYRIGHT:    (C) 2007 by Vaclav Petras, Anna Petrasova
-#               and the GRASS Development Team
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2007 Vaclav Petras, Anna Petrasova
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/raster/r.colors.matplotlib/r.colors.matplotlib.py
+++ b/src/raster/r.colors.matplotlib/r.colors.matplotlib.py
@@ -6,11 +6,9 @@
 # MODULE:       r.colors.matplotlib
 # AUTHOR:       Vaclav Petras <wenzeslaus gmail com>
 # PURPOSE:      Use Matplotlib color tables to GRASS GIS
-# COPYRIGHT:    (C) 2016 by Vaclav Petras and the GRASS Development Team
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2016 Vaclav Petras
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/raster/r.confusionmatrix/r.confusionmatrix.py
+++ b/src/raster/r.confusionmatrix/r.confusionmatrix.py
@@ -8,12 +8,9 @@
 #
 # PURPOSE:   Calculates a confusion matrix and accuracies for a given classification using r.kappa.
 #
-# COPYRIGHT: (C) 2020-2023 by mundialis and the GRASS Development Team
-#
-# 		This program is free software under the GNU General Public
-# 		License (>=v2). Read the file COPYING that comes with GRASS
-# 		for details.
-#
+# SPDX-FileCopyrightText: 2020-2023 mundialis
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %Module

--- a/src/raster/r.convergence/main.c
+++ b/src/raster/r.convergence/main.c
@@ -7,12 +7,8 @@
  * PURPOSE:      Calculate convergence index (parameter defining the local
  *               convergence of the relief)
  *
- * COPYRIGHT:    (C) 2002,2010 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2002,2010 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.crater/main.c
+++ b/src/raster/r.crater/main.c
@@ -5,12 +5,8 @@
  * PURPOSE:      Creates craters from meteorites
  *               or meteorites from craters
  *
- * COPYRIGHT:    (C) 2013 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with
- *               GRASS for details.
- *
+ * SPDX-FileCopyrightText: 2013 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdio.h>

--- a/src/raster/r.curvenumber/main.c
+++ b/src/raster/r.curvenumber/main.c
@@ -7,12 +7,9 @@
  * PURPOSE:      Generates the Curve Number raster based on landcover and
  *		 hydrologic soil group rasters
  *
- * COPYRIGHT:    (C) 2025 by Abdullah Azzam and the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2025 Abdullah Azzam
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdio.h>

--- a/src/raster/r.diversity/r.diversity.py
+++ b/src/raster/r.diversity/r.diversity.py
@@ -8,12 +8,9 @@
 # PURPOSE:    It calculates the mostly used indices of diversity based on
 #             information theory
 #
-# COPYRIGHT: (C) 2010-2012 by Luca Delucchi
-#
-#        This program is free software under the GNU General Public
-#        License (>=v2). Read the file COPYING that comes with GRASS
-#        for details.
-#
+# SPDX-FileCopyrightText: 2010-2012 Luca Delucchi
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/raster/r.droka/r.droka.py
+++ b/src/raster/r.droka/r.droka.py
@@ -8,12 +8,8 @@
 #               Andrea Filipello -filipello@provincia.verbania.it
 #               Daniele Strigaro - daniele.strigaro@gmail.com
 # PURPOSE:	Calculates run-out distance of a falling rock mass
-# COPYRIGHT:	(C) 2009 by the GRASS Development Team
-#
-# 		This program is free software under the GNU General Public
-# 		License (>=v2). Read the file COPYING that comes with GRASS
-# 		for details.
-#
+# SPDX-FileCopyrightText: 2009 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 # %Module
 # % description: Calculates run-out distance of a falling rock mass

--- a/src/raster/r.earthworks/r.earthworks.py
+++ b/src/raster/r.earthworks/r.earthworks.py
@@ -7,11 +7,9 @@
 #
 # PURPOSE:   Terrain modeling with cut and fill operations
 #
-# COPYRIGHT: (C) 2024 by Brendan Harmon and the GRASS Development Team
-#
-#            This program is free software under the GNU General Public
-#            License (>=v2). Read the file COPYING that comes with GRASS
-#            for details.
+# SPDX-FileCopyrightText: 2024 Brendan Harmon
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ##############################################################################
 
 """Earthworks"""

--- a/src/raster/r.exdet/r.exdet.py
+++ b/src/raster/r.exdet/r.exdet.py
@@ -12,11 +12,9 @@
 #               combinations between covariates (NT2).
 #               Based on Mesgaran et al.2014 [1]
 #
-# COPYRIGHT: (C) 2014-2017 by Paulo van Breugel and the GRASS Development Team
-#
-#        This program is free software under the GNU General Public
-#        License (>=v2). Read the file COPYING that comes with GRASS
-#        for details.
+# SPDX-FileCopyrightText: 2014-2017 Paulo van Breugel
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ##############################################################################
 
 # %module

--- a/src/raster/r.fill.category/r.fill.category.py
+++ b/src/raster/r.fill.category/r.fill.category.py
@@ -7,12 +7,9 @@
 # PURPOSE:   Replaces the values of pixels of a given category with values
 #            of the surrounding pixels
 #
-# COPYRIGHT: (C) 2019 by Stefano Gobbi and Paolo Zatelli
-#
-#   This program is free software under the GNU General Public
-#   License (>=v2). Read the file COPYING that comes with GRASS
-#   for details.
-#
+# SPDX-FileCopyrightText: 2019 Stefano Gobbi and Paolo Zatelli
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 # %Module
 # % description: Replaces the values of pixels of a given category with values of the surrounding pixels.

--- a/src/raster/r.findtheriver/main.c
+++ b/src/raster/r.findtheriver/main.c
@@ -9,12 +9,9 @@
  * PURPOSE:      Finds the nearest stream pixel to a coordinate pair using an
  *               upstream accumulating area map.
  *
- * COPYRIGHT:    (C) 2013 by the University of North Carolina at Chapel Hill
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2013 the University of North Carolina at Chapel Hill
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdlib.h>

--- a/src/raster/r.findtheriver/point_list.c
+++ b/src/raster/r.findtheriver/point_list.c
@@ -6,12 +6,9 @@
  * PURPOSE:      Finds the nearest stream pixel to a coordinate pair using
  *                                  an upstream accumulating area map.
  *
- * COPYRIGHT:    (C) 2013 by the University of North Carolina at Chapel Hill
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with
- *               GRASS for details.
- *
+ * SPDX-FileCopyrightText: 2013 the University of North Carolina at Chapel Hill
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdlib.h>

--- a/src/raster/r.flexure/testsuite/test_r_flexure.py
+++ b/src/raster/r.flexure/testsuite/test_r_flexure.py
@@ -5,12 +5,9 @@
 # MODULE:       test_r_flexure
 # AUTHOR:       Andrew Wickert
 # PURPOSE:      Tests for r.flexure (gridded flexural isostasy)
-# COPYRIGHT:    (C) 2026 by Andrew Wickert and the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2026 Andrew Wickert
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ############################################################################
 
 """

--- a/src/raster/r.flowaccumulation/main.c
+++ b/src/raster/r.flowaccumulation/main.c
@@ -8,12 +8,9 @@
  *               using the Memory-Efficient Flow Accumulation (MEFA) parallel
  *               algorithm by Cho (2023).
  *
- * COPYRIGHT:    (C) 2023 by Huidae Cho and the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2023 Huidae Cho
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdlib.h>

--- a/src/raster/r.forcircular/r.forcircular.py
+++ b/src/raster/r.forcircular/r.forcircular.py
@@ -5,12 +5,8 @@
 # MODULE:      r.forcircular
 # AUTHOR(S):   Francesco Geri, Sandro Sacchelli
 # PURPOSE:     Evaluation of circular bioeconomy level of forest ecosystems
-# COPYRIGHT:   (C) 2022 by the GRASS Development Team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2022 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 # %Module
 # % description: Evaluation of circular bioeconomy level of forest ecosystems

--- a/src/raster/r.forestfrag/r.forestfrag.py
+++ b/src/raster/r.forestfrag/r.forestfrag.py
@@ -17,12 +17,8 @@
 #            fragmentation. Conservation Ecology 4(2): 3. [online]
 #            URL: https://www.ecologyandsociety.org/vol4/iss2/art3/
 #
-# COPYRIGHT: (C) 1997-2016 by the GRASS Development Team
-#
-#            This program is free software under the GNU General Public
-#            License (>=v2). Read the file COPYING that comes with GRASS
-#            for details.
-#
+# SPDX-FileCopyrightText: 1997-2016 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/raster/r.forestfrag/testsuite/r_forestfrag_ncspm.py
+++ b/src/raster/r.forestfrag/testsuite/r_forestfrag_ncspm.py
@@ -5,12 +5,9 @@
 # MODULE:        r_forestfrag_ncspm
 # AUTHOR:        Vaclav Petras
 # PURPOSE:       Test using NC SPM data
-# COPYRIGHT:     (C) 2016 by Vaclav Petras and the GRASS Development Team
-#
-#                This program is free software under the GNU General Public
-#                License (>=v2). Read the file COPYING that comes with GRASS
-#                for details.
-#
+# SPDX-FileCopyrightText: 2016 Vaclav Petras
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 from grass.gunittest.case import TestCase

--- a/src/raster/r.forestfrag/testsuite/r_forestfrag_trivial.py
+++ b/src/raster/r.forestfrag/testsuite/r_forestfrag_trivial.py
@@ -5,12 +5,9 @@
 # MODULE:        r_forestfrag_trivial
 # AUTHOR:        Vaclav Petras
 # PURPOSE:       Test using example from the Riitters et al. 2000 paper
-# COPYRIGHT:     (C) 2016 by Vaclav Petras and the GRASS Development Team
-#
-#                This program is free software under the GNU General Public
-#                License (>=v2). Read the file COPYING that comes with GRASS
-#                for details.
-#
+# SPDX-FileCopyrightText: 2016 Vaclav Petras
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # This test led to discovery of #3067 (r68717) which was an r.mapcalc

--- a/src/raster/r.forestfrag/testsuite/r_forestfrag_xy.py
+++ b/src/raster/r.forestfrag/testsuite/r_forestfrag_xy.py
@@ -5,12 +5,9 @@
 # MODULE:        r_forestfrag_xy
 # AUTHOR:        Vaclav Petras
 # PURPOSE:       Test with complete but small ref output (diff windows)
-# COPYRIGHT:     (C) 2016 by Vaclav Petras and the GRASS Development Team
-#
-#                This program is free software under the GNU General Public
-#                License (>=v2). Read the file COPYING that comes with GRASS
-#                for details.
-#
+# SPDX-FileCopyrightText: 2016 Vaclav Petras
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 

--- a/src/raster/r.futures/r.futures.calib/r.futures.calib.py
+++ b/src/raster/r.futures/r.futures.calib/r.futures.calib.py
@@ -8,12 +8,8 @@
 #
 # PURPOSE:      FUTURES patches calibration tool
 #
-# COPYRIGHT:    (C) 2016 by the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2016 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ##############################################################################
 
 # %module

--- a/src/raster/r.futures/r.futures.devpressure/r.futures.devpressure.py
+++ b/src/raster/r.futures/r.futures.devpressure/r.futures.devpressure.py
@@ -9,12 +9,8 @@
 #
 # PURPOSE:      FUTURES development pressure computation
 #
-# COPYRIGHT:    (C) 2015 by the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2015 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ##############################################################################
 
 # %module

--- a/src/raster/r.futures/r.futures.gridvalidation/r.futures.gridvalidation.py
+++ b/src/raster/r.futures/r.futures.gridvalidation/r.futures.gridvalidation.py
@@ -9,12 +9,8 @@
 # PURPOSE:      Validation metrics computed on a grid
 #               (Quantity/Allocation Disagreement, Kappa Simulation)
 #
-# COPYRIGHT:    (C) 2016-2021 by the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2016-2021 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ##############################################################################
 
 # %module

--- a/src/raster/r.futures/r.futures.parallelpga/r.futures.parallelpga.py
+++ b/src/raster/r.futures/r.futures.parallelpga/r.futures.parallelpga.py
@@ -4,18 +4,9 @@
 # MODULE:       r.futures.parallelpga
 # AUTHOR(S):    Anna Petrasova
 # PURPOSE:      Run r.futures.simulation in parallel
-# COPYRIGHT:    (C) 2016 by Anna Petrasova, and the GRASS Development Team
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
+# SPDX-FileCopyrightText: 2016 Anna Petrasova
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ############################################################################
 
 # %module

--- a/src/raster/r.futures/r.futures.pga/r.futures.pga.py
+++ b/src/raster/r.futures/r.futures.pga/r.futures.pga.py
@@ -4,18 +4,9 @@
 # MODULE:       r.futures.pga
 # AUTHOR(S):    Anna Petrasova
 # PURPOSE:      Wrapper for r.futures.simulation for backward compatibility
-# COPYRIGHT:    (C) 2022 by Anna Petrasova, and the GRASS Development Team
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
+# SPDX-FileCopyrightText: 2022 Anna Petrasova
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ############################################################################
 
 # %module

--- a/src/raster/r.futures/r.futures.potential/r.futures.potential.py
+++ b/src/raster/r.futures/r.futures.potential/r.futures.potential.py
@@ -8,12 +8,8 @@
 #
 # PURPOSE:      FUTURES Potential submodel
 #
-# COPYRIGHT:    (C) 2016-2021 by the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2016-2021 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ##############################################################################
 
 # %module

--- a/src/raster/r.futures/r.futures.potsurface/r.futures.potsurface.py
+++ b/src/raster/r.futures/r.futures.potsurface/r.futures.potsurface.py
@@ -8,12 +8,8 @@
 #
 # PURPOSE:      FUTURES Potential surface for visualization
 #
-# COPYRIGHT:    (C) 2016-2020 by the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2016-2020 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ##############################################################################
 
 # %module

--- a/src/raster/r.futures/r.futures.simulation/r.futures.simulation.py
+++ b/src/raster/r.futures/r.futures.simulation/r.futures.simulation.py
@@ -4,18 +4,9 @@
 # MODULE:       r.futures.simulation
 # AUTHOR(S):    Anna Petrasova
 # PURPOSE:      Wrapper for r.futures.pga for forward compatibility
-# COPYRIGHT:    (C) 2022 by Anna Petrasova, and the GRASS Development Team
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
+# SPDX-FileCopyrightText: 2022 Anna Petrasova
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ############################################################################
 
 # %module

--- a/src/raster/r.futures/r.futures.validation/r.futures.validation.py
+++ b/src/raster/r.futures/r.futures.validation/r.futures.validation.py
@@ -8,12 +8,8 @@
 #
 # PURPOSE:      Validation metrics (Quantity/Allocation Disagreement, Kappa Simulation)
 #
-# COPYRIGHT:    (C) 2016-2021 by the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2016-2021 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ##############################################################################
 
 # %module

--- a/src/raster/r.fuzzy.logic/main.c
+++ b/src/raster/r.fuzzy.logic/main.c
@@ -4,12 +4,8 @@
  * AUTHOR(S):    Jarek Jasiewicz <jarekj amu.edu.pl>
  * PURPOSE:      Performs logical operations on membership images created with
  *                   r.fuzzy or different method. Use families for fuzzy logic
- * COPYRIGHT:    (C) 1999-2010 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 1999-2010 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  ****************************************************************************
  */
 

--- a/src/raster/r.fuzzy.set/main.c
+++ b/src/raster/r.fuzzy.set/main.c
@@ -4,12 +4,8 @@
  * AUTHOR(S):    Jarek Jasiewicz <jarekj amu.edu.pl>
  * PURPOSE:      Calculate membership value of any raster map according user's
  *               rules
- * COPYRIGHT:    (C) 1999-2010 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 1999-2010 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  ****************************************************************************
  */
 

--- a/src/raster/r.fuzzy.system/main.c
+++ b/src/raster/r.fuzzy.system/main.c
@@ -4,12 +4,8 @@
  * AUTHOR(S):    Jarek Jasiewicz <jarekj amu.edu.pl>
  * PURPOSE:      Fuzzy logic classification system with several fuzzy logic
  *               families implication and defuzzification and methods.
- * COPYRIGHT:    (C) 1999-2010 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 1999-2010 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *************************************************************************** */
 
 #include <grass/gis.h>

--- a/src/raster/r.gdd/main.c
+++ b/src/raster/r.gdd/main.c
@@ -4,12 +4,8 @@
  * AUTHOR(S):    Markus Metz
  *               based on r.series
  * PURPOSE:      Calculate GDD, Winler index, BEDD, Huglin
- * COPYRIGHT:    (C) 2012 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2012 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <string.h>

--- a/src/raster/r.gradient/r.gradient.py
+++ b/src/raster/r.gradient/r.gradient.py
@@ -7,12 +7,9 @@
 # AUTHOR(S):     Luca Delucchi
 # PURPOSE:       r.gradient create a gradient map
 #
-# COPYRIGHT:        (C) 2014 by Luca Delucchi
-#
-#                This program is free software under the GNU General Public
-#                License (>=v2). Read the file COPYING that comes with GRASS
-#                for details.
-#
+# SPDX-FileCopyrightText: 2014 Luca Delucchi
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/raster/r.gravity.terrain/r.gravity.terrain.py
+++ b/src/raster/r.gravity.terrain/r.gravity.terrain.py
@@ -7,11 +7,9 @@
 #
 # PURPOSE:   A GRASS tool to calculate gravity terrain corrections
 #
-# COPYRIGHT: (C) 2025 by David Farris and the GRASS Development Team
-#
-#            This program is free software under the GNU General Public
-#            License (>=v2). Read the file COPYING that comes with GRASS
-#            for details.
+# SPDX-FileCopyrightText: 2025 David Farris
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ##############################################################################
 
 """A GRASS tool to calculate gravity terrain corrections"""

--- a/src/raster/r.green/r.green.biomassfor/libforest/financial.py
+++ b/src/raster/r.green/r.green.biomassfor/libforest/financial.py
@@ -4,12 +4,8 @@
 # AUTHOR(S):   Giulia Garegnani
 # PURPOSE:     libraries for the financial module of biomassfor
 #              original module developed by Francesco Geri and Pietro Zambelli
-# COPYRIGHT:   (C) 2014 by the GRASS Development Team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2014 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 import os

--- a/src/raster/r.green/r.green.biomassfor/libforest/harvesting.py
+++ b/src/raster/r.green/r.green.biomassfor/libforest/harvesting.py
@@ -4,12 +4,8 @@
 # AUTHOR(S):   Giulia Garegnani
 # PURPOSE:     Libraries for the technical modul of biomassfor
 #              original module developed by Francesco Geri and Pietro Zambelli
-# COPYRIGHT:   (C) 2014 by the GRASS Development Team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2014 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 

--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.co2/r.green.biomassfor.co2.py
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.co2/r.green.biomassfor.co2.py
@@ -9,12 +9,8 @@
 # PURPOSE:     Calculates impacts and multifunctionality values regarding fertility maintenance,
 #              soil water protection, biodiversity, sustainable bioenergy,
 #              avoided CO2 emission, fire risk, recreation
-# COPYRIGHT:   (C) 2013 by the GRASS Development Team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2013 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 # %Module

--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.financial/r.green.biomassfor.financial.py
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.financial/r.green.biomassfor.financial.py
@@ -10,12 +10,8 @@
 #              reviewed by Marco Ciolli
 #              Last version rewritten by Giulia Garegnani, Gianluca Grilli
 # PURPOSE:     Calculates the economic value of a forests in terms of bioenergy assortments
-# COPYRIGHT:   (C) 2013 by the GRASS Development Team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2013 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 # default values for prices1: 79.54,81.33,69.51,193,83.45

--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.impact/r.green.biomassfor.impact.py
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.impact/r.green.biomassfor.impact.py
@@ -9,12 +9,8 @@
 # PURPOSE:     Calculates impacts and multifunctionality values regarding fertility maintenance,
 #              soil water protection, biodiversity, sustainable bioenergy,
 #              avoided CO2 emission, fire risk, recreation
-# COPYRIGHT:   (C) 2013 by the GRASS Development Team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2013 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 # %Module

--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.legal/r.green.biomassfor.legal.py
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.legal/r.green.biomassfor.legal.py
@@ -7,12 +7,8 @@
 # AUTHOR(S):   Sandro Sacchelli, Francesco Geri
 #              Converted to Python by Pietro Zambelli and Francesco Geri, reviewed by Marco Ciolli
 # PURPOSE:     Calculates the potential Ecological Bioenergy contained in a forest
-# COPYRIGHT:   (C) 2013 by the GRASS Development Team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2013 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 # %Module
 # % description: Estimates potential bioenergy depending on forest increment, forest management and forest treatment

--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.recommended/r.green.biomassfor.recommended.py
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.recommended/r.green.biomassfor.recommended.py
@@ -7,12 +7,8 @@
 # AUTHOR(S):   Francesco Geri, Sandro Sacchelli
 #              Converted to Python by Francesco Geri reviewed by Marco Ciolli
 # PURPOSE:     Calculates the potential bioenergy contained in a forest accortding to several constraints
-# COPYRIGHT:   (C) 2013 by the GRASS Development Team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2013 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 # %Module
 # % description: Estimates potential bioenergy according to environmental restriction

--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.technical/biomasfor.technical.py
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.technical/biomasfor.technical.py
@@ -7,12 +7,8 @@
 # AUTHOR(S):   Sandro Sacchelli
 #              Converted to Python by Pietro Zambelli, reviewed by Marco Ciolli
 # PURPOSE:     Calculates the technical potential taking into account morphology and operative technical limits
-# COPYRIGHT:   (C) 2013 by the GRASS Development Team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2013 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 # %Module

--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.technical/r.green.biomassfor.technical.py
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.technical/r.green.biomassfor.technical.py
@@ -7,12 +7,8 @@
 # AUTHOR(S):   Sandro Sacchelli, Francesco Geri
 #              Converted to Python by Pietro Zambelli, reviewed by Marco Ciolli
 # PURPOSE:     Calculates the technical potential taking into account morphology and operative technical limits
-# COPYRIGHT:   (C) 2013 by the GRASS Development Team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2013 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 # %Module

--- a/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.theoretical/r.green.biomassfor.theoretical.py
+++ b/src/raster/r.green/r.green.biomassfor/r.green.biomassfor.theoretical/r.green.biomassfor.theoretical.py
@@ -7,12 +7,8 @@
 # AUTHOR(S):   Sandro Sacchelli, Francesco Geri
 #              Converted to Python by Pietro Zambelli and Francesco Geri, reviewed by Marco Ciolli
 # PURPOSE:     Calculates the potential Ecological Bioenergy contained in a forest
-# COPYRIGHT:   (C) 2013 by the GRASS Development Team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2013 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 # %Module
 # % description: Estimates potential bioenergy depending on forest increment, forest management and forest treatment

--- a/src/raster/r.green/r.green.gshp/r.green.gshp.technical/r.green.gshp.technical.py
+++ b/src/raster/r.green/r.green.gshp/r.green.gshp.technical/r.green.gshp.technical.py
@@ -7,12 +7,8 @@
 # AUTHOR(S):   Pietro Zambelli
 # PURPOSE:     Calculate the ground source heat pump technical potential using
 #              the ASHRAE method
-# COPYRIGHT:   (C) 2017 by the GRASS Development Team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2017 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 

--- a/src/raster/r.green/r.green.gshp/r.green.gshp.theoretical/r.green.gshp.theoretical.py
+++ b/src/raster/r.green/r.green.gshp/r.green.gshp.theoretical/r.green.gshp.theoretical.py
@@ -6,12 +6,8 @@
 # MODULE:      r.green.gshp.theoretical
 # AUTHOR(S):   Pietro Zambelli
 # PURPOSE:     Calculate the Near Surface Geothermal Energy potential
-# COPYRIGHT:   (C) 2017 by the GRASS Development Team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2017 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 

--- a/src/raster/r.green/r.green.hydro/libhydro/basin.py
+++ b/src/raster/r.green/r.green.hydro/libhydro/basin.py
@@ -5,12 +5,8 @@
 #
 # AUTHOR(S):   Giulia Garegnani
 # PURPOSE:     Definition of the object basin and functions
-# COPYRIGHT:   (C) 2014 by the GRASS Development Team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2014 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.closest/r.green.hydro.closest.py
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.closest/r.green.hydro.closest.py
@@ -6,12 +6,8 @@
 # MODULE:      r.green.hydro.potential
 # AUTHOR(S):   Pietro Zambelli
 # PURPOSE:     Calculate the hydropower energy potential for each basin
-# COPYRIGHT:   (C) 2014 by the GRASS Development Team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2014 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.delplants/r.green.hydro.delplants.py
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.delplants/r.green.hydro.delplants.py
@@ -6,12 +6,8 @@
 # MODULE:      r.green.hydro.delplants
 # AUTHOR(S):   Pietro Zambelli & Giulia Garegnani
 # PURPOSE:     Delete segments where there is an existing plant
-# COPYRIGHT:   (C) 2014 by the GRASS Development Team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2014 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 # %Module

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.discharge/r.green.hydro.discharge.py
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.discharge/r.green.hydro.discharge.py
@@ -6,12 +6,8 @@
 # MODULE:      r.green.hydro.discharge
 # AUTHOR(S):   Giulia Garegnani
 # PURPOSE:     ?
-# COPYRIGHT:   (C) 2014 by the GRASS Development Team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2014 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.financial/r.green.hydro.financial.py
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.financial/r.green.hydro.financial.py
@@ -6,12 +6,8 @@
 # MODULE:      r.green.hydro.financial
 # AUTHOR(S):   Sandro Sacchelli (BASH-concept), Pietro Zambelli (Python)
 # PURPOSE:     Assess the hydro plant costs
-# COPYRIGHT:   (C) 2014 by the GRASS Development Team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2014 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 # %Module

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.optimal/r.green.hydro.optimal.py
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.optimal/r.green.hydro.optimal.py
@@ -6,12 +6,8 @@
 # MODULE:      r.green.hydro.optimal
 # AUTHOR(S):   Giulia Garegnani
 # PURPOSE:     Calculate the optimal position of a plant along a river
-# COPYRIGHT:   (C) 2014 by the GRASS Development Team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2014 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 # %module

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.planning/r.green.hydro.planning.py
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.planning/r.green.hydro.planning.py
@@ -7,12 +7,8 @@
 # AUTHOR(S):   Giulia Garegnani
 # PURPOSE:     Calculate the optimal position of a plant along a river
 #              following user's recommendations
-# COPYRIGHT:   (C) 2014 by the GRASS Development Team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2014 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.recommended/r.green.hydro.recommended.py
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.recommended/r.green.hydro.recommended.py
@@ -7,12 +7,8 @@
 # AUTHOR(S):   Giulia Garegnani
 # PURPOSE:     Calculate the optimal position of a plant along a river
 #              following user's recommendations
-# COPYRIGHT:   (C) 2014 by the GRASS Development Team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2014 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.structure/r.green.hydro.structure.py
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.structure/r.green.hydro.structure.py
@@ -6,12 +6,8 @@
 # MODULE:      r.green.hydro.structure
 # AUTHOR(S):
 # PURPOSE:
-# COPYRIGHT:   (C) 2014 by the GRASS Development Team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2014 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 # %Module

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.technical/r.green.hydro.technical.py
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.technical/r.green.hydro.technical.py
@@ -7,12 +7,8 @@
 # AUTHOR(S):   Giulia Garegnani, Julie Gros, Pietro Zambelli
 # PURPOSE:
 #
-# COPYRIGHT:   (C) 2014 by the GRASS Development Team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2014 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ############################################################################
 #
 #

--- a/src/raster/r.green/r.green.hydro/r.green.hydro.theoretical/r.green.hydro.theoretical.py
+++ b/src/raster/r.green/r.green.hydro/r.green.hydro.theoretical/r.green.hydro.theoretical.py
@@ -6,12 +6,8 @@
 # MODULE:      r.green.hydro.potential
 # AUTHOR(S):   Giulia Garegnani, Pietro Zambelli
 # PURPOSE:     Calculate the theoretical hydropower energy potential for each basin and segments of river
-# COPYRIGHT:   (C) 2014 by the GRASS Development Team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2014 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 

--- a/src/raster/r.green/r.green.install/r.green.install.py
+++ b/src/raster/r.green/r.green.install/r.green.install.py
@@ -6,12 +6,8 @@
 # MODULE:      r.green.install
 # AUTHOR(S):   Pietro Zambelli
 # PURPOSE:     Check missing python libraries and wrong paths and fix them
-# COPYRIGHT:   (C) 2014 by the GRASS Development Team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2014 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 

--- a/src/raster/r.gwr/main.c
+++ b/src/raster/r.gwr/main.c
@@ -9,12 +9,8 @@
  *               y = b0 + b1*x1 + b2*x2 + ... +  bn*xn + e
  *               with localized b coefficients
  *
- * COPYRIGHT:    (C) 2011-2016 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2011-2016 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdio.h>

--- a/src/raster/r.hand/r.hand.py
+++ b/src/raster/r.hand/r.hand.py
@@ -5,11 +5,9 @@
 # MODULE:       r.hand
 # AUTHOR:       Corey T. White, OpenPlains Inc.
 # PURPOSE:      Performs Height Above Nearest Drainage (HAND) analysis.
-# COPYRIGHT:    (C) 2025 OpenPlains Inc. and the GRASS Development Team
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2025 OpenPlains Inc.
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/raster/r.hand/testsuite/test_r_hand.py
+++ b/src/raster/r.hand/testsuite/test_r_hand.py
@@ -5,11 +5,9 @@
 # MODULE:       test_r_hand.py
 # AUTHOR:       Corey T. White, OpenPlains Inc.
 # PURPOSE:      Performs Height Above Nearest Drainage (HAND) analysis.
-# COPYRIGHT:    (C) 2025 OpenPlains Inc. and the GRASS Development Team
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2025 OpenPlains Inc.
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 

--- a/src/raster/r.hants/main.c
+++ b/src/raster/r.hants/main.c
@@ -6,12 +6,8 @@
  *               Markus Metz, converted to C, 2013
  *               based on r.series
  * PURPOSE:      time series correction
- * COPYRIGHT:    (C) 2013 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2013 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <string.h>

--- a/src/raster/r.houghtransform/main.cpp
+++ b/src/raster/r.houghtransform/main.cpp
@@ -6,12 +6,8 @@
  *
  * PURPOSE:      Line segment extraction using Hough transformation.
  *
- * COPYRIGHT:    (C) 2012 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with
- *               GRASS for details.
- *
+ * SPDX-FileCopyrightText: 2012 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include "hough.h"

--- a/src/raster/r.hydrobasin/main.c
+++ b/src/raster/r.hydrobasin/main.c
@@ -8,12 +8,9 @@
  *               Memory-Efficient Watershed Delineation (MESHED) OpenMP
  *               parallel algorithm by Cho (2025).
  *
- * COPYRIGHT:    (C) 2024-2025 by Huidae Cho and the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2024-2025 Huidae Cho
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdlib.h>

--- a/src/raster/r.hydrodem/main.c
+++ b/src/raster/r.hydrodem/main.c
@@ -4,12 +4,8 @@
  * AUTHOR(S):    Markus Metz <markus.metz.giswork gmail.com>
  * PURPOSE:      Hydrological analysis
  *               DEM hydrological conditioning based on A* Search
- * COPYRIGHT:    (C) 1999-2009 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 1999-2009 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdlib.h>

--- a/src/raster/r.in.nasadem/r.in.nasadem.py
+++ b/src/raster/r.in.nasadem/r.in.nasadem.py
@@ -9,12 +9,8 @@
 #
 # PURPOSE:      Create a DEM from 1 arcsec NASADEM tiles
 #
-# COPYRIGHT:    (C) 2020-2021 GRASS development team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2020-2021 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/raster/r.in.srtm.region/r.in.srtm.region.py
+++ b/src/raster/r.in.srtm.region/r.in.srtm.region.py
@@ -9,12 +9,8 @@
 #
 # PURPOSE:      Create a DEM from 3 arcsec SRTM v2.1 or 1 arcsec SRTM v3 tiles
 #
-# COPYRIGHT:    (C) 2011-2021 GRASS development team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2011-2021 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/raster/r.in.ssurgo/r.in.ssurgo.py
+++ b/src/raster/r.in.ssurgo/r.in.ssurgo.py
@@ -5,11 +5,9 @@
 # MODULE:       r.in.ssurgo
 # AUTHOR:       Corey T. White, GeoForAll Lab, NCSU
 # PURPOSE:      Download and import SSURGO data
-# COPYRIGHT:    (C) 2025-2026 Corey White and the GRASS Development Team
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2025-2026 Corey White
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/raster/r.in.usgs/r.in.usgs.py
+++ b/src/raster/r.in.usgs/r.in.usgs.py
@@ -11,12 +11,9 @@
 #
 # PURPOSE:   Download user-requested products through the USGS TNM API.
 #
-# COPYRIGHT: (C) 2017-2021 Zechariah Krautwurst and the GRASS Development Team
-#
-#            This program is free software under the GNU General Public
-#            License (>=v2). Read the file COPYING that comes with GRASS
-#            for details.
-#
+# SPDX-FileCopyrightText: 2017-2021 Zechariah Krautwurst
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ############################################################################
 
 # %module

--- a/src/raster/r.jpdf/main.c
+++ b/src/raster/r.jpdf/main.c
@@ -4,12 +4,8 @@
  * AUTHOR(S):    Thomas Huld <thomas.huld@jrc.ec.europa.eu> (original
  *                  contributor)
  * PURPOSE:
- * COPYRIGHT:    (C) 2015 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2015 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <string.h>

--- a/src/raster/r.lake.series/r.lake.series.py
+++ b/src/raster/r.lake.series/r.lake.series.py
@@ -7,12 +7,8 @@
 # AUTHOR(S):    Vaclav Petras
 # PURPOSE:      Fills lake at given point(s) to given levels.
 #
-# COPYRIGHT:    (C) 2013 by the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2013 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 

--- a/src/raster/r.lfp/main.c
+++ b/src/raster/r.lfp/main.c
@@ -9,12 +9,9 @@
  *               Longest Flow Path (MELFP) OpenMP parallel algorithm by Cho
  *               (2025).
  *
- * COPYRIGHT:    (C) 2025 by Huidae Cho and the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2025 Huidae Cho
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 #define _MAIN_C_
 

--- a/src/raster/r.local.relief/r.local.relief.py
+++ b/src/raster/r.local.relief/r.local.relief.py
@@ -6,12 +6,8 @@
 # AUTHOR(S): Vaclav Petras <wenzeslaus gmail.com>,
 #            Eric Goddard <egoddard memphis.edu>
 # PURPOSE:   Create a local relief model from elevation map
-# COPYRIGHT: (C) 2013 by the GRASS Development Team
-#
-#            This program is free software under the GNU General Public
-#            License (>=v2). Read the file COPYING that comes with GRASS
-#            for details.
-#
+# SPDX-FileCopyrightText: 2013 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/raster/r.manning/r.manning.py
+++ b/src/raster/r.manning/r.manning.py
@@ -7,11 +7,9 @@
 #
 # PURPOSE:   Converts land cover raster to Manning's roughness coefficient raster.
 #
-# COPYRIGHT: (C) 2026 by Anna Petrasova and the GRASS Development Team
-#
-#            This program is free software under the GNU General Public
-#            License (>=v2). Read the file COPYING that comes with GRASS
-#            for details.
+# SPDX-FileCopyrightText: 2026 Anna Petrasova
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ##############################################################################
 
 """Converts land cover raster to Manning's roughness coefficient raster."""

--- a/src/raster/r.mapcalc.tiled/r.mapcalc.tiled.py
+++ b/src/raster/r.mapcalc.tiled/r.mapcalc.tiled.py
@@ -7,11 +7,8 @@
 #
 # PURPOSE:	Run r.mapcalc over tiles of the input map
 #               to allow parallel processing
-# COPYRIGHT:	(C) 2019 by the GRASS Development Team
-#
-# 		This program is free software under the GNU General Public
-# 		License (>=v2). Read the file COPYING that comes with GRASS
-# 		for details.
+# SPDX-FileCopyrightText: 2019 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %Module

--- a/src/raster/r.mapcalc.tiled/tests/test.py
+++ b/src/raster/r.mapcalc.tiled/tests/test.py
@@ -6,11 +6,8 @@
 # AUTHOR(S):	Anika Bettge, mundialis
 #
 # PURPOSE:	    Run r.mapcalc vs r.mapcalc.tiled with different parameters
-# COPYRIGHT:	(C) 2020 by the GRASS Development Team
-#
-# 		This program is free software under the GNU General Public
-# 		License (>=v2). Read the file COPYING that comes with GRASS
-# 		for details.
+# SPDX-FileCopyrightText: 2020 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # python3 test.py config.ini

--- a/src/raster/r.mapcalc.tiled/tests/visualization.py
+++ b/src/raster/r.mapcalc.tiled/tests/visualization.py
@@ -6,11 +6,8 @@
 # AUTHOR(S):	Anika Bettge, mundialis
 #
 # PURPOSE:	    Visualize test results of test.py
-# COPYRIGHT:	(C) 2020 by the GRASS Development Team
-#
-# 		This program is free software under the GNU General Public
-# 		License (>=v2). Read the file COPYING that comes with GRASS
-# 		for details.
+# SPDX-FileCopyrightText: 2020 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # python3 visualization.py rmapcalctiled_test.csv images

--- a/src/raster/r.mcda.electre/main.c
+++ b/src/raster/r.mcda.electre/main.c
@@ -7,12 +7,8 @@
  * PURPOSE:      Make a multicriteria decision analysis based on ELECTRE
  *               algorithm, with concordance and discordance indexes maps
  *
- * COPYRIGHT:    (C) GRASS Development Team (2015)
- *
- *               This program is free software under the GNU General
- *               Public License (>=v2). Read the file COPYING that comes with
- *               GRASS for details.
- *
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdio.h>

--- a/src/raster/r.meb/r.meb.py
+++ b/src/raster/r.meb/r.meb.py
@@ -18,12 +18,9 @@
 #               and median of MES values in B (MESb), divided by the median of
 #               the absolute deviations of MESb from the median of MESb (MAD)
 #
-# COPYRIGHT: (C) 2014-2023 by Paulo van Breugel and the GRASS Development Team
-#
-#            This program is free software under the GNU General Public
-#            License (>=v2). Read the file COPYING that comes with GRASS
-#            for details.
-#
+# SPDX-FileCopyrightText: 2014-2023 Paulo van Breugel
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ########################################################################
 #
 # %Module

--- a/src/raster/r.mess/r.mess.py
+++ b/src/raster/r.mess/r.mess.py
@@ -8,13 +8,9 @@
 #               surface (MESS) as proposed by Elith et al., 2010,
 #               Methods in Ecology & Evolution, 1(330–342).
 #
-# COPYRIGHT: (C) 2014-2024 by Paulo van Breugel and the GRASS Development
-#            Team
-#
-#            This program is free software under the GNU General Public
-#            License (>=v2). Read the file COPYING that comes with GRASS
-#            for details.
-#
+# SPDX-FileCopyrightText: 2014-2024 Paulo van Breugel
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ########################################################################
 #
 # %Module

--- a/src/raster/r.mregression.series/r.mregression.series.py
+++ b/src/raster/r.mregression.series/r.mregression.series.py
@@ -9,12 +9,8 @@
 #
 # PURPOSE:      multiple regression between several time series
 #
-# COPYRIGHT:    (C) 2015 by the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2015 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %Module

--- a/src/raster/r.neighborhoodmatrix/main.c
+++ b/src/raster/r.neighborhoodmatrix/main.c
@@ -8,12 +8,8 @@
  * PURPOSE:      Calculates a neighborhood matrix for a raster map with regions
  *               (e.g. the output of r.clump or i.segment)
  *
- * COPYRIGHT:    (C) 2018 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2018 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  ***************************************************************************/
 
 #include <stdlib.h>

--- a/src/raster/r.noaa.atlas14/r.noaa.atlas14.py
+++ b/src/raster/r.noaa.atlas14/r.noaa.atlas14.py
@@ -8,8 +8,8 @@
 # PURPOSE:   Import NOAA Atlas 14 precipitation-frequency data from PFDS point
 #            queries or official GIS-compatible grid downloads.
 #
-# COPYRIGHT: (C) 2026 by Corey T. White and the GRASS Development Team
-#
+# SPDX-FileCopyrightText: 2026 Corey T. White
+# SPDX-FileCopyrightText: Other GRASS authors
 # SPDX-License-Identifier: GPL-2.0-or-later
 ##############################################################################
 

--- a/src/raster/r.null.all/r.null.all.py
+++ b/src/raster/r.null.all/r.null.all.py
@@ -6,12 +6,9 @@
 # AUTHOR(S):    Vaclav Petras <wenzeslaus gmail com>
 #
 # PURPOSE:      Manage null values for all raster maps in a mapset
-# COPYRIGHT:    (C) 2019 by Vaclav Petras and the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2019 Vaclav Petras
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/raster/r.object.spatialautocor/r.object.spatialautocor.py
+++ b/src/raster/r.object.spatialautocor/r.object.spatialautocor.py
@@ -6,12 +6,8 @@
 # AUTHOR(S):    Moritz Lennert
 #
 # PURPOSE:      Calculates global spatial autocorrelation on raster objects
-# COPYRIGHT:    (C) 1997-2017 by the GRASS Development Team
-#
-#       This program is free software under the GNU General Public
-#       License (>=v2). Read the file COPYING that comes with GRASS
-#       for details.
-#
+# SPDX-FileCopyrightText: 1997-2017 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 # References:
 #

--- a/src/raster/r.object.thickness/r.object.thickness.py
+++ b/src/raster/r.object.thickness/r.object.thickness.py
@@ -7,12 +7,9 @@
 # PURPOSE:   Evaluates the maximum thickness of objects of a given category
 #            on a raster map
 #
-# COPYRIGHT: (C) 2019 Paolo Zatelli
-#
-#   This program is free software under the GNU General Public
-#   License (>=v2). Read the file COPYING that comes with GRASS
-#   for details.
-#
+# SPDX-FileCopyrightText: 2019 Paolo Zatelli
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 # %Module
 # % description: Evaluates minimum, maximum and mean thickness of objects of a given category on a raster map.

--- a/src/raster/r.out.kde/r.out.kde.py
+++ b/src/raster/r.out.kde/r.out.kde.py
@@ -6,12 +6,8 @@
 # AUTHOR(S): Anna Petrasova
 #
 # PURPOSE:
-# COPYRIGHT: (C) 2013 - 2019 by the GRASS Development Team
-#
-#                This program is free software under the GNU General Public
-#                License (>=v2). Read the file COPYING that comes with GRASS
-#                for details.
-#
+# SPDX-FileCopyrightText: 2013 - 2019 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/raster/r.out.legend/r.out.legend.py
+++ b/src/raster/r.out.legend/r.out.legend.py
@@ -8,12 +8,9 @@
 # DESCRIPTION:  Export the legend of a raster as image, which can be used
 #               in e.g., the map composer in QGIS.
 #
-# COPYRIGHT: (C) 2014-2024 by Paulo van Breugel and the GRASS Development Team
-#
-#            This program is free software under the GNU General Public
-#            License (>=v2). Read the file COPYING that comes with GRASS
-#            for details.
-#
+# SPDX-FileCopyrightText: 2014-2024 Paulo van Breugel
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ########################################################################
 #
 # %Module

--- a/src/raster/r.out.ntv2/r.out.ntv2.py
+++ b/src/raster/r.out.ntv2/r.out.ntv2.py
@@ -5,12 +5,8 @@
 # MODULE:      r.out.ntv2
 # AUTHOR(S):   Maciej Sieczka
 # PURPOSE:     Export NTv2 datum transformation grid.
-# COPYRIGHT:   (C) 2016 by the GRASS Development Team
-#
-#              This program is free software under the GNU General Public
-#              License (>=v2). Read the file COPYING that comes with GRASS
-#              for details.
-#
+# SPDX-FileCopyrightText: 2016 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %Module

--- a/src/raster/r.patch.smooth/r.patch.smooth.py
+++ b/src/raster/r.patch.smooth/r.patch.smooth.py
@@ -9,12 +9,8 @@
 #
 # PURPOSE:      Patch raster and smooth along edges
 #
-# COPYRIGHT:    (C) 2015 by the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2015 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ##############################################################################
 
 # %module

--- a/src/raster/r.pi/r.pi.corearea/main.c
+++ b/src/raster/r.pi/r.pi.corearea/main.c
@@ -5,12 +5,8 @@
  *               Markus Metz (update to GRASS 7)
  * PURPOSE:      Non-linear core area analysis
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.pi/r.pi.corr.mw/main.c
+++ b/src/raster/r.pi/r.pi.corr.mw/main.c
@@ -6,12 +6,8 @@
  * PURPOSE:      Moving window correlation analysis
  *               Put together from pieces of r.covar and r.neighbors
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <string.h>

--- a/src/raster/r.pi/r.pi.csr.mw/main.c
+++ b/src/raster/r.pi/r.pi.csr.mw/main.c
@@ -6,12 +6,8 @@
  * PURPOSE:      Analysis of CSR (complete spatial randomness) based on movinw
  *window
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.pi/r.pi.energy.pr/main.c
+++ b/src/raster/r.pi/r.pi.energy.pr/main.c
@@ -8,12 +8,8 @@
  *               energy-based - iterative removal of patches for patch
  *               relevance analysis
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.pi/r.pi.energy/main.c
+++ b/src/raster/r.pi/r.pi.energy/main.c
@@ -7,12 +7,8 @@
  * PURPOSE:      Individual-based dispersal model for connectivity analysis -
  *               energy-based
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.pi/r.pi.enn.pr/main.c
+++ b/src/raster/r.pi/r.pi.enn.pr/main.c
@@ -5,12 +5,8 @@
  *               Markus Metz (update to GRASS 7)
  * PURPOSE:      Iterative removal of patches and analysis of patch relevance
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.pi/r.pi.enn/main.c
+++ b/src/raster/r.pi/r.pi.enn/main.c
@@ -6,12 +6,8 @@
  * PURPOSE:      Analysis of n-th euclidean nearest neighbour distance
  *               and spatial attributes of nearest neighbour patches
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.pi/r.pi.export/main.c
+++ b/src/raster/r.pi/r.pi.export/main.c
@@ -5,12 +5,8 @@
  *               Markus Metz (update to GRASS 7)
  * PURPOSE:      Export of patch based raster information
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.pi/r.pi.fnn/main.c
+++ b/src/raster/r.pi/r.pi.fnn/main.c
@@ -6,12 +6,8 @@
  * PURPOSE:      Analysis of n-th functional/ecological nearest neighbour
  *               distance and spatial attributes of nearest neighbour patches
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.pi/r.pi.graph.dec/main.c
+++ b/src/raster/r.pi/r.pi.graph.dec/main.c
@@ -6,12 +6,8 @@
  * PURPOSE:      Graph Theory approach for connectivity analysis on patch
  *               level - successive removal of patches based on defined criteria
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.pi/r.pi.graph.pr/main.c
+++ b/src/raster/r.pi/r.pi.graph.pr/main.c
@@ -6,12 +6,8 @@
  * PURPOSE:      Graph Theory approach for connectivity analysis on patch
  *               level - iterative patch removal option (patch relevance)
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.pi/r.pi.graph.red/main.c
+++ b/src/raster/r.pi/r.pi.graph.red/main.c
@@ -6,12 +6,8 @@
  * PURPOSE:      Graph Theory approach for connectivity analysis on patch
  *               level - decreasing distance threshold option
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.pi/r.pi.graph/main.c
+++ b/src/raster/r.pi/r.pi.graph/main.c
@@ -5,12 +5,8 @@
  *               Markus Metz (update to GRASS 7)
  * PURPOSE:      Graph Theory approach for connectivity analysis on patch level
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.pi/r.pi.grow/main.c
+++ b/src/raster/r.pi/r.pi.grow/main.c
@@ -5,12 +5,8 @@
  *               Markus Metz (update to GRASS 7)
  * PURPOSE:      Size and landscape suitability based region growing
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.pi/r.pi.import/main.c
+++ b/src/raster/r.pi/r.pi.import/main.c
@@ -7,12 +7,8 @@
  *               (Reads a text-file with Patch IDs and values and creates a
  *               raster file with these values for patches)
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.pi/r.pi.index/main.c
+++ b/src/raster/r.pi/r.pi.index/main.c
@@ -5,12 +5,8 @@
  *               Markus Metz (update to GRASS 7)
  * PURPOSE:      Fragmentation analysis - basic spatial indices
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.pi/r.pi.lm/main.c
+++ b/src/raster/r.pi/r.pi.lm/main.c
@@ -5,12 +5,8 @@
  *               Markus Metz (update to GRASS 7)
  * PURPOSE:      Linear regression analysis for patches (not pixel based)
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include "local_proto.h"

--- a/src/raster/r.pi/r.pi.neigh/main.c
+++ b/src/raster/r.pi/r.pi.neigh/main.c
@@ -6,12 +6,8 @@
  * PURPOSE:      Neighbourhood analysis - value of patches within a defined
  *               range
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.pi/r.pi.nlm.circ/main.c
+++ b/src/raster/r.pi/r.pi.nlm.circ/main.c
@@ -6,12 +6,8 @@
  * PURPOSE:      a simple r.nlm (neutral landscape model) module based on
  *               circular growth
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include "local_proto.h"

--- a/src/raster/r.pi/r.pi.nlm.stats/main.c
+++ b/src/raster/r.pi/r.pi.nlm.stats/main.c
@@ -7,12 +7,8 @@
  * PURPOSE:      Generation of Neutral Landscapes and statistical analysis
  *                               of fragmentation indices
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.pi/r.pi.nlm/main.c
+++ b/src/raster/r.pi/r.pi.nlm/main.c
@@ -6,12 +6,8 @@
  * PURPOSE:      Generation of Neutral Landscapes (fractal landscapes), similar
  *               to r.pi.nlm, but fractal landscapes instead of circular growth
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include "local_proto.h"

--- a/src/raster/r.pi/r.pi.odc/main.c
+++ b/src/raster/r.pi/r.pi.odc/main.c
@@ -6,12 +6,8 @@
  * PURPOSE:      omnidirectional connectivity analysis based on polygons
  *                               (related to voronoi for points)
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.pi/r.pi.prob.mw/main.c
+++ b/src/raster/r.pi/r.pi.prob.mw/main.c
@@ -7,12 +7,8 @@
  *               located within the same patch - patch-to-patch distance setting
  *               optional
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.pi/r.pi.prox/main.c
+++ b/src/raster/r.pi/r.pi.prox/main.c
@@ -5,12 +5,8 @@
  *               Markus Metz (update to GRASS 7)
  * PURPOSE:      Proximity analysis - values of patches within a defined range
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.pi/r.pi.rectangle/main.c
+++ b/src/raster/r.pi/r.pi.rectangle/main.c
@@ -6,12 +6,8 @@
  * PURPOSE:      Delineation of rectangular study areas based on GPS location
  *                               of the respective corners
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include "local_proto.h"

--- a/src/raster/r.pi/r.pi.searchtime.mw/main.c
+++ b/src/raster/r.pi/r.pi.searchtime.mw/main.c
@@ -6,12 +6,8 @@
  * PURPOSE:      Individual-based dispersal model for connectivity analysis
  *               - time-based - within a moving window. Based on r.pi.searchtime
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.pi/r.pi.searchtime.pr/main.c
+++ b/src/raster/r.pi/r.pi.searchtime.pr/main.c
@@ -7,12 +7,8 @@
  *               - time-based - within iterative removal of patches.
  *               Based on r.pi.searchtime
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.pi/r.pi.searchtime/main.c
+++ b/src/raster/r.pi/r.pi.searchtime/main.c
@@ -6,12 +6,8 @@
  * PURPOSE:      Individual-based dispersal model for connectivity analysis -
  *               time-based
  *
- * COPYRIGHT:    (C) 2009-2011,2017 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2011,2017 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.quantile.ref/main.c
+++ b/src/raster/r.quantile.ref/main.c
@@ -3,12 +3,8 @@
  * MODULE:       r.quantile.ref
  * AUTHOR(S):    Markus Metz
  * PURPOSE:      Get quantile of the input value from reference maps
- * COPYRIGHT:    (C) 2015 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2015 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 #include <string.h>
 #include <stdlib.h>

--- a/src/raster/r.random.walk/r.random.walk.py
+++ b/src/raster/r.random.walk/r.random.walk.py
@@ -5,11 +5,9 @@
 # MODULE:       r.random.walk
 # AUTHOR:       Corey T. White, Center for Geospatial Analytics, North Carolina State University
 # PURPOSE:      Performs a random walk on a raster surface.
-# COPYRIGHT:    (C) 2022 Corey White
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2022 Corey White
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/raster/r.random.walk/testsuite/test_r_random_walk.py
+++ b/src/raster/r.random.walk/testsuite/test_r_random_walk.py
@@ -8,12 +8,9 @@
 #
 # PURPOSE:   This is a test file for r.random.walk
 #
-# COPYRIGHT: (C) 2022 by Corey T. White and the GRASS Development Team
-#
-#            This program is free software under the GNU General Public
-#            License (>=v2). Read the file COPYING that comes with GRASS
-#            for details.
-#
+# SPDX-FileCopyrightText: 2022 Corey T. White
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # Dependencies

--- a/src/raster/r.recode.attr/r.recode.attr.py
+++ b/src/raster/r.recode.attr/r.recode.attr.py
@@ -7,13 +7,9 @@
 # PURPOSE:      Recode raster to one or more new layers using an
 #               attribute table (csv file) as input
 #
-# COPYRIGHT: (C) 2015-2024 by Paulo van Breugel
-#            and the GRASS Development Team
-#
-#            This program is free software under the GNU General Public
-#            License (>=v2). Read the file COPYING that comes with GRASS
-#            for details.
-#
+# SPDX-FileCopyrightText: 2015-2024 Paulo van Breugel
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ########################################################################
 #
 # %Module

--- a/src/raster/r.regression.series/main.c
+++ b/src/raster/r.regression.series/main.c
@@ -12,12 +12,8 @@
  *
  * PURPOSE:      regression between two time series
  *
- * COPYRIGHT:    (C) 2011 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2011 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 #include <string.h>
 #include <stdlib.h>

--- a/src/raster/r.resamp.tps/main.c
+++ b/src/raster/r.resamp.tps/main.c
@@ -6,13 +6,9 @@
  *
  * PURPOSE:      Thin Plate Spline interpolation with covariables
  *
- * COPYRIGHT:    (C) 2016 by by the GRASS Development Team
- *
- *               This program is free software under the
- *               GNU General Public License (>=v2).
- *               Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2016 by
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  **********************************************************************/
 
 #include <stdlib.h>

--- a/src/raster/r.roughness.vector/r.roughness.vector.py
+++ b/src/raster/r.roughness.vector/r.roughness.vector.py
@@ -27,12 +27,8 @@
 # 		set to INPUT_MAP_roughness_vector_NxN
 # 		where N is the window size.
 #
-# COPYRIGHT:	(C) 2014 by the GRASS Development Team
-#
-# 		This program is free software under the GNU General Public
-# 		License (>=v2). Read the file COPYING that comes with GRASS
-# 		for details.
-#
+# SPDX-FileCopyrightText: 2014 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 # %Module

--- a/src/raster/r.runoff/r.runoff.py
+++ b/src/raster/r.runoff/r.runoff.py
@@ -7,11 +7,9 @@
 #
 # PURPOSE:   Computes the runoff depth, volume, and peak discharge rasters using the SCS Curve Number Method
 #
-# COPYRIGHT: (C) 2025 by Abdullah Azzam and the GRASS Development Team
-#
-#            This program is free software under the GNU General Public
-#            License (>=v2). Read the file COPYING that comes with GRASS
-#            for details.
+# SPDX-FileCopyrightText: 2025 Abdullah Azzam
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ##############################################################################
 
 """Computes the runoff depth, volume, and peak discharge rasters using the SCS Curve Number Method"""

--- a/src/raster/r.scatterplot/main.c
+++ b/src/raster/r.scatterplot/main.c
@@ -7,12 +7,8 @@
  *
  * PURPOSE:      Creates a scatter plot of two or more raster maps
  *
- * COPYRIGHT:    (C) 2016 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2016 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 /*

--- a/src/raster/r.seasons/main.c
+++ b/src/raster/r.seasons/main.c
@@ -3,12 +3,8 @@
  * MODULE:       r.seasons
  * AUTHOR(S):    Markus Metz
  * PURPOSE:      season extraction from a time series
- * COPYRIGHT:    (C) 2016 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2016 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdlib.h>

--- a/src/raster/r.series.decompose/r.series.decompose.py
+++ b/src/raster/r.series.decompose/r.series.decompose.py
@@ -10,12 +10,8 @@
 # PURPOSE:      Perform decomposition of time series X :
 #               X(t) = b0 + b1 *t + sin(2*pi*t/N) + cos(2*pi*t/N) + ... + sin(2*pi*t/k*N) + cos(2*pi*t/k*N)
 #
-# COPYRIGHT:    (C) 2015 by the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2015 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %Module

--- a/src/raster/r.series.filter/r.series.filter.py
+++ b/src/raster/r.series.filter/r.series.filter.py
@@ -9,12 +9,8 @@
 #
 # PURPOSE:      Perform filtering of raster time series X
 #
-# COPYRIGHT:    (C) 2015 by the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2015 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %Module

--- a/src/raster/r.series.lwr/main.c
+++ b/src/raster/r.series.lwr/main.c
@@ -4,12 +4,8 @@
  * AUTHOR(S):    Markus Metz
  *               based on r.hants
  * PURPOSE:      time series correction
- * COPYRIGHT:    (C) 2016 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2016 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <string.h>

--- a/src/raster/r.shaded.pca/r.shaded.pca.py
+++ b/src/raster/r.shaded.pca/r.shaded.pca.py
@@ -5,12 +5,9 @@
 # MODULE:    r.shaded.pca
 # AUTHOR(S): Vaclav Petras
 # PURPOSE:   Creates RGB composition from PCA of hill shades
-# COPYRIGHT: (C) 2013-2014 by Vaclav Petras and the GRASS Development Team
-#
-#                This program is free software under the GNU General Public
-#                License (>=v2). Read the file COPYING that comes with GRASS
-#                for details.
-#
+# SPDX-FileCopyrightText: 2013-2014 Vaclav Petras
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/raster/r.sim.water.mp/erod.c
+++ b/src/raster/r.sim.water.mp/erod.c
@@ -4,12 +4,8 @@
  * AUTHOR(S):    Helena Mitasova, Jaro Hofierka, Lubos Mitas:
  * PURPOSE:      Hydrologic and sediment transport simulation (SIMWE)
  *
- * COPYRIGHT:    (C) 2002 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2002 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 /* erod.c (simlib), 20.nov.2002, JH */

--- a/src/raster/r.sim.water.mp/hydro.c
+++ b/src/raster/r.sim.water.mp/hydro.c
@@ -4,12 +4,8 @@
  * AUTHOR(S):    Helena Mitasova, Jaro Hofierka, Lubos Mitas:
  * PURPOSE:      Hydrologic and sediment transport simulation (SIMWE)
  *
- * COPYRIGHT:    (C) 2002 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2002 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 /* hydro.c (simlib), 20.nov.2002, JH */

--- a/src/raster/r.slopeunits/r.slopeunits.clean/r.slopeunits.clean.py
+++ b/src/raster/r.slopeunits/r.slopeunits.clean/r.slopeunits.clean.py
@@ -7,12 +7,8 @@
 #               (Refactoring, partly translation to python), Carmen Tawalika
 #               (creation of extra addon)
 # PURPOSE:      Clean slope units layer
-# COPYRIGHT:    (C) 2004-2024 by the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2004-2024 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 # %module

--- a/src/raster/r.slopeunits/r.slopeunits.create/r.slopeunits.create.py
+++ b/src/raster/r.slopeunits/r.slopeunits.create/r.slopeunits.create.py
@@ -5,12 +5,8 @@
 # MODULE:       r.slopeunits.create for GRASS 8
 # AUTHOR(S):    Ivan Marchesini, Massimiliano Alvioli, Markus Metz (Refactoring)
 # PURPOSE:      To create a raster layer of slope units
-# COPYRIGHT:    (C) 2004-2024 by the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2004-2024 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 # %module

--- a/src/raster/r.slopeunits/r.slopeunits.metrics/r.slopeunits.metrics.py
+++ b/src/raster/r.slopeunits/r.slopeunits.metrics/r.slopeunits.metrics.py
@@ -6,12 +6,8 @@
 # AUTHOR(S):    Ivan Marchesini, Massimiliano Alvioli, Carmen Tawalika
 #               (Translation to python)
 # PURPOSE:      Create metrics for slope units
-# COPYRIGHT:    (C) 2004-2024 by the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2004-2024 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 # %module

--- a/src/raster/r.slopeunits/r.slopeunits.optimize/r.slopeunits.optimize.py
+++ b/src/raster/r.slopeunits/r.slopeunits.optimize/r.slopeunits.optimize.py
@@ -6,12 +6,8 @@
 # AUTHOR(S):    Ivan Marchesini, Massimiliano Alvioli, Carmen Tawalika
 #               (Translation to python, Refactoring)
 # PURPOSE:      Optimize inputs for slope units
-# COPYRIGHT:    (C) 2004-2024 by the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2004-2024 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 # %module

--- a/src/raster/r.slopeunits/testsuite/test_r_slopeunits.py
+++ b/src/raster/r.slopeunits/testsuite/test_r_slopeunits.py
@@ -6,19 +6,9 @@
 # AUTHOR(S):   Carmen Tawalika
 
 # PURPOSE:      Tests r.slopeunit
-# COPYRIGHT:   (C) 2024 by mundialis GmbH & Co. KG and the GRASS Development
-#              Team
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
+# SPDX-FileCopyrightText: 2024 mundialis GmbH & Co. KG
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 """
 

--- a/src/raster/r.smooth.seg/main.c
+++ b/src/raster/r.smooth.seg/main.c
@@ -16,12 +16,9 @@
  *
  * REFERENCE:    http://www.ing.unitn.it/~vittia/phd/vitti_phd.pdf
  *
- * COPYRIGHT:    (C) 2007-2015 by Alfonso Vitti, and the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2007-2015 Alfonso Vitti
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdio.h>

--- a/src/raster/r.soils.texture/local_include.h
+++ b/src/raster/r.soils.texture/local_include.h
@@ -5,12 +5,8 @@
  * PURPOSE:      Intended to define soil texture from sand and clay grid.
  *                 Require texture scheme supplied in scheme directory
  *
- * COPYRIGHT:    (C) 2008 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with
- *               GRASS for details.
- *
+ * SPDX-FileCopyrightText: 2008 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 /* for gettext macros - i18N localization */

--- a/src/raster/r.soils.texture/main.c
+++ b/src/raster/r.soils.texture/main.c
@@ -5,12 +5,9 @@
  * PURPOSE:      Intended to define soil texture from sand and clay grid.
  *                 Require texture scheme supplied in scheme directory
  *
- * COPYRIGHT:    (C) 2008 by Gianluca MAssei and the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with
- *               GRASS for details.
- *
+ * SPDX-FileCopyrightText: 2008 Gianluca MAssei
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdio.h>

--- a/src/raster/r.stream.basins/main.c
+++ b/src/raster/r.stream.basins/main.c
@@ -11,12 +11,8 @@
  *               list of coordinates;
  *               with analogous  direction map;
  *
- * COPYRIGHT:    (C) 2002,2010-2014 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with
- *               GRASS for details.
- *
+ * SPDX-FileCopyrightText: 2002,2010-2014 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.stream.channel/main.c
+++ b/src/raster/r.stream.channel/main.c
@@ -8,12 +8,8 @@
  *               distance to channel init/join, elevation below channel init,
  *               optionally distance to outlet, elevation above outlet;
 
- * COPYRIGHT:    (C) 2002,2010-2014 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2002,2010-2014 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.stream.distance/main.c
+++ b/src/raster/r.stream.distance/main.c
@@ -10,12 +10,8 @@
  *               input map shall contains streams or points outlets with or
  *               without unique categories.
  *
- * COPYRIGHT:    (C) 2002,2009-2014 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with
- *               GRASS for details.
- *
+ * SPDX-FileCopyrightText: 2002,2009-2014 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.stream.order/main.c
+++ b/src/raster/r.stream.order/main.c
@@ -9,12 +9,8 @@
  *               The output are set of raster maps and vector file
  *               containing additional stream attributes.
  *
- * COPYRIGHT:    (C) 2009-2014 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2009-2014 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.stream.segment/main.c
+++ b/src/raster/r.stream.segment/main.c
@@ -10,12 +10,8 @@
  *               particular streams of the same order into near-straight
  *               line portions.
  *
- * COPYRIGHT:    (C) 2002,2010-2014 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2002,2010-2014 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.stream.slope/main.c
+++ b/src/raster/r.stream.slope/main.c
@@ -7,12 +7,8 @@
  *                  calculate local downstream elevation change
  *                  and local downstream minimum and maximum curvature
 
- * COPYRIGHT:    (C) 2002, 2010-2014 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2002, 2010-2014 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdio.h>

--- a/src/raster/r.stream.snap/main.c
+++ b/src/raster/r.stream.snap/main.c
@@ -8,12 +8,8 @@
  *               maximum snap distance and minimum accumulation value to snap
  *
  *
- * COPYRIGHT:    (C) 2002,2010-2014 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with
- *               GRASS for details.
- *
+ * SPDX-FileCopyrightText: 2002,2010-2014 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define MAIN

--- a/src/raster/r.stream.stats/main.c
+++ b/src/raster/r.stream.stats/main.c
@@ -13,12 +13,8 @@
  *               direction map from r.stream.extract dir map must be patched
  *               with that of r.watershed.
  *
- * COPYRIGHT:    (C) 2002,2010-2014 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with
- *               GRASS for details.
- *
+ * SPDX-FileCopyrightText: 2002,2010-2014 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 #define MAIN
 #include <grass/glocale.h>

--- a/src/raster/r.stream.variables/r.stream.variables.sh
+++ b/src/raster/r.stream.variables/r.stream.variables.sh
@@ -12,12 +12,8 @@
 # PURPOSE:      Calculation of contiguous stream-specific variables that account
 #				for the upstream environment (based on r.stream.watersheds).
 #
-# COPYRIGHT:    (C) 2001-2012 by the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2001-2012 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %Module

--- a/src/raster/r.stream.watersheds/r.stream.watersheds.sh
+++ b/src/raster/r.stream.watersheds/r.stream.watersheds.sh
@@ -13,12 +13,8 @@
 #				stream sections ('sub-stream') for each grid cell of a
 #				stream network
 #
-# COPYRIGHT:    (C) 2001-2012 by the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2001-2012 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %Module

--- a/src/raster/r.subdayprecip.design/r.subdayprecip.design.py
+++ b/src/raster/r.subdayprecip.design/r.subdayprecip.design.py
@@ -8,12 +8,9 @@
 #
 # PURPOSE:      Computes subday design precipitation totals.
 #
-# COPYRIGHT:    (C) 2015 Martin Landa and GRASS development team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2015 Martin Landa
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/raster/r.suitability.regions/r.suitability.regions.py
+++ b/src/raster/r.suitability.regions/r.suitability.regions.py
@@ -4,12 +4,9 @@
 # MODULE:         Locate suitable regions
 # AUTHOR(S):      Paulo van Breugel
 # PURPOSE:        From suitability map to suitable regions
-# COPYRIGHT: (C) 2021-2024 by Paulo van Breugel and the GRASS Development Team
-#
-#            This program is free software under the GNU General Public
-#            License (>=v2). Read the file COPYING that comes with GRASS
-#            for details.
-#
+# SPDX-FileCopyrightText: 2021-2024 Paulo van Breugel
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ##############################################################################
 
 # %module

--- a/src/raster/r.sun.daily/r.sun.daily.py
+++ b/src/raster/r.sun.daily/r.sun.daily.py
@@ -7,12 +7,8 @@
 #            Nikos Alexandris (updates for linke, albedo, latitude, horizon)
 #
 # PURPOSE:
-# COPYRIGHT: (C) 2013 - 2019 by the GRASS Development Team
-#
-#                This program is free software under the GNU General Public
-#                License (>=v2). Read the file COPYING that comes with GRASS
-#                for details.
-#
+# SPDX-FileCopyrightText: 2013 - 2019 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/raster/r.sun.daily/test.r.sun.daily.sh
+++ b/src/raster/r.sun.daily/test.r.sun.daily.sh
@@ -5,12 +5,8 @@
 # TEST:      test.r.sun.daily
 # AUTHOR(S): Vaclav Petras, Anna Petrasova
 # PURPOSE:   This is test for r.sun.daily module
-# COPYRIGHT: (C) 2013 by the GRASS Development Team
-#
-#                This program is free software under the GNU General Public
-#                License (>=v2). Read the file COPYING that comes with GRASS
-#                for details.
-#
+# SPDX-FileCopyrightText: 2013 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # @preprocess step

--- a/src/raster/r.sun.hourly/r.sun.hourly.py
+++ b/src/raster/r.sun.hourly/r.sun.hourly.py
@@ -5,12 +5,8 @@
 # MODULE:    r.sun.hourly for GRASS 8
 # AUTHOR(S): Vaclav Petras, Anna Petrasova
 # PURPOSE:
-# COPYRIGHT: (C) 2013 - 2022 by the GRASS Development Team
-#
-#                This program is free software under the GNU General Public
-#                License (>=v2). Read the file COPYING that comes with GRASS
-#                for details.
-#
+# SPDX-FileCopyrightText: 2013 - 2022 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/raster/r.sun.hourly/test.r.sun.hourly.sh
+++ b/src/raster/r.sun.hourly/test.r.sun.hourly.sh
@@ -5,12 +5,8 @@
 # TEST:      test.r.sun.hourly
 # AUTHOR(S): Vaclav Petras, Anna Petrasova
 # PURPOSE:   This is test for r.sun.hourly module
-# COPYRIGHT: (C) 2013 by the GRASS Development Team
-#
-#                This program is free software under the GNU General Public
-#                License (>=v2). Read the file COPYING that comes with GRASS
-#                for details.
-#
+# SPDX-FileCopyrightText: 2013 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # @preprocess step

--- a/src/raster/r.surf.idw2/main.c
+++ b/src/raster/r.surf.idw2/main.c
@@ -9,12 +9,8 @@
  *               Jan-Oliver Wagner <jan intevation.de>,
  *               Radim Blazek <radim.blazek gmail.com>
  * PURPOSE:
- * COPYRIGHT:    (C) 1999-2006 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 1999-2006 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdlib.h>

--- a/src/raster/r.survey/r.survey.py
+++ b/src/raster/r.survey/r.survey.py
@@ -24,12 +24,9 @@
 # due to problem in the management of the temporary_regions. In this case
 # please reduce the number of processes.
 #
-# COPYRIGHT: (C) 2021 Ivan Marchesini and Txomin Bornaetxea, and by the GRASS
-#           Development Team
-#
-#           This program is free software under the GNU General Public
-#           License (>=v2). Read the file COPYING that comes with GRASS
-#           for details.
+# SPDX-FileCopyrightText: 2021 Ivan Marchesini and Txomin Bornaetxea
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %Module

--- a/src/raster/r.texture.tiled/r.texture.tiled.py
+++ b/src/raster/r.texture.tiled/r.texture.tiled.py
@@ -7,11 +7,8 @@
 #
 # PURPOSE:	Run r.texture over tiles of the input map
 #               to allow parallel processing
-# COPYRIGHT:	(C) 1997-2018 by the GRASS Development Team
-#
-# 		This program is free software under the GNU General Public
-# 		License (>=v2). Read the file COPYING that comes with GRASS
-# 		for details.
+# SPDX-FileCopyrightText: 1997-2018 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %Module

--- a/src/raster/r.to.vect.lines/r.to.vect.lines.py
+++ b/src/raster/r.to.vect.lines/r.to.vect.lines.py
@@ -4,12 +4,9 @@
 # MODULE:       r.to.vect.lines
 # AUTHOR(S):    Hamish Bowman, Dunedin, New Zealand
 # PURPOSE:      Extracts wiggle lines from raster data for use with e.g. NVIZ
-# COPYRIGHT:    (C) 2012 by Hamish Bowman, and the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2012 Hamish Bowman
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 #
 # To make a wiggle line plot in NVIZ:

--- a/src/raster/r.to.vect.tiled/r.to.vect.tiled.py
+++ b/src/raster/r.to.vect.tiled/r.to.vect.tiled.py
@@ -4,18 +4,8 @@
 # MODULE:       r.to.vect.tiled
 # AUTHOR(S):    Markus Metz
 # PURPOSE:      Tiled raster to vector conversion
-# COPYRIGHT:    (C) 2014 by the GRASS Development Team
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
+# SPDX-FileCopyrightText: 2014 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ############################################################################
 
 # %module

--- a/src/raster/r.upflowlength/main.c
+++ b/src/raster/r.upflowlength/main.c
@@ -8,12 +8,9 @@
  *               map using the Memory-Efficient Upstream Flow Length (MEUFL)
  *               OpenMP parallel algorithm by Cho (2026).
  *
- * COPYRIGHT:    (C) 2026 by Huidae Cho and the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2026 Huidae Cho
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 #include <stdlib.h>
 #include <string.h>

--- a/src/raster/r.vect.stats/r.vect.stats.py
+++ b/src/raster/r.vect.stats/r.vect.stats.py
@@ -5,12 +5,9 @@
 # MODULE:    r.vect.stats
 # AUTHOR(S): Vaclav Petras <wenzeslaus gmail com>
 # PURPOSE:
-# COPYRIGHT: (C) 2017 by Vaclav Petras and the GRASS Development Team
-#
-#            This program is free software under the GNU General Public
-#            License (>=v2). Read the file COPYING that comes with GRASS
-#            for details.
-#
+# SPDX-FileCopyrightText: 2017 Vaclav Petras
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/raster/r.vif/r.vif.py
+++ b/src/raster/r.vif/r.vif.py
@@ -13,12 +13,9 @@
 #               VIF. This will be repeated till the VIF falls below the user
 #               defined VIF threshold value.
 #
-# COPYRIGHT: (C) 2015 - 2026 Paulo van Breugel and the GRASS Development Team
-#
-#            This program is free software under the GNU General Public
-#            License (>=v2). Read the file COPYING that comes with GRASS
-#            for details.
-#
+# SPDX-FileCopyrightText: 2015 - 2026 Paulo van Breugel
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ########################################################################
 #
 # %Module

--- a/src/raster/r.wateroutlet.lessmem/main.c
+++ b/src/raster/r.wateroutlet.lessmem/main.c
@@ -12,12 +12,8 @@
  * PURPOSE:      This program makes a watershed basin raster map using the
  *               drainage pointer map, from an outlet point defined by an
  *               easting and a northing.
- * COPYRIGHT:    (C) 1999-2006, 2010, 2013, 2015 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 1999-2006, 2010, 2013, 2015 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #define _MAIN_C_

--- a/src/raster3d/r3.count.categories/r3.count.categories.py
+++ b/src/raster3d/r3.count.categories/r3.count.categories.py
@@ -5,12 +5,9 @@
 # MODULE:        r3.count.categories
 # AUTHOR(S):     Vaclav Petras <wenzeslaus gmail com>
 # PURPOSE:       Count categories in vertical direction
-# COPYRIGHT:     (C) 2016 by Vaclav Petras, and the GRASS Development Team
-#
-#                This program is free software under the GNU General Public
-#                License (>=v2). Read the file COPYING that comes with GRASS
-#                for details.
-#
+# SPDX-FileCopyrightText: 2016 Vaclav Petras
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/raster3d/r3.forestfrag/r3.forestfrag.py
+++ b/src/raster3d/r3.forestfrag/r3.forestfrag.py
@@ -17,12 +17,8 @@
 #            fragmentation. Conservation Ecology 4(2): 3. [online]
 #            URL: http://www.consecol.org/vol4/iss2/art3/
 #
-# COPYRIGHT: (C) 1997-2016 by the GRASS Development Team
-#
-#            This program is free software under the GNU General Public
-#            License (>=v2). Read the file COPYING that comes with GRASS
-#            for details.
-#
+# SPDX-FileCopyrightText: 1997-2016 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/raster3d/r3.forestfrag/testsuite/r3_forestfrag_trivial.py
+++ b/src/raster3d/r3.forestfrag/testsuite/r3_forestfrag_trivial.py
@@ -5,12 +5,9 @@
 # MODULE:        r3_forestfrag_trivial
 # AUTHOR:        Vaclav Petras
 # PURPOSE:       Test using a small example computed by hand
-# COPYRIGHT:     (C) 2016 by Vaclav Petras and the GRASS Development Team
-#
-#                This program is free software under the GNU General Public
-#                License (>=v2). Read the file COPYING that comes with GRASS
-#                for details.
-#
+# SPDX-FileCopyrightText: 2016 Vaclav Petras
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 from grass.gunittest.case import TestCase

--- a/src/raster3d/r3.forestfrag/testsuite/r_forestfrag_xy.py
+++ b/src/raster3d/r3.forestfrag/testsuite/r_forestfrag_xy.py
@@ -7,12 +7,9 @@
 # MODULE:        r_forestfrag_xy
 # AUTHOR:        Vaclav Petras
 # PURPOSE:       Test with complete but small ref output (diff windows)
-# COPYRIGHT:     (C) 2016 by Vaclav Petras and the GRASS Development Team
-#
-#                This program is free software under the GNU General Public
-#                License (>=v2). Read the file COPYING that comes with GRASS
-#                for details.
-#
+# SPDX-FileCopyrightText: 2016 Vaclav Petras
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 

--- a/src/raster3d/r3.profile/main.c
+++ b/src/raster3d/r3.profile/main.c
@@ -7,12 +7,8 @@
  *
  * PURPOSE:      Profiles (slices vertically) 3D raster at 2D coordinates
  *
- * COPYRIGHT:    (C) 2000-2016 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2000-2016 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdlib.h>

--- a/src/raster3d/r3.scatterplot/main.c
+++ b/src/raster3d/r3.scatterplot/main.c
@@ -6,12 +6,8 @@
  *
  * PURPOSE:      Creates a scatter plot of two or more 3D maps
  *
- * COPYRIGHT:    (C) 2016 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2016 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 /*

--- a/src/raster3d/r3.to.group/r3.to.group.py
+++ b/src/raster3d/r3.to.group/r3.to.group.py
@@ -5,12 +5,9 @@
 # MODULE:        r3.to.group
 # AUTHOR(S):     Vaclav Petras <wenzeslaus gmail com>
 # PURPOSE:       Create an imagery group from 3D raster
-# COPYRIGHT:     (C) 2016 by Vaclav Petras, and the GRASS Development Team
-#
-#                This program is free software under the GNU General Public
-#                License (>=v2). Read the file COPYING that comes with GRASS
-#                for details.
-#
+# SPDX-FileCopyrightText: 2016 Vaclav Petras
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/raster3d/r3.what/main.c
+++ b/src/raster3d/r3.what/main.c
@@ -6,12 +6,8 @@
  *
  * PURPOSE:      Queries 3D raster at specified 2D or 3D coordinates
  *
- * COPYRIGHT:    (C) 2016 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2016 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <grass/gis.h>

--- a/src/temporal/t.rast.import.netcdf/t.rast.import.netcdf.py
+++ b/src/temporal/t.rast.import.netcdf/t.rast.import.netcdf.py
@@ -8,8 +8,8 @@
 # PURPOSE:   Import netCDF files that adhere to the CF-convention as a
 #            Space Time Raster Dataset (STRDS)
 #
-# COPYRIGHT: (C) 2021-2025 by Stefan Blumentrath and the GRASS Development Team
-#
+# SPDX-FileCopyrightText: 2021-2025 Stefan Blumentrath
+# SPDX-FileCopyrightText: Other GRASS authors
 # SPDX-License-Identifier: GPL-2.0-or-later
 ##############################################################################
 

--- a/src/temporal/t.rast.import.netcdf/testsuite/test_t_rast_import_netcdf.py
+++ b/src/temporal/t.rast.import.netcdf/testsuite/test_t_rast_import_netcdf.py
@@ -7,8 +7,8 @@
 #
 # PURPOSE:   Test of t.rast.import.netcdf with chirps and seNorge data
 #
-# COPYRIGHT: (C) 2021-2025 by Stefan Blumentrath and the GRASS Development Team
-#
+# SPDX-FileCopyrightText: 2021-2025 Stefan Blumentrath
+# SPDX-FileCopyrightText: Other GRASS authors
 # SPDX-License-Identifier: GPL-2.0-or-later
 ##############################################################################
 

--- a/src/temporal/t.rast.import.netcdf/testsuite/test_t_rast_import_netcdf_sentinel.py
+++ b/src/temporal/t.rast.import.netcdf/testsuite/test_t_rast_import_netcdf_sentinel.py
@@ -7,8 +7,8 @@
 #
 # PURPOSE:   Test of t.rast.import.netcdf with Sentinel-2 data
 #
-# COPYRIGHT: (C) 2021-2025 by Stefan Blumentrath and the GRASS Development Team
-#
+# SPDX-FileCopyrightText: 2021-2025 Stefan Blumentrath
+# SPDX-FileCopyrightText: Other GRASS authors
 # SPDX-License-Identifier: GPL-2.0-or-later
 ##############################################################################
 

--- a/src/temporal/t.rast.kappa/t.rast.kappa.py
+++ b/src/temporal/t.rast.kappa/t.rast.kappa.py
@@ -8,12 +8,9 @@
 # PURPOSE:      t.rast.kappa calculate kappa parameter for accuracy
 #               assessment in a space time raster dataset
 #
-# COPYRIGHT:        (C) 2017 by Luca Delucchi
-#
-#                This program is free software under the GNU General Public
-#                License (>=v2). Read the file COPYING that comes with GRASS
-#                for details.
-#
+# SPDX-FileCopyrightText: 2017 Luca Delucchi
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ################################################
 
 # %module

--- a/src/temporal/t.rast.null/t.rast.null.py
+++ b/src/temporal/t.rast.null/t.rast.null.py
@@ -7,12 +7,9 @@
 # AUTHOR(S):    Luca Delucchi
 # PURPOSE:      Manages NULL-values of a given space time raster dataset.
 #
-# COPYRIGHT:    (C) 2018 by Luca Delucchi
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2018 Luca Delucchi
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ################################################
 
 # %module

--- a/src/temporal/t.rast.patch/t.rast.patch.py
+++ b/src/temporal/t.rast.patch/t.rast.patch.py
@@ -6,18 +6,9 @@
 # AUTHOR(S):    Anika Bettge
 #
 # PURPOSE:    Patches rasters that have gaps with subsequent maps in time within a space time raster dataset using r.patch
-# COPYRIGHT:    (C) 2019 by by mundialis and the GRASS Development Team
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
+# SPDX-FileCopyrightText: 2019 by mundialis
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/temporal/t.stac/libstac/staclib.py
+++ b/src/temporal/t.stac/libstac/staclib.py
@@ -5,11 +5,9 @@
 # MODULE:       staclib
 # AUTHOR:       Corey T. White, OpenPlains Inc. & NCSU
 # PURPOSE:      Helper library to import STAC data in to GRASS.
-# COPYRIGHT:    (C) 2024 Corey White
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2024 Corey White
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 from __future__ import annotations
 

--- a/src/temporal/t.stac/t.stac.catalog/t.stac.catalog.py
+++ b/src/temporal/t.stac/t.stac.catalog/t.stac.catalog.py
@@ -5,11 +5,9 @@
 # MODULE:       t.stac.catalog
 # AUTHOR:       Corey T. White, OpenPlains Inc.
 # PURPOSE:      View SpatioTemporal Asset Catalogs (STAC) collection.
-# COPYRIGHT:    (C) 2024 Corey White
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2024 Corey White
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/temporal/t.stac/t.stac.collection/t.stac.collection.py
+++ b/src/temporal/t.stac/t.stac.collection/t.stac.collection.py
@@ -5,11 +5,9 @@
 # MODULE:       t.stac.collection
 # AUTHOR:       Corey T. White, OpenPlains Inc.
 # PURPOSE:      View SpatioTemporal Asset Catalogs (STAC) collection.
-# COPYRIGHT:    (C) 2023-2024 Corey White
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2023-2024 Corey White
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/temporal/t.stac/t.stac.item/t.stac.item.py
+++ b/src/temporal/t.stac/t.stac.item/t.stac.item.py
@@ -5,11 +5,9 @@
 # MODULE:       t.stac.item
 # AUTHOR:       Corey T. White, OpenPlains Inc.
 # PURPOSE:      Get items from a STAC API server
-# COPYRIGHT:    (C) 2023-2024 Corey White
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2023-2024 Corey White
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/tools/mk_isis_menu.sh
+++ b/src/tools/mk_isis_menu.sh
@@ -6,12 +6,8 @@
 # AUTHOR(S):    Yann Chemin
 # PURPOSE:      Run through $ISISROOT/Isis/bin/* and
 #               build a wxpython menu toolbox
-# COPYRIGHT:    (C) 2014 by the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2014 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 #In $GRASS_HOME/gui/wxpython/gis_set.py it will not be appropriate

--- a/src/vector/v.area.stats/main.c
+++ b/src/vector/v.area.stats/main.c
@@ -3,12 +3,8 @@
  * MODULE:       v.to.db
  * AUTHOR(S):    Pietro Zambelli <peter.zamb gmail com> (from v.to.db)
  * PURPOSE:      load values from vector to database
- * COPYRIGHT:    (C) 2000-2010 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2000-2010 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdlib.h>

--- a/src/vector/v.area.weigh/v.area.weigh.py
+++ b/src/vector/v.area.weigh/v.area.weigh.py
@@ -5,12 +5,8 @@
 # MODULE:        v.area.weigh
 # AUTHOR(S):        Markus Metz
 # PURPOSE:        Rasterize vector areas using cell weights
-# COPYRIGHT:        (C) 2013 by the GRASS Development Team
-#
-#                This program is free software under the GNU General Public
-#                License (>=v2). Read the file COPYING that comes with GRASS
-#                for details.
-#
+# SPDX-FileCopyrightText: 2013 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/vector/v.build.pg/v.build.pg.py
+++ b/src/vector/v.build.pg/v.build.pg.py
@@ -4,12 +4,9 @@
 # MODULE:       v.build.pg
 # AUTHOR(S):    Martin Landa
 # PURPOSE:      Builds PostGIS topology for PG-linked vector map.
-# COPYRIGHT:    (C) 2012 by Martin Landa, and the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2012 Martin Landa
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/vector/v.centerpoint/main.c
+++ b/src/vector/v.centerpoint/main.c
@@ -6,13 +6,8 @@
  *
  * PURPOSE:    Calculates center points
  *
- * COPYRIGHT:  (C) 2013 by the GRASS Development Team
- *
- *             This program is free software under the
- *             GNU General Public License (>=v2).
- *             Read the file COPYING that comes with GRASS
- *             for details.
- *
+ * SPDX-FileCopyrightText: 2013 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  ****************************************************************/
 
 #include <stdio.h>

--- a/src/vector/v.class.ml/v.class.ml.py
+++ b/src/vector/v.class.ml/v.class.ml.py
@@ -7,12 +7,8 @@
 #
 # AUTHOR(S):   Pietro Zambelli (University of Trento)
 #
-# COPYRIGHT:        (C) 2013 by the GRASS Development Team
-#
-#                This program is free software under the GNU General Public
-#                License (>=v2). Read the file COPYING that comes with GRASS
-#                for details.
-#
+# SPDX-FileCopyrightText: 2013 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %Module

--- a/src/vector/v.class.mlpy/v.class.mlpy.py
+++ b/src/vector/v.class.mlpy/v.class.mlpy.py
@@ -5,18 +5,9 @@
 # MODULE:    v.class.mlpy
 # AUTHOR(S): Vaclav Petras
 # PURPOSE:   Classifies features in vecor map.
-# COPYRIGHT: (C) 2012 by Vaclav Petras, and the GRASS Development Team
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
+# SPDX-FileCopyrightText: 2012 Vaclav Petras
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ############################################################################
 
 # %module

--- a/src/vector/v.clean.ogr/v.clean.ogr.py
+++ b/src/vector/v.clean.ogr/v.clean.ogr.py
@@ -4,18 +4,8 @@
 # MODULE:       v.clean.ogr
 # AUTHOR(S):    Markus Metz
 # PURPOSE:      Import, clean, and export an OGR layer
-# COPYRIGHT:    (C) 2018 by the GRASS Development Team
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
+# SPDX-FileCopyrightText: 2018 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ############################################################################
 
 # %module

--- a/src/vector/v.concave.hull/v.concave.hull.py
+++ b/src/vector/v.concave.hull/v.concave.hull.py
@@ -5,12 +5,8 @@
 # MODULE:        v.concave.hull
 # AUTHOR(S):        Markus Metz
 # PURPOSE:        Creates a concave hull around points
-# COPYRIGHT:        (C) 2013-2014 by the GRASS Development Team
-#
-#                This program is free software under the GNU General Public
-#                License (>=v2). Read the file COPYING that comes with GRASS
-#                for details.
-#
+# SPDX-FileCopyrightText: 2013-2014 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 

--- a/src/vector/v.convert.all/v.convert.all.py
+++ b/src/vector/v.convert.all/v.convert.all.py
@@ -6,12 +6,8 @@
 # AUTHOR(S):        Markus Neteler, converted to Python by Glynn Clements
 # PURPOSE:        converts all old GRASS < V5.7 vector maps to current format
 #                in current mapset
-# COPYRIGHT:        (C) 2004, 2008 by the GRASS Development Team
-#
-#                This program is free software under the GNU General Public
-#                License (>=v2). Read the file COPYING that comes with GRASS
-#                for details.
-#
+# SPDX-FileCopyrightText: 2004, 2008 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/vector/v.convert/main.c
+++ b/src/vector/v.convert/main.c
@@ -7,13 +7,8 @@
  * PURPOSE:      Convert GRASS vector maps versions:
  *               from 3 or 4 to 5.0
  *
- * COPYRIGHT:    (C) 2001 by the GRASS Development Team
- *
- *               This program is free software under the
- *               GNU General Public License (>=v2).
- *               Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2001 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  ****************************************************************/
 
 #include <stdio.h>

--- a/src/vector/v.db.pyupdate/v.db.pyupdate.py
+++ b/src/vector/v.db.pyupdate/v.db.pyupdate.py
@@ -8,12 +8,9 @@
 #
 # PURPOSE:      Update a column values using Python expressions
 #
-# COPYRIGHT:    (C) 2020 by Vaclav Petras and the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2020 Vaclav Petras
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 """Update GRASS GIS vector attributes using Python expressions.

--- a/src/vector/v.delaunay3d/main.cpp
+++ b/src/vector/v.delaunay3d/main.cpp
@@ -6,12 +6,9 @@
  *
  * PURPOSE:      Creates a 3D Delaunay triangulation vector map
  *
- * COPYRIGHT:    (C) 2013 by Martin Landa, and the GRASS Development Team
- *
- *               This program is free software under the GNU General
- *               Public License (>=v2). Read the file COPYING that
- *               comes with GRASS for details.
- *
+ * SPDX-FileCopyrightText: 2013 Martin Landa
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  ****************************************************************/
 
 #include <cstdlib>

--- a/src/vector/v.ellipse/main.c
+++ b/src/vector/v.ellipse/main.c
@@ -7,11 +7,9 @@
  * PURPOSE:      Computes the best-fitting ellipse for
  *               given vector data
  *
- * COPYRIGHT:    (C) 2015 by Tereza Fiedlerova, and the GRASS Development Team
- *
- *               This program is free software under the GNU General
- *               Public License (>=v2). Read the file COPYING that
- *               comes with GRASS for details.
+ * SPDX-FileCopyrightText: 2015 Tereza Fiedlerova
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  **************************************************************/
 
 #include <stdio.h>

--- a/src/vector/v.explode/v.explode.py
+++ b/src/vector/v.explode/v.explode.py
@@ -9,18 +9,9 @@
 #
 # PURPOSE:      "Explode" polylines, splitting them to separate lines
 #
-# COPYRIGHT:    (C) 2016 Alexander Muriy / GRASS Development Team
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
+# SPDX-FileCopyrightText: 2016 Alexander Muriy /
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ############################################################################
 # %Module
 # %  description: "Explode" polylines, splitting them to separate lines (uses v.split + v.category)

--- a/src/vector/v.external.all/v.external.all.py
+++ b/src/vector/v.external.all/v.external.all.py
@@ -4,12 +4,9 @@
 # MODULE:       v.external.all
 # AUTHOR(S):    Martin Landa
 # PURPOSE:      Links all OGR layers available in given OGR datasource.
-# COPYRIGHT:    (C) 2012 by Martin Landa, and the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2012 Martin Landa
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/vector/v.feature.algebra/map.c
+++ b/src/vector/v.feature.algebra/map.c
@@ -4,12 +4,8 @@
  * AUTHOR(S):    Christoph Simon (original contributor)
  *
  * PURPOSE:
- * COPYRIGHT:    (C) 2002 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2002 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdio.h>

--- a/src/vector/v.flexure/testsuite/test_v_flexure.py
+++ b/src/vector/v.flexure/testsuite/test_v_flexure.py
@@ -5,12 +5,9 @@
 # MODULE:       test_v_flexure
 # AUTHOR:       Andrew Wickert
 # PURPOSE:      Tests for v.flexure (point-load flexural isostasy)
-# COPYRIGHT:    (C) 2026 by Andrew Wickert and the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2026 Andrew Wickert
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ############################################################################
 
 """

--- a/src/vector/v.greedycolors/main.c
+++ b/src/vector/v.greedycolors/main.c
@@ -6,12 +6,8 @@
  *
  * PURPOSE:      Create greedy colors for vector areas
  *
- * COPYRIGHT:    (C) 2021 by the GRASS Development Team
- *
- *               This program is free software under the GNU General
- *               Public License (>=v2).  Read the file COPYING that
- *               comes with GRASS for details.
- *
+ * SPDX-FileCopyrightText: 2021 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  **************************************************************/
 
 #include <stdlib.h>

--- a/src/vector/v.in.ags/v.in.ags.py
+++ b/src/vector/v.in.ags/v.in.ags.py
@@ -10,8 +10,8 @@
 #            (which auto-pages and reprojects to the project CRS). An optional
 #            Esri Feature Buffer (PBF) fast path decodes features in-process.
 #
-# COPYRIGHT: (C) 2026 by Corey White and the GRASS Development Team
-#
+# SPDX-FileCopyrightText: 2026 Corey White
+# SPDX-FileCopyrightText: Other GRASS authors
 # SPDX-License-Identifier: GPL-2.0-or-later
 ##############################################################################
 

--- a/src/vector/v.in.geopaparazzi/v.in.geopaparazzi.py
+++ b/src/vector/v.in.geopaparazzi/v.in.geopaparazzi.py
@@ -6,12 +6,8 @@
 # AUTHOR(S):    Luca Delucchi
 #
 # PURPOSE:      Import data from Geopaparazzi database
-# COPYRIGHT:    (C) 2012 by the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2012 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 # %module
 # % description: Imports data from Geopaparazzi database.

--- a/src/vector/v.in.ply/main.c
+++ b/src/vector/v.in.ply/main.c
@@ -6,12 +6,8 @@
  *
  * PURPOSE:      Convert PLY (Polygon file format) files to GRASS vectors
  *
- * COPYRIGHT:    (C) 2011 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2011 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdio.h>

--- a/src/vector/v.in.redwg/entity.c
+++ b/src/vector/v.in.redwg/entity.c
@@ -7,13 +7,8 @@
  *
  *  PURPOSE:      Import of DWG files (using free software lib)
  *
- *  COPYRIGHT:    (C) 2001, 2010 by the GRASS Development Team
- *
- *                This program is free software under the
- *                GNU General Public License (>=v2).
- *                Read the file COPYING that comes with GRASS
- *                for details.
- *
+ * SPDX-FileCopyrightText: 2001, 2010 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * **************************************************************/
 
 /*

--- a/src/vector/v.in.redwg/global.h
+++ b/src/vector/v.in.redwg/global.h
@@ -7,13 +7,8 @@
  *
  *  PURPOSE:      Import of DWG/DXF files
  *
- *  COPYRIGHT:    (C) 2001, 2010 by the GRASS Development Team
- *
- *                This program is free software under the
- *                GNU General Public License (>=v2).
- *                Read the file COPYING that comes with GRASS
- *                for details.
- *
+ * SPDX-FileCopyrightText: 2001, 2010 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * **************************************************************/
 
 /* transformation, first level is 0 ( called from main ) and transformation

--- a/src/vector/v.in.redwg/main.c
+++ b/src/vector/v.in.redwg/main.c
@@ -7,13 +7,8 @@
  *
  *  PURPOSE:      Import of DWG files (using free software lib)
  *
- *  COPYRIGHT:    (C) 2001, 2010 by the GRASS Development Team
- *
- *                This program is free software under the
- *                GNU General Public License (>=v2).
- *                Read the file COPYING that comes with GRASS
- *                for details.
- *
+ * SPDX-FileCopyrightText: 2001, 2010 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * **************************************************************/
 
 #include <stdio.h>

--- a/src/vector/v.kriging/main.c
+++ b/src/vector/v.kriging/main.c
@@ -12,12 +12,9 @@
  *               Interpolation method Ordinary kriging has been extended for
  *               3D points (v = f(x,y) -> v = f(x,y,z)).
  *
- * COPYRIGHT:  (C) 2012-2014 Eva Stopková and by the GRASS Development Team
- *
- *        This program is free software under the GNU General Public
- *        License (>=v2). Read the file COPYING that
- *        comes with GRASS for details.
- *
+ * SPDX-FileCopyrightText: 2012-2014 Eva Stopková
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  **************************************************************/
 
 #include "local_proto.h"

--- a/src/vector/v.label.sa/annealing.c
+++ b/src/vector/v.label.sa/annealing.c
@@ -4,12 +4,8 @@
  * AUTHOR(S):    Wolf Bergenheim
  * PURPOSE:      This file contains functions which have to do with the
  *               annealing part of the algorithm.
- * COPYRIGHT:    (C) 2007 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2007 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include "labels.h"

--- a/src/vector/v.label.sa/main.c
+++ b/src/vector/v.label.sa/main.c
@@ -7,12 +7,8 @@
  *               This file contains the command line parsing and main function.
  *               The paint label file writing funtion (print_label()) is also
  *               part of this file.
- * COPYRIGHT:    (C) 2007 by the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2007 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <time.h>

--- a/src/vector/v.median/v.median.py
+++ b/src/vector/v.median/v.median.py
@@ -6,12 +6,8 @@
 # AUTHOR(S):    Luca Delucchi, Fondazione E. Mach (Italy)
 #
 # PURPOSE:      Return the barycenter of a cloud of point
-# COPYRIGHT:    (C) 2011 by the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2011 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 # %module
 # % description: Return the barycenter of a cloud of point.

--- a/src/vector/v.net.curvedarcs/v.net.curvedarcs.py
+++ b/src/vector/v.net.curvedarcs/v.net.curvedarcs.py
@@ -5,12 +5,8 @@
 # MODULE:       v.net.curvedarcs
 # AUTHOR(S):    Moritz Lennert
 # PURPOSE:      Draws curved arcs
-# COPYRIGHT:    (C) 2017 by the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2017 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 

--- a/src/vector/v.net.salesman.opt/main.c
+++ b/src/vector/v.net.salesman.opt/main.c
@@ -6,13 +6,8 @@
  *
  *  PURPOSE:      Create a cycle connecting given nodes.
  *
- *  COPYRIGHT:    (C) 2001-2011 by the GRASS Development Team
- *
- *                This program is free software under the
- *                GNU General Public License (>=v2).
- *                Read the file COPYING that comes with GRASS
- *                for details.
- *
+ * SPDX-FileCopyrightText: 2001-2011 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  **************************************************************/
 #include <stdlib.h>
 #include <string.h>

--- a/src/vector/v.nnstat/main.c
+++ b/src/vector/v.nnstat/main.c
@@ -10,12 +10,9 @@
  * PURPOSE:      Module indicates clusters, separations or random distribution
  *               of point set in 2D or 3D space.
  *
- * COPYRIGHT:    (C) 2013-2014 by Eva Stopková and the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2013-2014 Eva Stopková
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  **************************************************************/
 
 #include "local_proto.h"

--- a/src/vector/v.out.ply/main.c
+++ b/src/vector/v.out.ply/main.c
@@ -6,12 +6,8 @@
  *
  * PURPOSE:    Writes GRASS vector data as PLY files
  *
- * COPYRIGHT:  (C) 2011 by the GRASS Development Team
- *
- *             This program is free software under the GNU General
- *             Public License (>=v2). Read the file COPYING that comes
- *             with GRASS for details.
- *
+ * SPDX-FileCopyrightText: 2011 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdio.h>

--- a/src/vector/v.out.png/v.out.png.py
+++ b/src/vector/v.out.png/v.out.png.py
@@ -6,12 +6,8 @@
 # AUTHOR(S):    Luca Delucchi, Fondazione E. Mach (Italy)
 #
 # PURPOSE:      Pack up a vector map, collect vector map elements => gzip
-# COPYRIGHT:    (C) 2011 by the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2011 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/vector/v.profile.points/v.profile.points.py
+++ b/src/vector/v.profile.points/v.profile.points.py
@@ -10,12 +10,9 @@
 #               which is a point map but with x showing distance and y
 #               showing height
 #
-# COPYRIGHT:    (C) 2016 by Vaclav Petras and the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2016 Vaclav Petras
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #########################################################################
 
 # %module

--- a/src/vector/v.rast.move/v.rast.move.py
+++ b/src/vector/v.rast.move/v.rast.move.py
@@ -8,12 +8,9 @@
 #
 # PURPOSE:      Move individual vertices of features
 #
-# COPYRIGHT:    (C) 2023 by Vaclav Petras and the GRASS Development Team
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
-#
+# SPDX-FileCopyrightText: 2023 Vaclav Petras
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/vector/v.stats/v.stats.py
+++ b/src/vector/v.stats/v.stats.py
@@ -7,12 +7,8 @@
 #
 # AUTHOR(S):   Pietro Zambelli (University of Trento)
 #
-# COPYRIGHT:	(C) 2013 by the GRASS Development Team
-#
-# 		This program is free software under the GNU General Public
-# 		License (>=v2). Read the file COPYING that comes with GRASS
-# 		for details.
-#
+# SPDX-FileCopyrightText: 2013 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %Module

--- a/src/vector/v.stream.inbasin/testsuite/test_v_stream_inbasin.py
+++ b/src/vector/v.stream.inbasin/testsuite/test_v_stream_inbasin.py
@@ -1,11 +1,9 @@
 ##############################################################################
 # AUTHOR(S): Vaclav Petras <wenzeslaus gmail com>
 #
-# COPYRIGHT: (C) 2023 Vaclav Petras and the GRASS Development Team
-#
-#            This program is free software under the GNU General Public
-#            License (>=v2). Read the file COPYING that comes with GRASS
-#            for details.
+# SPDX-FileCopyrightText: 2023 Vaclav Petras
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ##############################################################################
 
 """Test v.stream.inbasin tool using grass.gunittest with NC SPM dataset"""

--- a/src/vector/v.stream.order/v.stream.order.py
+++ b/src/vector/v.stream.order/v.stream.order.py
@@ -11,12 +11,8 @@
 #
 # PURPOSE:      Compute the stream order of stream networks stored in
 #               a vector map at specific outlet vector points
-# COPYRIGHT:    (C) 2015 by the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2015 Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/vector/v.surf.mass/main.c
+++ b/src/vector/v.surf.mass/main.c
@@ -7,13 +7,9 @@
  * PURPOSE:      Mass-preserving area interpolation
  *               (Smooth Pycnophylactic Interpolation after Tobler 1979)
  *
- * COPYRIGHT:    (C) 2013 by by the GRASS Development Team
- *
- *               This program is free software under the
- *               GNU General Public License (>=v2).
- *               Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2013 by
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  **********************************************************************/
 
 #include <stdlib.h>

--- a/src/vector/v.surf.rst.cv/testsuite/test_v_surf_rast_cv.py
+++ b/src/vector/v.surf.rst.cv/testsuite/test_v_surf_rast_cv.py
@@ -7,11 +7,9 @@
 # PURPOSE:      Performs cross-validation proceedure to optimize the
 #               parameterization of v.surf.rst tension and smoothing
 #               paramters.
-# COPYRIGHT:    (C) 2025 OpenPlains Inc. and the GRASS Development Team
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2025 OpenPlains Inc.
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 import os

--- a/src/vector/v.surf.rst.cv/v.surf.rst.cv.py
+++ b/src/vector/v.surf.rst.cv/v.surf.rst.cv.py
@@ -7,11 +7,9 @@
 # PURPOSE:      Cross-validation of procedures for optimizing regularized spline
 #               with tension interpolation (RST) smoothing and tension parameters
 #               for use with v.surf.rst.
-# COPYRIGHT:    (C) 2025 OpenPlains Inc. and the GRASS Development Team
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2025 OpenPlains Inc.
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 # %module

--- a/src/vector/v.surf.tps/main.c
+++ b/src/vector/v.surf.tps/main.c
@@ -6,13 +6,9 @@
  *
  * PURPOSE:      Thin Plate Spline interpolation with covariables
  *
- * COPYRIGHT:    (C) 2016 by by the GRASS Development Team
- *
- *               This program is free software under the
- *               GNU General Public License (>=v2).
- *               Read the file COPYING that comes with GRASS
- *               for details.
- *
+ * SPDX-FileCopyrightText: 2016 by
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  **********************************************************************/
 
 #include <stdlib.h>

--- a/src/vector/v.tin.to.rast/v.tin.to.rast.py
+++ b/src/vector/v.tin.to.rast/v.tin.to.rast.py
@@ -14,13 +14,9 @@
 #
 # PURPOSE:    Converts (rasterize) a TIN map into a raster map
 #
-# COPYRIGHT:  (C) 2011-2015 Antonio Alliegro, 2015 Alexander Muriy,
-#             and the GRASS Development Team
-#
-#             This program is free software under the GNU General
-#             Public License (>=v2). Read the file COPYING that
-#             comes with GRASS for details.
-#
+# SPDX-FileCopyrightText: 2011-2015 Antonio Alliegro, 2015 Alexander Muriy
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ############################################################################
 
 # %module

--- a/src/vector/v.to.rast.multi/v.to.rast.multi.py
+++ b/src/vector/v.to.rast.multi/v.to.rast.multi.py
@@ -4,18 +4,9 @@
 # MODULE:       v.to.rast.multi
 # AUTHOR(S):    Stefan Blumentrath
 # PURPOSE:      Create multiple raster maps from attribute columns in a vector map
-# COPYRIGHT:    (C) 2022 by Stefan Blumentrath, and the GRASS Development Team
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
+# SPDX-FileCopyrightText: 2022 Stefan Blumentrath
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ############################################################################
 
 # %module

--- a/src/vector/v.vect.stats.multi/v.vect.stats.multi.py
+++ b/src/vector/v.vect.stats.multi/v.vect.stats.multi.py
@@ -5,12 +5,9 @@
 # MODULE:    v.vect.stats.multi
 # AUTHOR(S): Vaclav Petras
 # PURPOSE:   Compute statistics for multiple columns using v.vect.stats
-# COPYRIGHT: (C) 2020 by Vaclav Petras and the GRASS Development Team
-#
-#                This program is free software under the GNU General Public
-#                License (>=v2). Read the file COPYING that comes with GRASS
-#                for details.
-#
+# SPDX-FileCopyrightText: 2020 Vaclav Petras
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #############################################################################
 
 """Compute zonal statistics for each column."""

--- a/src/vector/v.vol.idw/main.c
+++ b/src/vector/v.vol.idw/main.c
@@ -4,12 +4,8 @@
  * AUTHOR(S):    Original s.to.rast3: Jaro Hofierka, Geomodel s.r.o. (original
  *               contributor) 3/2015 Upgrade to GRASS GIS 7 by Noortheen Raja J
  * PURPOSE:      Converts vector points to 3D raster
- * COPYRIGHT:    (C) 1999-2015 by the GRASS Development Team
- *
- *               This program is free software under the GNU General
- *               Public License (>=v2). Read the file COPYING that
- *               comes with GRASS for details.
- *
+ * SPDX-FileCopyrightText: 1999-2015 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *****************************************************************************/
 
 #include <stdlib.h>

--- a/src/vector/v.what.rast.label/v.what.rast.label.py
+++ b/src/vector/v.what.rast.label/v.what.rast.label.py
@@ -7,11 +7,9 @@
 # PURPOSE:      Upload raster values and labels at positions of vector points
 #               to the vector attribute table.
 #
-# COPYRIGHT: (C) 2016-2022 by Paulo van Breugel and the GRASS Development Team
-#
-#        This program is free software under the GNU General Public
-#        License (>=v2). Read the file COPYING that comes with GRASS
-#        for details.
+# SPDX-FileCopyrightText: 2016-2022 Paulo van Breugel
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ##############################################################################
 
 # %module

--- a/src/vector/v.what.rast.multi/v.what.rast.multi.py
+++ b/src/vector/v.what.rast.multi/v.what.rast.multi.py
@@ -6,18 +6,9 @@
 # AUTHOR(S):    Pierre Roudier
 # PURPOSE:      Uploads values of multiple rasters at positions of vector
 #               points to the table.
-# COPYRIGHT:    (C) 2017 by Pierre Roudier, and the GRASS Development Team
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
+# SPDX-FileCopyrightText: 2017 Pierre Roudier
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ############################################################################
 
 # %module

--- a/src/vector/v.what.spoly/v.what.spoly.py
+++ b/src/vector/v.what.spoly/v.what.spoly.py
@@ -9,18 +9,9 @@
 #
 # PURPOSE:      Queries vector map with overlaping "spaghetti" polygons (e.g. Landsat footprints) at given location
 #
-# COPYRIGHT:    (C) 2016 Alexander Muriy / GRASS Development Team
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
+# SPDX-FileCopyrightText: 2016 Alexander Muriy /
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 ############################################################################
 # %Module
 # %  description: Queries vector map with overlapping "spaghetti" polygons (e.g. Landsat footprints) at given location. Polygons must have not intersected boundaries.


### PR DESCRIPTION
This PR implements the same solution that was described https://github.com/OSGeo/grass/pull/7729.

This PR replaces the old style license declarations with the standardized SPDX License short identifiers.

What was done:
Converted COPYRIGHT: (C) headers to SPDX-FileCopyrightText +
SPDX-License-Identifier: GPL-2.0-or-later across 329 source files.
"GRASS Development Team" → "Other GRASS authors". Named holders
preserved verbatim.

Skipped (unchanged): 8 files with COPYRIGHT past line 30, 6
institutional/third-party files, 1 Fortran file, 1 file with
"for the GRASS Development Team" phrasing, 1 wrapped-copyright
file, 116 files with extra content between GPL prose and closing
delimiter. Text file with these files appended: [skipped_files.txt](https://github.com/user-attachments/files/30079948/skipped_files.txt)

Co-authored-by: Vaclav Petras [wenzeslaus@gmail.com](mailto:wenzeslaus@gmail.com)
Co-authored-by: Markus Neteler [neteler@mundialis](mailto:neteler@mundialis)