### PR TITLE
contributing: Fix dead links in UNIT_TESTS.md and cover pytest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,8 +105,8 @@ the test needs the `nc_spm` sample dataset. CI runs the full gunittest suite
 against `nc_spm` (`.github/workflows/test.sh`, which calls
 `python3 -m grass.gunittest.main ... --min-success`). To run one suite,
 install the addon (the *g.extension* command above), start a GRASS session,
-and run it as described in the core `AGENTS.md`. This repository's
-[`UNIT_TESTS.md`](doc/development/submitting/UNIT_TESTS.md) is outdated.
+and run it as described in the core `AGENTS.md`. See also this repository's
+[`UNIT_TESTS.md`](doc/development/submitting/UNIT_TESTS.md).
 
 ## Linting, documentation, and commits
 

--- a/doc/development/submitting/UNIT_TESTS.md
+++ b/doc/development/submitting/UNIT_TESTS.md
@@ -25,14 +25,22 @@ sudo dnf install grass-devel
 
 If you have not done so yet, it is also helpful to install pre-commit. Follow
 [the
-instructions](https://github.com/OSGeo/grass/blob/main/doc/development/submitting/submitting.md#use-pre-commit)
+instructions](https://github.com/OSGeo/grass/blob/main/doc/development/style_guide.md#using-pre-commit)
 in the main GRASS repository.
 
 ## Create a unit test
 
-Unit tests must be stored in a subfolder named `testsuite` inside the add-on
-folder. For example, if you contributed a raster module named `r.mymodule` you
-would run:
+There are two testing frameworks. Tests written with _pytest_, which is
+preferred for new tests, are stored in a subfolder named `tests` inside the
+add-on folder. Tests written with the older _grass.gunittest_ framework, which
+is needed when the test uses the North Carolina sample dataset, are stored in a
+subfolder named `testsuite`. The rest of this page describes
+_grass.gunittest_; for _pytest_, see the
+[testing documentation](https://github.com/OSGeo/grass/blob/main/doc/development/testing.md)
+in the main GRASS repository, which applies to add-ons as well.
+
+For example, if you contributed a raster module named `r.mymodule` you would
+run:
 
 ```bash
 cd src/raster/r.mymodule
@@ -82,7 +90,7 @@ python testsuite/test_mymodule.py
 ## Submit a unit test
 
 The [general contribution
-guidelines](https://github.com/OSGeo/grass-addons/blob/master/CONTRIBUTING.md#changing-code-and-documentation)
+guidelines](https://github.com/OSGeo/grass-addons/blob/grass8/CONTRIBUTING.md#changing-code-and-documentation)
 apply to unit tests. In case you are submitting a new add-on, the unit tests
 should feature in the pull request with the module itself. Otherwise submit the
 unit tests in a dedicated pull request to facilitate the work of the reviewers.


### PR DESCRIPTION
UNIT_TESTS.md is the file which holds the testing documentation for addon contributors at this point, and CONTRIBUTING.md points at it. It described gunittest only and stated that unit tests must be stored in testsuite. This is no longer true and 24 addons already have pytest suites in tests/ directories and CI runs them.

This describes both frameworks, says pytest is preferred for new tests, and links to testing.md in the main repository for the conventions rather than restating them.

It also fixes the pre-commit link to style_guide.md and the contribution guidelines link to the grass8 branch. AGENTS.md no longer calls UNIT_TESTS.md outdated, since it no longer is.

This change was drafted with the help of Claude Code (Fable 5).

<details>
<summary><b>Details (AI-generated)</b></summary>

### Content

The Create a unit test section now says pytest goes in `tests/` and is preferred for new tests, gunittest goes in `testsuite/`, and links to `doc/development/testing.md` in the main repository. The rest of the page still describes gunittest, which remains the right choice when a test uses the North Carolina sample dataset or needs data supplied as files.

### Links

The pre-commit instructions pointed at `doc/development/submitting/submitting.md#use-pre-commit` in OSGeo/grass. That file does not exist and there is no `submitting` directory; the content is now in `style_guide.md#using-pre-commit`, which is what core `CONTRIBUTING.md` links. The contribution guidelines link used `blob/master`, while the branch is `grass8`, as `README.md` already uses.

### Not in this PR

`UNIT_TESTS.md` says "module" throughout where current GRASS terminology would say "tool", and "add-on" rather than "addon". Changing only the lines this PR touches would leave the file inconsistent with itself, so a terminology pass is left for its own change.

### Verification

Every link in the file was checked against the current core repository and the current branch layout.

</details>
