### PR TITLE
t.stac: Use get_lib_path from grass.script.utils

### DIFF
--- a/src/temporal/t.stac/libstac/testsuite/test_staclib.py
+++ b/src/temporal/t.stac/libstac/testsuite/test_staclib.py
@@ -7,7 +7,7 @@ import json
 import grass.script as gs
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-from grass.pygrass.utils import get_lib_path
+from grass.script.utils import get_lib_path
 from grass.pygrass.vector.geometry import Point
 from grass.exceptions import CalledModuleError
 from unittest.mock import patch, MagicMock

--- a/src/temporal/t.stac/t.stac.catalog/t.stac.catalog.py
+++ b/src/temporal/t.stac/t.stac.catalog/t.stac.catalog.py
@@ -74,7 +74,7 @@ from io import StringIO
 from contextlib import contextmanager
 from pprint import pprint
 import grass.script as gs
-from grass.pygrass.utils import get_lib_path
+from grass.script.utils import get_lib_path
 
 
 @contextmanager

--- a/src/temporal/t.stac/t.stac.collection/t.stac.collection.py
+++ b/src/temporal/t.stac/t.stac.collection/t.stac.collection.py
@@ -82,7 +82,7 @@ from io import StringIO
 from pprint import pprint
 from contextlib import contextmanager
 import grass.script as gs
-from grass.pygrass.utils import get_lib_path
+from grass.script.utils import get_lib_path
 
 
 @contextmanager

--- a/src/temporal/t.stac/t.stac.item/t.stac.item.py
+++ b/src/temporal/t.stac/t.stac.item/t.stac.item.py
@@ -269,7 +269,7 @@ import json
 import gettext
 from contextlib import contextmanager
 import grass.script as gs
-from grass.pygrass.utils import get_lib_path
+from grass.script.utils import get_lib_path
 
 # Set up translation function
 _ = gettext.gettext


### PR DESCRIPTION
Switches _get_lib_path_ imports in _t.stac.catalog_, _t.stac.collection_, _t.stac.item_, and the libstac testsuite from grass.pygrass.utils to grass.script.utils.

The pygrass version delegates to grass.script.utils.get_lib_path (marked deprecated since 7.1), but importing it loads grass.lib.gis through ctypes at module import time. That import runs during HTML doc generation when g.extension compiles the addon, and under the CMake build system the doc subprocess is not given LD_LIBRARY_PATH, so the library load fails and the install aborts:

```
ImportError: Could not load grass_gis.
gmake[2]: *** [t.stac.catalog/CMakeFiles/t.stac.catalog-docs.dir/build.make:74: output/docs/html/t.stac.catalog.html] Error 1
```

Observed with conda-forge GRASS 8.5.0 in Google Colab. The grass.script.utils implementation is pure Python, so the tools no longer depend on the dynamic loader at import time and doc generation succeeds regardless of the build environment.

[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ncsu-geoforall-lab/GIS582-assignments/blob/main/2AB%20-%20Geospatial%20Data/2A_Tutorial.ipynb)

The underlying CMake gap is filed separately as [OSGeo/grass#7850](https://github.com/OSGeo/grass/issues/7850); this change is worthwhile on its own since the scripts only need the path lookup, not pygrass.

No functional change to the tools.