### PR TITLE
r.stream.basins: fix ad-hoc size limitation of the outlets

### DIFF
--- a/src/raster/r.stream.basins/basins_inputs.c
+++ b/src/raster/r.stream.basins/basins_inputs.c
@@ -124,13 +124,10 @@ int ram_process_streams(char **cat_list, CELL **streams, int number_of_streams,
         for (c = 0; c < ncols; ++c) {
             streams_cell = streams[r][c];
             if (streams_cell > 0) {
-                if (outlets_num > 6 * (out_max - 1))
-                    G_fatal_error(
-                        _("Stream and direction maps probably do not match"));
-
-                if (outlets_num > (out_max - 1)) {
+                if (outlets_num >= out_max) {
+                    out_max *= 2;
                     outlets = (OUTLET *)G_realloc(outlets,
-                                                  out_max * 6 * sizeof(OUTLET));
+                                                  out_max * sizeof(OUTLET));
                 }
 
                 dirs_cell = dirs[r][c];


### PR DESCRIPTION
I wanted to adapt the analysis for country level or even continental level DEM processing. The earlier limit was ad-hoc and served for small to medium area of interest analysis.