### PR TITLE
Update r.traveltime documentation

### DIFF
--- a/src/raster/r.traveltime/r.traveltime.html
+++ b/src/raster/r.traveltime/r.traveltime.html
@@ -80,7 +80,7 @@ r.colors ttime colors=blues
 <h2>REFERENCES</h2>
 
 <ul>
-<li>Förster, K., (2026): <em>r.traveltime – historical technical description.</em>, 
+<li>Förster, K., (2026): <em>r.traveltime – historical technical description.</em>,
 Software documentation. Zenodo. https://doi.org/10.5281/ZENODO.22226846 </li>
 <li>Kilgore, J. L. (1997): <em>Development and evaluation of a GIS-based
 spatially distributed unit hydrograph model</em>, master thesis,

--- a/src/raster/r.traveltime/r.traveltime.html
+++ b/src/raster/r.traveltime/r.traveltime.html
@@ -29,6 +29,26 @@ r.fill.dir program using the "agnps" format option.
 The program does not work correctly if Manning's roughness grid is
 defined as double (float expected). To define a simple uniform
 roughness distribution try: r.mapcalc 'roughness = 0.1f'
+Some users reported void spaces in results, which might be caused by
+problem areas identified by r.fill.dir. The solution is explained in
+the r.fill.dir documentation: "In some cases it may be necessary to 
+run r.fill.dir repeatedly (using output from one run as input to the 
+next run) before all of problem areas are filled."
+If catchment boundaries are located in flat areas, the flow direction
+from r.fill.dir might differ from drainage directions from r.watershed,
+since both modules identify direction in a different manner. Converting
+the drainage map to the "agnps" format to be used as input to r.traveltime
+(direction) could help to overcome this limitation:
+<div class="code"><pre>
+r.mapcalc "drain_agnps2 = if(drainage == 1, 2, \
+                          if(drainage == 2, 1, \
+                          if(drainage == 3, 8, \
+                          if(drainage == 4, 7, \
+                          if(drainage == 5, 6, \
+                          if(drainage == 6, 5, \
+                          if(drainage == 7, 4, \
+                          if(drainage == 8, 3, null()))))))))"
+</pre></div>
 
 <h2>EXAMPLE</h2>
 <i>This example uses the North Carolina sample dataset.</i>
@@ -55,12 +75,13 @@ r.colors ttime colors=blues
 <a href="https://grass.osgeo.org/grass-stable/manuals/r.watershed.html">r.watershed</a>,
 <a href="https://grass.osgeo.org/grass-stable/manuals/r.fill.dir.html">r.fill.dir</a>
 </em>
-<br>
-<a href="https://jesbergwetter.twoday.net/stories/4845555/">https://jesbergwetter.twoday.net/stories/4845555/</a>
+
 
 <h2>REFERENCES</h2>
 
 <ul>
+<li>Förster, K., (2026): <em>r.traveltime – historical technical description.</em>, 
+Software documentation. Zenodo. https://doi.org/10.5281/ZENODO.22226846 </li>
 <li>Kilgore, J. L. (1997): <em>Development and evaluation of a GIS-based
 spatially distributed unit hydrograph model</em>, master thesis,
 Virginia

--- a/src/raster/r.traveltime/r.traveltime.html
+++ b/src/raster/r.traveltime/r.traveltime.html
@@ -31,8 +31,8 @@ defined as double (float expected). To define a simple uniform
 roughness distribution try: r.mapcalc 'roughness = 0.1f'
 Some users reported void spaces in results, which might be caused by
 problem areas identified by r.fill.dir. The solution is explained in
-the r.fill.dir documentation: "In some cases it may be necessary to 
-run r.fill.dir repeatedly (using output from one run as input to the 
+the r.fill.dir documentation: "In some cases it may be necessary to
+run r.fill.dir repeatedly (using output from one run as input to the
 next run) before all of problem areas are filled."
 If catchment boundaries are located in flat areas, the flow direction
 from r.fill.dir might differ from drainage directions from r.watershed,

--- a/src/raster/r.traveltime/r.traveltime.md
+++ b/src/raster/r.traveltime/r.traveltime.md
@@ -42,7 +42,7 @@ since both modules identify direction in a different manner. Converting
 the drainage map to the "agnps" format to be used as input to r.traveltime
 (direction) could help to overcome this limitation:
 
-```
+```sh
 r.mapcalc "drain_agnps2 = if(drainage == 1, 2, \
                           if(drainage == 2, 1, \
                           if(drainage == 3, 8, \

--- a/src/raster/r.traveltime/r.traveltime.md
+++ b/src/raster/r.traveltime/r.traveltime.md
@@ -33,8 +33,8 @@ defined as double (float expected). To define a simple uniform roughness
 distribution try: r.mapcalc 'roughness = 0.1f'
 Some users reported void spaces in results, which might be caused by
 problem areas identified by r.fill.dir. The solution is explained in
-the r.fill.dir documentation: "In some cases it may be necessary to 
-run r.fill.dir repeatedly (using output from one run as input to the 
+the r.fill.dir documentation: "In some cases it may be necessary to
+run r.fill.dir repeatedly (using output from one run as input to the
 next run) before all of problem areas are filled."
 If catchment boundaries are located in flat areas, the flow direction
 from r.fill.dir might differ from drainage directions from r.watershed,

--- a/src/raster/r.traveltime/r.traveltime.md
+++ b/src/raster/r.traveltime/r.traveltime.md
@@ -31,6 +31,27 @@ definitions are in accordance to the r.fill.dir program using the
 The program does not work correctly if Manning's roughness grid is
 defined as double (float expected). To define a simple uniform roughness
 distribution try: r.mapcalc 'roughness = 0.1f'
+Some users reported void spaces in results, which might be caused by
+problem areas identified by r.fill.dir. The solution is explained in
+the r.fill.dir documentation: "In some cases it may be necessary to 
+run r.fill.dir repeatedly (using output from one run as input to the 
+next run) before all of problem areas are filled."
+If catchment boundaries are located in flat areas, the flow direction
+from r.fill.dir might differ from drainage directions from r.watershed,
+since both modules identify direction in a different manner. Converting
+the drainage map to the "agnps" format to be used as input to r.traveltime
+(direction) could help to overcome this limitation:
+
+```
+r.mapcalc "drain_agnps2 = if(drainage == 1, 2, \
+                          if(drainage == 2, 1, \
+                          if(drainage == 3, 8, \
+                          if(drainage == 4, 7, \
+                          if(drainage == 5, 6, \
+                          if(drainage == 6, 5, \
+                          if(drainage == 7, 4, \
+                          if(drainage == 8, 3, null()))))))))"
+```
 
 ## EXAMPLE
 
@@ -54,10 +75,11 @@ r.colors ttime colors=blues
 
 *[r.watershed](https://grass.osgeo.org/grass-stable/manuals/r.watershed.html),
 [r.fill.dir](https://grass.osgeo.org/grass-stable/manuals/r.fill.dir.html)*  
-<https://jesbergwetter.twoday.net/stories/4845555/>
 
 ## REFERENCES
-
+- Förster, K., (2026): *r.traveltime – historical technical description.*
+    Software documentation. Zenodo.
+    [https://doi.org/10.5281/ZENODO.22226846](https://doi.org/10.5281/ZENODO.22226846)
 - Kilgore, J. L. (1997): *Development and evaluation of a GIS-based
     spatially distributed unit hydrograph model*, master thesis,
     Virginia Polytechnic Institute and State University.

--- a/src/raster/r.traveltime/r.traveltime.md
+++ b/src/raster/r.traveltime/r.traveltime.md
@@ -77,6 +77,7 @@ r.colors ttime colors=blues
 [r.fill.dir](https://grass.osgeo.org/grass-stable/manuals/r.fill.dir.html)*  
 
 ## REFERENCES
+
 - Förster, K., (2026): *r.traveltime – historical technical description.*
     Software documentation. Zenodo.
     [https://doi.org/10.5281/ZENODO.22226846](https://doi.org/10.5281/ZENODO.22226846)


### PR DESCRIPTION
I suggest updating the documentation of r.traveltime (html and md files) for mainly two reasons:

1. The link to the technical description pointed to my old blog website (https://jesbergwetter.twoday.net/stories/4845555/) and I plan to deactivate the entire blog. Thus, I converted the historical documentation of r.traveltime to md and pdf and published this via github (https://github.com/kristianfoerster/r.traveltime-documentation) and zenodo (https://doi.org/10.5281/zenodo.22226846), still preserving the original content published in 2007 and 2008 on the blog, in order warrant long-term archiving.
2. While revisiting r.traveltime I was glad to see that it has been used but I also realized that users encountered unexpected behavior of the module. I collected the main issues, tested it and included some possible solutions to the known issues section. This resolves issues #788 and #816 which can be attributed to inconsistent input data, rather than a software bug. 