### PR TITLE
r.learn.predict: catch error when group or model not existing

### DIFF
--- a/src/raster/r.learn.ml2/r.learn.predict/r.learn.predict.py
+++ b/src/raster/r.learn.ml2/r.learn.predict/r.learn.predict.py
@@ -117,7 +117,10 @@ def main():
 
     # reload fitted model and training data
     gs.message("Loading fitted model and training data ...")
-    estimator, y, class_labels = joblib.load(model_load)
+    try:
+        estimator, y, class_labels = joblib.load(model_load)
+    except FileNotFoundError:
+        gs.fatal("Model file <{model}> not found.".format(model=model_load))
 
     # define RasterStack
     stack = RasterStack(group=group)

--- a/src/raster/r.learn.ml2/rlearnlib/raster.py
+++ b/src/raster/r.learn.ml2/rlearnlib/raster.py
@@ -4,6 +4,7 @@ import os
 from subprocess import PIPE
 
 import grass.script as gs
+from grass.exceptions import CalledModuleError
 import numpy as np
 from grass.pygrass.gis.region import Region
 from grass.pygrass.modules.shortcuts import general as g
@@ -77,21 +78,17 @@ class RasterStack(StatisticsMixin):
             gs.fatal('arguments "rasters" and "group" are mutually exclusive')
 
         if group:
-            groups_in_mapset = (
-                g.list(type="group", stdout_=PIPE)
-                .outputs.stdout.strip()
-                .split(os.linesep)
-            )
-            groups_in_mapset = [i.split("@")[0] for i in groups_in_mapset]
-            group = group.split("@")[0]
-
-            if group not in groups_in_mapset:
-                gs.fatal("Imagery group {group} does not exist".format(group=group))
-            else:
+            try:
                 map_list = im.group(
                     group=group, flags=["l", "g"], quiet=True, stdout_=PIPE
                 )
-                rasters = map_list.outputs.stdout.strip().split(os.linesep)
+            except CalledModuleError:
+                gs.fatal(
+                    "Imagery group <{group}> not found. Make sure it exists.".format(
+                        group=group
+                    )
+                )
+            rasters = map_list.outputs.stdout.strip().split(os.linesep)
 
         self.layers = rasters  # call property
 


### PR DESCRIPTION
This PR fixes Python errorswhen group or model are not existing.

Example:

```sh
r.learn.predict group=bla load_model=rf_model.gz output=rf_classification
Loading fitted model and training data ...
Traceback (most recent call last):
  File "/home/mneteler/.grass8/addons/scripts/r.learn.predict", line 167, in <module>
    main()
    ~~~~^^
  File "/home/mneteler/.grass8/addons/scripts/r.learn.predict", line 120, in main
    estimator, y, class_labels = joblib.load(model_load)
                                 ~~~~~~~~~~~^^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/joblib/numpy_pickle.py", line 735, in load
    with open(filename, "rb") as f:
         ~~~~^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'rf_model.gz'
```

With this PR:

```sh
r.learn.predict group=bla load_model=rf_model.gz output=rf_classification
Loading fitted model and training data ...
ERROR: Model file <rf_model.gz> not found.
```

AI assisted with Deepseek4/opencode.