### PR TITLE
cronjob: fix manuals 403 and cross-user /tmp collision

### DIFF
--- a/utils/cronjobs_osgeo_lxd/fetch_unpack_manual_GHA.sh
+++ b/utils/cronjobs_osgeo_lxd/fetch_unpack_manual_GHA.sh
@@ -15,10 +15,22 @@
 # - executes gh_cli_download_artifact.sh
 # - unpacks the Documentation artifact both in grass85 and grass-devel dirs on the server
 #
+# NOTE: one-time server-side setup (cannot be done from this job): the target
+# manuals directories themselves must be writable by every user running this
+# job, e.g. shared group ownership with g+ws on the directories
+#
 #########
 
 GRASSSTABLE=85
 GRASSSDEVEL=86
+
+# per-user directory for artifact ZIPs and staging: the job runs as different
+# users (neteler, grassbot, ...) and a shared /tmp path lets one user's
+# leftover file block another user's run (sticky /tmp forbids replacing it);
+# gh_cli_download_artifact.sh honors this variable for its output path
+OUTPUT_DIR="${OUTPUT_DIR:-${TMPDIR:-/tmp}/grass_manuals_${USER}}"
+export OUTPUT_DIR
+mkdir -p "$OUTPUT_DIR" || exit 1
 
 cd "$HOME" || exit 1
 
@@ -28,7 +40,7 @@ cd "$HOME" || exit 1
 fetch_and_unpack () {
   BRANCH=$1
   shift
-  ZIP="/tmp/${BRANCH}.zip"
+  ZIP="$OUTPUT_DIR/${BRANCH}.zip"
 
   # fetch artifact; do not touch the existing manuals if the download failed
   # (e.g. "gh: Artifact has expired (HTTP 410)")
@@ -45,15 +57,23 @@ fetch_and_unpack () {
   fi
 
   # unpack into a staging directory first
-  STAGING=$(mktemp -d "/tmp/${BRANCH}.XXXXXX")
+  STAGING=$(mktemp -d "$OUTPUT_DIR/${BRANCH}.XXXXXX")
   if ! unzip -q "$ZIP" -d "$STAGING"; then
     echo "ERROR: Failed to unpack <$ZIP>, keeping existing manuals."
     rm -rf "$STAGING"
     return 1
   fi
 
+  # GitHub artifact ZIPs carry no unix permissions, so unzip creates files
+  # per the cron user's umask; make everything world-readable so the web
+  # server can serve it (a restrictive umask otherwise leads to 403 errors)
+  chmod -R u+rwX,g+rwX,o+rX "$STAGING"
+
   for TARGET in "$@"; do
     rm -rf "${TARGET:?}"/* && cp -a "$STAGING"/. "$TARGET"/
+    # keep the tree group-writable so the other job users (e.g. "grassbot"
+    # when run as "neteler") can replace it on the next run
+    chmod -R a+rX,g+w "$TARGET"
   done
 
   # cleanup staging directory and artifact file
@@ -81,11 +101,5 @@ fetch_and_unpack main \
   /var/www/code_and_data/grass-devel/manuals || STATUS=1
 
 ####
-
-# if run as "neteler", grant write access also to "grassbot" user
-chmod -R g+rw /var/www/code_and_data/grass${GRASSSTABLE}/manuals/* \
-              /var/www/code_and_data/grass-stable/manuals/* \
-              /var/www/code_and_data/grass${GRASSSDEVEL}/manuals/* \
-              /var/www/code_and_data/grass-devel/manuals/*
 
 exit $STATUS

--- a/utils/cronjobs_osgeo_lxd/gh_cli_download_artifact.sh
+++ b/utils/cronjobs_osgeo_lxd/gh_cli_download_artifact.sh
@@ -41,10 +41,13 @@ REPO_LOCAL="$HOME/src/$MYBRANCH/"       # e.g., neteler@grasslxd:~/src/main/ or 
 WORKFLOW_NAME="documentation.yml"  # or the workflow filename/id
 ARTIFACT_NAME="mkdocs-site" # the name of the artifact
 ZIP_OUTPUT="${MYBRANCH}.zip"  # must match the path expected by fetch_unpack_manual_GHA.sh
-OUTPUT_DIR="/tmp"
+# per-user directory: the job runs as different users (neteler, grassbot, ...)
+# and a shared /tmp path lets one user's leftover file block another user's run
+OUTPUT_DIR="${OUTPUT_DIR:-${TMPDIR:-/tmp}/grass_manuals_${USER}}"
 
 # === Script ===
 # cleanup from previous run
+mkdir -p "$OUTPUT_DIR" || exit 1
 cd "$OUTPUT_DIR" || exit 1
 rm -f "$ZIP_OUTPUT"
 


### PR DESCRIPTION
Follow-up to 
- #1803.
- https://github.com/OSGeo/grass/issues/7765

The deployed manual pages returned 403 Forbidden because the GitHub artifact ZIPs carry no unix permissions, so unzip created files per the cron user's umask and nothing granted world-read access. We now normalize permissions on the staging tree and on each deployed target (a+rX,g+w) by using a per-user artifact/staging directory instead of fixed /tmp paths, so jobs run by different users  can no longer block each other via leftover files in /tmp.

