### PR TITLE
i.landsat8.swlst: fix namedtuple use with duplicated keys

### DIFF
--- a/src/imagery/i.landsat8.swlst/landsat8_mtl.py
+++ b/src/imagery/i.landsat8.swlst/landsat8_mtl.py
@@ -118,7 +118,7 @@ class Landsat8_MTL:
             field_values.append(field_value)
 
         # named tuple
-        named_tuple = namedtuple(name_for_tuple, field_names)
+        named_tuple = namedtuple(name_for_tuple, field_names, rename=True)
 
         # return named tuple
         return named_tuple(*field_values)


### PR DESCRIPTION
Since the creation of the addon, the metadata have changed and they include some duplicated keys. However, these keys are not used within the addon - this simply renames them to make the addon work.