### PR TITLE
r.random.walk: Fix divison by zero error when nproc is 0

### DIFF
--- a/src/raster/r.random.walk/r.random.walk.py
+++ b/src/raster/r.random.walk/r.random.walk.py
@@ -355,8 +355,6 @@ def run_parallel(
     tmp_rasters, processes, directions, boundary, steps, avoid, path_sampling, memory
 ):
     gs.message(_("Smoothed Walk"))
-    max_cpus = os.cpu_count() - 1
-    gs.message(_("Max CPUs: {0}, Used CPUs: {1}").format(max_cpus, processes))
     start_pos = False
     if path_sampling:
         start_pos = starting_position(boundary[0], boundary[1])
@@ -412,7 +410,17 @@ def main():
     gs.message(_("Region with {0} rows and {1} columns").format(rows, cols))
     boundary = [rows, cols]
     path_sampling = flags["t"]
+
     processes = int(options["nprocs"])
+    if hasattr(gs, "resolve_nprocs"):  # added in GRASS 8.6
+        processes = gs.resolve_nprocs(processes)
+    elif processes <= 0:
+        # 0 means all cores, negative means cpu_count + nprocs
+        cpus = os.cpu_count() or 1
+        processes = max(1, cpus + processes) if processes < 0 else cpus
+
+    gs.verbose(_("Using {0} parallel processes").format(processes))
+
     smooth = int(options["nwalkers"])
     _tmp_rasters = [f"{PREFIX}{i}" for i in range(0, smooth)]
     TMP_RASTERS.append(_tmp_rasters)

--- a/src/raster/r.random.walk/testsuite/test_r_random_walk.py
+++ b/src/raster/r.random.walk/testsuite/test_r_random_walk.py
@@ -120,6 +120,26 @@ class TestRandomWalk(TestCase):
             flags="st",
         )
 
+    def test_random_walk_nprocs_zero(self):
+        """Test that nprocs=0 resolves to all cores instead of failing"""
+        self.assertModule(
+            "r.random.walk",
+            output=self.random_walk,
+            steps=1000,
+            seed=0,
+            nprocs=0,
+        )
+
+    def test_random_walk_nprocs_negative(self):
+        """Test that a negative nprocs resolves to cpu_count + nprocs"""
+        self.assertModule(
+            "r.random.walk",
+            output=self.random_walk,
+            steps=1000,
+            seed=0,
+            nprocs=-1,
+        )
+
     def test_take_step_dir_4(self):
         """
         Tests 4 directional step


### PR DESCRIPTION
Fix DivisionByZero error when nproc is set to 0 found in issue #1831 