### PR TITLE
CI: manual deployment script updates

### DIFF
--- a/utils/cronjobs_osgeo_lxd/fetch_unpack_manual_GHA.sh
+++ b/utils/cronjobs_osgeo_lxd/fetch_unpack_manual_GHA.sh
@@ -22,22 +22,28 @@ GRASSSDEVEL=86
 
 cd $HOME
 # fetch artifact stable
+echo "## Processing grass${GRASSSTABLE} / grass-stable manual pages..."
 bash /home/neteler/cronjobs/gh_cli_download_artifact.sh releasebranch_8_5
-# unpack stable-version
-cd /var/www/code_and_data/grass${GRASSSTABLE}/manuals/ && rm -rf * && unzip -q /tmp/mkdocs-site.zip
+# unpack stable-version: due to the needed SEO meta canonical injection we keep it "duplicated"
+cd /var/www/code_and_data/grass${GRASSSTABLE}/manuals/ && rm -rf * && unzip -q /tmp/releasebranch_8_5.zip
+cd /var/www/code_and_data/grass-stable/manuals/ && rm -rf * && unzip -q /tmp/releasebranch_8_5.zip
 
 ####
 
 # fetch artifact devel
+echo "## Processing grass${GRASSSDEVEL} / grass-devel manual pages..."
 bash /home/neteler/cronjobs/gh_cli_download_artifact.sh main
-# unpack devel-version
-cd /var/www/code_and_data/grass${GRASSSDEVEL}/manuals/ && rm -rf * && unzip -q /tmp/mkdocs-site.zip
+# unpack devel-version: due to the needed SEO meta canonical injection we keep it "duplicated"
+cd /var/www/code_and_data/grass${GRASSSDEVEL}/manuals/ && rm -rf * && unzip -q /tmp/main.zip
+cd /var/www/code_and_data/grass-devel/manuals/ && rm -rf * && unzip -q /tmp/main.zip
 
 ####
 
 # if run as "neteler", grant write access also to "grassbot" user
 chmod -R g+rw /var/www/code_and_data/grass${GRASSSTABLE}/manuals/* \
-              /var/www/code_and_data/grass${GRASSSDEVEL}/manuals/*
+              /var/www/code_and_data/grass-stable/manuals/* \
+              /var/www/code_and_data/grass${GRASSSDEVEL}/manuals/* \
+              /var/www/code_and_data/grass-devel/manuals/*
 
 # cleanup the artifact file
-rm -f /tmp/mkdocs-site.zip
+rm -f /tmp/releasebranch_8_5.zip /tmp/main.zip


### PR DESCRIPTION
Fixes hotfix of `fetch_unpack_manual_GHA.sh` (PR #1795) to reflect that we need to keep the version-numbered manual URL and "grass-stable/grass-devel" named manual URL separate for the injection of SEO canonical meta stuff.

Also fixes the artifact ZIP file names.