### PR TITLE
r.stream: Fix segment calculation forcing swap mode

### DIFF
--- a/src/raster/r.stream.basins/main.c
+++ b/src/raster/r.stream.basins/main.c
@@ -156,8 +156,8 @@ int main(int argc, char *argv[])
 
     number_of_segs = (int)(number_of_segs / seg_size);
 
-    number_of_segs_total =
-        (nrows / SROWS + nrows % SROWS) * (ncols / SCOLS + ncols % SCOLS);
+    number_of_segs_total = (nrows / SROWS + (nrows % SROWS ? 1 : 0)) *
+                           (ncols / SCOLS + (ncols % SCOLS ? 1 : 0));
 
     if (!segmentation) {
         /* force use of the segment version

--- a/src/raster/r.stream.channel/main.c
+++ b/src/raster/r.stream.channel/main.c
@@ -156,8 +156,8 @@ int main(int argc, char *argv[])
 
     number_of_segs = (int)(number_of_segs / seg_size);
 
-    number_of_segs_total =
-        (nrows / SROWS + nrows % SROWS) * (ncols / SCOLS + ncols % SCOLS);
+    number_of_segs_total = (nrows / SROWS + (nrows % SROWS ? 1 : 0)) *
+                           (ncols / SCOLS + (ncols % SCOLS ? 1 : 0));
 
     if (!segmentation) {
         /* force use of the segment version

--- a/src/raster/r.stream.distance/main.c
+++ b/src/raster/r.stream.distance/main.c
@@ -161,8 +161,8 @@ int main(int argc, char *argv[])
 
     number_of_segs = (int)(number_of_segs / seg_size);
 
-    number_of_segs_total =
-        (nrows / SROWS + nrows % SROWS) * (ncols / SCOLS + ncols % SCOLS);
+    number_of_segs_total = (nrows / SROWS + (nrows % SROWS ? 1 : 0)) *
+                           (ncols / SCOLS + (ncols % SCOLS ? 1 : 0));
 
     if (!segmentation) {
         /* force use of the segment version

--- a/src/raster/r.stream.order/main.c
+++ b/src/raster/r.stream.order/main.c
@@ -176,8 +176,8 @@ int main(int argc, char *argv[])
 
     number_of_segs = (int)(number_of_segs / seg_size);
 
-    number_of_segs_total =
-        (nrows / SROWS + nrows % SROWS) * (ncols / SCOLS + ncols % SCOLS);
+    number_of_segs_total = (nrows / SROWS + (nrows % SROWS ? 1 : 0)) *
+                           (ncols / SCOLS + (ncols % SCOLS ? 1 : 0));
 
     if (!segmentation) {
         /* force use of the segment version

--- a/src/raster/r.stream.segment/main.c
+++ b/src/raster/r.stream.segment/main.c
@@ -146,8 +146,8 @@ int main(int argc, char *argv[])
 
     number_of_segs = (int)(number_of_segs / seg_size);
 
-    number_of_segs_total =
-        (nrows / SROWS + nrows % SROWS) * (ncols / SCOLS + ncols % SCOLS);
+    number_of_segs_total = (nrows / SROWS + (nrows % SROWS ? 1 : 0)) *
+                           (ncols / SCOLS + (ncols % SCOLS ? 1 : 0));
 
     if (!segmentation) {
         /* force use of the segment version

--- a/src/raster/r.stream.stats/main.c
+++ b/src/raster/r.stream.stats/main.c
@@ -116,8 +116,8 @@ int main(int argc, char *argv[])
 
     number_of_segs = (int)(number_of_segs / seg_size);
 
-    number_of_segs_total =
-        (nrows / SROWS + nrows % SROWS) * (ncols / SCOLS + ncols % SCOLS);
+    number_of_segs_total = (nrows / SROWS + (nrows % SROWS ? 1 : 0)) *
+                           (ncols / SCOLS + (ncols % SCOLS ? 1 : 0));
 
     if (!segmentation) {
         /* force use of the segment version


### PR DESCRIPTION
## Description
In `r.stream.basins`, `r.stream.channel`, `r.stream.distance`, `r.stream.order`, `r.stream.segment`, and `r.stream.stats`, the automatic check determining whether the raster maps fit in RAM or require fallback to segmented disk-swapping mode (`-m`) evaluated the required number of segments as:

```c
number_of_segs_total =
    (nrows / SROWS + nrows % SROWS) * (ncols / SCOLS + ncols % SCOLS);
```

Instead of performing ceiling division (`ceil(nrows / SROWS)`), this formula directly added the remainder `nrows % SROWS` and `ncols % SCOLS` to the quotient.

Because `SROWS` and `SCOLS` are `128`, whenever `nrows % 128 > 0` or `ncols % 128 > 0`, the remainder (up to 127) was added directly. For instance:
- **NC SPM sample dataset (60x60 grid):** requires 1 tile (`~0.125 MB`), but computed `(0 + 60) * (0 + 60) = 3600` tiles (`~450 MB`). With default `memory=300` (max 2400 tiles), `3600 > 2400` erroneously forced `segmentation = 1` (disk swapping) for a 3.6 KB raster.
- **500x500 grid:** requires 16 tiles (`~2 MB`), but computed `(3 + 116) * (3 + 116) = 14161` tiles (`~1.77 GB`), erroneously forcing disk-swapping mode.

This PR corrects the calculation across all 6 modules to standard ceiling division:
```c
number_of_segs_total = (nrows / SROWS + (nrows % SROWS ? 1 : 0)) *
                       (ncols / SCOLS + (ncols % SCOLS ? 1 : 0));
```

## Fixes
Fixes #1837

## Testing & Validation
- Verified the arithmetic logic against tile boundary cases (`nrows % 128 == 0`, `nrows < 128`, and arbitrary dimensions).
- Clean code formatting verified via `pre-commit` (`clang-format`, `editorconfig-checker`, `git-hooks`).

Signed-off-by: bhuvan-somisetty <somisettybhuvan5@gmail.com>
