### PR TITLE
i.sentinel.download: use mapped product type for ID search

### DIFF
--- a/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
+++ b/src/imagery/i.sentinel/i.sentinel.download/i.sentinel.download.py
@@ -427,7 +427,7 @@ def main():
                     id=options["id"],
                     output=outdir,
                     provider=eodag_provider,
-                    producttype=options["producttype"],
+                    producttype=eodag_producttype,
                     footprints=options["footprints"],
                 )
             )


### PR DESCRIPTION
## Description

When searching for a product by `id`, the module passes the GRASS product type name to `i.eodag`.

For example, `S2MSI2A` is passed instead of the EODAG product type `S2_MSI_L2A`, causing the search to fail.

## Testing

Tested with a Sentinel-2 L2A product. The product was successfully found and downloaded after the change.